### PR TITLE
Small bugfixes

### DIFF
--- a/public/less/heights.less
+++ b/public/less/heights.less
@@ -16,6 +16,10 @@
     height: 120px;
 }
 
+.height-125 {
+    height: 125px;
+}
+
 .height-200 {
     height: 200px;
 }

--- a/public/templates/agents/agents-audit.html
+++ b/public/templates/agents/agents-audit.html
@@ -107,10 +107,10 @@
             </div>
         </div>
 
-        <div layout="row" layout-align="center stretch" class="height-530">
+        <div layout="row" layout-align="center stretch" class="height-550">
             <md-card flex>
                 <md-card-content class="wazuh-column">
-                    <span class="md-headline">Last alerts</span>
+                    <span class="md-headline">Alerts summary</span>
                     <kbn-vis class="kbn-chart" vis-id="'Wazuh-App-Agents-Audit-Last-alerts'" id="Wazuh-App-Agents-Audit-Last-alerts"></kbn-vis>
                 </md-card-content>
             </md-card>

--- a/public/templates/agents/agents-audit.html
+++ b/public/templates/agents/agents-audit.html
@@ -2,7 +2,7 @@
 
     <!-- View: Panels -->
     <div ng-show="resultState === 'ready' && tabView === 'panels'">
-        <div layout="row" layout-align="center stretch" class="height-120">
+        <div layout="row" layout-align="center stretch" class="height-125">
             <md-card flex>
                 <md-card-content class="wazuh-column">
                     <span class="metric-headline md-headline">New files</span>

--- a/public/templates/agents/agents-oscap.html
+++ b/public/templates/agents/agents-oscap.html
@@ -92,10 +92,10 @@
             </md-card>
         </div>
 
-        <div layout="row" layout-align="center stretch" class="height-540">
+        <div layout="row" layout-align="center stretch" class="height-550">
             <md-card flex>
                 <md-card-content class="wazuh-column">
-                    <span class="md-headline">Last alerts</span>
+                    <span class="md-headline">Alerts summary</span>
                     <kbn-vis class="kbn-chart" vis-id="'Wazuh-App-Agents-OSCAP-Last-alerts'" id="Wazuh-App-Agents-OSCAP-Last-alerts"></kbn-vis>
                 </md-card-content>
             </md-card>

--- a/public/templates/agents/agents-pci.html
+++ b/public/templates/agents/agents-pci.html
@@ -30,10 +30,10 @@
             </md-card>
         </div>
 
-        <div layout="row" layout-align="center stretch" class="height-540">
+        <div layout="row" layout-align="center stretch" class="height-550">
             <md-card flex>
                 <md-card-content class="wazuh-column">
-                    <span class="md-headline">Last alerts</span>
+                    <span class="md-headline">Alerts summary</span>
                     <kbn-vis class="kbn-chart" vis-id="'Wazuh-App-Agents-PCI-Last-alerts'" id="Wazuh-App-Agents-PCI-Last-alerts"></kbn-vis>
                 </md-card-content>
             </md-card>

--- a/public/templates/overview/overview-audit.html
+++ b/public/templates/overview/overview-audit.html
@@ -3,7 +3,7 @@
     <!-- View: Panels -->
     <div ng-show="resultState === 'ready' && tabView === 'panels'">
 
-        <div layout="row" layout-align="center stretch" class="height-120">
+        <div layout="row" layout-align="center stretch" class="height-125">
             <md-card flex="10">
                 <md-card-content class="wazuh-column">
                     <span class="metric-headline md-headline">New files</span>

--- a/public/templates/overview/overview-audit.html
+++ b/public/templates/overview/overview-audit.html
@@ -113,10 +113,10 @@
             </div>
         </div>
 
-        <div flex layout="row" class="height-530">
+        <div flex layout="row" class="height-550">
             <md-card flex>
                 <md-card-content class="wazuh-column">
-                    <span class="md-headline">Last alerts</span>
+                    <span class="md-headline">Alerts summary</span>
                     <kbn-vis class="kbn-chart" vis-id="'Wazuh-App-Overview-Audit-Last-alerts'" id="Wazuh-App-Overview-Audit-Last-alerts"></kbn-vis>
                 </md-card-content>
             </md-card>

--- a/public/templates/overview/overview-oscap.html
+++ b/public/templates/overview/overview-oscap.html
@@ -97,10 +97,10 @@
             </md-card>
         </div>
 
-        <div layout="row" layout-align="center stretch" class="height-530">
+        <div layout="row" layout-align="center stretch" class="height-550">
             <md-card flex>
                 <md-card-content class="wazuh-column">
-                    <span class="md-headline">Last alerts</span>
+                    <span class="md-headline">Alerts summary</span>
                     <kbn-vis class="kbn-chart" vis-id="'Wazuh-App-Overview-OSCAP-Last-alerts'" id="Wazuh-App-Overview-OSCAP-Last-alerts"></kbn-vis>
                 </md-card-content>
             </md-card>

--- a/public/templates/overview/overview-pci.html
+++ b/public/templates/overview/overview-pci.html
@@ -55,10 +55,10 @@
             </md-card>
         </div>
 
-        <div layout="row" layout-align="center stretch" class="height-530">
+        <div layout="row" layout-align="center stretch" class="height-550">
             <md-card flex>
                 <md-card-content class="wazuh-column">
-                    <span class="md-headline">Last alerts</span>
+                    <span class="md-headline">Alerts summary</span>
                     <kbn-vis class="kbn-chart" vis-id="'Wazuh-App-Overview-PCI-DSS-Last-alerts'" id="Wazuh-App-Overview-PCI-DSS-Last-alerts"></kbn-vis>
                 </md-card-content>
             </md-card>


### PR DESCRIPTION
This PR does the following:
* Fix the height of some metric visualizations where the numbers were cut.
![arreglo 1](https://user-images.githubusercontent.com/10928321/35053871-ae786a10-fbab-11e7-84f3-9f90635ab7d5.PNG)
* Now all the data table visualizations should not have their pagination cut and the title has been changed to **Alerts summary**.