### PR TITLE
Minor HTML/CSS and visualizations bugfixes (6.2.x)

### DIFF
--- a/public/templates/manager/manager-osseclog.html
+++ b/public/templates/manager/manager-osseclog.html
@@ -82,9 +82,6 @@
                 </md-list-item>
             </md-list>
         </md-content>
-        <md-divider></md-divider>
-        <md-content>
-            <md-progress-linear class="md-accent" md-mode="indeterminate" ng-show="logs.busy"></md-progress-linear>
-        </md-content>
+        <md-progress-linear class="md-accent" md-mode="indeterminate" ng-show="logs.busy"></md-progress-linear>
     </div>
 </div>

--- a/public/templates/manager/manager-osseclog.html
+++ b/public/templates/manager/manager-osseclog.html
@@ -52,7 +52,7 @@
         <!-- Realtime -->
         <md-toolbar ng-if="realtime" layout="row" class="wazuh-toolbar md-toolbar-tools">
             <span flex="15">Timestamp</span>
-            <span flex="10">Tag</span>
+            <span flex="25">Tag</span>
             <span flex="10">Level</span>
             <span flex>Description</span>
         </md-toolbar>
@@ -62,7 +62,7 @@
             <md-list class="wazuh-list" ng-class-odd="'odd'" ng-class-even="'even'" ng-repeat="log in logs.items | filter : searchTerm | orderBy : logs.sortValue : logs.sortDir">
                 <md-list-item class="wazuh-list-item no-height-limit" layout="row">
                     <span flex="15">{{log.timestamp}}</span>
-                    <span flex="10">{{log.tag}}</span>
+                    <span flex="25">{{log.tag}}</span>
                     <span flex="10">{{log.level}}</span>
                     <span flex>{{log.description}}</span>
                     <div flex layout="row" layout-align="end center"></div>
@@ -75,7 +75,7 @@
             <md-list class="wazuh-list" ng-class-odd="'odd'" ng-class-even="'even'" ng-repeat="log in realLogs | filter : searchTerm">
                 <md-list-item class="wazuh-list-item no-height-limit" layout="row">
                     <span flex="15">{{log.timestamp}}</span>
-                    <span flex="10">{{log.tag}}</span>
+                    <span flex="25">{{log.tag}}</span>
                     <span flex="10">{{log.level}}</span>
                     <span flex>{{log.description}}</span>
                     <div flex layout="row" layout-align="end center"></div>

--- a/public/templates/manager/manager-osseclog.html
+++ b/public/templates/manager/manager-osseclog.html
@@ -40,7 +40,7 @@
             <span flex="15" ng-click="logs.sort('timestamp')">Timestamp
                 <i class="fa" ng-class="logs.sortValue === 'timestamp' ? (logs.sortDir ? 'fa-sort-asc' : 'fa-sort-desc') : 'fa-sort'" aria-hidden="true"></i>
             </span>
-            <span flex="10" ng-click="logs.sort('tag')" >Tag
+            <span flex="25" ng-click="logs.sort('tag')" >Tag
                 <i class="fa" ng-class="logs.sortValue === 'tag' ? (logs.sortDir ? 'fa-sort-asc' : 'fa-sort-desc') : 'fa-sort'" aria-hidden="true"></i>
             </span>
             <span flex="10" ng-click="logs.sort('level')">Level

--- a/server/integration_files/app_objects_file_alerts.json
+++ b/server/integration_files/app_objects_file_alerts.json
@@ -2299,7 +2299,7 @@
 		"_type": "visualization",
 		"_source": {
 			"title": "Wazuh App Overview VULS Top 5 affected packages",
-			"visState": "{\"title\":\"Wazuh App Overview VULS Top 5 affected packages\",\"type\":\"pie\",\"params\":{\"type\":\"pie\",\"addTooltip\":true,\"addLegend\":true,\"legendPosition\":\"right\",\"isDonut\":true,\"labels\":{\"show\":false,\"values\":true,\"last_level\":true,\"truncate\":100}},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"segment\",\"params\":{\"field\":\"data.vulnerability.affected_package\",\"size\":5,\"order\":\"desc\",\"orderBy\":\"1\",\"customLabel\":\"Affected package\"}}]}",
+			"visState": "{\"title\":\"Wazuh App Overview VULS Top 5 affected packages\",\"type\":\"pie\",\"params\":{\"type\":\"pie\",\"addTooltip\":true,\"addLegend\":true,\"legendPosition\":\"right\",\"isDonut\":true,\"labels\":{\"show\":false,\"values\":true,\"last_level\":true,\"truncate\":100}},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"segment\",\"params\":{\"field\":\"data.vulnerability.package.name\",\"size\":5,\"order\":\"desc\",\"orderBy\":\"1\",\"customLabel\":\"Affected package\"}}]}",
 			"uiStateJSON": "{}",
 			"description": "",
 			"version": 1,


### PR DESCRIPTION
This PR provides the following modifications and fixes:

* Changed a **vulnerability-detector** visualization to adapt the latest Wazuh core changes.
* Removed undesired `md-divider` from **Manager/Logs**.
* Adjusted the width of a column in **Manager/Logs** to avoid overflow issues with the text.

Example screenshot of the column width change:
![arreglo1](https://user-images.githubusercontent.com/10928321/36101427-9bf76072-1009-11e8-921f-d716b9febac1.PNG)