### PR TITLE
More CSS tweaks

### DIFF
--- a/public/less/angular-md.less
+++ b/public/less/angular-md.less
@@ -6,10 +6,13 @@
     background-color: rgba(158, 158, 158, 0.2);
 }
 
-
-
 md-card-content .ng-binding {
     color: rgb(102, 102, 102);
+}
+
+/* Fix text color from visualizations tooltips */
+.tooltip > .tooltip-inner {
+    color: white !important;
 }
 
 .md-button.md-fab {

--- a/public/less/common.less
+++ b/public/less/common.less
@@ -128,3 +128,8 @@ md-progress-linear.md-default-theme ._md-bar,
 md-progress-linear ._md-bar {
     background-color: #3caed2;
 }
+
+/* Manager Groups Agents/Files tabs fix */
+.md-tab.md-active {
+    color: rgb(60, 174, 210) !important;
+}


### PR DESCRIPTION
* Fixed colour from active tab in Manager/Groups
* Fixed tooltip text colour:
![fotito](https://user-images.githubusercontent.com/10928321/33329296-8469c30c-d45c-11e7-8ff0-f14e2464d4b7.png)
