### PR TITLE
No id on kbn-vis

### DIFF
--- a/public/kibana-integrations/kibana-visualization.js
+++ b/public/kibana-integrations/kibana-visualization.js
@@ -51,14 +51,13 @@ var app = require('ui/modules').get('apps/webinar_app', [])
                                     };
                                     params = {timeRange: timeRange}
                                 }
-
-                                $("#"+$scope.visID).on('renderStart', () => {
+                                $(`[vis-id="'${$scope.visID}'"]`).on('renderStart', () => {
+                                //$("#"+$scope.visID).on('renderStart', () => {
                                     // TBD: Use renderStart to couple it with renderComplete?
                                 });
-
-                                visHandler = loader.embedVisualizationWithSavedObject($("#"+$scope.visID), visualization, params); 
+ 
+                                visHandler = loader.embedVisualizationWithSavedObject($(`[vis-id="'${$scope.visID}'"]`), visualization, params); 
                                 
-
                                 $rootScope.ownHandlers.push(visHandler);
                                 visHandler.addRenderCompleteListener(renderComplete);
                             });     

--- a/public/templates/agents/agents-audit.html
+++ b/public/templates/agents/agents-audit.html
@@ -6,31 +6,31 @@
             <md-card flex>
                 <md-card-content class="wazuh-column">
                     <span class="metric-headline md-headline">New files</span>
-                    <kbn-vis class="metric" vis-id="'Wazuh-App-Agents-Audit-New-files-metric'" id="Wazuh-App-Agents-Audit-New-files-metric"></kbn-vis>
+                    <kbn-vis class="metric" vis-id="'Wazuh-App-Agents-Audit-New-files-metric'"></kbn-vis>
                 </md-card-content>
             </md-card>
             <md-card flex>
                 <md-card-content class="wazuh-column">
                     <span class="metric-headline md-headline">Read files</span>
-                    <kbn-vis class="metric" vis-id="'Wazuh-App-Agents-Audit-Read-files-metric'" id="Wazuh-App-Agents-Audit-Read-files-metric"></kbn-vis>
+                    <kbn-vis class="metric" vis-id="'Wazuh-App-Agents-Audit-Read-files-metric'"></kbn-vis>
                 </md-card-content>
             </md-card>
             <md-card flex>
                 <md-card-content class="wazuh-column">
                     <span class="metric-headline md-headline">Modified files</span>
-                    <kbn-vis class="metric" vis-id="'Wazuh-App-Agents-Audit-Modified-files-metric'" id="Wazuh-App-Agents-Audit-Modified-files-metric"></kbn-vis>
+                    <kbn-vis class="metric" vis-id="'Wazuh-App-Agents-Audit-Modified-files-metric'"></kbn-vis>
                 </md-card-content>
             </md-card>
             <md-card flex>
                 <md-card-content class="wazuh-column">
                     <span class="metric-headline md-headline">Removed files</span>
-                    <kbn-vis class="metric" vis-id="'Wazuh-App-Agents-Audit-Removed-files-metric'" id="Wazuh-App-Agents-Audit-Removed-files-metric"></kbn-vis>
+                    <kbn-vis class="metric" vis-id="'Wazuh-App-Agents-Audit-Removed-files-metric'"></kbn-vis>
                 </md-card-content>
             </md-card>
             <md-card flex="50">
                 <md-card-content class="wazuh-column text-center">
                     <div class="ng-binding">Latest alert</div>
-                    <kbn-vis class="kbn-vis-value" vis-id="'Wazuh-App-Agents-Audit-Latest-alert'" id="Wazuh-App-Agents-Audit-Latest-alert"></kbn-vis>
+                    <kbn-vis class="kbn-vis-value" vis-id="'Wazuh-App-Agents-Audit-Latest-alert'"></kbn-vis>
                 </md-card-content>
             </md-card>
         </div>
@@ -39,19 +39,19 @@
             <md-card flex>
                 <md-card-content class="wazuh-column">
                     <span class="md-headline">Groups</span>
-                    <kbn-vis vis-id="'Wazuh-App-Agents-Audit-Groups'" id="Wazuh-App-Agents-Audit-Groups"></kbn-vis>
+                    <kbn-vis vis-id="'Wazuh-App-Agents-Audit-Groups'"></kbn-vis>
                 </md-card-content>
             </md-card>
             <md-card flex>
                 <md-card-content class="wazuh-column">
                     <span class="md-headline">Directories</span>
-                    <kbn-vis vis-id="'Wazuh-App-Agents-Audit-Directories'" id="Wazuh-App-Agents-Audit-Directories"></kbn-vis>
+                    <kbn-vis vis-id="'Wazuh-App-Agents-Audit-Directories'"></kbn-vis>
                 </md-card-content>
             </md-card>
             <md-card flex>
                 <md-card-content class="wazuh-column">
                     <span class="md-headline">Files</span>
-                    <kbn-vis vis-id="'Wazuh-App-Agents-Audit-Files'" id="Wazuh-App-Agents-Audit-Files"></kbn-vis>
+                    <kbn-vis vis-id="'Wazuh-App-Agents-Audit-Files'"></kbn-vis>
                 </md-card-content>
             </md-card>
         </div>
@@ -60,7 +60,7 @@
             <md-card flex>
                 <md-card-content class="wazuh-column">
                     <span class="md-headline">Alerts over time</span>
-                    <kbn-vis vis-id="'Wazuh-App-Agents-Audit-Alerts-over-time'" id="Wazuh-App-Agents-Audit-Alerts-over-time"></kbn-vis>
+                    <kbn-vis vis-id="'Wazuh-App-Agents-Audit-Alerts-over-time'"></kbn-vis>
                 </md-card-content>
             </md-card>
         </div>
@@ -70,14 +70,14 @@
                 <md-card flex>
                     <md-card-content class="wazuh-column">
                         <span class="md-headline">File read access</span>
-                        <kbn-vis vis-id="'Wazuh-App-Agents-Audit-File-read-access'" id="Wazuh-App-Agents-Audit-File-read-access"></kbn-vis>
+                        <kbn-vis vis-id="'Wazuh-App-Agents-Audit-File-read-access'"></kbn-vis>
                     </md-card-content>
                 </md-card>
 
                 <md-card flex>
                     <md-card-content class="wazuh-column">
                         <span class="md-headline">File write access</span>
-                        <kbn-vis vis-id="'Wazuh-App-Agents-Audit-File-write-access'" id="Wazuh-App-Agents-Audit-File-write-access"></kbn-vis>
+                        <kbn-vis vis-id="'Wazuh-App-Agents-Audit-File-write-access'"></kbn-vis>
                     </md-card-content>
                 </md-card>
             </div>
@@ -86,7 +86,7 @@
                 <md-card flex>
                     <md-card-content class="wazuh-column">
                         <span class="md-headline">Commands</span>
-                        <kbn-vis vis-id="'Wazuh-App-Agents-Audit-Commands'" id="Wazuh-App-Agents-Audit-Commands"></kbn-vis>
+                        <kbn-vis vis-id="'Wazuh-App-Agents-Audit-Commands'"></kbn-vis>
                     </md-card-content>
                 </md-card>
             </div>
@@ -95,13 +95,13 @@
                 <md-card flex>
                     <md-card-content class="wazuh-column">
                         <span class="md-headline">Created files</span>
-                        <kbn-vis vis-id="'Wazuh-App-Agents-Audit-Created-files'" id="Wazuh-App-Agents-Audit-Created-files"></kbn-vis>
+                        <kbn-vis vis-id="'Wazuh-App-Agents-Audit-Created-files'"></kbn-vis>
                     </md-card-content>
                 </md-card>
                 <md-card flex>
                     <md-card-content class="wazuh-column">
                         <span class="md-headline">Removed files</span>
-                        <kbn-vis vis-id="'Wazuh-App-Agents-Audit-Removed-files'" id="Wazuh-App-Agents-Audit-Removed-files"></kbn-vis>
+                        <kbn-vis vis-id="'Wazuh-App-Agents-Audit-Removed-files'"></kbn-vis>
                     </md-card-content>
                 </md-card>
             </div>
@@ -111,7 +111,7 @@
             <md-card flex>
                 <md-card-content class="wazuh-column">
                     <span class="md-headline">Alerts summary</span>
-                    <kbn-vis class="kbn-chart" vis-id="'Wazuh-App-Agents-Audit-Last-alerts'" id="Wazuh-App-Agents-Audit-Last-alerts"></kbn-vis>
+                    <kbn-vis class="kbn-chart" vis-id="'Wazuh-App-Agents-Audit-Last-alerts'"></kbn-vis>
                 </md-card-content>
             </md-card>
         </div>

--- a/public/templates/agents/agents-fim.html
+++ b/public/templates/agents/agents-fim.html
@@ -7,19 +7,19 @@
             <md-card flex="33">
                 <md-card-content class="wazuh-column">
                     <span class="md-headline">Users</span>
-                    <kbn-vis vis-id="'Wazuh-App-Agents-FIM-Users'" id="Wazuh-App-Agents-FIM-Users">
+                    <kbn-vis vis-id="'Wazuh-App-Agents-FIM-Users'">
                 </md-card-content>
             </md-card>
             <md-card flex="33">
                 <md-card-content class="wazuh-column">
                     <span class="md-headline">Groups</span>
-                    <kbn-vis vis-id="'Wazuh-App-Agents-FIM-Groups'" id="Wazuh-App-Agents-FIM-Groups">
+                    <kbn-vis vis-id="'Wazuh-App-Agents-FIM-Groups'">
                 </md-card-content>
             </md-card>
             <md-card flex="33">
                 <md-card-content class="wazuh-column">
                     <span class="md-headline">Permissions</span>
-                    <kbn-vis vis-id="'Wazuh-App-Agents-FIM-Permissions'" id="Wazuh-App-Agents-FIM-Permissions">
+                    <kbn-vis vis-id="'Wazuh-App-Agents-FIM-Permissions'">
                 </md-card-content>
             </md-card>
         </div>
@@ -28,7 +28,7 @@
             <md-card flex>
                 <md-card-content class="wazuh-column">
                     <span class="md-headline">Events</span>
-                    <kbn-vis vis-id="'Wazuh-App-Agents-FIM-Events'" id="Wazuh-App-Agents-FIM-Events"></kbn-vis>
+                    <kbn-vis vis-id="'Wazuh-App-Agents-FIM-Events'"></kbn-vis>
                 </md-card-content>
             </md-card>
         </div>
@@ -37,19 +37,19 @@
             <md-card flex="33">
                 <md-card-content class="wazuh-column">
                     <span class="md-headline">Files added</span>
-                    <kbn-vis vis-id="'Wazuh-App-Agents-FIM-Files-added'" id="Wazuh-App-Agents-FIM-Files-added"></kbn-vis>
+                    <kbn-vis vis-id="'Wazuh-App-Agents-FIM-Files-added'"></kbn-vis>
                 </md-card-content>
             </md-card>
             <md-card flex="33">
                 <md-card-content class="wazuh-column">
                     <span class="md-headline">Files modified</span>
-                    <kbn-vis vis-id="'Wazuh-App-Agents-FIM-Files-modified'" id="Wazuh-App-Agents-FIM-Files-modified"></kbn-vis>
+                    <kbn-vis vis-id="'Wazuh-App-Agents-FIM-Files-modified'"></kbn-vis>
                 </md-card-content>
             </md-card>
             <md-card flex="33">
                 <md-card-content class="wazuh-column">
                     <span class="md-headline">Files deleted</span>
-                    <kbn-vis vis-id="'Wazuh-App-Agents-FIM-Files-deleted'" id="Wazuh-App-Agents-FIM-Files-deleted"></kbn-vis>
+                    <kbn-vis vis-id="'Wazuh-App-Agents-FIM-Files-deleted'"></kbn-vis>
                 </md-card-content>
             </md-card>
         </div>
@@ -58,7 +58,7 @@
             <md-card flex>
                 <md-card-content class="wazuh-column">
                     <span class="md-headline">Alerts summary</span>
-                    <kbn-vis class="kbn-chart" vis-id="'Wazuh-App-Agents-FIM-Alerts-summary'" id="Wazuh-App-Agents-FIM-Alerts-summary"></kbn-vis>
+                    <kbn-vis class="kbn-chart" vis-id="'Wazuh-App-Agents-FIM-Alerts-summary'"></kbn-vis>
                 </md-card-content>
             </md-card>
        </div>

--- a/public/templates/agents/agents-general.html
+++ b/public/templates/agents/agents-general.html
@@ -88,19 +88,19 @@
             <md-card flex="33">
                 <md-card-content class="wazuh-column">
                     <span class="md-headline">Top 5 alerts</span>
-                    <kbn-vis vis-id="'Wazuh-App-Agents-Overview-Top-5-alerts'" id="Wazuh-App-Agents-Overview-Top-5-alerts"></kbn-vis>
+                    <kbn-vis vis-id="'Wazuh-App-Agents-Overview-Top-5-alerts'"></kbn-vis>
                 </md-card-content>
             </md-card>
             <md-card flex="33">
                 <md-card-content class="wazuh-column">
                     <span class="md-headline">Top 5 groups</span>
-                    <kbn-vis vis-id="'Wazuh-App-Agents-Overview-Top-5-groups'" id="Wazuh-App-Agents-Overview-Top-5-groups"></kbn-vis>
+                    <kbn-vis vis-id="'Wazuh-App-Agents-Overview-Top-5-groups'"></kbn-vis>
                 </md-card-content>
             </md-card>
             <md-card flex="33">
                 <md-card-content class="wazuh-column">
                     <span class="md-headline">Top 5 PCI DSS Requirements</span>
-                    <kbn-vis vis-id="'Wazuh-App-Agents-Overview-Top-5-PCI-DSS-Requirements'" id="Wazuh-App-Agents-Overview-Top-5-PCI-DSS-Requirements"></kbn-vis>
+                    <kbn-vis vis-id="'Wazuh-App-Agents-Overview-Top-5-PCI-DSS-Requirements'"></kbn-vis>
                 </md-card-content>
             </md-card>
         </div>
@@ -109,13 +109,13 @@
             <md-card flex>
                 <md-card-content class="wazuh-column">
                     <span class="md-headline">Alert level evolution</span>
-                    <kbn-vis vis-id="'Wazuh-App-Agents-Overview-Alert-level-evolution'" id="Wazuh-App-Agents-Overview-Alert-level-evolution"></kbn-vis>
+                    <kbn-vis vis-id="'Wazuh-App-Agents-Overview-Alert-level-evolution'"></kbn-vis>
                 </md-card-content>
             </md-card>
             <md-card flex="60">
                 <md-card-content class="wazuh-column">
                     <span class="md-headline">Alerts</span>
-                    <kbn-vis vis-id="'Wazuh-App-Agents-Overview-Alerts'" id="Wazuh-App-Agents-Overview-Alerts"></kbn-vis>
+                    <kbn-vis vis-id="'Wazuh-App-Agents-Overview-Alerts'"></kbn-vis>
                 </md-card-content>
             </md-card>
         </div>
@@ -124,13 +124,13 @@
             <md-card  flex="60">
                 <md-card-content class="wazuh-column">
                     <span class="md-headline">Alerts summary</span>
-                    <kbn-vis class="kbn-chart" vis-id="'Wazuh-App-Agents-Overview-Alerts-summary'" id="Wazuh-App-Agents-Overview-Alerts-summary"></kbn-vis>
+                    <kbn-vis class="kbn-chart" vis-id="'Wazuh-App-Agents-Overview-Alerts-summary'"></kbn-vis>
                 </md-card-content>
             </md-card>
             <md-card flex="40">
                 <md-card-content class="wazuh-column">
                     <span class="md-headline">Groups summary</span>
-                    <kbn-vis class="kbn-chart" vis-id="'Wazuh-App-Agents-Overview-Groups-summary'" id="Wazuh-App-Agents-Overview-Groups-summary"></kbn-vis>
+                    <kbn-vis class="kbn-chart" vis-id="'Wazuh-App-Agents-Overview-Groups-summary'"></kbn-vis>
                 </md-card-content>
             </md-card>
         </div>

--- a/public/templates/agents/agents-oscap.html
+++ b/public/templates/agents/agents-oscap.html
@@ -5,24 +5,24 @@
         <div layout="row" layout-align="center stretch" class="height-120">
             <md-card flex="20">
                 <md-card-content class="wazuh-column">
-                    <kbn-vis class="metric" vis-id="'Wazuh-App-Agents-OSCAP-Higher-score-metric'" id="Wazuh-App-Agents-OSCAP-Higher-score-metric"></kbn-vis>
+                    <kbn-vis class="metric" vis-id="'Wazuh-App-Agents-OSCAP-Higher-score-metric'"></kbn-vis>
                 </md-card-content>
             </md-card>
             <md-card flex="20">
                 <md-card-content class="wazuh-column">
-                    <kbn-vis class="metric" vis-id="'Wazuh-App-Agents-OSCAP-Lower-score-metric'" id="Wazuh-App-Agents-OSCAP-Lower-score-metric"></kbn-vis>
+                    <kbn-vis class="metric" vis-id="'Wazuh-App-Agents-OSCAP-Lower-score-metric'"></kbn-vis>
                 </md-card-content>
             </md-card>
             <md-card flex="20">
                 <md-card-content class="wazuh-column text-center">
                     <div class="ng-binding">Last score</div>
-                    <kbn-vis class="kbn-vis-value" vis-id="'Wazuh-App-Agents-OSCAP-Last-score'" id="Wazuh-App-Agents-OSCAP-Last-score"></kbn-vis>
+                    <kbn-vis class="kbn-vis-value" vis-id="'Wazuh-App-Agents-OSCAP-Last-score'"></kbn-vis>
                 </md-card-content>
             </md-card>
             <md-card flex="40">
                 <md-card-content class="wazuh-column text-center">
                     <div class="ng-binding">Last scan profile</div>
-                    <kbn-vis class="kbn-vis-value" vis-id="'Wazuh-App-Agents-OSCAP-Last-scan-profile'" id="Wazuh-App-Agents-OSCAP-Last-scan-profile"></kbn-vis>
+                    <kbn-vis class="kbn-vis-value" vis-id="'Wazuh-App-Agents-OSCAP-Last-scan-profile'"></kbn-vis>
                 </md-card-content>
             </md-card>
         </div>
@@ -31,26 +31,26 @@
             <md-card flex="25">
                 <md-card-content class="wazuh-column">
                     <span class="md-headline">Scans</span>
-                    <kbn-vis vis-id="'Wazuh-App-Agents-OSCAP-Scans'" id="Wazuh-App-Agents-OSCAP-Scans"></kbn-vis>
+                    <kbn-vis vis-id="'Wazuh-App-Agents-OSCAP-Scans'"></kbn-vis>
                 </md-card-content>
             </md-card>
             <md-card flex="25">
                 <md-card-content class="wazuh-column">
                     <span class="md-headline">Profiles</span>
-                    <kbn-vis vis-id="'Wazuh-App-Agents-OSCAP-Profiles'" id="Wazuh-App-Agents-OSCAP-Profiles"></kbn-vis>
+                    <kbn-vis vis-id="'Wazuh-App-Agents-OSCAP-Profiles'"></kbn-vis>
                 </md-card-content>
             </md-card>
             <md-card flex="25">
                 <md-card-content class="wazuh-column">
                     <span class="md-headline">Content</span>
-                    <kbn-vis vis-id="'Wazuh-App-Agents-OSCAP-Content'" id="Wazuh-App-Agents-OSCAP-Content"></kbn-vis>
+                    <kbn-vis vis-id="'Wazuh-App-Agents-OSCAP-Content'"></kbn-vis>
                 </md-card-content>
             </md-card>
 
             <md-card flex="25">
                 <md-card-content class="wazuh-column">
                     <span class="md-headline">Severity</span>
-                    <kbn-vis vis-id="'Wazuh-App-Agents-OSCAP-Severity'" id="Wazuh-App-Agents-OSCAP-Severity"></kbn-vis>
+                    <kbn-vis vis-id="'Wazuh-App-Agents-OSCAP-Severity'"></kbn-vis>
                 </md-card-content>
             </md-card>
         </div>
@@ -59,7 +59,7 @@
             <md-card flex>
                 <md-card-content class="wazuh-column">
                     <span class="md-headline">Daily scans evolution</span>
-                    <kbn-vis vis-id="'Wazuh-App-Agents-OSCAP-Daily-scans-evolution'" id="Wazuh-App-Agents-OSCAP-Daily-scans-evolution"></kbn-vis>
+                    <kbn-vis vis-id="'Wazuh-App-Agents-OSCAP-Daily-scans-evolution'"></kbn-vis>
                 </md-card-content>
             </md-card>
         </div>
@@ -68,7 +68,7 @@
             <md-card flex>
                 <md-card-content class="wazuh-column">
                     <span class="md-headline">Top 5 - Alerts</span>
-                    <kbn-vis vis-id="'Wazuh-App-Agents-OSCAP-Top-5-Alerts'" id="Wazuh-App-Agents-OSCAP-Top-5-Alerts"></kbn-vis>
+                    <kbn-vis vis-id="'Wazuh-App-Agents-OSCAP-Top-5-Alerts'"></kbn-vis>
                 </md-card-content>
             </md-card>
             <md-card flex class="wazuh-column">
@@ -78,7 +78,7 @@
                     </md-card-title-text>
                 </md-card-title>
                 <md-card-content class="wazuh-column">
-                    <kbn-vis vis-id="'Wazuh-App-Agents-OSCAP-Top-5-High-risk-alerts'" id="Wazuh-App-Agents-OSCAP-Top-5-High-risk-alerts"></kbn-vis>
+                    <kbn-vis vis-id="'Wazuh-App-Agents-OSCAP-Top-5-High-risk-alerts'"></kbn-vis>
                 </md-card-content>
             </md-card>
         </div>
@@ -86,7 +86,7 @@
         <div layout="row" layout-align="center stretch" class="height-120">
             <md-card flex>
                 <md-card-content class="wazuh-column text-center">
-                    <kbn-vis class="kbn-vis-value" vis-id="'Wazuh-App-Agents-OSCAP-Top-alert'" id="Wazuh-App-Agents-OSCAP-Top-alert"></kbn-vis>
+                    <kbn-vis class="kbn-vis-value" vis-id="'Wazuh-App-Agents-OSCAP-Top-alert'"></kbn-vis>
                     <div class="ng-binding">Top alert</div>
                 </md-card-content>
             </md-card>
@@ -96,7 +96,7 @@
             <md-card flex>
                 <md-card-content class="wazuh-column">
                     <span class="md-headline">Alerts summary</span>
-                    <kbn-vis class="kbn-chart" vis-id="'Wazuh-App-Agents-OSCAP-Last-alerts'" id="Wazuh-App-Agents-OSCAP-Last-alerts"></kbn-vis>
+                    <kbn-vis class="kbn-chart" vis-id="'Wazuh-App-Agents-OSCAP-Last-alerts'"></kbn-vis>
                 </md-card-content>
             </md-card>
         </div>

--- a/public/templates/agents/agents-pci.html
+++ b/public/templates/agents/agents-pci.html
@@ -19,13 +19,13 @@
             <md-card flex="70">
                 <md-card-content class="wazuh-column">
                     <span class="md-headline">Requirements</span>
-                    <kbn-vis vis-id="'Wazuh-App-Agents-PCI-Requirements'" id="Wazuh-App-Agents-PCI-Requirements"></kbn-vis>
+                    <kbn-vis vis-id="'Wazuh-App-Agents-PCI-Requirements'"></kbn-vis>
                 </md-card-content>
             </md-card>
             <md-card flex="30">
                 <md-card-content class="wazuh-column">
                     <span class="md-headline">Groups</span>
-                    <kbn-vis vis-id="'Wazuh-App-Agents-PCI-Groups'" id="Wazuh-App-Agents-PCI-Groups"></kbn-vis>
+                    <kbn-vis vis-id="'Wazuh-App-Agents-PCI-Groups'"></kbn-vis>
                 </md-card-content>
             </md-card>
         </div>
@@ -34,7 +34,7 @@
             <md-card flex>
                 <md-card-content class="wazuh-column">
                     <span class="md-headline">Alerts summary</span>
-                    <kbn-vis class="kbn-chart" vis-id="'Wazuh-App-Agents-PCI-Last-alerts'" id="Wazuh-App-Agents-PCI-Last-alerts"></kbn-vis>
+                    <kbn-vis class="kbn-chart" vis-id="'Wazuh-App-Agents-PCI-Last-alerts'"></kbn-vis>
                 </md-card-content>
             </md-card>
         </div>

--- a/public/templates/agents/agents-pm.html
+++ b/public/templates/agents/agents-pm.html
@@ -8,19 +8,19 @@
             <md-card flex="50">
                 <md-card-content class="wazuh-column">
                     <span class="md-headline">Alerts over time</span>
-                    <kbn-vis vis-id="'Wazuh-App-Agents-PM-Alerts-over-time'" id="Wazuh-App-Agents-PM-Alerts-over-time"></kbn-vis>
+                    <kbn-vis vis-id="'Wazuh-App-Agents-PM-Alerts-over-time'"></kbn-vis>
                 </md-card-content>
             </md-card>
             <md-card flex="25">
                 <md-card-content class="wazuh-column">
                     <span class="md-headline">Top 5 CIS Requirements</span>
-                    <kbn-vis vis-id="'Wazuh-App-Agents-PM-Top-5-CIS-Requirements'" id="Wazuh-App-Agents-PM-Top-5-CIS-Requirements"></kbn-vis>
+                    <kbn-vis vis-id="'Wazuh-App-Agents-PM-Top-5-CIS-Requirements'"></kbn-vis>
                 </md-card-content>
             </md-card>
             <md-card flex="25">
                 <md-card-content class="wazuh-column">
                     <span class="md-headline">Top 5 PCI DSS Requirements</span>
-                    <kbn-vis vis-id="'Wazuh-App-Agents-PM-Top-5-PCI-DSS-Requirements'" id="Wazuh-App-Agents-PM-Top-5-PCI-DSS-Requirements"></kbn-vis>
+                    <kbn-vis vis-id="'Wazuh-App-Agents-PM-Top-5-PCI-DSS-Requirements'"></kbn-vis>
                 </md-card-content>
             </md-card>
         </div>
@@ -29,7 +29,7 @@
             <md-card flex="100">
                 <md-card-content class="wazuh-column">
                     <span class="md-headline">Alerts summary</span>
-                    <kbn-vis class="kbn-chart" vis-id="'Wazuh-App-Agents-PM-Alerts-summary'" id="Wazuh-App-Agents-PM-Alerts-summary"></kbn-vis>
+                    <kbn-vis class="kbn-chart" vis-id="'Wazuh-App-Agents-PM-Alerts-summary'"></kbn-vis>
                 </md-card-content>
             </md-card>
        </div>

--- a/public/templates/agents/agents-virustotal.html
+++ b/public/templates/agents/agents-virustotal.html
@@ -4,17 +4,17 @@
 
             <md-card flex>
                 <md-card-content class="wazuh-column">
-                    <kbn-vis class="metric" vis-id="'Wazuh-App-Overview-Virustotal-Total-Malicious'" id="Wazuh-App-Overview-Virustotal-Total-Malicious"></kbn-vis>
+                    <kbn-vis class="metric" vis-id="'Wazuh-App-Overview-Virustotal-Total-Malicious'"></kbn-vis>
                 </md-card-content>
             </md-card>
             <md-card flex>
                 <md-card-content class="wazuh-column">
-                    <kbn-vis class="metric" vis-id="'Wazuh-App-Overview-Virustotal-Total-Positives'" id="Wazuh-App-Overview-Virustotal-Total-Positives"></kbn-vis>
+                    <kbn-vis class="metric" vis-id="'Wazuh-App-Overview-Virustotal-Total-Positives'"></kbn-vis>
                 </md-card-content>
             </md-card>
             <md-card flex>
                 <md-card-content class="wazuh-column">
-                    <kbn-vis class="metric" vis-id="'Wazuh-App-Overview-Virustotal-Total'" id="Wazuh-App-Overview-Virustotal-Total"></kbn-vis>
+                    <kbn-vis class="metric" vis-id="'Wazuh-App-Overview-Virustotal-Total'"></kbn-vis>
                 </md-card-content>
             </md-card>
 
@@ -24,13 +24,13 @@
             <md-card flex="33">
                 <md-card-content class="wazuh-column">
                     <span class="md-headline">Last scanned files</span>
-                    <kbn-vis vis-id="'Wazuh-App-Overview-Virustotal-Last-Files-Pie'" id="Wazuh-App-Overview-Virustotal-Last-Files-Pie"></kbn-vis>
+                    <kbn-vis vis-id="'Wazuh-App-Overview-Virustotal-Last-Files-Pie'"></kbn-vis>
                 </md-card-content>
             </md-card>
             <md-card flex>
                 <md-card-content class="wazuh-column">
                     <span class="md-headline">Malicious files alerts Evolution</span>
-                    <kbn-vis vis-id="'Wazuh-App-Overview-Virustotal-Malicious-Evolution'" id="Wazuh-App-Overview-Virustotal-Malicious-Evolution"></kbn-vis>
+                    <kbn-vis vis-id="'Wazuh-App-Overview-Virustotal-Malicious-Evolution'"></kbn-vis>
                 </md-card-content>
             </md-card>
         </div>
@@ -38,7 +38,7 @@
             <md-card flex>
                 <md-card-content class="wazuh-column">
                     <span class="md-headline">Last files</span>
-                    <kbn-vis class="kbn-chart" vis-id="'Wazuh-App-Overview-Virustotal-Files-Table'" id="Wazuh-App-Overview-Virustotal-Files-Table"></kbn-vis>
+                    <kbn-vis class="kbn-chart" vis-id="'Wazuh-App-Overview-Virustotal-Files-Table'"></kbn-vis>
                 </md-card-content>
             </md-card>
         </div>

--- a/public/templates/agents/agents-vuls.html
+++ b/public/templates/agents/agents-vuls.html
@@ -6,22 +6,22 @@
         <div layout="row" layout-align="center stretch" class="height-120">
             <md-card flex>
                 <md-card-content class="wazuh-column">
-                    <kbn-vis class="metric" vis-id="'Wazuh-App-Overview-VULS-Metric-Critical-severity'" id="Wazuh-App-Overview-VULS-Metric-Critical-severity"></kbn-vis>
+                    <kbn-vis class="metric" vis-id="'Wazuh-App-Overview-VULS-Metric-Critical-severity'"></kbn-vis>
                 </md-card-content>
             </md-card>
             <md-card flex>
                 <md-card-content class="wazuh-column">
-                    <kbn-vis class="metric" vis-id="'Wazuh-App-Overview-VULS-Metric-High-severity'" id="Wazuh-App-Overview-VULS-Metric-High-severity"></kbn-vis>
+                    <kbn-vis class="metric" vis-id="'Wazuh-App-Overview-VULS-Metric-High-severity'"></kbn-vis>
                 </md-card-content>
             </md-card>
             <md-card flex>
                 <md-card-content class="wazuh-column">
-                    <kbn-vis class="metric" vis-id="'Wazuh-App-Overview-VULS-Metric-Medium-severity'" id="Wazuh-App-Overview-VULS-Metric-Medium-severity"></kbn-vis>
+                    <kbn-vis class="metric" vis-id="'Wazuh-App-Overview-VULS-Metric-Medium-severity'"></kbn-vis>
                 </md-card-content>
             </md-card>
             <md-card flex>
                 <md-card-content class="wazuh-column">
-                    <kbn-vis class="metric" vis-id="'Wazuh-App-Overview-VULS-Metric-Low-severity'" id="Wazuh-App-Overview-VULS-Metric-Low-severity"></kbn-vis>
+                    <kbn-vis class="metric" vis-id="'Wazuh-App-Overview-VULS-Metric-Low-severity'"></kbn-vis>
                 </md-card-content>
             </md-card>
         </div>
@@ -30,13 +30,13 @@
             <md-card flex="60">
                 <md-card-content class="wazuh-column">
                     <span class="md-headline">Alerts severity over time</span>
-                    <kbn-vis vis-id="'Wazuh-App-Overview-VULS-Alerts-severity-over-time'" id="Wazuh-App-Overview-VULS-Alerts-severity-over-time"></kbn-vis>
+                    <kbn-vis vis-id="'Wazuh-App-Overview-VULS-Alerts-severity-over-time'"></kbn-vis>
                 </md-card-content>
             </md-card>
             <md-card flex="40">
                 <md-card-content class="wazuh-column">
                     <span class="md-headline">Affected packages - Top 5</span>
-                    <kbn-vis vis-id="'Wazuh-App-Overview-VULS-Top-5-affected-packages'" id="Wazuh-App-Overview-VULS-Top-5-affected-packages"></kbn-vis>
+                    <kbn-vis vis-id="'Wazuh-App-Overview-VULS-Top-5-affected-packages'"></kbn-vis>
                 </md-card-content>
             </md-card>
         </div>
@@ -45,7 +45,7 @@
             <md-card flex>
                 <md-card-content class="wazuh-column">
                     <span class="md-headline">Alerts summary</span>
-                    <kbn-vis class="kbn-chart" vis-id="'Wazuh-App-Overview-VULS-Alerts-summary'" id="Wazuh-App-Overview-VULS-Alerts-summary"></kbn-vis>
+                    <kbn-vis class="kbn-chart" vis-id="'Wazuh-App-Overview-VULS-Alerts-summary'"></kbn-vis>
                 </md-card-content>
             </md-card>
         </div>

--- a/public/templates/manager/ruleset/ruleset-decoders.html
+++ b/public/templates/manager/ruleset/ruleset-decoders.html
@@ -9,7 +9,7 @@
         <md-card flex class="manager-ruleset-decoders-top-24">
             <md-card-content class="wazuh-column">
                 <span class="md-headline-small">Top 24h - Decoder name</span>
-                <kbn-vis specific-time-range="true" vis-id="'Wazuh-App-Manager-Ruleset-Decoders-Top-24h-Decoder-name'" id="Wazuh-App-Manager-Ruleset-Decoders-Top-24h-Decoder-name"></kbn-vis>
+                <kbn-vis specific-time-range="true" vis-id="'Wazuh-App-Manager-Ruleset-Decoders-Top-24h-Decoder-name'"></kbn-vis>
             </md-card-content>
         </md-card>
     </div>

--- a/public/templates/manager/ruleset/ruleset-rules.html
+++ b/public/templates/manager/ruleset/ruleset-rules.html
@@ -9,25 +9,25 @@
         <md-card flex>
             <md-card-content class="wazuh-column">
                 <span class="md-headline">Top 24h - Rule ID</span>
-                <kbn-vis specific-time-range="true" vis-id="'Wazuh-App-Manager-Ruleset-Rules-Top-24h-Rule-ID'" id="Wazuh-App-Manager-Ruleset-Rules-Top-24h-Rule-ID"></kbn-vis>
+                <kbn-vis specific-time-range="true" vis-id="'Wazuh-App-Manager-Ruleset-Rules-Top-24h-Rule-ID'"></kbn-vis>
             </md-card-content>
         </md-card>
         <md-card flex>
             <md-card-content class="wazuh-column">
                 <span class="md-headline">Top 24h - Groups</span>
-                <kbn-vis specific-time-range="true" vis-id="'Wazuh-App-Manager-Ruleset-Rules-Top-24h-Groups'" id="Wazuh-App-Manager-Ruleset-Rules-Top-24h-Groups"></kbn-vis>
+                <kbn-vis specific-time-range="true" vis-id="'Wazuh-App-Manager-Ruleset-Rules-Top-24h-Groups'"></kbn-vis>
             </md-card-content>
         </md-card>
         <md-card flex>
             <md-card-content class="wazuh-column">
                 <span class="md-headline">Top 24h - PCI DSS requirements</span>
-                <kbn-vis specific-time-range="true" vis-id="'Wazuh-App-Manager-Ruleset-Rules-Top-24h-PCI-DSS-requirements'" id="Wazuh-App-Manager-Ruleset-Rules-Top-24h-PCI-DSS-requirements"></kbn-vis>
+                <kbn-vis specific-time-range="true" vis-id="'Wazuh-App-Manager-Ruleset-Rules-Top-24h-PCI-DSS-requirements'"></kbn-vis>
             </md-card-content>
         </md-card>
         <md-card flex>
             <md-card-content class="wazuh-column">
                 <span class="md-headline">Top 24h - Level</span>
-                <kbn-vis specific-time-range="true" vis-id="'Wazuh-App-Manager-Ruleset-Rules-Top-24h-Level'" id="Wazuh-App-Manager-Ruleset-Rules-Top-24h-Level"></kbn-vis>
+                <kbn-vis specific-time-range="true" vis-id="'Wazuh-App-Manager-Ruleset-Rules-Top-24h-Level'"></kbn-vis>
             </md-card-content>
         </md-card>
     </div>

--- a/public/templates/overview/overview-audit.html
+++ b/public/templates/overview/overview-audit.html
@@ -7,31 +7,31 @@
             <md-card flex="10">
                 <md-card-content class="wazuh-column">
                     <span class="metric-headline md-headline">New files</span>
-                    <kbn-vis class="metric" vis-id="'Wazuh-App-Overview-Audit-New-files'" id="Wazuh-App-Overview-Audit-New-files"></kbn-vis>
+                    <kbn-vis class="metric" vis-id="'Wazuh-App-Overview-Audit-New-files'"></kbn-vis>
                 </md-card-content>
             </md-card>
             <md-card flex="10">
                 <md-card-content class="wazuh-column">
                     <span class="metric-headline md-headline">Read files</span>
-                    <kbn-vis class="metric" vis-id="'Wazuh-App-Overview-Audit-Read-files'" id="Wazuh-App-Overview-Audit-Read-files"></kbn-vis>
+                    <kbn-vis class="metric" vis-id="'Wazuh-App-Overview-Audit-Read-files'"></kbn-vis>
                 </md-card-content>
             </md-card>
             <md-card flex="12">
                 <md-card-content class="wazuh-column">
                     <span class="metric-headline md-headline">Modified files</span>
-                    <kbn-vis class="metric" vis-id="'Wazuh-App-Overview-Audit-Modified-files'" id="Wazuh-App-Overview-Audit-Modified-files"></kbn-vis>
+                    <kbn-vis class="metric" vis-id="'Wazuh-App-Overview-Audit-Modified-files'"></kbn-vis>
                 </md-card-content>
             </md-card>
             <md-card flex="12">
                 <md-card-content class="wazuh-column">
                     <span class="metric-headline md-headline">Removed files</span>
-                    <kbn-vis class="metric" vis-id="'Wazuh-App-Overview-Audit-Removed-files'" id="Wazuh-App-Overview-Audit-Removed-files"></kbn-vis>
+                    <kbn-vis class="metric" vis-id="'Wazuh-App-Overview-Audit-Removed-files'"></kbn-vis>
                 </md-card-content>
             </md-card>
             <md-card flex="auto">
                 <md-card-content class="wazuh-column text-center">
                     <div class="ng-binding">Latest alert</div>
-                    <kbn-vis class="kbn-vis-value" vis-id="'Wazuh-App-Overview-Audit-Latest-alert'" id="Wazuh-App-Overview-Audit-Latest-alert"></kbn-vis>
+                    <kbn-vis class="kbn-vis-value" vis-id="'Wazuh-App-Overview-Audit-Latest-alert'"></kbn-vis>
                 </md-card-content>
             </md-card>
         </div>
@@ -40,25 +40,25 @@
             <md-card flex="25">
                 <md-card-content class="wazuh-column">
                     <span class="md-headline">Groups</span>
-                    <kbn-vis vis-id="'Wazuh-App-Overview-Audit-Groups'" id="Wazuh-App-Overview-Audit-Groups"></kbn-vis>
+                    <kbn-vis vis-id="'Wazuh-App-Overview-Audit-Groups'"></kbn-vis>
                 </md-card-content>
             </md-card>
             <md-card flex="25">
                 <md-card-content class="wazuh-column">
                     <span class="md-headline">Agents</span>
-                    <kbn-vis vis-id="'Wazuh-App-Overview-Audit-Agents'" id="Wazuh-App-Overview-Audit-Agents"></kbn-vis>
+                    <kbn-vis vis-id="'Wazuh-App-Overview-Audit-Agents'"></kbn-vis>
                 </md-card-content>
             </md-card>
             <md-card flex="25">
                 <md-card-content class="wazuh-column">
                     <span class="md-headline">Directories</span>
-                    <kbn-vis vis-id="'Wazuh-App-Overview-Audit-Directories'" id="Wazuh-App-Overview-Audit-Directories"></kbn-vis>
+                    <kbn-vis vis-id="'Wazuh-App-Overview-Audit-Directories'"></kbn-vis>
                 </md-card-content>
             </md-card>
             <md-card flex="25">
                 <md-card-content class="wazuh-column">
                     <span class="md-headline">Files</span>
-                    <kbn-vis vis-id="'Wazuh-App-Overview-Audit-Files'" id="Wazuh-App-Overview-Audit-Files"></kbn-vis>
+                    <kbn-vis vis-id="'Wazuh-App-Overview-Audit-Files'"></kbn-vis>
                 </md-card-content>
             </md-card>
         </div>
@@ -67,7 +67,7 @@
             <md-card flex>
                 <md-card-content class="wazuh-column">
                     <span class="md-headline">Alerts over time</span>
-                    <kbn-vis vis-id="'Wazuh-App-Overview-Audit-Alerts-over-time'" id="Wazuh-App-Overview-Audit-Alerts-over-time"></kbn-vis>
+                    <kbn-vis vis-id="'Wazuh-App-Overview-Audit-Alerts-over-time'"></kbn-vis>
                 </md-card-content>
             </md-card>
         </div>
@@ -77,13 +77,13 @@
                 <md-card flex="50">
                     <md-card-content class="wazuh-column">
                         <span class="md-headline">File read access</span>
-                        <kbn-vis vis-id="'Wazuh-App-Overview-Audit-File-read-access'" id="Wazuh-App-Overview-Audit-File-read-access"></kbn-vis>
+                        <kbn-vis vis-id="'Wazuh-App-Overview-Audit-File-read-access'"></kbn-vis>
                     </md-card-content>
                 </md-card>
                 <md-card flex="50">
                     <md-card-content class="wazuh-column">
                         <span class="md-headline">File write access</span>
-                        <kbn-vis vis-id="'Wazuh-App-Overview-Audit-File-write-access'" id="Wazuh-App-Overview-Audit-File-write-access"></kbn-vis>
+                        <kbn-vis vis-id="'Wazuh-App-Overview-Audit-File-write-access'"></kbn-vis>
                     </md-card-content>
                 </md-card>
             </div>
@@ -92,7 +92,7 @@
                 <md-card flex>
                     <md-card-content class="wazuh-column">
                         <span class="md-headline">Commands</span>
-                        <kbn-vis vis-id="'Wazuh-App-Overview-Audit-Commands'" id="Wazuh-App-Overview-Audit-Commands"></kbn-vis>
+                        <kbn-vis vis-id="'Wazuh-App-Overview-Audit-Commands'"></kbn-vis>
                     </md-card-content>
                 </md-card>
             </div>
@@ -101,13 +101,13 @@
                 <md-card flex="50">
                     <md-card-content class="wazuh-column">
                         <span class="md-headline">Created files</span>
-                        <kbn-vis vis-id="'Wazuh-App-Overview-Audit-Files-created'" id="Wazuh-App-Overview-Audit-Files-created"></kbn-vis>
+                        <kbn-vis vis-id="'Wazuh-App-Overview-Audit-Files-created'"></kbn-vis>
                     </md-card-content>
                 </md-card>
                 <md-card flex="50">
                     <md-card-content class="wazuh-column">
                         <span class="md-headline">Removed files</span>
-                        <kbn-vis vis-id="'Wazuh-App-Overview-Audit-Files-deleted'" id="Wazuh-App-Overview-Audit-Files-deleted"></kbn-vis>
+                        <kbn-vis vis-id="'Wazuh-App-Overview-Audit-Files-deleted'"></kbn-vis>
                     </md-card-content>
                 </md-card>
             </div>
@@ -117,7 +117,7 @@
             <md-card flex>
                 <md-card-content class="wazuh-column">
                     <span class="md-headline">Alerts summary</span>
-                    <kbn-vis class="kbn-chart" vis-id="'Wazuh-App-Overview-Audit-Last-alerts'" id="Wazuh-App-Overview-Audit-Last-alerts"></kbn-vis>
+                    <kbn-vis class="kbn-chart" vis-id="'Wazuh-App-Overview-Audit-Last-alerts'"></kbn-vis>
                 </md-card-content>
             </md-card>
         </div>

--- a/public/templates/overview/overview-aws.html
+++ b/public/templates/overview/overview-aws.html
@@ -8,20 +8,20 @@
                 <md-card flex>
                     <md-card-content class="wazuh-column">
                         <span class="md-headline">Instances</span>
-                        <kbn-vis vis-id="'Wazuh-App-Overview-AWS-Instances'" id="Wazuh-App-Overview-AWS-Instances"></kbn-vis>
+                        <kbn-vis vis-id="'Wazuh-App-Overview-AWS-Instances'"></kbn-vis>
                     </md-card-content>
                 </md-card>
             </div>
             <div flex="25" layout="column">
                 <md-card flex>
                     <md-card-content class="wazuh-column text-center">
-                        <kbn-vis class="metric" vis-id="'Wazuh-App-Overview-AWS-Metric-Successful-logins'" id="Wazuh-App-Overview-AWS-Metric-Successful-logins"></kbn-vis>
+                        <kbn-vis class="metric" vis-id="'Wazuh-App-Overview-AWS-Metric-Successful-logins'"></kbn-vis>
                     </md-card-content>
                 </md-card>
                 <md-card flex>
                     <md-card-content class="wazuh-column text-center">
                         <div class="ng-binding">Most active user</div>
-                        <kbn-vis class="kbn-vis-value" vis-id="'Wazuh-App-Overview-AWS-Most-active-user'" id="Wazuh-App-Overview-AWS-Most-active-user"></kbn-vis>
+                        <kbn-vis class="kbn-vis-value" vis-id="'Wazuh-App-Overview-AWS-Most-active-user'"></kbn-vis>
                     </md-card-content>
                 </md-card>
             </div>
@@ -31,12 +31,12 @@
             <div flex="25" layout="column">
                 <md-card flex>
                     <md-card-content class="wazuh-column">
-                        <kbn-vis class="metric" vis-id="'Wazuh-App-Overview-AWS-Metric-Authorize-security'" id="Wazuh-App-Overview-AWS-Metric-Authorize-security"></kbn-vis>
+                        <kbn-vis class="metric" vis-id="'Wazuh-App-Overview-AWS-Metric-Authorize-security'"></kbn-vis>
                     </md-card-content>
                 </md-card>
                 <md-card flex>
                     <md-card-content class="wazuh-column">
-                        <kbn-vis class="metric" vis-id="'Wazuh-App-Overview-AWS-Metric-Revoke-security'" id="Wazuh-App-Overview-AWS-Metric-Revoke-security"></kbn-vis>
+                        <kbn-vis class="metric" vis-id="'Wazuh-App-Overview-AWS-Metric-Revoke-security'"></kbn-vis>
                     </md-card-content>
                 </md-card>
             </div>
@@ -44,7 +44,7 @@
                 <md-card flex>
                     <md-card-content class="wazuh-column">
                         <span class="md-headline">Security groups over time</span>
-                        <kbn-vis vis-id="'Wazuh-App-Overview-AWS-Security-groups-over-time'" id="Wazuh-App-Overview-AWS-Security-groups-over-time"></kbn-vis>
+                        <kbn-vis vis-id="'Wazuh-App-Overview-AWS-Security-groups-over-time'"></kbn-vis>
                     </md-card-content>
                 </md-card>
             </div>
@@ -54,7 +54,7 @@
             <md-card flex>
                 <md-card-content class="wazuh-column">
                     <span class="md-headline">Events over time</span>
-                    <kbn-vis vis-id="'Wazuh-App-Overview-AWS-Events-over-time'" id="Wazuh-App-Overview-AWS-Events-over-time"></kbn-vis>
+                    <kbn-vis vis-id="'Wazuh-App-Overview-AWS-Events-over-time'"></kbn-vis>
                 </md-card-content>
             </md-card>
         </div>
@@ -63,13 +63,13 @@
             <md-card flex="65">
                 <md-card-content class="wazuh-column">
                     <span class="md-headline">Event sources over time</span>
-                    <kbn-vis vis-id="'Wazuh-App-Overview-AWS-Event-sources-over-time'" id="Wazuh-App-Overview-AWS-Event-sources-over-time"></kbn-vis>
+                    <kbn-vis vis-id="'Wazuh-App-Overview-AWS-Event-sources-over-time'"></kbn-vis>
                 </md-card-content>
             </md-card>
             <md-card flex="35">
                 <md-card-content class="wazuh-column">
                     <span class="md-headline">Success login - Top 5 countries</span>
-                    <kbn-vis vis-id="'Wazuh-App-Overview-AWS-Success-login-Top-5-countries'" id="Wazuh-App-Overview-AWS-Success-login-Top-5-countries"></kbn-vis>
+                    <kbn-vis vis-id="'Wazuh-App-Overview-AWS-Success-login-Top-5-countries'"></kbn-vis>
                 </md-card-content>
             </md-card>
         </div>
@@ -78,7 +78,7 @@
             <md-card flex>
                 <md-card-content class="wazuh-column">
                     <span class="md-headline">Alerts summary</span>
-                    <kbn-vis class="kbn-chart" vis-id="'Wazuh-App-Overview-AWS-Alerts-summary'" id="Wazuh-App-Overview-AWS-Alerts-summary"></kbn-vis>
+                    <kbn-vis class="kbn-chart" vis-id="'Wazuh-App-Overview-AWS-Alerts-summary'"></kbn-vis>
                 </md-card-content>
             </md-card>
         </div>

--- a/public/templates/overview/overview-fim.html
+++ b/public/templates/overview/overview-fim.html
@@ -7,17 +7,17 @@
             <div flex="15" layout="column">
                 <md-card flex>
                     <md-card-content class="wazuh-column">
-                        <kbn-vis class="metric" vis-id="'Wazuh-App-Overview-FIM-Added'" id="Wazuh-App-Overview-FIM-Added"></kbn-vis>
+                        <kbn-vis class="metric" vis-id="'Wazuh-App-Overview-FIM-Added'" ></kbn-vis>
                     </md-card-content>
                 </md-card>
                 <md-card flex>
                     <md-card-content class="wazuh-column">
-                        <kbn-vis class="metric" vis-id="'Wazuh-App-Overview-FIM-Modified'" id="Wazuh-App-Overview-FIM-Modified"></kbn-vis>
+                        <kbn-vis class="metric" vis-id="'Wazuh-App-Overview-FIM-Modified'"></kbn-vis>
                     </md-card-content>
                 </md-card>
                 <md-card flex>
                     <md-card-content class="wazuh-column">
-                        <kbn-vis class="metric" vis-id="'Wazuh-App-Overview-FIM-Deleted'" id="Wazuh-App-Overview-FIM-Deleted"></kbn-vis>
+                        <kbn-vis class="metric" vis-id="'Wazuh-App-Overview-FIM-Deleted'"></kbn-vis>
                     </md-card-content>
                 </md-card>
             </div>
@@ -26,7 +26,7 @@
                 <md-card flex>
                     <md-card-content class="wazuh-column">
                         <span class="md-headline">Events over time</span>
-                        <kbn-vis vis-id="'Wazuh-App-Overview-FIM-Events-over-time'" id="Wazuh-App-Overview-FIM-Events-over-time"></kbn-vis>
+                        <kbn-vis vis-id="'Wazuh-App-Overview-FIM-Events-over-time'"></kbn-vis>
                     </md-card-content>
                 </md-card>
             </div>
@@ -35,13 +35,13 @@
                 <md-card flex>
                     <md-card-content class="wazuh-column">
                         <span class="md-headline">Top user owners</span>
-                        <kbn-vis vis-id="'Wazuh-App-Overview-FIM-Top-user-owners'" id="Wazuh-App-Overview-FIM-Top-user-owners"></kbn-vis>
+                        <kbn-vis vis-id="'Wazuh-App-Overview-FIM-Top-user-owners'"></kbn-vis>
                     </md-card-content>
                 </md-card>
                 <md-card flex>
                     <md-card-content class="wazuh-column">
                         <span class="md-headline">Top group owners</span>
-                        <kbn-vis vis-id="'Wazuh-App-Overview-FIM-Top-group-owners'" id="Wazuh-App-Overview-FIM-Top-group-owners"></kbn-vis>
+                        <kbn-vis vis-id="'Wazuh-App-Overview-FIM-Top-group-owners'"></kbn-vis>
                     </md-card-content>
                 </md-card>
             </div>
@@ -51,19 +51,19 @@
             <md-card flex>
                 <md-card-content class="wazuh-column text-center">
                     <div class="ng-binding">Last file modified</div>
-                    <kbn-vis class="kbn-vis-value" vis-id="'Wazuh-App-Overview-FIM-Last-file-modified'" id="Wazuh-App-Overview-FIM-Last-file-modified"></kbn-vis>
+                    <kbn-vis class="kbn-vis-value" vis-id="'Wazuh-App-Overview-FIM-Last-file-modified'"></kbn-vis>
                 </md-card-content>
             </md-card >
             <md-card flex>
                 <md-card-content class="wazuh-column text-center">
                     <div class="ng-binding">Last file added</div>
-                    <kbn-vis class="kbn-vis-value" vis-id="'Wazuh-App-Overview-FIM-Last-file-added'" id="Wazuh-App-Overview-FIM-Last-file-added"></kbn-vis>
+                    <kbn-vis class="kbn-vis-value" vis-id="'Wazuh-App-Overview-FIM-Last-file-added'"></kbn-vis>
                 </md-card-content>
             </md-card>
             <md-card flex>
                 <md-card-content class="wazuh-column text-center">
                     <div class="ng-binding">Last file deleted</div>
-                    <kbn-vis class="kbn-vis-value" vis-id="'Wazuh-App-Overview-FIM-Last-file-deleted'" id="Wazuh-App-Overview-FIM-Last-file-deleted"></kbn-vis>
+                    <kbn-vis class="kbn-vis-value" vis-id="'Wazuh-App-Overview-FIM-Last-file-deleted'"></kbn-vis>
                 </md-card-content>
             </md-card>
         </div>
@@ -72,21 +72,21 @@
             <md-card flex>
                 <md-card-content class="wazuh-column">
                     <span class="md-headline">Top file changes</span>
-                    <kbn-vis vis-id="'Wazuh-App-Overview-FIM-Top-file-changes'" id="Wazuh-App-Overview-FIM-Top-file-changes"></kbn-vis>
+                    <kbn-vis vis-id="'Wazuh-App-Overview-FIM-Top-file-changes'"></kbn-vis>
                 </md-card-content>
             </md-card>
 
             <md-card flex>
                 <md-card-content class="wazuh-column">
                     <span class="md-headline">Root user file changes</span>
-                    <kbn-vis vis-id="'Wazuh-App-Overview-FIM-Root-user-file-changes'" id="Wazuh-App-Overview-FIM-Root-user-file-changes"></kbn-vis>
+                    <kbn-vis vis-id="'Wazuh-App-Overview-FIM-Root-user-file-changes'"></kbn-vis>
                 </md-card-content>
             </md-card>
 
             <md-card flex>
                 <md-card-content class="wazuh-column">
                     <span class="md-headline">World writable modified files</span>
-                    <kbn-vis vis-id="'Wazuh-App-Overview-FIM-World-writable-modified-files'" id="Wazuh-App-Overview-FIM-World-writable-modified-files"></kbn-vis>
+                    <kbn-vis vis-id="'Wazuh-App-Overview-FIM-World-writable-modified-files'"></kbn-vis>
                 </md-card-content>
             </md-card>
         </div>
@@ -95,25 +95,25 @@
             <md-card flex="20">
                 <md-card-content class="wazuh-column text-center">
                     <div class="ng-binding">Top agent</div>
-                    <kbn-vis class="kbn-vis-value" vis-id="'Wazuh-App-Overview-FIM-Top-agent'" id="Wazuh-App-Overview-FIM-Top-agent"></kbn-vis>
+                    <kbn-vis class="kbn-vis-value" vis-id="'Wazuh-App-Overview-FIM-Top-agent'"></kbn-vis>
                 </md-card-content>
             </md-card>
             <md-card flex="20">
                 <md-card-content class="wazuh-column text-center">
                     <div class="ng-binding">Top PCI Requirement</div>
-                    <kbn-vis class="kbn-vis-value" vis-id="'Wazuh-App-Overview-FIM-Top-PCI-requirement'" id="Wazuh-App-Overview-FIM-Top-PCI-requirement"></kbn-vis>
+                    <kbn-vis class="kbn-vis-value" vis-id="'Wazuh-App-Overview-FIM-Top-PCI-requirement'"></kbn-vis>
                 </md-card-content>
             </md-card>
             <md-card flex="20">
                 <md-card-content class="wazuh-column text-center">
                     <div class="ng-binding">Most common permissions</div>
-                    <kbn-vis class="kbn-vis-value" vis-id="'Wazuh-App-Overview-FIM-Most-common-permissions'" id="Wazuh-App-Overview-FIM-Most-common-permissions"></kbn-vis>
+                    <kbn-vis class="kbn-vis-value" vis-id="'Wazuh-App-Overview-FIM-Most-common-permissions'"></kbn-vis>
                 </md-card-content>
             </md-card>
             <md-card flex="40">
                 <md-card-content class="wazuh-column text-center">
                     <div class="ng-binding">Most modified file</div>
-                    <kbn-vis class="kbn-vis-value" vis-id="'Wazuh-App-Overview-FIM-Most-modified-file'" id="Wazuh-App-Overview-FIM-Most-modified-file"></kbn-vis>
+                    <kbn-vis class="kbn-vis-value" vis-id="'Wazuh-App-Overview-FIM-Most-modified-file'"></kbn-vis>
                 </md-card-content>
             </md-card>
         </div>
@@ -122,7 +122,7 @@
             <md-card flex>
                 <md-card-content class="wazuh-column">
                     <span class="md-headline">Events summary</span>
-                    <kbn-vis class="kbn-chart" vis-id="'Wazuh-App-Overview-FIM-Events-summary'" id="Wazuh-App-Overview-FIM-Events-summary"></kbn-vis>
+                    <kbn-vis class="kbn-chart" vis-id="'Wazuh-App-Overview-FIM-Events-summary'"></kbn-vis>
                 </md-card-content>
             </md-card>
         </div>

--- a/public/templates/overview/overview-general.html
+++ b/public/templates/overview/overview-general.html
@@ -6,22 +6,22 @@
         <div layout="row" layout-align="center stretch" class="height-120">
             <md-card flex>
                 <md-card-content class="wazuh-column">
-                    <kbn-vis class="metric" vis-id="'Wazuh-App-Overview-General-Metric-alerts'" id="Wazuh-App-Overview-General-Metric-alerts"></kbn-vis>
+                    <kbn-vis class="metric" vis-id="'Wazuh-App-Overview-General-Metric-alerts'"></kbn-vis>
                 </md-card-content>
             </md-card>
             <md-card flex>
                 <md-card-content class="wazuh-column">
-                    <kbn-vis class="metric" vis-id="'Wazuh-App-Overview-General-Level-12-alerts'" id="Wazuh-App-Overview-General-Level-12-alerts"></kbn-vis>
+                    <kbn-vis class="metric" vis-id="'Wazuh-App-Overview-General-Level-12-alerts'"></kbn-vis>
                 </md-card-content>
             </md-card>
             <md-card flex>
                 <md-card-content class="wazuh-column">
-                    <kbn-vis class="metric" vis-id="'Wazuh-App-Overview-General-Authentication-failure'" id="Wazuh-App-Overview-General-Authentication-failure"></kbn-vis>
+                    <kbn-vis class="metric" vis-id="'Wazuh-App-Overview-General-Authentication-failure'"></kbn-vis>
                 </md-card-content>
             </md-card>
             <md-card flex>
                 <md-card-content class="wazuh-column">
-                    <kbn-vis class="metric" vis-id="'Wazuh-App-Overview-General-Authentication-success'" id="Wazuh-App-Overview-General-Authentication-success"></kbn-vis>
+                    <kbn-vis class="metric" vis-id="'Wazuh-App-Overview-General-Authentication-success'"></kbn-vis>
                 </md-card-content>
             </md-card>
         </div>
@@ -30,13 +30,13 @@
             <md-card flex="40">
                 <md-card-content class="wazuh-column">
                     <span class="md-headline">Alert level evolution</span>
-                    <kbn-vis vis-id="'Wazuh-App-Overview-General-Alert-level-evolution'" id="Wazuh-App-Overview-General-Alert-level-evolution"></kbn-vis>
+                    <kbn-vis vis-id="'Wazuh-App-Overview-General-Alert-level-evolution'"></kbn-vis>
                 </md-card-content>
             </md-card>
             <md-card flex="60">
                 <md-card-content class="wazuh-column">
                     <span class="md-headline">Alerts</span>
-                    <kbn-vis vis-id="'Wazuh-App-Overview-General-Alerts'" id="Wazuh-App-Overview-General-Alerts"></kbn-vis>
+                    <kbn-vis vis-id="'Wazuh-App-Overview-General-Alerts'"></kbn-vis>
                 </md-card-content>
             </md-card>
         </div>
@@ -45,19 +45,19 @@
             <md-card flex>
                 <md-card-content class="wazuh-column">
                     <span class="md-headline">Top 5 agents</span>
-                    <kbn-vis vis-id="'Wazuh-App-Overview-General-Top-5-agents'" id="Wazuh-App-Overview-General-Top-5-agents"></kbn-vis>
+                    <kbn-vis vis-id="'Wazuh-App-Overview-General-Top-5-agents'"></kbn-vis>
                 </md-card-content>
             </md-card>
             <md-card flex>
                 <md-card-content class="wazuh-column">
                     <span class="md-headline">Alerts evolution - Top 5 agents</span>
-                    <kbn-vis vis-id="'Wazuh-App-Overview-General-Alerts-evolution-Top-5-agents'" id="Wazuh-App-Overview-General-Alerts-evolution-Top-5-agents"></kbn-vis>
+                    <kbn-vis vis-id="'Wazuh-App-Overview-General-Alerts-evolution-Top-5-agents'"></kbn-vis>
                 </md-card-content>
             </md-card>
             <md-card flex="35">
                 <md-card-content class="wazuh-column">
                     <span class="md-headline">Agents status</span>
-                    <kbn-vis vis-id="'Wazuh-App-Overview-General-Agents-status'" id="Wazuh-App-Overview-General-Agents-status"></kbn-vis>
+                    <kbn-vis vis-id="'Wazuh-App-Overview-General-Agents-status'"></kbn-vis>
                 </md-card-content>
             </md-card>
         </div>
@@ -66,25 +66,25 @@
             <md-card flex>
                 <md-card-content class="wazuh-column text-center">
                     <div class="ng-binding">Top source user</div>
-                    <kbn-vis class="kbn-vis-value" vis-id="'Wazuh-App-Overview-General-Top-source-user'" id="Wazuh-App-Overview-General-Top-source-user"></kbn-vis>
+                    <kbn-vis class="kbn-vis-value" vis-id="'Wazuh-App-Overview-General-Top-source-user'"></kbn-vis>
                 </md-card-content>
             </md-card>
             <md-card flex>
                 <md-card-content class="wazuh-column text-center">
                     <div class="ng-binding">Top source IP</div>
-                    <kbn-vis class="kbn-vis-value" vis-id="'Wazuh-App-Overview-General-Top-source-IP'" id="Wazuh-App-Overview-General-Top-source-IP"></kbn-vis>
+                    <kbn-vis class="kbn-vis-value" vis-id="'Wazuh-App-Overview-General-Top-source-IP'"></kbn-vis>
                 </md-card-content>
             </md-card>
             <md-card flex>
                 <md-card-content class="wazuh-column text-center">
                     <div class="ng-binding">Top group</div>
-                    <kbn-vis class="kbn-vis-value" vis-id="'Wazuh-App-Overview-General-Top-group'" id="Wazuh-App-Overview-General-Top-group"></kbn-vis>
+                    <kbn-vis class="kbn-vis-value" vis-id="'Wazuh-App-Overview-General-Top-group'"></kbn-vis>
                 </md-card-content>
             </md-card>
             <md-card flex>
                 <md-card-content class="wazuh-column text-center">
                     <div class="ng-binding">Top PCI DSS requirement</div>
-                    <kbn-vis class="kbn-vis-value" vis-id="'Wazuh-App-Overview-General-Top-PCI-DSS-requirement'" id="Wazuh-App-Overview-General-Top-PCI-DSS-requirement"></kbn-vis>
+                    <kbn-vis class="kbn-vis-value" vis-id="'Wazuh-App-Overview-General-Top-PCI-DSS-requirement'"></kbn-vis>
                 </md-card-content>
             </md-card>
         </div>
@@ -93,13 +93,13 @@
             <md-card flex="60">
                 <md-card-content class="wazuh-column">
                     <span class="md-headline">Alerts summary</span>
-                    <kbn-vis class="kbn-chart" vis-id="'Wazuh-App-Overview-General-Alerts-summary'" id="Wazuh-App-Overview-General-Alerts-summary"></kbn-vis>
+                    <kbn-vis class="kbn-chart" vis-id="'Wazuh-App-Overview-General-Alerts-summary'"></kbn-vis>
                 </md-card-content>
             </md-card>
             <md-card flex="40">
                 <md-card-content class="wazuh-column">
                     <span class="md-headline">Groups summary</span>
-                    <kbn-vis class="kbn-chart" vis-id="'Wazuh-App-Overview-General-Groups-summary'" id="Wazuh-App-Overview-General-Groups-summary"></kbn-vis>
+                    <kbn-vis class="kbn-chart" vis-id="'Wazuh-App-Overview-General-Groups-summary'"></kbn-vis>
                 </md-card-content>
             </md-card>
         </div>

--- a/public/templates/overview/overview-oscap.html
+++ b/public/templates/overview/overview-oscap.html
@@ -7,19 +7,19 @@
             <md-card flex="20">
                 <md-card-content class="wazuh-column text-center">
                     <div class="ng-binding">Last score</div>
-                    <kbn-vis class="kbn-vis-value" vis-id="'Wazuh-App-Overview-OSCAP-Last-score'" id="Wazuh-App-Overview-OSCAP-Last-score"></kbn-vis>
+                    <kbn-vis class="kbn-vis-value" vis-id="'Wazuh-App-Overview-OSCAP-Last-score'"></kbn-vis>
                 </md-card-content>
             </md-card>
             <md-card flex="40">
                 <md-card-content class="wazuh-column text-center">
                     <div class="ng-binding">Last agent scanned</div>
-                    <kbn-vis class="kbn-vis-value" vis-id="'Wazuh-App-Overview-OSCAP-Last-agent-scanned'" id="Wazuh-App-Overview-OSCAP-Last-agent-scanned"></kbn-vis>
+                    <kbn-vis class="kbn-vis-value" vis-id="'Wazuh-App-Overview-OSCAP-Last-agent-scanned'"></kbn-vis>
                 </md-card-content>
             </md-card>
             <md-card flex="40">
                 <md-card-content class="wazuh-column text-center">
                     <div class="ng-binding">Last scan profile</div>
-                    <kbn-vis class="kbn-vis-value" vis-id="'Wazuh-App-Overview-OSCAP-Last-scan-profile'" id="Wazuh-App-Overview-OSCAP-Last-scan-profile"></kbn-vis>
+                    <kbn-vis class="kbn-vis-value" vis-id="'Wazuh-App-Overview-OSCAP-Last-scan-profile'"></kbn-vis>
                 </md-card-content>
             </md-card>
         </div>
@@ -28,25 +28,25 @@
             <md-card flex="25">
                 <md-card-content class="wazuh-column">
                     <span class="md-headline">Agents</span>
-                    <kbn-vis vis-id="'Wazuh-App-Overview-OSCAP-Agents'" id="Wazuh-App-Overview-OSCAP-Agents"></kbn-vis>
+                    <kbn-vis vis-id="'Wazuh-App-Overview-OSCAP-Agents'"></kbn-vis>
                 </md-card-content>
             </md-card>
             <md-card flex="25">
                 <md-card-content class="wazuh-column">
                     <span class="md-headline">Profiles</span>
-                    <kbn-vis vis-id="'Wazuh-App-Overview-OSCAP-Profiles'" id="Wazuh-App-Overview-OSCAP-Profiles"></kbn-vis>
+                    <kbn-vis vis-id="'Wazuh-App-Overview-OSCAP-Profiles'"></kbn-vis>
                 </md-card-content>
             </md-card>
             <md-card flex="25">
                 <md-card-content class="wazuh-column">
                     <span class="md-headline">Content</span>
-                    <kbn-vis vis-id="'Wazuh-App-Overview-OSCAP-Content'" id="Wazuh-App-Overview-OSCAP-Content"></kbn-vis>
+                    <kbn-vis vis-id="'Wazuh-App-Overview-OSCAP-Content'"></kbn-vis>
                 </md-card-content>
             </md-card>
             <md-card flex="25">
                 <md-card-content class="wazuh-column">
                     <span class="md-headline">Severity</span>
-                    <kbn-vis vis-id="'Wazuh-App-Overview-OSCAP-Severity'" id="Wazuh-App-Overview-OSCAP-Severity"></kbn-vis>
+                    <kbn-vis vis-id="'Wazuh-App-Overview-OSCAP-Severity'"></kbn-vis>
                 </md-card-content>
             </md-card>
         </div>
@@ -55,7 +55,7 @@
             <md-card flex>
                 <md-card-content class="wazuh-column">
                     <span class="md-headline">Top 5 Agents - Severity high</span>
-                    <kbn-vis vis-id="'Wazuh-App-Overview-OSCAP-Top-5-agents-Severity-high'" id="Wazuh-App-Overview-OSCAP-Top-5-agents-Severity-high"></kbn-vis>
+                    <kbn-vis vis-id="'Wazuh-App-Overview-OSCAP-Top-5-agents-Severity-high'"></kbn-vis>
                 </md-card-content>
             </md-card>
         </div>
@@ -64,14 +64,14 @@
             <md-card flex="50">
                 <md-card-content class="wazuh-column">
                     <span class="md-headline">Top 10 - Alerts</span>
-                    <kbn-vis vis-id="'Wazuh-App-Overview-OSCAP-Top-10-alerts'" id="Wazuh-App-Overview-OSCAP-Top-10-alerts"></kbn-vis>
+                    <kbn-vis vis-id="'Wazuh-App-Overview-OSCAP-Top-10-alerts'"></kbn-vis>
                 </md-card-content>
             </md-card>
 
             <md-card flex="50">
                 <md-card-content class="wazuh-column">
                     <span class="md-headline">Top 10 - High risk alerts</span>
-                    <kbn-vis vis-id="'Wazuh-App-Overview-OSCAP-Top-10-high-risk-alerts'" id="Wazuh-App-Overview-OSCAP-Top-10-high-risk-alerts"></kbn-vis>
+                    <kbn-vis vis-id="'Wazuh-App-Overview-OSCAP-Top-10-high-risk-alerts'"></kbn-vis>
                 </md-card-content>
             </md-card>
         </div>
@@ -80,19 +80,19 @@
             <md-card flex="20">
                 <md-card-content class="wazuh-column text-center">
                     <div class="ng-binding">Highest score</div>
-                    <kbn-vis class="kbn-vis-value" vis-id="'Wazuh-App-Overview-OSCAP-Highest-score'" id="Wazuh-App-Overview-OSCAP-Highest-score"></kbn-vis>
+                    <kbn-vis class="kbn-vis-value" vis-id="'Wazuh-App-Overview-OSCAP-Highest-score'"></kbn-vis>
                 </md-card-content>
             </md-card>
             <md-card flex="20">
                 <md-card-content class="wazuh-column text-center">
                     <div class="ng-binding">Lowest score</div>
-                    <kbn-vis class="kbn-vis-value" vis-id="'Wazuh-App-Overview-OSCAP-Lowest-score'" id="Wazuh-App-Overview-OSCAP-Lowest-score"></kbn-vis>
+                    <kbn-vis class="kbn-vis-value" vis-id="'Wazuh-App-Overview-OSCAP-Lowest-score'"></kbn-vis>
                 </md-card-content>
             </md-card>
             <md-card flex="60">
                 <md-card-content class="wazuh-column text-center">
                     <div class="ng-binding">Latest alert</div>
-                    <kbn-vis class="kbn-vis-value" vis-id="'Wazuh-App-Overview-OSCAP-Latest-alert'" id="Wazuh-App-Overview-OSCAP-Latest-alert"></kbn-vis>
+                    <kbn-vis class="kbn-vis-value" vis-id="'Wazuh-App-Overview-OSCAP-Latest-alert'"></kbn-vis>
                 </md-card-content>
             </md-card>
         </div>
@@ -101,7 +101,7 @@
             <md-card flex>
                 <md-card-content class="wazuh-column">
                     <span class="md-headline">Alerts summary</span>
-                    <kbn-vis class="kbn-chart" vis-id="'Wazuh-App-Overview-OSCAP-Last-alerts'" id="Wazuh-App-Overview-OSCAP-Last-alerts"></kbn-vis>
+                    <kbn-vis class="kbn-chart" vis-id="'Wazuh-App-Overview-OSCAP-Last-alerts'"></kbn-vis>
                 </md-card-content>
             </md-card>
         </div>

--- a/public/templates/overview/overview-pci.html
+++ b/public/templates/overview/overview-pci.html
@@ -20,7 +20,7 @@
             <md-card flex>
                 <md-card-content class="wazuh-column">
                     <span class="md-headline">Last alerts</span>
-                    <kbn-vis vis-id="'Wazuh-App-Overview-PCI-DSS-Requirements-heatmap'" id="Wazuh-App-Overview-PCI-DSS-Requirements-heatmap"></kbn-vis>
+                    <kbn-vis vis-id="'Wazuh-App-Overview-PCI-DSS-Requirements-heatmap'"></kbn-vis>
                 </md-card-content>
             </md-card>
         </div>
@@ -29,13 +29,13 @@
             <md-card flex="70">
                 <md-card-content class="wazuh-column">
                     <span class="md-headline">Requirements</span>
-                    <kbn-vis vis-id="'Wazuh-App-Overview-PCI-DSS-requirements'" id="Wazuh-App-Overview-PCI-DSS-requirements"></kbn-vis>
+                    <kbn-vis vis-id="'Wazuh-App-Overview-PCI-DSS-requirements'"></kbn-vis>
                 </md-card-content>
             </md-card>
             <md-card flex="30">
                 <md-card-content class="wazuh-column">
                     <span class="md-headline">Groups</span>
-                    <kbn-vis vis-id="'Wazuh-App-Overview-PCI-DSS-Groups'" id="Wazuh-App-Overview-PCI-DSS-Groups"></kbn-vis>
+                    <kbn-vis vis-id="'Wazuh-App-Overview-PCI-DSS-Groups'"></kbn-vis>
                 </md-card-content>
             </md-card>
         </div>
@@ -44,13 +44,13 @@
             <md-card flex="30">
                 <md-card-content class="wazuh-column">
                     <span class="md-headline">Agents</span>
-                    <kbn-vis vis-id="'Wazuh-App-Overview-PCI-DSS-Agents'" id="Wazuh-App-Overview-PCI-DSS-Agents"></kbn-vis>
+                    <kbn-vis vis-id="'Wazuh-App-Overview-PCI-DSS-Agents'"></kbn-vis>
                 </md-card-content>
             </md-card>
             <md-card flex="70">
                 <md-card-content class="wazuh-column">
                     <span class="md-headline">Requirements by agent</span>
-                    <kbn-vis vis-id="'Wazuh-App-Overview-PCI-DSS-Requirements-by-agent'" id="Wazuh-App-Overview-PCI-DSS-Requirements-by-agent"></kbn-vis>
+                    <kbn-vis vis-id="'Wazuh-App-Overview-PCI-DSS-Requirements-by-agent'"></kbn-vis>
                 </md-card-content>
             </md-card>
         </div>
@@ -59,7 +59,7 @@
             <md-card flex>
                 <md-card-content class="wazuh-column">
                     <span class="md-headline">Alerts summary</span>
-                    <kbn-vis class="kbn-chart" vis-id="'Wazuh-App-Overview-PCI-DSS-Last-alerts'" id="Wazuh-App-Overview-PCI-DSS-Last-alerts"></kbn-vis>
+                    <kbn-vis class="kbn-chart" vis-id="'Wazuh-App-Overview-PCI-DSS-Last-alerts'"></kbn-vis>
                 </md-card-content>
             </md-card>
         </div>

--- a/public/templates/overview/overview-pm.html
+++ b/public/templates/overview/overview-pm.html
@@ -7,21 +7,21 @@
             <md-card flex="50">
                 <md-card-content class="wazuh-column">
                     <span class="md-headline">Events over time</span>
-                    <kbn-vis vis-id="'Wazuh-App-Overview-PM-Events-over-time'" id="Wazuh-App-Overview-PM-Events-over-time"></kbn-vis>
+                    <kbn-vis vis-id="'Wazuh-App-Overview-PM-Events-over-time'"></kbn-vis>
                 </md-card-content>
             </md-card>
 
             <md-card flex="25">
                 <md-card-content class="wazuh-column">
                     <span class="md-headline">Top 5 CIS Requirements</span>
-                    <kbn-vis vis-id="'Wazuh-App-Overview-PM-Top-5-CIS-requirements'" id="Wazuh-App-Overview-PM-Top-5-CIS-requirements"></kbn-vis>
+                    <kbn-vis vis-id="'Wazuh-App-Overview-PM-Top-5-CIS-requirements'"></kbn-vis>
                 </md-card-content>
             </md-card>
 
             <md-card flex="25">
                 <md-card-content class="wazuh-column">
                     <span class="md-headline">Top 5 PCI DSS Requirements</span>
-                    <kbn-vis vis-id="'Wazuh-App-Overview-PM-Top-5-PCI-DSS-requirements'" id="Wazuh-App-Overview-PM-Top-5-PCI-DSS-requirements"></kbn-vis>
+                    <kbn-vis vis-id="'Wazuh-App-Overview-PM-Top-5-PCI-DSS-requirements'"></kbn-vis>
                 </md-card-content>
             </md-card>
         </div>
@@ -30,7 +30,7 @@
             <md-card flex>
                 <md-card-content class="wazuh-column">
                     <span class="md-headline">Events per agent evolution</span>
-                    <kbn-vis vis-id="'Wazuh-App-Overview-PM-Events-per-agent-evolution'" id="Wazuh-App-Overview-PM-Events-per-agent-evolution"></kbn-vis>
+                    <kbn-vis vis-id="'Wazuh-App-Overview-PM-Events-per-agent-evolution'"></kbn-vis>
                 </md-card-content>
             </md-card>
         </div>
@@ -39,7 +39,7 @@
             <md-card flex>
                 <md-card-content class="wazuh-column">
                     <span class="md-headline">Alerts summary</span>
-                    <kbn-vis class="kbn-chart" vis-id="'Wazuh-App-Overview-PM-Alerts-summary'" id="Wazuh-App-Overview-PM-Alerts-summary"></kbn-vis>
+                    <kbn-vis class="kbn-chart" vis-id="'Wazuh-App-Overview-PM-Alerts-summary'"></kbn-vis>
                 </md-card-content>
             </md-card>
         </div>

--- a/public/templates/overview/overview-virustotal.html
+++ b/public/templates/overview/overview-virustotal.html
@@ -5,7 +5,7 @@
                 <div flex layout="row">
                     <md-card flex>
                         <md-card-content class="wazuh-column">
-                            <kbn-vis class="metric" vis-id="'Wazuh-App-Overview-Virustotal-Total-Malicious'" id="Wazuh-App-Overview-Virustotal-Total-Malicious"></kbn-vis>
+                            <kbn-vis class="metric" vis-id="'Wazuh-App-Overview-Virustotal-Total-Malicious'"></kbn-vis>
                         </md-card-content>
                     </md-card>
 
@@ -15,7 +15,7 @@
 
                     <md-card flex>
                         <md-card-content class="wazuh-column">
-                            <kbn-vis class="metric" vis-id="'Wazuh-App-Overview-Virustotal-Total-Positives'" id="Wazuh-App-Overview-Virustotal-Total-Positives"></kbn-vis>
+                            <kbn-vis class="metric" vis-id="'Wazuh-App-Overview-Virustotal-Total-Positives'"></kbn-vis>
                         </md-card-content>
                     </md-card>
                 </div>
@@ -23,7 +23,7 @@
 
                     <md-card flex>
                         <md-card-content class="wazuh-column">
-                            <kbn-vis class="metric" vis-id="'Wazuh-App-Overview-Virustotal-Total'" id="Wazuh-App-Overview-Virustotal-Total"></kbn-vis>
+                            <kbn-vis class="metric" vis-id="'Wazuh-App-Overview-Virustotal-Total'"></kbn-vis>
                         </md-card-content>
                     </md-card>
                 </div>
@@ -34,7 +34,7 @@
                     <md-card flex>
                         <md-card-content class="wazuh-column">
                             <span class="md-headline">Unique malicious files per agent</span>
-                            <kbn-vis vis-id="'Wazuh-App-Overview-Virustotal-Malicious-Per-Agent'" id="Wazuh-App-Overview-Virustotal-Malicious-Per-Agent"></kbn-vis>
+                            <kbn-vis vis-id="'Wazuh-App-Overview-Virustotal-Malicious-Per-Agent'"></kbn-vis>
                         </md-card-content>
                     </md-card>
                 </div>
@@ -44,7 +44,7 @@
                     <md-card flex>
                         <md-card-content class="wazuh-column">
                             <span class="md-headline">Last scanned files</span>
-                            <kbn-vis vis-id="'Wazuh-App-Overview-Virustotal-Last-Files-Pie'" id="Wazuh-App-Overview-Virustotal-Last-Files-Pie"></kbn-vis>
+                            <kbn-vis vis-id="'Wazuh-App-Overview-Virustotal-Last-Files-Pie'"></kbn-vis>
                         </md-card-content>
                     </md-card>
                 </div>
@@ -56,7 +56,7 @@
             <md-card flex>
                 <md-card-content class="wazuh-column">
                     <span class="md-headline">Top 10 agents with positive scans</span>
-                    <kbn-vis vis-id="'Wazuh-App-Overview-Virustotal-Positives-Heatmap'" id="Wazuh-App-Overview-Virustotal-Positives-Heatmap"></kbn-vis>
+                    <kbn-vis vis-id="'Wazuh-App-Overview-Virustotal-Positives-Heatmap'"></kbn-vis>
                 </md-card-content>
             </md-card>
         </div>
@@ -64,7 +64,7 @@
             <md-card flex>
                 <md-card-content class="wazuh-column">
                     <span class="md-headline">Malicious files alerts evolution</span>
-                    <kbn-vis vis-id="'Wazuh-App-Overview-Virustotal-Malicious-Evolution'" id="Wazuh-App-Overview-Virustotal-Malicious-Evolution"></kbn-vis>
+                    <kbn-vis vis-id="'Wazuh-App-Overview-Virustotal-Malicious-Evolution'"></kbn-vis>
                 </md-card-content>
             </md-card>
         </div>
@@ -72,7 +72,7 @@
             <md-card flex>
                 <md-card-content class="wazuh-column">
                     <span class="md-headline">Last files</span>
-                    <kbn-vis class="kbn-chart" vis-id="'Wazuh-App-Overview-Virustotal-Files-Table'" id="Wazuh-App-Overview-Virustotal-Files-Table"></kbn-vis>
+                    <kbn-vis class="kbn-chart" vis-id="'Wazuh-App-Overview-Virustotal-Files-Table'"></kbn-vis>
                 </md-card-content>
             </md-card>
         </div>

--- a/public/templates/overview/overview-vuls.html
+++ b/public/templates/overview/overview-vuls.html
@@ -6,22 +6,22 @@
         <div layout="row" layout-align="center stretch" class="height-120">
             <md-card flex>
                 <md-card-content class="wazuh-column">
-                    <kbn-vis class="metric" vis-id="'Wazuh-App-Overview-VULS-Metric-Critical-severity'" id="Wazuh-App-Overview-VULS-Metric-Critical-severity"></kbn-vis>
+                    <kbn-vis class="metric" vis-id="'Wazuh-App-Overview-VULS-Metric-Critical-severity'"></kbn-vis>
                 </md-card-content>
             </md-card>
             <md-card flex>
                 <md-card-content class="wazuh-column">
-                    <kbn-vis class="metric" vis-id="'Wazuh-App-Overview-VULS-Metric-High-severity'" id="Wazuh-App-Overview-VULS-Metric-High-severity"></kbn-vis>
+                    <kbn-vis class="metric" vis-id="'Wazuh-App-Overview-VULS-Metric-High-severity'"></kbn-vis>
                 </md-card-content>
             </md-card>
             <md-card flex>
                 <md-card-content class="wazuh-column">
-                    <kbn-vis class="metric" vis-id="'Wazuh-App-Overview-VULS-Metric-Medium-severity'" id="Wazuh-App-Overview-VULS-Metric-Medium-severity"></kbn-vis>
+                    <kbn-vis class="metric" vis-id="'Wazuh-App-Overview-VULS-Metric-Medium-severity'"></kbn-vis>
                 </md-card-content>
             </md-card>
             <md-card flex>
                 <md-card-content class="wazuh-column">
-                    <kbn-vis class="metric" vis-id="'Wazuh-App-Overview-VULS-Metric-Low-severity'" id="Wazuh-App-Overview-VULS-Metric-Low-severity"></kbn-vis>
+                    <kbn-vis class="metric" vis-id="'Wazuh-App-Overview-VULS-Metric-Low-severity'"></kbn-vis>
                 </md-card-content>
             </md-card>
         </div>
@@ -30,7 +30,7 @@
             <md-card flex>
                 <md-card-content class="wazuh-column">
                     <span class="md-headline">Alerts severity over time</span>
-                    <kbn-vis vis-id="'Wazuh-App-Overview-VULS-Alerts-severity-over-time'" id="Wazuh-App-Overview-VULS-Alerts-severity-over-time"></kbn-vis>
+                    <kbn-vis vis-id="'Wazuh-App-Overview-VULS-Alerts-severity-over-time'"></kbn-vis>
                 </md-card-content>
             </md-card>
         </div>
@@ -39,13 +39,13 @@
             <md-card flex="60">
                 <md-card-content class="wazuh-column">
                     <span class="md-headline">Top Agents severity</span>
-                    <kbn-vis vis-id="'Wazuh-App-Overview-VULS-Top-Agents-severity'" id="Wazuh-App-Overview-VULS-Top-Agents-severity"></kbn-vis>
+                    <kbn-vis vis-id="'Wazuh-App-Overview-VULS-Top-Agents-severity'"></kbn-vis>
                 </md-card-content>
             </md-card>
             <md-card flex="40">
                 <md-card-content class="wazuh-column">
                     <span class="md-headline">Affected packages - Top 5</span>
-                    <kbn-vis vis-id="'Wazuh-App-Overview-VULS-Top-5-affected-packages'" id="Wazuh-App-Overview-VULS-Top-5-affected-packages"></kbn-vis>
+                    <kbn-vis vis-id="'Wazuh-App-Overview-VULS-Top-5-affected-packages'"></kbn-vis>
                 </md-card-content>
             </md-card>
         </div>
@@ -54,7 +54,7 @@
             <md-card flex>
                 <md-card-content class="wazuh-column">
                     <span class="md-headline">Alerts summary</span>
-                    <kbn-vis class="kbn-chart" vis-id="'Wazuh-App-Overview-VULS-Alerts-summary'" id="Wazuh-App-Overview-VULS-Alerts-summary"></kbn-vis>
+                    <kbn-vis class="kbn-chart" vis-id="'Wazuh-App-Overview-VULS-Alerts-summary'"></kbn-vis>
                 </md-card-content>
             </md-card>
         </div>


### PR DESCRIPTION
- Hi team this PR makes a little fix on the visualization directive and now it's no longer neccessary the `id` field when using a `kbn-vis` element.
- Also all `kbn-vis` elements have no `id` field now.