### PR TITLE
Fixed oversizing of index selector box in Discover

### DIFF
--- a/public/less/main.less
+++ b/public/less/main.less
@@ -1,3 +1,7 @@
+input[type="search"] {
+    box-sizing: border-box !important;
+}
+
 ._md-select-value {
     border: none !important;
 }


### PR DESCRIPTION
Now the index selector from our Discover tab doesn't resize oddly.

![selector-fixed](https://user-images.githubusercontent.com/10928321/33267395-9fcc9ff4-d379-11e7-9ebe-6ab8ecdfbbe1.PNG)
