### PR TITLE
Fix wrong agent id parsing when come from groups twice

### DIFF
--- a/public/controllers/agents.js
+++ b/public/controllers/agents.js
@@ -149,7 +149,7 @@ function ($scope, $location, $q, $rootScope, appState, genericReq, apiReq, Agent
                 id = newAgentId;
                 $location.search('agent', id);
             } else {
-                if ($location.search().agent) { // There's one in the url
+                if ($location.search().agent && !$rootScope.globalAgent) { // There's one in the url
                     id = $location.search().agent;
                 } else { // We pick the one in the rootScope
                     id = $rootScope.globalAgent;
@@ -288,7 +288,7 @@ function ($scope, $location, $q, $rootScope, appState, genericReq, apiReq, Agent
             $scope.configurationError = false;
             $scope.load = true;
             let id;
-            if ($location.search().agent) { // There's one in the url
+            if ($location.search().agent && !$rootScope.globalAgent) { // There's one in the url
 				id = $location.search().agent;
 			} else { // We pick the one in the rootScope
 				id = $rootScope.globalAgent;


### PR DESCRIPTION
This PR fixes a wrong data flow when go from groups tab to a specific agent and the come back to groups tab. Once you are again on groups tab and go to a different agent it remains the last agent. Now it's working as expected.