### PR TITLE
Added "Unknown" platform to the agents tab. 

### DIFF
--- a/public/controllers/agentsPreview.js
+++ b/public/controllers/agentsPreview.js
@@ -40,6 +40,11 @@ app.controller('agentsPreviewController', function ($scope, Notifier, genericReq
                     }
                 }
             }
+            $scope.osPlatforms.push({
+                name:     'Unknown',
+                platform: 'Unknown',
+                version:  'Unknown'
+            });
         });
 
 

--- a/public/controllers/agentsPreview.js
+++ b/public/controllers/agentsPreview.js
@@ -40,11 +40,16 @@ app.controller('agentsPreviewController', function ($scope, Notifier, genericReq
                     }
                 }
             }
-            $scope.osPlatforms.push({
-                name:     'Unknown',
-                platform: 'Unknown',
-                version:  'Unknown'
-            });
+            return apiReq.request('GET', '/agents/summary', { });
+        })
+        .then(data => {
+            if(parseInt(data.data.data['Never connected']) > 0){
+                $scope.osPlatforms.push({
+                    name:     'Unknown',
+                    platform: 'Unknown',
+                    version:  'Unknown'
+                });
+            }
         });
 
 

--- a/public/services/dataHandler.js
+++ b/public/services/dataHandler.js
@@ -68,6 +68,7 @@ app.factory('DataHandler', function ($q, apiReq) {
                 name:  filterName,
                 value: value
             });
+
             this.search();
         }
 
@@ -97,21 +98,25 @@ app.factory('DataHandler', function ($q, apiReq) {
                 offset: 0,
                 limit:  this.initialBatch
             };
-
+            let isUnknown = false;
             for(let filter of this.filters){
-                if (filter.value !== '') requestData[filter.name] = filter.value;
+                if (filter.value !== '' && filter.value !== 'Unknown') requestData[filter.name] = filter.value;
+                if (filter.value === 'Unknown') isUnknown = true;
             }
 
             apiReq.request('GET', this.path, requestData)
-            .then(function (data) {
+            .then(data => {
                 this.items = [];
                 let items  = data.data.data.items;
                 for (let i = 0,len = items.length; i < len; i++) {
                     this.items.push(items[i]);
                     this.items[i].selected = false;
                 }
+                if(isUnknown){
+                    this.items = this.items.filter(item => typeof item.os === 'undefined');
+                }
                 this.offset = items.length;
-            }.bind(this));
+            });
         }
 
         sort(by) {


### PR DESCRIPTION
Now you can filter agents without os and having no conflict with the API call. The trick was check if is an "Unknown" case, then: 

```js
if(isUnknown){
       this.items = this.items.filter(item => typeof item.os === 'undefined');
}
```