### PR TITLE
Visualizations static timerange

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "3.1.0",
   "revision": "0373",
   "kibana": {
-    "version": "6.1.0"
+    "version": "6.1.1"
   },
   "description": "Wazuh App",
   "main": "index.js",

--- a/public/kibana-integrations/kibanaVisualizationDirective.js
+++ b/public/kibana-integrations/kibanaVisualizationDirective.js
@@ -7,6 +7,7 @@ var app = require('ui/modules').get('apps/webinar_app', [])
             restrict: 'E',
             scope: {
                 visID: '=visId',
+                specificTimeRange: '=specificTimeRange'
             },
             controller: function VisController($scope, $rootScope, savedVisualizations, implicitFilters) {
 
@@ -52,7 +53,16 @@ var app = require('ui/modules').get('apps/webinar_app', [])
                             .set('filter', implicitFilters.loadFilters());
                         }
 
-                        loader.embedVisualizationWithSavedObject($("#"+$scope.visID), visualization, {})
+                        let params = {};
+
+                        if ($scope.specificTimeRange == true) {
+                            const timeRange = {
+                                min: 'now-1d/d',
+                                max: 'now'
+                            };
+                            params = {timeRange: timeRange}
+                        }
+                        loader.embedVisualizationWithSavedObject($("#"+$scope.visID), visualization, params)
                         .then(handler => {
 
                             // We bind the renderComplete event to watch for proper loading screen

--- a/public/templates/manager/ruleset/ruleset-decoders.html
+++ b/public/templates/manager/ruleset/ruleset-decoders.html
@@ -6,7 +6,7 @@
         <md-card flex class="manager-ruleset-decoders-top-24">
             <md-card-content class="wazuh-column">
                 <span class="md-headline-small">Top 24h - Decoder name</span>
-                <kbn-vis vis-id="'Wazuh-App-Manager-Ruleset-Decoders-Top-24h-Decoder-name'" id="Wazuh-App-Manager-Ruleset-Decoders-Top-24h-Decoder-name"></kbn-vis>
+                <kbn-vis specific-time-range="true" vis-id="'Wazuh-App-Manager-Ruleset-Decoders-Top-24h-Decoder-name'" id="Wazuh-App-Manager-Ruleset-Decoders-Top-24h-Decoder-name"></kbn-vis>
             </md-card-content>
         </md-card>
     </div>
@@ -79,14 +79,14 @@
         </md-toolbar>
 
         <md-content flex layout="column" class="height-300" when-scrolled="decoders.nextPage('')">
-	            <md-list class="agents-preview-table" ng-class-odd="'odd'" ng-class-even="'even'" ng-repeat='decoder in decoders.items | orderBy : decoders.sortValue : decoders.sortDir' ng-class="activeItem === decoder.name+decoder.file+decoder.position ? 'ruleset_rules_row_active' : ''">
-	                <md-list-item class="rules-item-list" ng-click="closeOther(decoder.name+decoder.file+decoder.position)" ng-class="activeItem === decoder.name+decoder.file+decoder.position ? 'ruleset_rules_row_active' : ''">
-	                    <span flex="20">{{decoder.name}}</span>
-	                    <span flex="20">{{decoder.details["program_name"]}}</span>
-	                    <span flex="40">{{ decoder.details["order"] | limitTo: 80 }}{{decoder.details["order"].length > 80 ? '...' : ''}}</span>
-	                    <md-button md-no-ink class="invisibleButton" flex="20" ng-if="$parent.typeFilter == 'all'" ng-click="decodersApplyFilter({type: 'file', value: decoder.file}); $event.stopPropagation();">{{decoder.file}}</md-button>
-	                    <span flex="20" ng-if="$parent.typeFilter != 'all'">{{decoder.file}}</span>
-	                </md-list-item>
+                <md-list class="agents-preview-table" ng-class-odd="'odd'" ng-class-even="'even'" ng-repeat='decoder in decoders.items | orderBy : decoders.sortValue : decoders.sortDir' ng-class="activeItem === decoder.name+decoder.file+decoder.position ? 'ruleset_rules_row_active' : ''">
+                    <md-list-item class="rules-item-list" ng-click="closeOther(decoder.name+decoder.file+decoder.position)" ng-class="activeItem === decoder.name+decoder.file+decoder.position ? 'ruleset_rules_row_active' : ''">
+                        <span flex="20">{{decoder.name}}</span>
+                        <span flex="20">{{decoder.details["program_name"]}}</span>
+                        <span flex="40">{{ decoder.details["order"] | limitTo: 80 }}{{decoder.details["order"].length > 80 ? '...' : ''}}</span>
+                        <md-button md-no-ink class="invisibleButton" flex="20" ng-if="$parent.typeFilter == 'all'" ng-click="decodersApplyFilter({type: 'file', value: decoder.file}); $event.stopPropagation();">{{decoder.file}}</md-button>
+                        <span flex="20" ng-if="$parent.typeFilter != 'all'">{{decoder.file}}</span>
+                    </md-list-item>
 
                         <div layout="row" ng-if="activeItem === decoder.name+decoder.file+decoder.position" ng-class="activeItem === decoder.name+decoder.file+decoder.position ? 'ruleset_rules_row_active' : ''">
                             <md-card flex>
@@ -119,10 +119,10 @@
                                         </div>
                                    </md-card-content>
                             </md-card>
-	                </md-list>
-	            </md-list>
-	        </md-content>
+                    </md-list>
+                </md-list>
+            </md-content>
         <md-divider></md-divider>
-    	<md-content><md-progress-linear class="md-accent" md-mode="indeterminate" ng-show="decoders.busy"></md-progress-linear></md-content>
+        <md-content><md-progress-linear class="md-accent" md-mode="indeterminate" ng-show="decoders.busy"></md-progress-linear></md-content>
     </div>
 </div>

--- a/public/templates/manager/ruleset/ruleset-rules.html
+++ b/public/templates/manager/ruleset/ruleset-rules.html
@@ -9,25 +9,25 @@
         <md-card flex>
             <md-card-content class="wazuh-column">
                 <span class="md-headline">Top 24h - Rule ID</span>
-                <kbn-vis vis-id="'Wazuh-App-Manager-Ruleset-Rules-Top-24h-Rule-ID'" id="Wazuh-App-Manager-Ruleset-Rules-Top-24h-Rule-ID"></kbn-vis>
+                <kbn-vis specific-time-range="true" vis-id="'Wazuh-App-Manager-Ruleset-Rules-Top-24h-Rule-ID'" id="Wazuh-App-Manager-Ruleset-Rules-Top-24h-Rule-ID"></kbn-vis>
             </md-card-content>
         </md-card>
         <md-card flex>
             <md-card-content class="wazuh-column">
                 <span class="md-headline">Top 24h - Groups</span>
-                <kbn-vis vis-id="'Wazuh-App-Manager-Ruleset-Rules-Top-24h-Groups'" id="Wazuh-App-Manager-Ruleset-Rules-Top-24h-Groups"></kbn-vis>
+                <kbn-vis specific-time-range="true" vis-id="'Wazuh-App-Manager-Ruleset-Rules-Top-24h-Groups'" id="Wazuh-App-Manager-Ruleset-Rules-Top-24h-Groups"></kbn-vis>
             </md-card-content>
         </md-card>
         <md-card flex>
             <md-card-content class="wazuh-column">
                 <span class="md-headline">Top 24h - PCI DSS requirements</span>
-                <kbn-vis vis-id="'Wazuh-App-Manager-Ruleset-Rules-Top-24h-PCI-DSS-requirements'" id="Wazuh-App-Manager-Ruleset-Rules-Top-24h-PCI-DSS-requirements"></kbn-vis>
+                <kbn-vis specific-time-range="true" vis-id="'Wazuh-App-Manager-Ruleset-Rules-Top-24h-PCI-DSS-requirements'" id="Wazuh-App-Manager-Ruleset-Rules-Top-24h-PCI-DSS-requirements"></kbn-vis>
             </md-card-content>
         </md-card>
         <md-card flex>
             <md-card-content class="wazuh-column">
                 <span class="md-headline">Top 24h - Level</span>
-                <kbn-vis vis-id="'Wazuh-App-Manager-Ruleset-Rules-Top-24h-Level'" id="Wazuh-App-Manager-Ruleset-Rules-Top-24h-Level"></kbn-vis>
+                <kbn-vis specific-time-range="true" vis-id="'Wazuh-App-Manager-Ruleset-Rules-Top-24h-Level'" id="Wazuh-App-Manager-Ruleset-Rules-Top-24h-Level"></kbn-vis>
             </md-card-content>
         </md-card>
     </div>


### PR DESCRIPTION
Adding attribute to the visualization directive:
 - specific-time-range: if true, the visualization will be loaded using a specific time range instead of being controlled by the searchbar's time picker.

Modifying ruleset visualizations to use this new attribute.