### PR TITLE
Query filter patch

### DIFF
--- a/public/controllers/agents.js
+++ b/public/controllers/agents.js
@@ -175,7 +175,16 @@ app.controller('agentsController',
             }
         }
 
-        $scope.getAgent = async newAgentId => {
+        /** Prevents from double agent and come from autocomplete */
+        let lastAgent = null;
+        const checkDouble = id => {
+            if(lastAgent && lastAgent !== id){
+                $rootScope.agentsAutoCompleteFired = true;
+                if(!$rootScope.$$phase) $rootScope.$digest();
+            }            
+        }
+
+        $scope.getAgent = async (newAgentId,fromAutocomplete) => {
             try {
                 if($scope.tab === 'configuration'){
                     return $scope.getAgentConfig(newAgentId);
@@ -185,12 +194,15 @@ app.controller('agentsController',
                 // They passed an id
                 if (newAgentId) {
                     id = newAgentId;
+                    checkDouble(id);
                     $location.search('agent', id);
                 } else {
                     if ($location.search().agent && !$rootScope.globalAgent) { // There's one in the url
                         id = $location.search().agent;
+                        checkDouble(id);
                     } else { // We pick the one in the rootScope
                         id = $rootScope.globalAgent;
+                        checkDouble(id);
                         $location.search('agent', id);
                         delete $rootScope.globalAgent;
                     }
@@ -209,7 +221,7 @@ app.controller('agentsController',
 
                 // Agent
                 $scope.agent = data[0].data.data;
-
+                lastAgent    = data[0].data.data.id;
                 if ($scope.agent.os) {
                     $scope.agentOS = $scope.agent.os.name + ' ' + $scope.agent.os.version;
                 }

--- a/public/kibana-integrations/kibana-discover.js
+++ b/public/kibana-integrations/kibana-discover.js
@@ -332,15 +332,25 @@ function discoverController(
             ////////////////////////////////////////////////////////////////////////////
             
             /** Start of "Prevents from double agent" */
-            let agentsIncluded = [];
-            queryFilter.getFilters().filter(item => {
-                if(typeof item.query.match['agent.id'] !== 'undefined') agentsIncluded.push(item);
-            });
-            if(agentsIncluded.length > 1) {
-                const lastAgent = agentsIncluded.pop();
-                agentsIncluded.filter(item => queryFilter.removeFilter(item));
-                queryFilter.addFilters(lastAgent);
-                agentsIncluded = [];
+            if($rootScope.agentsAutoCompleteFired){
+              let agentsIncluded = [];
+              // Get all filters related to agent.id and store them on an array
+              queryFilter.getFilters().filter(item => {
+                  if(typeof item.query.match['agent.id'] !== 'undefined') agentsIncluded.push(item);
+              });
+              // If the array has a length greater than 1 it means that there are more than one agent.id filter
+              if(agentsIncluded.length > 1) {
+                  // Keep safe the last agent.id filter
+                  const lastAgent = agentsIncluded.pop();
+                  // Remove all the agent.id filters
+                  agentsIncluded.filter(item => queryFilter.removeFilter(item));
+                  // Add the safe kept agent.id filter
+                  queryFilter.addFilters(lastAgent);
+                  // Clear the temporary array
+                  agentsIncluded = [];
+              }
+              $rootScope.agentsAutoCompleteFired = false;
+              if(!$rootScope.$$phase) $rootScope.$digest();
             }
             /** End of "Prevents from double agent" */
 
@@ -940,7 +950,7 @@ function discoverController(
           );
         }
       }
-      
+
       queryFilter.addFilters(implicitFilter);
     }
   }

--- a/public/kibana-integrations/kibana-discover.js
+++ b/public/kibana-integrations/kibana-discover.js
@@ -330,6 +330,20 @@ function discoverController(
             ////////////////////////////////////////////////////////////////////////////
             ///////////////////////////////  WAZUH   ///////////////////////////////////
             ////////////////////////////////////////////////////////////////////////////
+            
+            /** Start of "Prevents from double agent" */
+            let agentsIncluded = [];
+            queryFilter.getFilters().filter(item => {
+                if(typeof item.query.match['agent.id'] !== 'undefined') agentsIncluded.push(item);
+            });
+            if(agentsIncluded.length > 1) {
+                const lastAgent = agentsIncluded.pop();
+                agentsIncluded.filter(item => queryFilter.removeFilter(item));
+                queryFilter.addFilters(lastAgent);
+                agentsIncluded = [];
+            }
+            /** End of "Prevents from double agent" */
+
             $rootScope.discoverPendingUpdates = [];
             $rootScope.discoverPendingUpdates.push($state.query, queryFilter.getFilters());
             $rootScope.$broadcast('updateVis', $state.query, queryFilter.getFilters());
@@ -926,7 +940,7 @@ function discoverController(
           );
         }
       }
-
+      
       queryFilter.addFilters(implicitFilter);
     }
   }

--- a/public/templates/agents/agents.head
+++ b/public/templates/agents/agents.head
@@ -23,7 +23,7 @@
 					md-no-cache="true"
 					md-select-on-match="false"
 					md-selected-item="_swpagent"
-					md-selected-item-change="getAgent(_swpagent.id)"
+					md-selected-item-change="getAgent(_swpagent.id,true)"
 					md-search-text="searchTerm"
 					md-items="agentAutoComplete in analizeAgents(searchTerm)"
 					md-item-text="agentAutoComplete.name"


### PR DESCRIPTION
Hello team, this pull request prevents double agent.id filter on agents tab. If you go to the agents tab and go into an agent and then change the agent, the agents are accumulated, it's wrong, now it's fixed. Read the code comments bellow for a better understanding.

