### PR TITLE
Added complete group config to JSON viewer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 ## Wazuh v3.2.0 - Kibana v6.2.2 - Revision 385
 ### Fixed
 - Fixed wrong data flow on *Agents/General* when coming from and going to the *Groups* tab ([#273](https://github.com/wazuh/wazuh-kibana-app/pull/273)).
+- Fixed bug on the *Agent configuration* JSON viewer who didn't properly SHOW the full group configuration ([#276](https://github.com/wazuh/wazuh-kibana-app/pull/276)).
 
 ## Wazuh v3.2.0 - Kibana v6.2.2 - Revision 384
 ### Added

--- a/public/controllers/agents.js
+++ b/public/controllers/agents.js
@@ -314,7 +314,7 @@ function ($scope, $location, $q, $rootScope, appState, genericReq, apiReq, Agent
 
             data                      = await apiReq.request('GET', `/agents/groups/${$scope.groupName}/configuration`, {});
             $scope.groupConfiguration = data.data.data.items[0];
-            $scope.rawJSON            = beautifier.prettyPrint($scope.groupConfiguration);
+            $scope.rawJSON            = beautifier.prettyPrint(data.data.data.items);
 
             data = await Promise.all([
                 apiReq.request('GET', `/agents/groups?search=${$scope.groupName}`, {}),


### PR DESCRIPTION
Hello all,

This PR will add the **complete JSON output** from the API when requesting the group configuration data. Previously, it only showed the first one, when no filters were applied.

This will help to see if more configuration is available through the JSON viewer until we finally decide the functionality of the `Agent configuration` tab.

![agents](https://user-images.githubusercontent.com/10928321/36662655-5dbcf246-1adf-11e8-80b0-52d8d8928c32.PNG)

Regards,
Juanjo
