### PR TITLE
Fix app typography to gain consistency

### DIFF
--- a/public/less/common.less
+++ b/public/less/common.less
@@ -30,10 +30,10 @@ pre {
     font-size: 24px !important;
 }
 
-/* Discover-Full Directive */
+/* Fix typography for better consistency */
 
-.sidebar-container {
-    font-family: "Open Sans", Helvetica, Arial, sans-serif
+html, body, button, textarea, input, select {
+    font-family: "Open Sans", Helvetica, Arial, sans-serif !important;
 }
 
 /* Loading Ring styles */


### PR DESCRIPTION
This PR changes the Wazuh app typography in order to gain more consistency between the app and the rest of Kibana sections.
![font](https://user-images.githubusercontent.com/10928321/33372272-a7dd6b80-d4fd-11e7-9822-80da479463db.png)

This is more noticeable if you look at the Kibana sidebar when on Discover/Visualize and Wazuh.