### PR TITLE
3.2 internal indices config

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -51,8 +51,8 @@
 #--------------------- Indices configuration ------------------------------------
 #
 # Configure .wazuh and .wazuh-version indices shards and replicas
-#wazuh.shards              : 3
-#wazuh.replicas            : 7
-#wazuh-version.shards      : 9
-#wazuh-version.replicas    : 6
+#wazuh.shards              : 1
+#wazuh.replicas            : 1
+#wazuh-version.shards      : 1
+#wazuh-version.replicas    : 1
 #

--- a/config.yml
+++ b/config.yml
@@ -46,3 +46,13 @@
 # Default value is 8000. It will be ignored if it is bellow 1500.
 # It means milliseconds before we consider a request as failed.
 #timeout: 4000
+#
+#
+#--------------------- Indices configuration ------------------------------------
+#
+# Configure .wazuh and .wazuh-version indices shards and replicas
+#wazuh.shards              : 3
+#wazuh.replicas            : 7
+#wazuh-version.shards      : 9
+#wazuh-version.replicas    : 6
+#


### PR DESCRIPTION
Hello,

this PR adds the possibility to use different shard and replica configuration for both .wazuh and .wazuh-version indices.

This are the options in the config.yml file:
```
#--------------------- Indices configuration ------------------------------------
#
# Configure .wazuh and .wazuh-version indices shards and replicas
#wazuh.shards              : 1
#wazuh.replicas            : 1
#wazuh-version.shards      : 1
#wazuh-version.replicas    : 1
```
Keep in mind that for it to work, the configuration file must be appropriately edited prior app installation.

Regards.