### PR TITLE
3.1 fix pin import

### DIFF
--- a/public/kibana-integrations/kibanaDiscoverDirective.js
+++ b/public/kibana-integrations/kibanaDiscoverDirective.js
@@ -317,6 +317,7 @@ function discoverController(
             ////////////////////////////////////////////////////////////////////////////
             ///////////////////////////////  WAZUH   ///////////////////////////////////
             ////////////////////////////////////////////////////////////////////////////
+            console.log("updating", queryFilter.getFilters());
             $rootScope.$broadcast('updateVis', $state.query, queryFilter.getFilters());
             $rootScope.$broadcast('fetch');
             if($location.search().tab != 'configuration') {
@@ -919,9 +920,8 @@ function discoverController(
   // Watch for changes in the location
   $scope.$on('$routeUpdate', () => {
     if ($location.search().tabView !=  $scope.tabView) { // No need to change the filters
-      if ($scope.tabView !== "discover") { // Should do this the first time, to avoid the squeezing of the visualization
+        console.log("change");
         $scope.updateQueryAndFetch($state.query);
-      }
       $scope.tabView = $location.search().tabView;
     }
     if ($location.search().tab !=  $scope.tab) { // Changing filters

--- a/public/kibana-integrations/kibanaDiscoverDirective.js
+++ b/public/kibana-integrations/kibanaDiscoverDirective.js
@@ -317,7 +317,6 @@ function discoverController(
             ////////////////////////////////////////////////////////////////////////////
             ///////////////////////////////  WAZUH   ///////////////////////////////////
             ////////////////////////////////////////////////////////////////////////////
-            console.log("updating", queryFilter.getFilters());
             $rootScope.$broadcast('updateVis', $state.query, queryFilter.getFilters());
             $rootScope.$broadcast('fetch');
             if($location.search().tab != 'configuration') {
@@ -920,7 +919,6 @@ function discoverController(
   // Watch for changes in the location
   $scope.$on('$routeUpdate', () => {
     if ($location.search().tabView !=  $scope.tabView) { // No need to change the filters
-        console.log("change");
         $scope.updateQueryAndFetch($state.query);
       $scope.tabView = $location.search().tabView;
     }

--- a/public/kibana-integrations/kibanaDiscoverDirective.js
+++ b/public/kibana-integrations/kibanaDiscoverDirective.js
@@ -919,7 +919,9 @@ function discoverController(
   // Watch for changes in the location
   $scope.$on('$routeUpdate', () => {
     if ($location.search().tabView !=  $scope.tabView) { // No need to change the filters
+      if ($scope.tabView !== "discover") { // Should do this the first time, to avoid the squeezing of the visualization
         $scope.updateQueryAndFetch($state.query);
+      }
       $scope.tabView = $location.search().tabView;
     }
     if ($location.search().tab !=  $scope.tab) { // Changing filters

--- a/public/kibana-integrations/kibanaVisualizationDirective.js
+++ b/public/kibana-integrations/kibanaVisualizationDirective.js
@@ -18,49 +18,33 @@ var app = require('ui/modules').get('apps/webinar_app', [])
                 let visualization  = null;
                 let visHandler     = null;
                 let pendingUpdates = [];
+                let realPending = true;
+                let realPendingUpdates = [];
 
                 // Listen for changes
                 $scope.$on('updateVis', function (event, query, filters) {
-                    console.log("update, rendered", rendered);
                     if (rendered) {
                         if (visTitle !== 'Wazuh App Overview General Agents status') { // We don't want to filter that visualization as it uses another index-pattern
 
-                            if (pendingUpdates.length != 0) {
-                                for (let i = 0; i < pendingUpdates.length; i++) {
-                                    for (let j = 0; j < implicitFilters.loadFilters().length; j++) {
-                                        console.log("comparing", pendingUpdates[i].query, implicitFilters.loadFilters()[j]);
-                                        if (pendingUpdates[i].query == implicitFilters.loadFilters()[j]) {
-                                            console.log("this is the same", )
-                                        }
-                                    }
-                                }
+                            if (query.query === '') {
+                                fullFilter = implicitFilter;
                             }
-
-                            if (query != null) {
-                                if (query.query === '') {
-                                    fullFilter = implicitFilter;
+                            else {
+                                if (implicitFilter !== '') {
+                                    fullFilter = implicitFilter + ' AND ' + query.query;
                                 }
                                 else {
-                                    if (implicitFilter !== '') {
-                                        fullFilter = implicitFilter + ' AND ' + query.query;
-                                    }
-                                    else {
-                                        fullFilter = query.query;
-                                    }
+                                    fullFilter = query.query;
                                 }
-
-                                console.log("updating inside", visTitle,filters);
-                                visualization.searchSource
-                                .query({ language: 'lucene', query: fullFilter })
-                                .set('filter', filters);
-                            } else { // Update with pending
-
                             }
+
+                            visualization.searchSource
+                            .query({ language: 'lucene', query: fullFilter })
+                            .set('filter', filters);
+
                         }
                     } else {
-                        pendingUpdates.push({"query": query, "filters": filters});
-                            console.log("pushing inside", visTitle, pendingUpdates);
-                            console.log("the implicits", implicitFilters.loadFilters());
+                        pendingUpdates.push.apply(pendingUpdates, filters);
                     }
                 });
 
@@ -68,8 +52,32 @@ var app = require('ui/modules').get('apps/webinar_app', [])
                     rendered = true;
 
                     if (pendingUpdates.length != 0) {
-                        console.log("emitting, pending updates");
-                        $rootScope.$broadcast('updateVis', null, null);
+
+                        realPendingUpdates = implicitFilters.loadFilters();
+
+                        for (let i = 0; i < pendingUpdates.length; i++) {
+                            for (let j = 0; j < implicitFilters.loadFilters().length; j++) {
+                                if (JSON.stringify(pendingUpdates[i].query) === JSON.stringify(implicitFilters.loadFilters()[j].query)) {
+                                    realPending = false;
+                                }
+                            }
+
+                            // There was a real pending update?
+                            if (realPending) {
+                                realPendingUpdates.push(pendingUpdates[i]) 
+                            }
+                            realPending = true;
+                        }
+
+                        //
+                        pendingUpdates = [];
+                        if (realPendingUpdates.length != 0) {
+                            visualization.searchSource
+                            .query({ language: 'lucene', query: implicitFilter })
+                            .set('filter', realPendingUpdates);
+                            $rootScope.$broadcast('fetch');
+                            realPendingUpdates = [];
+                        }
                     }
 
                     $rootScope.loadedVisualizations.push(true);

--- a/public/kibana-integrations/kibanaVisualizationDirective.js
+++ b/public/kibana-integrations/kibanaVisualizationDirective.js
@@ -17,33 +17,61 @@ var app = require('ui/modules').get('apps/webinar_app', [])
                 let rendered       = false;
                 let visualization  = null;
                 let visHandler     = null;
+                let pendingUpdates = [];
 
                 // Listen for changes
                 $scope.$on('updateVis', function (event, query, filters) {
+                    console.log("update, rendered", rendered);
                     if (rendered) {
                         if (visTitle !== 'Wazuh App Overview General Agents status') { // We don't want to filter that visualization as it uses another index-pattern
-                            if (query.query === '') {
-                                fullFilter = implicitFilter;
-                            }
-                            else {
-                                if (implicitFilter !== '') {
-                                    fullFilter = implicitFilter + ' AND ' + query.query;
-                                }
-                                else {
-                                    fullFilter = query.query;
+
+                            if (pendingUpdates.length != 0) {
+                                for (let i = 0; i < pendingUpdates.length; i++) {
+                                    for (let j = 0; j < implicitFilters.loadFilters().length; j++) {
+                                        console.log("comparing", pendingUpdates[i].query, implicitFilters.loadFilters()[j]);
+                                        if (pendingUpdates[i].query == implicitFilters.loadFilters()[j]) {
+                                            console.log("this is the same", )
+                                        }
+                                    }
                                 }
                             }
 
-                            console.log("updating inside", filters);
-                            visualization.searchSource
-                            .query({ language: 'lucene', query: fullFilter })
-                            .set('filter', filters);
+                            if (query != null) {
+                                if (query.query === '') {
+                                    fullFilter = implicitFilter;
+                                }
+                                else {
+                                    if (implicitFilter !== '') {
+                                        fullFilter = implicitFilter + ' AND ' + query.query;
+                                    }
+                                    else {
+                                        fullFilter = query.query;
+                                    }
+                                }
+
+                                console.log("updating inside", visTitle,filters);
+                                visualization.searchSource
+                                .query({ language: 'lucene', query: fullFilter })
+                                .set('filter', filters);
+                            } else { // Update with pending
+
+                            }
                         }
+                    } else {
+                        pendingUpdates.push({"query": query, "filters": filters});
+                            console.log("pushing inside", visTitle, pendingUpdates);
+                            console.log("the implicits", implicitFilters.loadFilters());
                     }
                 });
 
                 var renderComplete = function() {
                     rendered = true;
+
+                    if (pendingUpdates.length != 0) {
+                        console.log("emitting, pending updates");
+                        $rootScope.$broadcast('updateVis', null, null);
+                    }
+
                     $rootScope.loadedVisualizations.push(true);
                     $rootScope.loadingStatus = `Rendering visualizations... ${Math.round((100 * $rootScope.loadedVisualizations.length / $rootScope.tabVisualizations[$location.search().tab]) * 100) / 100} %`;
                     if ($rootScope.loadedVisualizations.length >= $rootScope.tabVisualizations[$location.search().tab]) {

--- a/public/kibana-integrations/kibanaVisualizationDirective.js
+++ b/public/kibana-integrations/kibanaVisualizationDirective.js
@@ -52,31 +52,32 @@ var app = require('ui/modules').get('apps/webinar_app', [])
                     rendered = true;
 
                     if (pendingUpdates.length != 0) {
+                        if (visTitle !== 'Wazuh App Overview General Agents status') { // We don't want to filter that visualization as it uses another index-pattern
+                            realPendingUpdates = implicitFilters.loadFilters();
 
-                        realPendingUpdates = implicitFilters.loadFilters();
-
-                        for (let i = 0; i < pendingUpdates.length; i++) {
-                            for (let j = 0; j < implicitFilters.loadFilters().length; j++) {
-                                if (JSON.stringify(pendingUpdates[i].query) === JSON.stringify(implicitFilters.loadFilters()[j].query)) {
-                                    realPending = false;
+                            for (let i = 0; i < pendingUpdates.length; i++) {
+                                for (let j = 0; j < implicitFilters.loadFilters().length; j++) {
+                                    if (JSON.stringify(pendingUpdates[i].query) === JSON.stringify(implicitFilters.loadFilters()[j].query)) {
+                                        realPending = false;
+                                    }
                                 }
+
+                                // There was a real pending update?
+                                if (realPending) {
+                                    realPendingUpdates.push(pendingUpdates[i]) 
+                                }
+                                realPending = true;
                             }
 
-                            // There was a real pending update?
-                            if (realPending) {
-                                realPendingUpdates.push(pendingUpdates[i]) 
+                            //
+                            pendingUpdates = [];
+                            if (realPendingUpdates.length != 0 && JSON.stringify(realPendingUpdates) !== JSON.stringify(implicitFilters.loadFilters())) {
+                                visualization.searchSource
+                                .query({ language: 'lucene', query: implicitFilter })
+                                .set('filter', realPendingUpdates);
+                                $rootScope.$broadcast('fetch');
+                                realPendingUpdates = [];
                             }
-                            realPending = true;
-                        }
-
-                        //
-                        pendingUpdates = [];
-                        if (realPendingUpdates.length != 0) {
-                            visualization.searchSource
-                            .query({ language: 'lucene', query: implicitFilter })
-                            .set('filter', realPendingUpdates);
-                            $rootScope.$broadcast('fetch');
-                            realPendingUpdates = [];
                         }
                     }
 

--- a/public/kibana-integrations/kibanaVisualizationDirective.js
+++ b/public/kibana-integrations/kibanaVisualizationDirective.js
@@ -34,6 +34,7 @@ var app = require('ui/modules').get('apps/webinar_app', [])
                                 }
                             }
 
+                            console.log("updating inside", filters);
                             visualization.searchSource
                             .query({ language: 'lucene', query: fullFilter })
                             .set('filter', filters);


### PR DESCRIPTION
- Considering pending updates while visualizations are rendered (mainly to properly filter pinned filters).
- Visualizations are re-imported in Kibana every time Kibana launches (had to do this because removing the plugin doesn't do that, obviously).