### PR TITLE
Removed old Wazuh App blue color from more app components

### DIFF
--- a/public/less/angular-md.less
+++ b/public/less/angular-md.less
@@ -36,7 +36,7 @@ md-card-content .ng-binding {
 }
 
 md-input-container>md-select {
-    background: #3caed2;
+    background: rgb(0,121,165);
     border-radius: 3px;
     color: white;
     padding: 3px;
@@ -93,7 +93,7 @@ md-input-container.md-input-invalid label {
 
 md-input-container.md-default-theme label.md-required:after,
 md-input-container label.md-required:after {
-    color: #3caed2 !important;
+    color: rgb(0,121,165) !important;
 }
 
 md-input-container.md-default-theme label,

--- a/public/less/angular-md.less
+++ b/public/less/angular-md.less
@@ -102,3 +102,26 @@ md-input-container.md-default-theme ._md-placeholder,
 md-input-container ._md-placeholder {
     font-size: 16px;
 }
+
+/* Overriding the colour for the navbar */
+
+.md-button.md-accent {
+    color: rgb(0,121,165);
+}
+
+md-nav-bar md-nav-ink-bar {
+    color: rgb(0,121,165);
+    background: rgb(0,121,165);
+}
+
+/* ------------------------------------------------------------------------ */
+/* ------------------------ Override for md-switch ------------------------ */
+/* ------------------------------------------------------------------------ */
+
+md-switch.md-checked .md-bar {
+    background-color: rgba(0,121,165,0.5); /* set selected bar color */
+}
+
+md-switch.md-checked .md-thumb {
+    background-color: rgb(0,121,165); /* selected switch color */
+}

--- a/public/less/buttons.less
+++ b/public/less/buttons.less
@@ -4,11 +4,11 @@
 
 .button-active.md-button:not([disabled]):hover,
 .buttonBlueLightRuleset.md-button:not([disabled]):hover {
-    background-color: #3caed2 !important;
+    background-color: rgb(0,121,165) !important;
 }
 
 .buttonBlueLight {
-    background-color: #3caed2 !important;
+    background-color: rgb(0,121,165) !important;
     color: white !important;
     box-shadow: none !important;
 }
@@ -29,7 +29,7 @@
 }
 
 .md-button.buttonMenu {
-    background-color: #3caed2;
+    background-color: rgb(0,121,165);
     color: white;
 }
 
@@ -38,11 +38,11 @@ button._md-no-style.md-button.md-ink-ripple {
 }
 
 .md-button.buttonBlueLight.md-default-theme:not([disabled]):hover {
-    background-color: rgb(60,174,210);
+    background-color: rgb(0,121,165);
 }
 
 .button-disabled {
-    background: rgb(60,174,210) !important;
+    background: rgb(0,121,165) !important;
     color: white !important;
 }
 
@@ -54,7 +54,7 @@ button._md-no-style.md-button.md-ink-ripple {
 }
 
 .md-button.buttonBlueLightSettings.md-raised.md-primary:not([disabled]):hover{
-    background-color: #3caed2 !important;
+    background-color: rgb(0,121,165) !important;
     color: white !important;
     box-shadow: none !important;
 }
@@ -66,7 +66,7 @@ button._md-no-style.md-button.md-ink-ripple {
 md-select-menu.md-default-theme md-content,
 md-select-menu md-content,
 .button-active {
-    background: #3caed2 !important;
+    background: rgb(0,121,165) !important;
     color: white !important;
     box-shadow: none !important;
 }
@@ -79,5 +79,5 @@ md-select-menu md-content,
 }
 
 .buttonPlayRealTime:hover {
-    background-color: #3caed2 !important;
+    background-color: rgb(0,121,165) !important;
 }

--- a/public/less/common.less
+++ b/public/less/common.less
@@ -23,34 +23,34 @@ body._md-toast-animating {
 
 .loading-logo-fail {
     width: 85px;
-    text-align: center;    
+    text-align: center;
 }
 
 .loading-logo {
     position:relative ;
-    top: -157px;  
+    top: -157px;
     width: 85px;
-    text-align: center;    
+    text-align: center;
 }
 
 .present-logo {
-    text-align: center;    
+    text-align: center;
 }
 
 .checks {
-    text-align: center;  
+    text-align: center;
     position: relative;
-    top: -100px;  
+    top: -100px;
 }
 
 .checks-fail {
-    text-align: center;  
+    text-align: center;
     position: relative;
-    top: 10px;  
+    top: 10px;
 }
 
 .healthCheck {
-    padding-top: 200px;    
+    padding-top: 200px;
     background-color: #F5F5F5;
 }
 
@@ -113,7 +113,7 @@ div.uil-ring-css {
     top: 20px;
     left: 20px;
     border-radius: 80px;
-    box-shadow: 0 3px 0 0 #3caed2;
+    box-shadow: 0 3px 0 0 rgb(0,121,165);
     -webkit-transform-origin: 80px 81.5px;
     transform-origin: 80px 81.5px;
     -webkit-animation: uil-ring-anim 1.5s linear infinite;
@@ -181,7 +181,7 @@ navbar {
 
 md-progress-linear.md-default-theme ._md-bar,
 md-progress-linear ._md-bar {
-    background-color: #3caed2;
+    background-color: rgb(0,121,165);
 }
 
 .wazuh-loading md-progress-linear {
@@ -202,7 +202,7 @@ md-progress-linear ._md-bar {
 
 /* Manager Groups Agents/Files tabs fix */
 .md-tab.md-active {
-    color: rgb(60, 174, 210) !important;
+    color: rgb(0,121,165) !important;
 }
 
 .directives-color-white {

--- a/public/less/main.less
+++ b/public/less/main.less
@@ -16,13 +16,9 @@ md-toolbar:not(.md-menu-toolbar) {
     background-color: #f7f7f7
 }
 
-
-
 .md-card-content-groups {
     padding-bottom: 0px !important;
 }
-
-
 
 md-list,
 md-list.odd,
@@ -167,15 +163,4 @@ md-select .md-select-value.md-select-placeholder {
 
 .groupsNoMarginTop {
     margin-top: 0px !important;
-}
-
-/* Overriding the colour for the navbar */
-
-.md-button.md-accent {
-    color: rgb(0,121,165);
-}
-
-md-nav-bar md-nav-ink-bar {
-    color: rgb(0,121,165);
-    background: rgb(0,121,165);
 }

--- a/public/less/main.less
+++ b/public/less/main.less
@@ -57,7 +57,7 @@ textarea.ng-invalid.ng-dirty,
 textarea.ng-invalid.ng-touched,
 select.ng-invalid.ng-dirty,
 select.ng-invalid.ng-touched {
-    border-color: #3caed2 !important;
+    border-color: rgb(0,121,165) !important;
 }
 
 md-autocomplete input::-webkit-input-placeholder,

--- a/public/less/main.less
+++ b/public/less/main.less
@@ -168,3 +168,14 @@ md-select .md-select-value.md-select-placeholder {
 .groupsNoMarginTop {
     margin-top: 0px !important;
 }
+
+/* Overriding the colour for the navbar */
+
+.md-button.md-accent {
+    color: rgb(0,121,165);
+}
+
+md-nav-bar md-nav-ink-bar {
+    color: rgb(0,121,165);
+    background: rgb(0,121,165);
+}

--- a/public/less/manager.less
+++ b/public/less/manager.less
@@ -1,5 +1,5 @@
 .horizontal-menu-right .buttonMenu{
-	background-color: #3caed2;
+	background-color: rgb(0,121,165);
 	color: white;
 }
 
@@ -70,7 +70,7 @@
 }
 
 .blue {
-	background-color: #3caed2;
+	background-color: rgb(0,121,165);
 }
 
 .statusBox.green {
@@ -316,4 +316,3 @@
     margin: 0px !important;
     width: 15px;
 }
-

--- a/public/less/wazuh-navbar.less
+++ b/public/less/wazuh-navbar.less
@@ -61,7 +61,7 @@ li#header_logo {
     padding-top: 12px;
     height: 70px;
     background-color: #00445a !important;
-    color: #3caed2;
+    color: rgb(0,121,165);
     font-size: 14px;
 }
 

--- a/public/templates/agents/agents-configuration.html
+++ b/public/templates/agents/agents-configuration.html
@@ -37,11 +37,8 @@
             <md-card flex>
                 <div layout="row" class="md-padding">
                     <h1 flex="90" ng-show="!load" class="md-title">Current group:
-                        <span ng-click="goGroup()" class="agents-head-5 blue">{{groupName}}
-                            <md-tooltip md-direction="bottom">Click to go to the group details</md-tooltip>
-                        </span>
-
-                        &nbsp;- Configuration status:
+                        <span ng-click="goGroup()" class="agents-head-5 blue">{{groupName}}<md-tooltip md-direction="bottom">Click to go to the group details</md-tooltip></span>
+                        &nbsp;&ndash;&nbsp;Configuration status:
                         <span ng-class="isSynchronized ? 'green' : 'red'" class="agents-head-5">{{isSynchronized ? 'SYNCHRONIZED' : 'NOT SYNCHRONIZED'}}</span>
                     </h1>
                     <md-switch flex="10" ng-model="toggleRAW">View JSON</md-switch>


### PR DESCRIPTION
Hi everyone,

This PR removes the old blue colour from some components of the app and uses a new, darker one which is more consistent with the new style of the app for Kibana 6.

On the attached screenshots, we can see an example of components with the modified colour.

![navbar](https://user-images.githubusercontent.com/10928321/35382719-642564c0-01c0-11e8-97f6-2b5b1a1e9fbb.png)

![md-switch](https://user-images.githubusercontent.com/10928321/35384927-19bace6e-01c7-11e8-9408-4ea4675610a5.PNG)

![captura](https://user-images.githubusercontent.com/10928321/35381449-99206408-01bc-11e8-8831-94dd5a55b83e.PNG)