### PR TITLE
Timeout limit on requesting

### DIFF
--- a/public/controllers/settings.js
+++ b/public/controllers/settings.js
@@ -273,6 +273,12 @@ let app = require('ui/modules').get('app/wazuh', []).controller('settingsControl
             case 'not_running':
                 text = 'There are not services running in the given URL.';
                 break;
+            case 'request_timeout_checkstored':
+                text = 'The request to /api/wazuh-api/checkStoredAPI took too long and was aborted.';
+                break;
+            case 'request_timeout_checkapi':
+                text = 'The request to /api/wazuh-api/checkAPI took too long and was aborted.';
+                break;
             default:
                 text = `Unexpected error. ${error.message}`;
         }

--- a/public/services/genericReq.js
+++ b/public/services/genericReq.js
@@ -14,7 +14,7 @@ require('ui/modules').get('app/wazuh', []).service('genericReq', function ($q, $
             return defered.promise;
         }
 
-        let requestHeaders = { headers: { "Content-Type": 'application/json' } };
+        let requestHeaders = { headers: { "Content-Type": 'application/json' }, timeout: 4000 };
 
         let tmpUrl = chrome.addBasePath(url), tmp = null;
 
@@ -32,20 +32,22 @@ require('ui/modules').get('app/wazuh', []).service('genericReq', function ($q, $
         }
 
         tmp
-        .then((data) => {
+        .then(data => {
             if (data.error && data.error !== '0') {
                 defered.reject(data);
             } else {
                 defered.resolve(data);
             }
         })
-        .catch((error) => {
-            if (error.error && error.error !== '0') {
+        .catch(error => {
+            if(error.status && error.status === -1){
+                defered.reject({data: 'request_timeout_genericreq', url });
+            }else if (error.error && error.error !== '0') {
                 defered.reject(error);
             } else {
                 defered.reject({
-                    'error': -2,
-                    'message': 'Error doing a request to Kibana API.'
+                    error  : -2,
+                    message: 'Error doing a request to Kibana API.'
                 });
             }
         });

--- a/public/services/prep-error.js
+++ b/public/services/prep-error.js
@@ -1,5 +1,9 @@
-module.exports = (err) => {
-    if (parseInt(err.error) < 0) {
+module.exports = err => {
+
+    if(err.data && err.data === 'request_timeout_genericreq' && err.url){
+        err['html'] = `The request to ${err.url} took too long and was aborted.`;
+        err.message = `The request to ${err.url} took too long and was aborted.`;
+    } else if (parseInt(err.error) < 0) {
         err['html'] = `Unexpected error located on controller. Error: <b>${err.message} (code ${err.error})</b>.`;
         err.message = `Unexpected error located on controller. Error: ${err.message} (code ${err.error}).`;
     } else if (parseInt(err.error) === 1) {

--- a/public/services/testAPI.js
+++ b/public/services/testAPI.js
@@ -4,7 +4,7 @@ require('ui/modules').get('app/wazuh', [])
     return {
         check_stored: (data) => {
             let defered = $q.defer();
-            $http.post(chrome.addBasePath('/api/wazuh-api/checkStoredAPI'), data)
+            $http.post(chrome.addBasePath('/api/wazuh-api/checkStoredAPI'), data,{timeout: 4000})
             .then((response) => {
                 if (response.error) {
                     defered.reject(response);
@@ -12,8 +12,10 @@ require('ui/modules').get('app/wazuh', [])
                     defered.resolve(response);
                 }
             })
-            .catch((error) => {
-                if (error.error) {
+            .catch(error => {
+                if(error.status && error.status === -1){
+                    defered.reject({data: 'request_timeout_checkstored'});
+                } else if (error.error) {
                     defered.reject(error);
                 }
             });
@@ -21,7 +23,7 @@ require('ui/modules').get('app/wazuh', [])
         },
         check: (data) => {
             let defered = $q.defer();
-            $http.post(chrome.addBasePath("/api/wazuh-api/checkAPI"), data)
+            $http.post(chrome.addBasePath("/api/wazuh-api/checkAPI"), data, {timeout: 4000})
             .then((response) => {
                 if (response.error) {
                     defered.reject(response);
@@ -29,8 +31,10 @@ require('ui/modules').get('app/wazuh', [])
                     defered.resolve(response);
                 }
             })
-            .catch((error) => {
-                if (error.error) {
+            .catch(error => {
+                if(error.status && error.status === -1){
+                    defered.reject({data: 'request_timeout_checkapi'});
+                }else if (error.error) {
                     defered.reject(error);
                 }
             });


### PR DESCRIPTION
- Errors related to a `timeout` request are handled and showed properly
- Sets the maximum time to finish a request to `4000ms` 