### PR TITLE
Ensure syscheck and rootcheck are showing properly

### DIFF
--- a/public/controllers/agents.js
+++ b/public/controllers/agents.js
@@ -180,6 +180,7 @@ function ($scope, $q, $routeParams, $route, $location, $rootScope, timefilter, N
 				validateRootCheck();	
 
 				$scope.loading = false;
+				$scope.$digest();
 			})
 			.catch(error => notify.error(error.message));
 		}

--- a/public/less/agents.less
+++ b/public/less/agents.less
@@ -23,6 +23,10 @@ md-list.agents-preview-table:focus {
     outline: none;
 }
 
+.agents-groups-preview .md-button:not([disabled]):hover {
+    background-color: transparent !important;
+}
+
 .agentsPreview md-input-container {
     height: 41px;
     margin-top: 17px;

--- a/public/less/buttons.less
+++ b/public/less/buttons.less
@@ -66,15 +66,6 @@ button._md-no-style.md-button.md-ink-ripple {
     border-radius: 0px;
 }
 
-// .md-button:not([disabled]):hover,
-.list-no-hover>.md-button:not([disabled]):hover,
-.list-no-hover>.md-button.buttonBlueLight.md-default-theme:not([disabled]):hover,
-.list-no-hover>.md-button.buttonBlueLight.md-raised.md-primary:not([disabled]):hover,
-.list-no-hover>.md-button.buttonMenu.md-default-theme:not([disabled]):hover,
-.list-no-hover>.md-button.md-default-theme:not([disabled]):hover {
-    background-color: transparent !important;
-}
-
 .md-button.buttonBlueLightSettings.md-raised.md-primary:not([disabled]):hover{
     background-color: #3caed2 !important;
     color: white !important;

--- a/public/services/dataHandler.js
+++ b/public/services/dataHandler.js
@@ -37,7 +37,7 @@ app.factory('DataHandler', function ($q, apiReq) {
                 if (filter.value !== '') requestData[filter.name] = filter.value;
             }
 
-            if(this.offset >= this.totalItems){
+            if(this.offset !== 0 && this.offset >= this.totalItems){
                 this.end = true;
                 this.busy = false;
                 return;
@@ -46,17 +46,19 @@ app.factory('DataHandler', function ($q, apiReq) {
             apiReq.request('GET', this.path, requestData)
             .then(data => {
                 if (data.data.data === 0){
+                    this.busy = false;
                     deferred.resolve(false);
                 }
                 this.totalItems = data.data.data.totalItems;
-                let items      = data.data.data.items;
+                let items       = data.data.data.items;
                 for (let i = 0,len = items.length; i < len; i++) {
                     this.items.push(items[i]);
                     this.items[i].selected = false;
                 }
                 this.offset += items.length;
-                (this.offset >= this.totalItems) ? this.end = true: this.busy = false;
+                if (this.offset >= this.totalItems) this.end = true; 
                 if (data.data.data !== 0){
+                    this.busy = false;
                     deferred.resolve(true);
                 }
             })

--- a/public/templates/agents-preview.html
+++ b/public/templates/agents-preview.html
@@ -88,7 +88,7 @@
 
     <md-content flex when-scrolled="agents.nextPage('')" class="agents-preview-agents-list">
         <md-list ng-repeat='agent in agents.items | orderBy : agents.sortValue : agents.sortDir' class="agents-preview-table">
-            <md-list-item ng-click="applyAgent(agent)" class="list-no-hover md-subhead">
+            <md-list-item ng-click="applyAgent(agent)" class="md-subhead agents-groups-preview">
                 <span flex="5">{{agent.id || 'Unknown'}}</span>
                 <span flex="25">{{agent.name || 'Unknown'}}</span>
                 <span flex="10">{{agent.ip || 'Unknown'}}</span>

--- a/public/templates/groups-preview.html
+++ b/public/templates/groups-preview.html
@@ -60,7 +60,7 @@
                                 </md-toolbar>
                                 <md-content when-scrolled="groupAgents.nextPage('')">
                                     <md-list ng-repeat='agent in groupAgents.items | orderBy : groupAgents.sortValue : groupAgents.sortDir' class="agents-preview-table">
-                                        <md-list-item class="md-subhead" ng-click="showAgent(agent)">
+                                        <md-list-item class="md-subhead agents-groups-preview" ng-click="showAgent(agent)">
                                             <span flex="5">{{agent.id || 'Unknown'}}</span>
                                             <span flex="25">{{agent.name || 'Unknown'}}</span>
                                             <span flex="10">{{agent.ip || 'Unknown'}}</span>


### PR DESCRIPTION
- It's only a `$scope.$digest()` (that only applies current $scope, not the whole app)
- Just noticed that `syscheck` and `rootcheck` minutes, sometimes they are showing and sometimes they aren't so I force to ensure update them when finished.
- Also adds an extra condition in order to prevent wrong offset with datahandler 
  - `if(this.offset !== 0 && this.offset >= this.totalItems){ ... }`
- Fixed wrong `hover` in groups tab and agents preview tab,