### PR TITLE
New Manager/Configuration redesign

### DIFF
--- a/public/less/kbn.less
+++ b/public/less/kbn.less
@@ -170,8 +170,10 @@ kbn-dis .euiText {
     color: #FFF !important;
 }
 
+.kuiLocalSearchInput,
 .kuiLocalSearchInput:focus {
-    box-shadow: none !important;
+    box-shadow: 0 2px 2px -1px rgba(0, 0, 0, 0.1) !important;
+    border: 1px solid #D9D9D9 !important;
 }
 
 /* Small fix for undesired bold in Discover, caused by Bootstrap import */

--- a/public/templates/agents/agents-configuration.html
+++ b/public/templates/agents/agents-configuration.html
@@ -37,7 +37,7 @@
             <md-card flex>
                 <div layout="row" class="md-padding">
                     <h1 flex="90" ng-show="!load" class="md-title">Current group:
-                        <span ng-click="goGroup()" class="agents-head-5 blue">{{groupName}}<md-tooltip md-direction="bottom">Click to go to the group details</md-tooltip></span>
+                        <span ng-click="goGroup()" class="agents-head-5 blue cursor-pointer">{{groupName}}<md-tooltip md-direction="bottom">Click to go to the group details</md-tooltip></span>
                         &nbsp;&ndash;&nbsp;Configuration status:
                         <span ng-class="isSynchronized ? 'green' : 'red'" class="agents-head-5">{{isSynchronized ? 'SYNCHRONIZED' : 'NOT SYNCHRONIZED'}}</span>
                     </h1>

--- a/public/templates/manager/manager-configuration.html
+++ b/public/templates/manager/manager-configuration.html
@@ -87,31 +87,17 @@
                     </span>
                     <md-divider></md-divider>
                     <!-- Summary -->
-                    <div layout="row" ng-if="managerConfiguration.rootcheck.scanall">
-                        <p class="manager-status-subtitle">Scan all</p>
-                        <p class="text-right color-grey">{{managerConfiguration.rootcheck.scanall}}</p>
-                    </div>
                     <div layout="row" ng-if="managerConfiguration.rootcheck.frequency">
                         <p class="manager-status-subtitle">Frequency</p>
                         <p class="text-right color-grey">{{managerConfiguration.rootcheck.frequency}}</p>
                     </div>
+                    <div layout="row" ng-if="managerConfiguration.rootcheck.skip_nfs">
+                        <p class="manager-status-subtitle">Skip NFS</p>
+                        <p class="text-right color-grey">{{managerConfiguration.rootcheck.skip_nfs}}</p>
+                    </div>
                 </md-card-content>
             </md-card>
             <!-- END ROOTCHECK -->
-
-            <!-- RULESET -->
-            <md-card flex class="no-margin-left" ng-if="managerConfiguration.ruleset">
-                <md-card-content>
-                    <!-- Section title -->
-                    <span class="md-headline cursor-pointer" ng-click="switchItem('ruleset')">
-                        Ruleset <i class="fa fa-eye"></i>
-                        <md-tooltip md-direction="right">Click to see more details</md-tooltip>
-                    </span>
-                    <md-divider></md-divider>
-                    <p class="manager-status-subtitle">Ruleset settings</p>
-                </md-card-content>
-            </md-card>
-            <!-- END RULESET -->
 
             <!-- LOGCOLLECTOR -->
             <md-card flex class="no-margin-left" ng-if="managerConfiguration.logcollector">
@@ -170,6 +156,20 @@
                 </md-card-content>
             </md-card>
             <!-- END AUTH -->
+
+            <!-- RULESET -->
+            <md-card flex class="no-margin-left" ng-if="managerConfiguration.ruleset">
+                <md-card-content>
+                    <!-- Section title -->
+                    <span class="md-headline cursor-pointer" ng-click="switchItem('ruleset')">
+                        Ruleset <i class="fa fa-eye"></i>
+                        <md-tooltip md-direction="right">Click to see more details</md-tooltip>
+                    </span>
+                    <md-divider></md-divider>
+                    <p class="manager-status-subtitle">Ruleset settings</p>
+                </md-card-content>
+            </md-card>
+            <!-- END RULESET -->
 
             <!-- COMMAND -->
             <md-card flex class="no-margin-left" ng-if="managerConfiguration.command">

--- a/public/templates/manager/manager-configuration.html
+++ b/public/templates/manager/manager-configuration.html
@@ -5,711 +5,781 @@
         <div></div>
     </div>
 
-    <div flex layout="column" ng-show="!load" layout-align="start stretch">
-        <div layout="row" flex>
-            <md-card flex>
+    <!-- The section container -->
+    <div flex layout="row" layout-align="start stretch" class="md-padding" ng-show="!load"  ng-init="selectedItem='global'">
+
+        <!-- Left column - Configuration summary and section links -->
+        <div flex="25">
+
+            <!-- GLOBAL -->
+            <md-card flex class="no-margin-left" ng-if="managerConfiguration.global">
                 <md-card-content>
-                    <div layout="row">
-                        <div layout="column" flex="15" ng-init="selectedItem='global'">
-                            <!-- Selecting a configuration -->
-                            <div flex layout="row" class="md-padding ">
-                                <div flex>
-                                    <h4>
-                                        <i class="fa fa-reorder"></i> Section
-                                    </h4>
-                                    <md-divider></md-divider>
-
-                                    <p ng-if="managerConfiguration.global">
-                                        <a ng-class="selectedItem === 'global' ? 'underline-config' : ''" ng-click="switchItem('global')">
-                                            Global
-                                        </a>
-                                    </p>
-                                    <p ng-if="managerConfiguration.email_alerts">
-                                        <a ng-class="selectedItem === 'email_alerts' ? 'underline-config' : ''" ng-click="switchItem('email_alerts')">
-                                            E-mail alerts
-                                        </a>
-                                    </p>
-                                    <p ng-if="managerConfiguration.remote">
-                                        <a ng-class="selectedItem === 'remote' ? 'underline-config' : ''" ng-click="switchItem('remote')">
-                                            Remote
-                                        </a>
-                                    </p>
-                                    <p ng-if="managerConfiguration.cluster">
-                                        <a ng-class="selectedItem === 'cluster' ? 'underline-config' : ''" ng-click="switchItem('cluster')">
-                                            Cluster
-                                        </a>
-
-                                    </p>
-                                    <p ng-if="managerConfiguration.auth">
-                                        <a ng-class="selectedItem === 'auth' ? 'underline-config' : ''" ng-click="switchItem('auth')">
-                                            Auth
-                                        </a>
-                                    </p>
-                                    <p ng-if="managerConfiguration.command">
-                                        <a ng-class="selectedItem === 'command' ? 'underline-config' : ''" ng-click="switchItem('command')">
-                                            Command
-                                        </a>
-                                    </p>
-                                    <p ng-if="managerConfiguration.syscheck">
-                                        <a ng-class="selectedItem === 'syscheck' ? 'underline-config' : ''" ng-click="switchItem('syscheck')">
-                                            Syscheck
-                                        </a>
-                                    </p>
-                                    <p ng-if="managerConfiguration.rootcheck">
-                                        <a ng-class="selectedItem === 'rootcheck' ? 'underline-config' : ''" ng-click="switchItem('rootcheck')">
-                                            Rootcheck
-                                        </a>
-                                    </p>
-                                    <p ng-if="managerConfiguration.ruleset">
-                                        <a ng-class="selectedItem === 'ruleset' ? 'underline-config' : ''" ng-click="switchItem('ruleset')">
-                                            Ruleset
-                                        </a>
-                                    </p>
-                                    <p ng-if="managerConfiguration.logcollector">
-                                        <a ng-class="selectedItem === 'logcollector' ? 'underline-config' : ''" ng-click="switchItem('logcollector')">
-                                            Logcollector
-                                        </a>
-                                    </p>
-                                    <!--<p ng-if="managerConfiguration['open-scap']">
-                                        <a ng-class="selectedItem === 'open-scap' ? 'underline-config' : ''" ng-click="switchItem('open-scap')">
-                                            OpenSCAP
-                                        </a>
-                                    </p>-->
-                                    <p ng-if="managerConfiguration['active-response'].length > 0">
-                                        <a ng-class="selectedItem === 'active-response' ? 'underline-config' : ''" ng-click="switchItem('active-response')">
-                                            Active response
-                                        </a>
-                                    </p>
-                                </div>
-                            </div>
-                        </div>
-
-                        <!-- Global -->
-                        <div layout="column" flex class="ownNavBarCluster topPaddingSearchNoBottom" ng-show="selectedItem==='global'">
-                            <div flex layout="row" class="md-padding">
-                                <div flex="60">
-                                    <h4>
-                                        <i class="fa fa-dashboard"></i> Global</h4>
-                                    <md-divider></md-divider>
-                                    <p ng-if="managerConfiguration.global.white_list">
-                                        JSON output
-                                        <span ng-class="managerConfiguration.global.jsonout_output === 'no' ? 'wazuh-greyed' : ''" class="md-secondary pull-right">{{managerConfiguration.global.jsonout_output}}</span>
-                                    </p>
-                                    <p ng-if="managerConfiguration.global.logall">
-                                        Log all
-                                        <span ng-class="managerConfiguration.global.logall === 'no' ? 'wazuh-greyed' : ''" class="md-secondary pull-right">{{managerConfiguration.global.logall}}
-                                        </span>
-                                    </p>
-                                    <p ng-if="managerConfiguration.global.logall">
-                                        Log all in JSON
-                                        <span ng-class="managerConfiguration.global.logall_json === 'no' ? 'wazuh-greyed' : ''" class="md-secondary pull-right">{{managerConfiguration.global.logall_json}}
-                                        </span>
-                                    </p>
-                                    <p ng-if="managerConfiguration.global.white_list">
-                                        White list
-                                        <span class="md-secondary pull-right">{{ managerConfiguration.global.white_list.length
-                                            <=5 ? managerConfiguration.global.white_list : managerConfiguration.global.white_list.length }} </span>
-                                    </p>
-                                    <p ng-if="managerConfiguration.global.stats">
-                                        Stats
-                                        <span class="md-secondary pull-right">{{ managerConfiguration.global.stats }}
-                                        </span>
-                                    </p>
-                                    <p ng-if="managerConfiguration.global.host_infomation">
-                                        Host information
-                                        <span class="md-secondary pull-right">{{ managerConfiguration.global.host_infomation }}
-                                        </span>
-                                    </p>
-                                    <p ng-if="managerConfiguration.alerts.log_alert_level">
-                                        Log alert level
-                                        <span class="md-secondary pull-right">{{ managerConfiguration.alerts.log_alert_level }}
-                                        </span>
-                                    </p>
-                                    <p ng-if="managerConfiguration.global.email_notification">
-                                        E-mail notifications
-                                        <span ng-class="managerConfiguration.global.email_notification === 'no' ? 'wazuh-greyed' : ''" class="md-secondary pull-right">{{ managerConfiguration.global.email_notification }}
-                                        </span>
-                                    </p>
-                                    <p ng-if="managerConfiguration.global.email_alert_level">
-                                        E-mail alert level
-                                        <span class="md-secondary pull-right">{{ managerConfiguration.global.email_alert_level }}
-                                        </span>
-                                    </p>
-                                    <p ng-if="managerConfiguration.global.email_to">
-                                        E-mail to
-                                        <span class="md-secondary pull-right">{{ managerConfiguration.global.email_to }}
-                                        </span>
-                                    </p>
-                                    <p ng-if="managerConfiguration.global.email_from">
-                                        E-mail from
-                                        <span class="md-secondary pull-right">{{ managerConfiguration.global.email_from }}
-                                        </span>
-                                    </p>
-                                    <p ng-if="managerConfiguration.global.smtp_server">
-                                        SMTP server
-                                        <span class="md-secondary pull-right">{{ managerConfiguration.global.smtp_server }}
-                                        </span>
-                                    </p>
-                                    <p ng-if="managerConfiguration.global.email_maxperhour">
-                                        Max email per hour
-                                        <span class="md-secondary pull-right">{{ managerConfiguration.global.email_maxperhour }}</span>
-                                    </p>
-                                    <p ng-if="managerConfiguration.global.email_idsname">
-                                        E-mail IDS name
-                                        <span class="md-secondary pull-right">{{ managerConfiguration.global.email_idsname }}
-                                        </span>
-                                    </p>
-                                </div>
-                                <div flex></div>
-                            </div>
-                        </div>
-                        <!-- End global -->
-
-                        <!-- E-mail alerts -->
-                        <div layout="column" flex class="ownNavBarCluster topPaddingSearchNoBottom" ng-show="selectedItem==='email_alerts'">
-                            <div flex layout="row" class="md-padding">
-                                <div flex="60">
-                                    <h4>
-                                        <i class="fa fa-envelope-o"></i> E-mail alerts</h4>
-                                    <md-divider></md-divider>
-                                    <p ng-if="managerConfiguration.email_alerts.email_to">
-                                        Email to
-                                        <span class="md-secondary pull-right">{{ managerConfiguration.email_alerts.email_to }}
-                                        </span>
-                                    </p>
-                                    <p ng-if="managerConfiguration.email_alerts.level">
-                                        Alert level
-                                        <span class="md-secondary pull-right">{{ managerConfiguration.email_alerts.level }}
-                                        </span>
-                                    </p>
-                                    <p ng-if="managerConfiguration.email_alerts.group">
-                                        Group
-                                        <span class="md-secondary pull-right">{{ managerConfiguration.email_alerts.group }}
-                                        </span>
-                                    </p>
-                                    <p ng-if="managerConfiguration.email_alerts.event_location">
-                                        Event location
-                                        <span class="md-secondary pull-right">{{ managerConfiguration.email_alerts.event_location }}
-                                        </span>
-                                    </p>
-                                    <p ng-if="managerConfiguration.email_alerts.format">
-                                        Format
-                                        <span class="md-secondary pull-right">{{ managerConfiguration.email_alerts.format }}
-                                        </span>
-                                    </p>
-                                    <p ng-if="managerConfiguration.email_alerts.rule_id">
-                                        Rule ID
-                                        <span class="md-secondary pull-right">{{ managerConfiguration.email_alerts.rule_id }}
-                                        </span>
-                                    </p>
-                                    <p ng-if="managerConfiguration.email_alerts.do_not_delay">
-                                        Do not delay
-                                        <span class="md-secondary pull-right">{{ managerConfiguration.email_alerts.do_not_delay }}
-                                        </span>
-                                    </p>
-                                    <p ng-if="managerConfiguration.email_alerts.do_not_group">
-                                        Do not group
-                                        <span class="md-secondary pull-right">{{ managerConfiguration.email_alerts.do_not_group }}
-                                        </span>
-                                    </p>
-                                </div>
-                            </div>
-                        </div>
-                        <!-- End e-mail alerts -->
-
-                        <!-- Remote -->
-                        <div layout="column" flex class="ownNavBarCluster topPaddingSearchNoBottom" ng-show="selectedItem==='remote'">
-                            <div flex layout="row" class="md-padding">
-                                <div flex="60">
-                                    <h4>
-                                        <i class="fa fa-feed"></i> Remote</h4>
-                                    <md-divider></md-divider>
-                                    <div ng-repeat="item in managerConfiguration.remote">
-                                        <p>
-                                            Connection
-                                            <span class="md-secondary pull-right">{{item.connection}}</span>
-                                        </p>
-                                        <p>
-                                            Port
-                                            <span class="md-secondary pull-right">{{item.port}}</span>
-                                        </p>
-                                        <p>
-                                            Protocol
-                                            <span class="md-secondary pull-right">{{item.protocol}}</span>
-                                        </p>
-                                        <md-divider ng-if="!$last"></md-divider>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                        <!-- End remote -->
-
-                        <!-- Cluster -->
-                        <div layout="column" flex class="ownNavBarCluster topPaddingSearchNoBottom" ng-show="selectedItem==='cluster'">
-                            <div flex layout="row" class="md-padding">
-                                <div flex="60">
-                                    <h4>
-                                        <i class="fa fa-server"></i> Cluster</h4>
-                                    <md-divider></md-divider>
-                                    <p>
-                                        Name
-                                        <span class="md-secondary pull-right">{{managerConfiguration.cluster.name}}</span>
-                                    </p>
-                                    <p>
-                                        Interval
-                                        <span class="md-secondary pull-right">{{managerConfiguration.cluster.interval}}</span>
-                                    </p>
-                                    <p>
-                                        Node name
-                                        <span class="md-secondary pull-right">{{managerConfiguration.cluster.node_name}}</span>
-                                    </p>
-                                    <p>
-                                        Bind address
-                                        <span class="md-secondary pull-right">{{managerConfiguration.cluster.bind_addr}}</span>
-                                    </p>
-                                    <p>
-                                        Node type
-                                        <span class="md-secondary pull-right">{{managerConfiguration.cluster.node_type}}</span>
-                                    </p>
-                                    <p>
-                                        Nodes
-                                        <span class="md-secondary pull-right">{{managerConfiguration.cluster.nodes}}</span>
-                                    </p>
-                                    <p>
-                                        Port
-                                        <span class="md-secondary pull-right">{{managerConfiguration.cluster.port}}</span>
-                                    </p>
-                                </div>
-                            </div>
-                        </div>
-                        <!-- End cluster -->
-
-                        <!-- Syscheck -->
-                        <div layout="column" flex class="ownNavBarCluster topPaddingSearchNoBottom" ng-show="selectedItem==='syscheck'">
-                            <div flex layout="row" class="md-padding">
-                                <div ng-class="managerConfiguration.syscheck.disabled === 'yes' ? 'wazuh-greyed' : ''" flex="60">
-                                    <h4>
-                                        <i class="fa fa-shield"></i> Syscheck</h4>
-                                    <md-divider></md-divider>
-                                    <p>
-                                        Syscheck disabled
-                                        <span ng-class="managerConfiguration.syscheck.disabled === 'yes' ? 'wazuh-greyed' : ''" class="md-secondary pull-right">{{managerConfiguration.syscheck.disabled}}</span>
-                                    </p>
-                                    <p>
-                                        Frequency
-                                        <span class="md-secondary pull-right">{{managerConfiguration.syscheck.frequency}}</span>
-                                    </p>
-                                    <p ng-if="managerConfiguration.syscheck.scan_time">
-                                        Scan time
-                                        <span class="md-secondary pull-right">{{managerConfiguration.syscheck.scan_time}}</span>
-                                    </p>
-                                    <p ng-if="managerConfiguration.syscheck.scan_day">
-                                        Scan day
-                                        <span class="md-secondary pull-right">{{managerConfiguration.syscheck.scan_day}}</span>
-                                    </p>
-                                    <p>
-                                        Auto ignore
-                                        <span ng-class="managerConfiguration.syscheck.auto_ignore === 'no' ? 'wazuh-greyed' : ''" class="md-secondary pull-right">{{managerConfiguration.syscheck.auto_ignore}}</span>
-                                    </p>
-                                    <p>
-                                        Alert new files
-                                        <span ng-class="managerConfiguration.syscheck.alert_new_files === 'no' ? 'wazuh-greyed' : ''" class="md-secondary pull-right">{{managerConfiguration.syscheck.alert_new_files}}</span>
-                                    </p>
-                                    <p>
-                                        Scan on start
-                                        <span ng-class="managerConfiguration.syscheck.scan_on_start === 'no' ? 'wazuh-greyed' : ''" class="md-secondary pull-right">{{managerConfiguration.syscheck.scan_on_start}}</span>
-                                    </p>
-                                    <p>
-                                        No diff
-                                        <span class="md-secondary pull-right">{{managerConfiguration.syscheck.nodiff}}</span>
-                                    </p>
-                                    <p>
-                                        Skip NFS
-                                        <span ng-class="managerConfiguration.syscheck.skip_nfs === 'no' ? 'wazuh-greyed' : ''" class="md-secondary pull-right">{{managerConfiguration.syscheck.skip_nfs}}</span>
-                                    </p>
-                                    <br>
-                                    <h4>
-                                        <i class="fa fa-folder-o"></i> Monitoring directories</h4>
-                                    <md-divider></md-divider>
-                                    <div ng-repeat="item in managerConfiguration.syscheck.directories">
-                                        <p>
-                                            Path
-                                            <span class="md-secondary pull-right">{{item.path}}</span>
-                                        </p>
-                                        <p>
-                                            Check all
-                                            <span ng-class="item.check_all === 'no' ? 'wazuh-greyed' : ''" class="md-secondary pull-right">{{item.check_all}}</span>
-                                        </p>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                        <!-- End syscheck -->
-
-                        <!-- Rootcheck -->
-                        <div layout="column" flex class="ownNavBarCluster topPaddingSearchNoBottom" ng-show="selectedItem==='rootcheck'">
-                            <div flex layout="row" class="md-padding">
-                                <div ng-class="managerConfiguration.rootcheck.disabled === 'yes' ? 'wazuh-greyed' : ''" flex="60">
-                                    <h4>
-                                        <i class="fa fa-check"></i> Rootcheck</h4>
-                                    <md-divider></md-divider>
-                                    <p>
-                                        Rootcheck disabled
-                                        <span ng-class="managerConfiguration.rootcheck.disabled === 'yes' ? 'wazuh-greyed' : ''" class="md-secondary pull-right">{{managerConfiguration.rootcheck.disabled}}</span>
-                                    </p>
-                                    <p>
-                                        Rootkit files
-                                        <span class="md-secondary pull-right">{{managerConfiguration.rootcheck.rootkit_files}}</span>
-                                    </p>
-                                    <p>
-                                        Rootkit trojans
-                                        <span class="md-secondary pull-right">{{managerConfiguration.rootcheck.rootkit_trojans}}</span>
-                                    </p>
-                                    <p ng-if="managerConfiguration.rootcheck.base_directory">
-                                        Base directory
-                                        <span class="md-secondary pull-right">{{managerConfiguration.rootcheck.base_directory}}</span>
-                                    </p>
-                                    <p ng-if="managerConfiguration.rootcheck.scanall">
-                                        Scan all
-                                        <span class="md-secondary pull-right">{{managerConfiguration.rootcheck.scanall}}</span>
-                                    </p>
-                                    <p>
-                                        Frequency
-                                        <span class="md-secondary pull-right">{{managerConfiguration.rootcheck.frequency}}</span>
-                                    </p>
-                                    <p>
-                                        Skip NFS
-                                        <span ng-class="managerConfiguration.rootcheck.skip_nfs === 'no' ? 'wazuh-greyed' : ''" class="md-secondary pull-right">{{managerConfiguration.rootcheck.skip_nfs}}</span>
-                                    </p>
-                                    <br>
-                                    <h4>
-                                        <i class="fa fa-file-o"></i> System audit files</h4>
-                                    <md-divider></md-divider>
-                                    <div ng-repeat="item in managerConfiguration.rootcheck.system_audit">
-                                        <p>
-                                            File
-                                            <span class="md-secondary pull-right">{{item}}</span>
-                                        </p>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                        <!-- End rootcheck -->
-
-                        <!-- Auth -->
-                        <div layout="column" flex class="ownNavBarCluster topPaddingSearchNoBottom" ng-show="selectedItem==='auth'">
-                            <div flex layout="row" class="md-padding">
-                                <div ng-class="managerConfiguration.auth.disabled === 'yes' ? 'wazuh-greyed' : ''" flex="60">
-                                    <h4>
-                                        <i class="fa fa-user"></i> Auth</h4>
-                                    <md-divider></md-divider>
-                                    <p>
-                                        Disabled
-                                        <span ng-class="managerConfiguration.auth.disabled === 'yes' ? 'wazuh-greyed' : ''" class="md-secondary pull-right">{{managerConfiguration.auth.disabled}}</span>
-                                    </p>
-                                    <p>
-                                        Purge
-                                        <span ng-class="managerConfiguration.auth.purge === 'no' ? 'wazuh-greyed' : ''" class="md-secondary pull-right">{{managerConfiguration.auth.purge}}</span>
-                                    </p>
-                                    <p>
-                                        Force insert
-                                        <span ng-class="managerConfiguration.auth.force_insert === 'no' ? 'wazuh-greyed' : ''" class="md-secondary pull-right">{{managerConfiguration.auth.force_insert}}</span>
-                                    </p>
-                                    <p>
-                                        SSL verify host
-                                        <span ng-class="managerConfiguration.auth.ssl_verify_host === 'no' ? 'wazuh-greyed' : ''" class="md-secondary pull-right">{{managerConfiguration.auth.ssl_verify_host}}</span>
-                                    </p>
-                                    <p>
-                                        Limit max agents
-                                        <span ng-class="managerConfiguration.auth.limit_maxagents === 'no' ? 'wazuh-greyed' : ''" class="md-secondary pull-right">{{managerConfiguration.auth.limit_maxagents}}</span>
-                                    </p>
-                                    <p>
-                                        Force time
-                                        <span class="md-secondary pull-right">{{managerConfiguration.auth.force_time}}</span>
-                                    </p>
-                                    <p>
-                                        SSL manager key
-                                        <span class="md-secondary pull-right">{{managerConfiguration.auth.ssl_manager_key}}</span>
-                                    </p>
-                                    <p>
-                                        SSL manager cert
-                                        <span class="md-secondary pull-right">{{managerConfiguration.auth.ssl_manager_cert}}</span>
-                                    </p>
-                                    <p>
-                                        Use source ip
-                                        <span ng-class="managerConfiguration.auth.use_source_ip === 'no' ? 'wazuh-greyed' : ''" class="md-secondary pull-right">{{managerConfiguration.auth.use_source_ip}}</span>
-                                    </p>
-                                    <p>
-                                        Use password
-                                        <span ng-class="managerConfiguration.auth.use_password === 'no' ? 'wazuh-greyed' : ''" class="md-secondary pull-right">{{managerConfiguration.auth.use_password}}</span>
-                                    </p>
-                                    <p>
-                                        Port
-                                        <span class="md-secondary pull-right">{{managerConfiguration.auth.port}}</span>
-                                    </p>
-                                    <p>
-                                        SSL auto negotiate
-                                        <span ng-class="managerConfiguration.auth.ssl_auto_negotiate === 'no' ? 'wazuh-greyed' : ''" class="md-secondary pull-right">{{managerConfiguration.auth.ssl_auto_negotiate}}</span>
-                                    </p>
-                                    <p>
-                                        Ciphers
-                                        <span class="md-secondary pull-right">{{managerConfiguration.auth.ciphers}}</span>
-                                    </p>
-                                </div>
-                                <div flex></div>
-                            </div>
-                        </div>
-                        <!-- End auth -->
-
-                        <!-- Logcollector -->
-                        <div layout="column" flex class="ownNavBarCluster topPaddingSearchNoBottom" ng-show="selectedItem==='logcollector'">
-                            <div flex layout="row" class="md-padding">
-                                <div flex="60">
-                                    <h4>
-                                        <i class="fa fa-reorder"></i> Logcollector
-                                    </h4>
-                                    <md-divider></md-divider>
-                                    <div ng-repeat="item in managerConfiguration['localfile'] | orderBy:['location', 'command']">
-                                        <p ng-if="item.location">
-                                            Location
-                                            <span class="md-secondary pull-right">{{item.location}}</span>
-                                        </p>
-                                        <p ng-if="item.command">
-                                            Command
-                                            <span class="md-secondary pull-right">{{item.command}}</span>
-                                        </p>
-                                        <p>
-                                            Log format
-                                            <span class="md-secondary pull-right">{{item.log_format}}</span>
-                                        </p>
-                                        <p ng-if="item.frequency">
-                                            Frequency
-                                            <span class="md-secondary pull-right">{{item.frequency}}</span>
-                                        </p>
-                                        <p ng-if="item.alias">
-                                            Alias
-                                            <span class="md-secondary pull-right">{{item.alias}}</span>
-                                        </p>
-                                        <p ng-if="item.check_diff">
-                                            Check diff
-                                            <span class="md-secondary pull-right">{{item.check_diff}}</span>
-                                        </p>
-                                        <md-divider ng-if="!$last"></md-divider>
-                                    </div>
-                                </div>
-                                <div flex>
-                                </div>
-                            </div>
-                        </div>
-                        <!-- End logcollector -->
-
-                        <!-- Command -->
-                        <div layout="column" flex class="ownNavBarCluster topPaddingSearchNoBottom" ng-show="selectedItem==='command'">
-                            <div flex layout="row" class="md-padding">
-                                <div flex="60">
-                                    <h4>
-                                        <i class="fa fa-terminal"></i> Command
-                                    </h4>
-                                    <md-divider></md-divider>
-                                    <div ng-repeat="item in managerConfiguration.command|orderBy:'name'">
-
-                                        <p>
-                                            Name
-                                            <span class="md-secondary pull-right"> {{ item.name }} </span>
-
-                                        </p>
-                                        <p ng-if="item.expect">
-                                            Expect
-                                            <span class="md-secondary pull-right">{{ item.expect }}
-                                            </span>
-                                        </p>
-                                        <p ng-if="item.executable">
-                                            Executable
-                                            <span class="md-secondary pull-right">{{ item.executable }}
-                                            </span>
-                                        </p>
-                                        <p ng-if="item.timeout_allowed">
-                                            Timeout allowed
-                                            <span ng-class="item.timeout_allowed === 'no' ? 'wazuh-greyed' : ''" class="md-secondary pull-right">{{ item.timeout_allowed}}
-                                            </span>
-                                        </p>
-                                        <md-divider ng-if="!$last"></md-divider>
-                                    </div>
-                                </div>
-                                <div flex>
-                                </div>
-                            </div>
-                        </div>
-                        <!-- End logcollector -->
-
-                        <!-- Ruleset -->
-                        <div layout="column" flex class="ownNavBarCluster topPaddingSearchNoBottom" ng-show="selectedItem==='ruleset'">
-                            <div flex layout="row" class="md-padding">
-                                <div flex="60">
-                                    <h4>
-                                        <i class="fa fa-dot-circle-o"></i> Ruleset
-                                    </h4>
-                                    <md-divider></md-divider>
-                                    <h4 ng-if="managerConfiguration.ruleset.decoder_dir">Decoder directories</h4>
-                                    <div ng-repeat="item in managerConfiguration.ruleset.decoder_dir|orderBy">
-                                        <p>Path
-                                            <span class="md-secondary pull-right">{{ item }}
-                                            </span></p>
-                                    </div>
-                                    <h4 ng-if="managerConfiguration.ruleset.decoder_exclude">Decoder excludes</h4>
-                                    <div ng-repeat="item in managerConfiguration.ruleset.decoder_exclude|orderBy">
-                                        <p>Path
-                                            <span class="md-secondary pull-right">{{ item }}
-                                            </span></p>
-                                    </div>
-                                    <h4 ng-if="managerConfiguration.ruleset.decoder">Decoder files</h4>
-                                    <div ng-repeat="item in managerConfiguration.ruleset.decoder|orderBy">
-                                        <p>Path
-                                            <span class="md-secondary pull-right">{{ item }}
-                                            </span></p>
-                                    </div>
-                                    <h4 ng-if="managerConfiguration.ruleset.rule_dir">Rules directories</h4>
-                                    <div ng-repeat="item in managerConfiguration.ruleset.rule_dir|orderBy">
-                                        <p>Path
-                                            <span class="md-secondary pull-right">{{ item }}
-                                            </span></p>
-                                    </div>
-                                    <h4 ng-if="managerConfiguration.ruleset.include">Rules files</h4>
-                                    <div ng-repeat="item in managerConfiguration.ruleset.include|orderBy">
-                                        <p>Path
-                                            <span class="md-secondary pull-right">{{ item }}
-                                            </span></p>
-                                    </div>
-                                    <h4 ng-if="managerConfiguration.ruleset.rule_exclude">Rule excludes</h4>
-                                    <div ng-if="isArray(managerConfiguration.ruleset.rule_exclude)" ng-repeat="item in managerConfiguration.ruleset['rule_exclude'] track by $index">
-                                        <p>Path
-                                            <span class="md-secondary pull-right">{{ item }}
-                                            </span></p>
-                                    </div>
-                                    <div ng-if="!isArray(managerConfiguration.ruleset.rule_exclude)">
-                                        <p>Path
-                                            <span class="md-secondary pull-right">{{ managerConfiguration.ruleset.rule_exclude }}
-                                            </span></p>
-                                    </div>
-                                    <h4 ng-if="managerConfiguration.ruleset.list">CDB lists</h4>
-                                    <div ng-if="isArray(managerConfiguration.ruleset.list)" ng-repeat="item in managerConfiguration.ruleset.list|orderBy">
-                                        <p>Path
-                                            <span class="md-secondary pull-right">{{ item }}
-                                            </span></p>
-                                    </div>
-                                    <div ng-if="!isArray(managerConfiguration.ruleset.list)">
-                                        <p>Path
-                                            <span class="md-secondary pull-right">{{ managerConfiguration.ruleset.list }}
-                                            </span></p>
-                                    </div>
-                                </div>
-                                <div flex>
-                                </div>
-                            </div>
-                        </div>
-                        <!-- End ruleset -->
-
-                        <!-- Wodle -->
-                        <!--<div layout="column" flex class="ownNavBarCluster topPaddingSearchNoBottom" ng-show="selectedItem==='open-scap'">
-                            <div flex layout="row" class="md-padding">
-                                <div flex="60">
-                                    <h4>
-                                        <i class="fa fa-sliders"></i> OpenSCAP
-                                    </h4>
-                                    <md-divider></md-divider>
-                                    <p ng-if="managerConfiguration['open-scap'].disabled">
-                                        Disabled
-                                        <span class="md-secondary pull-right">{{managerConfiguration['open-scap'].disabled}}</span>
-                                    </p>
-                                    <p ng-if="managerConfiguration['open-scap'].timeout">
-                                        Timeout
-                                        <span class="md-secondary pull-right">{{managerConfiguration['open-scap'].timeout}}</span>
-                                    </p>
-                                    <p ng-if="managerConfiguration['open-scap'].interval">
-                                        Interval
-                                        <span class="md-secondary pull-right">{{managerConfiguration['open-scap'].interval}}</span>
-                                    </p>
-                                    <p ng-if="managerConfiguration['open-scap']['scan-on-start']">
-                                        Scan on start
-                                        <span class="md-secondary pull-right">{{managerConfiguration['open-scap']['scan-on-start']}}</span>
-                                    </p>
-                                    <h4 ng-if="managerConfiguration['open-scap'].content">Content</h4>
-                                    <div ng-if="!isArray(managerConfiguration['open-scap'].content)">
-                                        <p>Policy
-                                            <span class="md-secondary pull-right">{{managerConfiguration['open-scap'].content.path}}
-                                            </span></p>
-                                        <p>Type
-                                            <span class="md-secondary pull-right">{{managerConfiguration['open-scap'].content.type}}
-                                            </span></p>
-                                        <p>Policy
-                                            <span class="md-secondary pull-right">{{managerConfiguration['open-scap'].content.path}}
-                                            </span></p>
-                                        <p ng-if="!isArray(managerConfiguration['open-scap'].content.profile)">
-                                            Profile <span class="md-secondary pull-right">{{managerConfiguration['open-scap'].content.profile.$t}}</span>
-                                        </p>
-                                    </div>
-                                    <div ng-if="isArray(managerConfiguration['open-scap'].content)" ng-repeat="item in managerConfiguration['open-scap'].content track by $index">
-                                        <p>Policy
-                                            <span class="md-secondary pull-right">{{item.path}}
-                                            </span></p>
-                                        <p>Type
-                                            <span class="md-secondary pull-right">{{item.type}}
-                                            </span></p>
-                                        <p>Policy
-                                            <span class="md-secondary pull-right">{{item.path}}
-                                            </span></p>
-                                        <p ng-if="!isArray(item.profile)">
-                                            Profile <span class="md-secondary pull-right">{{item.profile.$t}}</span>
-                                        </p>
-                                        <md-divider ng-if="!$last"></md-divider>
-                                    </div>
-                                </div>
-                                <div flex></div>
-                            </div>
-                        </div> -->
-                        <!-- End wodle -->
-
-                        <!-- Active response -->
-                        <div layout="column" flex class="ownNavBarCluster topPaddingSearchNoBottom" ng-show="selectedItem==='active-response'">
-                            <div flex layout="row" class="md-padding">
-                                <div flex="60">
-                                    <h4>
-                                        <i class="fa fa-random"></i> Active response
-                                    </h4>
-                                    <md-divider></md-divider>
-                                    <div ng-repeat="item in managerConfiguration['active-response']|orderBy:'command'">
-                                        <p ng-if="item.command">Command
-                                            <span class="md-secondary pull-right">{{item.command}}
-                                            </span></p>
-                                        <p ng-if="item.location">Location
-                                            <span class="md-secondary pull-right">{{item.location}}
-                                            </span></p>
-                                        <p ng-if="item.agent_id">Agent ID(s)
-                                            <span class="md-secondary pull-right">{{item.agent_id}}
-                                            </span></p>
-                                        <p ng-if="item.level">
-                                            Level <span class="md-secondary pull-right">{{item.level}}</span>
-                                        </p>
-                                        <p ng-if="item.timeout">
-                                            Timeout <span class="md-secondary pull-right">{{item.timeout}}</span>
-                                        </p>
-                                        <p ng-if="item.rules_id">
-                                            Rules ID(s) <span class="md-secondary pull-right">{{item.rules_id}}</span>
-                                        </p>
-                                        <p ng-if="item.repeated_offenders">
-                                            Repeated offenders <span class="md-secondary pull-right">{{item.repeated_offenders}}</span>
-                                        </p>
-                                        <md-divider ng-if="!$last"></md-divider>
-                                    </div>
-                                </div>
-                                <div flex></div>
-                            </div>
-                        </div>
-                        <!-- End active response -->
-
+                    <!-- Section title -->
+                    <span class="md-headline cursor-pointer" ng-click="switchItem('global')">
+                        Global <i class="fa fa-eye"></i>
+                        <md-tooltip md-direction="right">Click to see more details</md-tooltip>
+                    </span>
+                    <md-divider></md-divider>
+                    <!-- Summary -->
+                    <div layout="row" ng-if="managerConfiguration.global.jsonout_output">
+                        <p class="manager-status-subtitle">JSON output</p>
+                        <p class="text-right color-grey">{{managerConfiguration.global.jsonout_output}}</p>
+                    </div>
+                    <div layout="row" ng-if="managerConfiguration.alerts.log_alert_level">
+                        <p class="manager-status-subtitle">Log alert level</p>
+                        <p class="text-right color-grey">{{managerConfiguration.alerts.log_alert_level}}</p>
                     </div>
                 </md-card-content>
             </md-card>
+            <!-- END GLOBAL -->
+
+            <!-- CLUSTER -->
+            <md-card flex class="no-margin-left" ng-if="managerConfiguration.cluster">
+                <md-card-content>
+                    <!-- Section title -->
+                    <span class="md-headline cursor-pointer" ng-click="switchItem('cluster')">
+                        Cluster <i class="fa fa-eye"></i>
+                        <md-tooltip md-direction="right">Click to see more details</md-tooltip>
+                    </span>
+                    <md-divider></md-divider>
+                    <!-- Summary -->
+                    <div layout="row" ng-if="managerConfiguration.cluster.name">
+                        <p class="manager-status-subtitle">Name</p>
+                        <p class="text-right color-grey">{{managerConfiguration.cluster.name}}</p>
+                    </div>
+                    <div layout="row" ng-if="managerConfiguration.cluster.node_type">
+                        <p class="manager-status-subtitle">Node type</p>
+                        <p class="text-right color-grey">{{managerConfiguration.cluster.node_type}}</p>
+                    </div>
+                </md-card-content>
+            </md-card>
+            <!-- END CLUSTER -->
+
+            <!-- SYSCHECK -->
+            <md-card flex class="no-margin-left" ng-if="managerConfiguration.syscheck">
+                <md-card-content>
+                    <!-- Section title -->
+                    <span class="md-headline cursor-pointer" ng-click="switchItem('syscheck')">
+                        Syscheck <i class="fa fa-eye"></i>
+                        <md-tooltip md-direction="right">Click to see more details</md-tooltip>
+                    </span>
+                    <md-divider></md-divider>
+                    <!-- Summary -->
+                    <div layout="row" ng-if="managerConfiguration.syscheck.frequency">
+                        <p class="manager-status-subtitle">Frequency</p>
+                        <p class="text-right color-grey">{{managerConfiguration.syscheck.frequency}}</p>
+                    </div>
+                    <div layout="row" ng-if="managerConfiguration.syscheck.alert_new_files">
+                        <p class="manager-status-subtitle">Alert new files</p>
+                        <p class="text-right color-grey">{{managerConfiguration.syscheck.alert_new_files}}</p>
+                    </div>
+                </md-card-content>
+            </md-card>
+            <!-- END SYSCHECK -->
+
+            <!-- ROOTCHECK -->
+            <md-card flex class="no-margin-left" ng-if="managerConfiguration.rootcheck">
+                <md-card-content>
+                    <!-- Section title -->
+                    <span class="md-headline cursor-pointer" ng-click="switchItem('rootcheck')">
+                        Rootcheck <i class="fa fa-eye"></i>
+                        <md-tooltip md-direction="right">Click to see more details</md-tooltip>
+                    </span>
+                    <md-divider></md-divider>
+                    <!-- Summary -->
+                    <div layout="row" ng-if="managerConfiguration.rootcheck.scanall">
+                        <p class="manager-status-subtitle">Scan all</p>
+                        <p class="text-right color-grey">{{managerConfiguration.rootcheck.scanall}}</p>
+                    </div>
+                    <div layout="row" ng-if="managerConfiguration.rootcheck.frequency">
+                        <p class="manager-status-subtitle">Frequency</p>
+                        <p class="text-right color-grey">{{managerConfiguration.rootcheck.frequency}}</p>
+                    </div>
+                </md-card-content>
+            </md-card>
+            <!-- END ROOTCHECK -->
+
+            <!-- RULESET -->
+            <md-card flex class="no-margin-left" ng-if="managerConfiguration.ruleset">
+                <md-card-content>
+                    <!-- Section title -->
+                    <span class="md-headline cursor-pointer" ng-click="switchItem('ruleset')">
+                        Ruleset <i class="fa fa-eye"></i>
+                        <md-tooltip md-direction="right">Click to see more details</md-tooltip>
+                    </span>
+                    <md-divider></md-divider>
+                    <p class="manager-status-subtitle">Ruleset settings</p>
+                </md-card-content>
+            </md-card>
+            <!-- END RULESET -->
+
+            <!-- LOGCOLLECTOR -->
+            <md-card flex class="no-margin-left" ng-if="managerConfiguration.logcollector">
+                <md-card-content>
+                    <!-- Section title -->
+                    <span class="md-headline cursor-pointer" ng-click="switchItem('logcollector')">
+                        Logcollector <i class="fa fa-eye"></i>
+                        <md-tooltip md-direction="right">Click to see more details</md-tooltip>
+                    </span>
+                    <md-divider></md-divider>
+                    <p class="manager-status-subtitle">Logcollector settings</p>
+                </md-card-content>
+            </md-card>
+            <!-- END LOGCOLLECTOR -->
+
+            <!-- E-MAIL ALERTS -->
+            <md-card flex class="no-margin-left" ng-if="managerConfiguration.email_alerts">
+                <md-card-content>
+                    <!-- Section title -->
+                    <span class="md-headline cursor-pointer" ng-click="switchItem('email_alerts')">
+                        E-mail alerts <i class="fa fa-eye"></i>
+                        <md-tooltip md-direction="right">Click to see more details</md-tooltip>
+                    </span>
+                    <md-divider></md-divider>
+                    <!-- Summary -->
+                    <div layout="row" ng-if="managerConfiguration.email_alerts.email_to">
+                        <p class="manager-status-subtitle">Email to</p>
+                        <p class="text-right color-grey">{{managerConfiguration.email_alerts.email_to}}</p>
+                    </div>
+                    <div layout="row" ng-if="managerConfiguration.email_alerts.alert_level">
+                        <p class="manager-status-subtitle">Alert level</p>
+                        <p class="text-right color-grey">{{managerConfiguration.email_alerts.alert_level}}</p>
+                    </div>
+                </md-card-content>
+            </md-card>
+            <!-- END E-MAIL ALERTS -->
+
+            <!-- AUTH -->
+            <md-card flex class="no-margin-left" ng-if="managerConfiguration.auth">
+                <md-card-content>
+                    <!-- Section title -->
+                    <span class="md-headline cursor-pointer" ng-click="switchItem('auth')">
+                        Auth <i class="fa fa-eye"></i>
+                        <md-tooltip md-direction="right">Click to see more details</md-tooltip>
+                    </span>
+                    <md-divider></md-divider>
+                    <!-- Summary -->
+                    <div layout="row" ng-if="managerConfiguration.auth.purge">
+                        <p class="manager-status-subtitle">Purge</p>
+                        <p class="text-right color-grey">{{managerConfiguration.auth.purge}}</p>
+                    </div>
+                    <div layout="row" ng-if="managerConfiguration.auth.force_insert">
+                        <p class="manager-status-subtitle">Force insert</p>
+                        <p class="text-right color-grey">{{managerConfiguration.auth.force_insert}}</p>
+                    </div>
+                </md-card-content>
+            </md-card>
+            <!-- END AUTH -->
+
+            <!-- COMMAND -->
+            <md-card flex class="no-margin-left" ng-if="managerConfiguration.command">
+                <md-card-content>
+                    <!-- Section title -->
+                    <span class="md-headline cursor-pointer" ng-click="switchItem('command')">
+                        Command <i class="fa fa-eye"></i>
+                        <md-tooltip md-direction="right">Click to see more details</md-tooltip>
+                    </span>
+                    <md-divider></md-divider>
+                    <p class="manager-status-subtitle">Command settings</p>
+                </md-card-content>
+            </md-card>
+            <!-- END COMMAND -->
+
+            <!-- ACTIVE RESPONSE -->
+            <md-card flex class="no-margin-left" ng-if="managerConfiguration['active-response'].length > 0">
+                <md-card-content>
+                    <!-- Section title -->
+                    <span class="md-headline cursor-pointer" ng-click="switchItem('active-response')">
+                        Active response <i class="fa fa-eye"></i>
+                        <md-tooltip md-direction="right">Click to see more details</md-tooltip>
+                    </span>
+                    <md-divider></md-divider>
+                    <p class="manager-status-subtitle">Active response settings</p>
+                </md-card-content>
+            </md-card>
+            <!-- END ACTIVE RESPONSE -->
+
+            <!-- REMOTE -->
+            <md-card flex class="no-margin-left" ng-if="managerConfiguration.remote">
+                <md-card-content>
+                    <!-- Section title -->
+                    <span class="md-headline cursor-pointer" ng-click="switchItem('remote')">
+                        Remote <i class="fa fa-eye"></i>
+                        <md-tooltip md-direction="right">Click to see more details</md-tooltip>
+                    </span>
+                    <md-divider></md-divider>
+                    <p class="manager-status-subtitle">Agents events listening settings</p>
+                </md-card-content>
+            </md-card>
+            <!-- END REMOTE -->
+
         </div>
+        <!-- End left column -->
+
+        <!-- Right column - Full configuration details -->
+        <div flex="75" layout="row" layout-align="start stretch">
+
+            <!-- GLOBAL -->
+            <md-card flex class="no-margin-left" ng-show="selectedItem === 'global'">
+                <md-card-content>
+                    <!-- Section title -->
+                    <h4><i class="fa fa-fw fa-dashboard"></i> Global</h4>
+                    <md-divider></md-divider>
+                    <!-- Full details -->
+                    <div layout="row" ng-if="managerConfiguration.global.jsonout_output">
+                        <p class="manager-status-subtitle">JSON output</p>
+                        <p class="text-right color-grey">{{managerConfiguration.global.jsonout_output}}</p>
+                    </div>
+                    <div layout="row" ng-if="managerConfiguration.global.logall">
+                        <p class="manager-status-subtitle">Log all</p>
+                        <p class="text-right color-grey">{{managerConfiguration.global.logall}}</p>
+                    </div>
+                    <div layout="row" ng-if="managerConfiguration.global.logall">
+                        <p class="manager-status-subtitle">Log all in JSON</p>
+                        <p class="text-right color-grey">{{managerConfiguration.global.logall_json}}</p>
+                    </div>
+                    <div layout="row" ng-if="managerConfiguration.global.white_list">
+                        <p class="manager-status-subtitle">White list</p>
+                        <p class="text-right color-grey">{{managerConfiguration.global.white_list.length
+                            <= 5 ? managerConfiguration.global.white_list : managerConfiguration.global.white_list.length}}</p>
+                    </div>
+                    <div layout="row" ng-if="managerConfiguration.global.stats">
+                        <p class="manager-status-subtitle">Stats</p>
+                        <p class="text-right color-grey">{{managerConfiguration.global.stats}}</p>
+                    </div>
+                    <div layout="row" ng-if="managerConfiguration.global.host_infomation">
+                        <p class="manager-status-subtitle">Host information</p>
+                        <p class="text-right color-grey">{{managerConfiguration.global.host_infomation}}</p>
+                    </div>
+                    <div layout="row" ng-if="managerConfiguration.alerts.log_alert_level">
+                        <p class="manager-status-subtitle">Log alert level</p>
+                        <p class="text-right color-grey">{{managerConfiguration.alerts.log_alert_level}}</p>
+                    </div>
+                    <div layout="row" ng-if="managerConfiguration.global.email_notification">
+                        <p class="manager-status-subtitle">E-mail notifications</p>
+                        <p class="text-right color-grey">{{managerConfiguration.global.email_notification}}</p>
+                    </div>
+                    <div layout="row" ng-if="managerConfiguration.alerts.email_alert_level">
+                        <p class="manager-status-subtitle">E-mail alert level</p>
+                        <p class="text-right color-grey">{{ managerConfiguration.alerts.email_alert_level }}</p>
+                    </div>
+                    <div layout="row" ng-if="managerConfiguration.global.email_to">
+                        <p class="manager-status-subtitle">E-mail to</p>
+                        <p class="text-right color-grey">{{managerConfiguration.global.email_to}}</p>
+                    </div>
+                    <div layout="row" ng-if="managerConfiguration.global.email_from">
+                        <p class="manager-status-subtitle">E-mail from</p>
+                        <p class="text-right color-grey">{{managerConfiguration.global.email_from}}</p>
+                    </div>
+                    <div layout="row" ng-if="managerConfiguration.global.smtp_server">
+                        <p class="manager-status-subtitle">SMTP server</p>
+                        <p class="text-right color-grey">{{managerConfiguration.global.smtp_server}}</p>
+                    </div>
+                    <div layout="row" ng-if="managerConfiguration.global.email_maxperhour">
+                        <p class="manager-status-subtitle">Max email per hour</p>
+                        <p class="text-right color-grey">{{managerConfiguration.global.email_maxperhour}}</p>
+                    </div>
+                    <div layout="row" ng-if="managerConfiguration.global.email_idsname">
+                        <p class="manager-status-subtitle">E-mail IDS name</p>
+                        <p class="text-right color-grey">{{managerConfiguration.global.email_idsname}}</p>
+                    </div>
+                </md-card-content>
+            </md-card>
+            <!-- END GLOBAL -->
+
+            <!-- CLUSTER -->
+            <md-card flex class="no-margin-left" ng-show="selectedItem === 'cluster'">
+                <md-card-content>
+                    <!-- Section title -->
+                    <h4><i class="fa fa-fw fa-server"></i> Cluster</h4>
+                    <md-divider></md-divider>
+                    <!-- Full details -->
+                    <div layout="row" ng-if="managerConfiguration.cluster.disabled">
+                        <p class="manager-status-subtitle">Disabled</p>
+                        <p class="text-right color-grey">{{managerConfiguration.cluster.disabled}}</p>
+                    </div>
+                    <div layout="row" ng-if="managerConfiguration.cluster.hidden">
+                        <p class="manager-status-subtitle">Hidden</p>
+                        <p class="text-right color-grey">{{managerConfiguration.cluster.hidden}}</p>
+                    </div>
+                    <div layout="row" ng-if="managerConfiguration.cluster.name">
+                        <p class="manager-status-subtitle">Name</p>
+                        <p class="text-right color-grey">{{managerConfiguration.cluster.name}}</p>
+                    </div>
+                    <div layout="row" ng-if="managerConfiguration.cluster.interval">
+                        <p class="manager-status-subtitle">Interval</p>
+                        <p class="text-right color-grey">{{managerConfiguration.cluster.interval}}</p>
+                    </div>
+                    <div layout="row" ng-if="managerConfiguration.cluster.node_name">
+                        <p class="manager-status-subtitle">Node name</p>
+                        <p class="text-right color-grey">{{managerConfiguration.cluster.node_name}}</p>
+                    </div>
+                    <div layout="row" ng-if="managerConfiguration.cluster.node_type">
+                        <p class="manager-status-subtitle">Node type</p>
+                        <p class="text-right color-grey">{{managerConfiguration.cluster.node_type}}</p>
+                    </div>
+                    <div layout="row" ng-if="managerConfiguration.cluster.port">
+                        <p class="manager-status-subtitle">Port</p>
+                        <p class="text-right color-grey">{{managerConfiguration.cluster.port}}</p>
+                    </div>
+                    <div layout="row" ng-if="managerConfiguration.cluster.bind_addr">
+                        <p class="manager-status-subtitle">Bind address</p>
+                        <p class="text-right color-grey">{{managerConfiguration.cluster.bind_addr}}</p>
+                    </div>
+                    <div layout="row" ng-if="managerConfiguration.cluster.nodes">
+                        <p class="manager-status-subtitle">Nodes</p>
+                        <p class="text-right color-grey">{{managerConfiguration.cluster.nodes}}</p>
+                    </div>
+                </md-card-content>
+            </md-card>
+            <!-- END CLUSTER -->
+
+            <!-- SYSCHECK -->
+            <md-card flex class="no-margin-left" ng-show="selectedItem === 'syscheck'">
+                <md-card-content>
+                    <!-- Section title -->
+                    <h4><i class="fa fa-fw fa-shield"></i> Syscheck</h4>
+                    <md-divider></md-divider>
+                    <!-- Full details -->
+                    <div layout="row" ng-if="managerConfiguration.syscheck.disabled">
+                        <p class="manager-status-subtitle">Disabled</p>
+                        <p class="text-right color-grey">{{managerConfiguration.syscheck.disabled}}</p>
+                    </div>
+                    <div layout="row" ng-if="managerConfiguration.syscheck.frequency">
+                        <p class="manager-status-subtitle">Frequency</p>
+                        <p class="text-right color-grey">{{managerConfiguration.syscheck.frequency}}</p>
+                    </div>
+                    <div layout="row" ng-if="managerConfiguration.syscheck.scan_time">
+                        <p class="manager-status-subtitle">Scan time</p>
+                        <p class="text-right color-grey">{{managerConfiguration.syscheck.scan_time}}</p>
+                    </div>
+                    <div layout="row" ng-if="managerConfiguration.syscheck.scan_day">
+                        <p class="manager-status-subtitle">Scan day</p>
+                        <p class="text-right color-grey">{{managerConfiguration.syscheck.scan_day}}</p>
+                    </div>
+                    <div layout="row" ng-if="managerConfiguration.syscheck.auto_ignore">
+                        <p class="manager-status-subtitle">Auto ignore</p>
+                        <p class="text-right color-grey">{{managerConfiguration.syscheck.auto_ignore}}</p>
+                    </div>
+                    <div layout="row" ng-if="managerConfiguration.syscheck.alert_new_files">
+                        <p class="manager-status-subtitle">Alert new files</p>
+                        <p class="text-right color-grey">{{managerConfiguration.syscheck.alert_new_files}}</p>
+                    </div>
+                    <div layout="row" ng-if="managerConfiguration.syscheck.scan_on_start">
+                        <p class="manager-status-subtitle">Scan on start</p>
+                        <p class="text-right color-grey">{{managerConfiguration.syscheck.scan_on_start}}</p>
+                    </div>
+                    <div layout="row" ng-if="managerConfiguration.syscheck.nodiff">
+                        <p class="manager-status-subtitle">No diff</p>
+                        <p class="text-right color-grey">{{managerConfiguration.syscheck.nodiff}}</p>
+                    </div>
+                    <div layout="row" ng-if="managerConfiguration.syscheck.skip_nfs">
+                        <p class="manager-status-subtitle">Skip NFS</p>
+                        <p class="text-right color-grey">{{managerConfiguration.syscheck.skip_nfs}}</p>
+                    </div>
+
+                    <!-- Section title -->
+                    <h4><i class="fa fa-fw fa-folder-o"></i> Monitoring directories</h4>
+                    <md-divider></md-divider>
+                    <!-- Full details -->
+                    <div ng-repeat="item in managerConfiguration.syscheck.directories">
+                        <div layout="row" ng-if="item.path">
+                            <p class="manager-status-subtitle">Path</p>
+                            <p class="text-right color-grey">{{item.path}}</p>
+                        </div>
+                        <div layout="row" ng-if="item.check_all">
+                            <p class="manager-status-subtitle">Check all</p>
+                            <p class="text-right color-grey">{{item.check_all}}</p>
+                        </div>
+                        <md-divider ng-if="!$last"></md-divider>
+                    </div>
+                </md-card-content>
+            </md-card>
+            <!-- END SYSCHECK -->
+
+            <!-- ROOTCHECK -->
+            <md-card flex class="no-margin-left" ng-show="selectedItem === 'rootcheck'">
+                <md-card-content>
+                    <!-- Section title -->
+                    <h4><i class="fa fa-fw fa-check"></i> Rootcheck</h4>
+                    <md-divider></md-divider>
+                    <!-- Full details -->
+                    <div layout="row" ng-if="managerConfiguration.rootcheck.disabled">
+                        <p class="manager-status-subtitle">Disabled</p>
+                        <p class="text-right color-grey">{{managerConfiguration.rootcheck.disabled}}</p>
+                    </div>
+                    <div layout="row" ng-if="managerConfiguration.rootcheck.rootkit_files">
+                        <p class="manager-status-subtitle">Rootkit files</p>
+                        <p class="text-right color-grey">{{managerConfiguration.rootcheck.rootkit_files}}</p>
+                    </div>
+                    <div layout="row" ng-if="managerConfiguration.rootcheck.rootkit_trojans">
+                        <p class="manager-status-subtitle">Rootkit trojans</p>
+                        <p class="text-right color-grey">{{managerConfiguration.rootcheck.rootkit_trojans}}</p>
+                    </div>
+                    <div layout="row" ng-if="managerConfiguration.rootcheck.base_directory">
+                        <p class="manager-status-subtitle">Base directory</p>
+                        <p class="text-right color-grey">{{managerConfiguration.rootcheck.base_directory}}</p>
+                    </div>
+                    <div layout="row" ng-if="managerConfiguration.rootcheck.scanall">
+                        <p class="manager-status-subtitle">Scan all</p>
+                        <p class="text-right color-grey">{{managerConfiguration.rootcheck.scanall}}</p>
+                    </div>
+                    <div layout="row" ng-if="managerConfiguration.rootcheck.frequency">
+                        <p class="manager-status-subtitle">Frequency</p>
+                        <p class="text-right color-grey">{{managerConfiguration.rootcheck.frequency}}</p>
+                    </div>
+                    <div layout="row" ng-if="managerConfiguration.rootcheck.skip_nfs">
+                        <p class="manager-status-subtitle">Skip NFS</p>
+                        <p class="text-right color-grey">{{managerConfiguration.rootcheck.skip_nfs}}</p>
+                    </div>
+
+                    <!-- Section title -->
+                    <h4><i class="fa fa-fw fa-file-o"></i> System audit files</h4>
+                    <md-divider></md-divider>
+                    <!-- Full details -->
+                    <div ng-repeat="item in managerConfiguration.rootcheck.system_audit">
+                        <div layout="row" ng-if="item">
+                            <p class="manager-status-subtitle">File</p>
+                            <p class="text-right color-grey">{{item}}</p>
+                        </div>
+                        <md-divider ng-if="!$last"></md-divider>
+                    </div>
+                </md-card-content>
+            </md-card>
+            <!-- END ROOTCHECK -->
+
+            <!-- RULESET -->
+            <md-card flex class="no-margin-left" ng-show="selectedItem === 'ruleset'">
+                <md-card-content>
+                    <!-- Section title -->
+                    <h4><i class="fa fa-fw fa-dot-circle-o"></i> Ruleset</h4>
+                    <md-divider></md-divider>
+                    <!-- Decoder directories -->
+                    <h4 ng-if="managerConfiguration.ruleset.decoder_dir">Decoder directories</h4>
+                    <div ng-repeat="item in managerConfiguration.ruleset.decoder_dir|orderBy">
+                        <div layout="row">
+                            <p class="manager-status-subtitle">Path</p>
+                            <p class="text-right color-grey">{{item}}</p>
+                        </div>
+                        <md-divider ng-if="!$last"></md-divider>
+                    </div>
+
+                    <!-- Decoder excludes -->
+                    <h4 ng-if="managerConfiguration.ruleset.decoder_exclude">Decoder excludes</h4>
+                    <div ng-repeat="item in managerConfiguration.ruleset.decoder_exclude|orderBy">
+                        <div layout="row">
+                            <p class="manager-status-subtitle">Path</p>
+                            <p class="text-right color-grey">{{item}}</p>
+                        </div>
+                        <md-divider ng-if="!$last"></md-divider>
+                    </div>
+
+                    <!-- Decoder files -->
+                    <h4 ng-if="managerConfiguration.ruleset.decoder">Decoder files</h4>
+                    <div ng-repeat="item in managerConfiguration.ruleset.decoder|orderBy">
+                        <div layout="row">
+                            <p class="manager-status-subtitle">Path</p>
+                            <p class="text-right color-grey">{{item}}</p>
+                        </div>
+                        <md-divider ng-if="!$last"></md-divider>
+                    </div>
+
+                    <!-- Rules directories -->
+                    <h4 ng-if="managerConfiguration.ruleset.rule_dir">Rules directories</h4>
+                    <div ng-repeat="item in managerConfiguration.ruleset.rule_dir|orderBy">
+                        <div layout="row">
+                            <p class="manager-status-subtitle">Path</p>
+                            <p class="text-right color-grey">{{item}}</p>
+                        </div>
+                        <md-divider ng-if="!$last"></md-divider>
+                    </div>
+
+                    <!-- Rules files -->
+                    <h4 ng-if="managerConfiguration.ruleset.include">Rules files</h4>
+                    <div ng-repeat="item in managerConfiguration.ruleset.include|orderBy">
+                        <div layout="row">
+                            <p class="manager-status-subtitle">Path</p>
+                            <p class="text-right color-grey">{{item}}</p>
+                        </div>
+                        <md-divider ng-if="!$last"></md-divider>
+                    </div>
+
+                    <!-- Rule excludes -->
+                    <h4 ng-if="managerConfiguration.ruleset.rule_exclude">Rule excludes</h4>
+                    <div ng-if="isArray(managerConfiguration.ruleset.rule_exclude)" ng-repeat="item in managerConfiguration.ruleset['rule_exclude'] track by $index">
+                        <div layout="row">
+                            <p class="manager-status-subtitle">Path</p>
+                            <p class="text-right color-grey">{{item}}</p>
+                        </div>
+                        <md-divider ng-if="!$last"></md-divider>
+                    </div>
+                    <div layout="row" ng-if="!isArray(managerConfiguration.ruleset.rule_exclude)">
+                        <p class="manager-status-subtitle">Path</p>
+                        <p class="text-right color-grey">{{managerConfiguration.ruleset.rule_exclude}}</p>
+                    </div>
+
+                    <!-- CDB Lists -->
+                    <h4 ng-if="managerConfiguration.ruleset.list">CDB Lists</h4>
+                    <div ng-if="isArray(managerConfiguration.ruleset.list)" ng-repeat="item in managerConfiguration.ruleset.list|orderBy">
+                        <div layout="row">
+                            <p class="manager-status-subtitle">Path</p>
+                            <p class="text-right color-grey">{{item}}</p>
+                        </div>
+                        <md-divider ng-if="!$last"></md-divider>
+                    </div>
+                    <div layout="row" ng-if="!isArray(managerConfiguration.ruleset.list)">
+                        <p class="manager-status-subtitle">Path</p>
+                        <p class="text-right color-grey">{{managerConfiguration.ruleset.list}}</p>
+                    </div>
+                </md-card-content>
+            </md-card>
+            <!-- END RULESET -->
+
+            <!-- LOGCOLLECTOR -->
+            <md-card flex class="no-margin-left" ng-show="selectedItem === 'logcollector'">
+                <md-card-content>
+                    <!-- Section title -->
+                    <h4><i class="fa fa-fw fa-reorder"></i> Logcollector</h4>
+                    <md-divider></md-divider>
+                    <!-- Full details -->
+                    <div ng-repeat="item in managerConfiguration['localfile'] | orderBy:['location', 'command']">
+                        <div layout="row" ng-if="item.location">
+                            <p class="manager-status-subtitle">Location</p>
+                            <p class="text-right color-grey">{{item.location}}</p>
+                        </div>
+                        <div layout="row" ng-if="item.command">
+                            <p class="manager-status-subtitle">Command</p>
+                            <p class="text-right color-grey">{{item.command}}</p>
+                        </div>
+                        <div layout="row" ng-if="item.log_format">
+                            <p class="manager-status-subtitle">Log format</p>
+                            <p class="text-right color-grey">{{item.log_format}}</p>
+                        </div>
+                        <div layout="row" ng-if="item.frequency">
+                            <p class="manager-status-subtitle">Frequency</p>
+                            <p class="text-right color-grey">{{item.frequency}}</p>
+                        </div>
+                        <div layout="row" ng-if="item.alias">
+                            <p class="manager-status-subtitle">Alias</p>
+                            <p class="text-right color-grey">{{item.alias}}</p>
+                        </div>
+                        <div layout="row" ng-if="item.check_diff">
+                            <p class="manager-status-subtitle">Check diff</p>
+                            <p class="text-right color-grey">{{item.check_diff}}</p>
+                        </div>
+                        <md-divider ng-if="!$last"></md-divider>
+                    </div>
+                </md-card-content>
+            </md-card>
+            <!-- END LOGCOLLECTOR -->
+
+            <!-- EMAIL ALERTS -->
+            <md-card flex class="no-margin-left" ng-show="selectedItem === 'email_alerts'">
+                <md-card-content>
+                    <!-- Section title -->
+                    <h4><i class="fa fa-fw fa-envelope-o"></i> E-mail alerts</h4>
+                    <md-divider></md-divider>
+                    <!-- Full details -->
+                    <div layout="row" ng-if="managerConfiguration.email_alerts.email_to">
+                        <p class="manager-status-subtitle">Email to</p>
+                        <p class="text-right color-grey">{{managerConfiguration.email_alerts.email_to}}</p>
+                    </div>
+                    <div layout="row" ng-if="managerConfiguration.email_alerts.alert_level">
+                        <p class="manager-status-subtitle">Alert level</p>
+                        <p class="text-right color-grey">{{managerConfiguration.email_alerts.alert_level}}</p>
+                    </div>
+                    <div layout="row" ng-if="managerConfiguration.email_alerts.group">
+                        <p class="manager-status-subtitle">Group</p>
+                        <p class="text-right color-grey">{{managerConfiguration.email_alerts.group}}</p>
+                    </div>
+                    <div layout="row" ng-if="managerConfiguration.email_alerts.event_location">
+                        <p class="manager-status-subtitle">Event location</p>
+                        <p class="text-right color-grey">{{managerConfiguration.email_alerts.event_location}}</p>
+                    </div>
+                    <div layout="row" ng-if="managerConfiguration.email_alerts.format">
+                        <p class="manager-status-subtitle">Format</p>
+                        <p class="text-right color-grey">{{managerConfiguration.email_alerts.format}}</p>
+                    </div>
+                    <div layout="row" ng-if="managerConfiguration.email_alerts.rule_id">
+                        <p class="manager-status-subtitle">Rule ID</p>
+                        <p class="text-right color-grey">{{managerConfiguration.email_alerts.rule_id}}</p>
+                    </div>
+                    <div layout="row" ng-if="managerConfiguration.email_alerts.do_not_delay">
+                        <p class="manager-status-subtitle">Do not delay</p>
+                        <p class="text-right color-grey">{{managerConfiguration.email_alerts.do_not_delay}}</p>
+                    </div>
+                    <div layout="row" ng-if="managerConfiguration.email_alerts.do_not_group">
+                        <p class="manager-status-subtitle">Do not group</p>
+                        <p class="text-right color-grey">{{managerConfiguration.email_alerts.do_not_group}}</p>
+                    </div>
+                </md-card-content>
+            </md-card>
+            <!-- END EMAIL ALERTS -->
+
+            <!-- AUTH -->
+            <md-card flex class="no-margin-left" ng-show="selectedItem === 'auth'">
+                <md-card-content>
+                    <!-- Section title -->
+                    <h4><i class="fa fa-fw fa-server"></i> Auth</h4>
+                    <md-divider></md-divider>
+                    <!-- Full details -->
+                    <div layout="row" ng-if="managerConfiguration.auth.disabled">
+                        <p class="manager-status-subtitle">Disabled</p>
+                        <p class="text-right color-grey">{{managerConfiguration.auth.disabled}}</p>
+                    </div>
+                    <div layout="row" ng-if="managerConfiguration.auth.purge">
+                        <p class="manager-status-subtitle">Purge</p>
+                        <p class="text-right color-grey">{{managerConfiguration.auth.purge}}</p>
+                    </div>
+                    <div layout="row" ng-if="managerConfiguration.auth.force_insert">
+                        <p class="manager-status-subtitle">Force insert</p>
+                        <p class="text-right color-grey">{{managerConfiguration.auth.force_insert}}</p>
+                    </div>
+                    <div layout="row" ng-if="managerConfiguration.auth.ssl_verify_host">
+                        <p class="manager-status-subtitle">SSL verify host</p>
+                        <p class="text-right color-grey">{{managerConfiguration.auth.ssl_verify_host}}</p>
+                    </div>
+                    <div layout="row" ng-if="managerConfiguration.auth.limit_maxagents">
+                        <p class="manager-status-subtitle">Limit max agents</p>
+                        <p class="text-right color-grey">{{managerConfiguration.auth.limit_maxagents}}</p>
+                    </div>
+                    <div layout="row" ng-if="managerConfiguration.auth.force_time">
+                        <p class="manager-status-subtitle">Force time</p>
+                        <p class="text-right color-grey">{{managerConfiguration.auth.force_time}}</p>
+                    </div>
+                    <div layout="row" ng-if="managerConfiguration.auth.ssl_manager_key">
+                        <p class="manager-status-subtitle">SSL manager key</p>
+                        <p class="text-right color-grey">{{managerConfiguration.auth.ssl_manager_key}}</p>
+                    </div>
+                    <div layout="row" ng-if="managerConfiguration.auth.ssl_manager_cert">
+                        <p class="manager-status-subtitle">SSL manager cert</p>
+                        <p class="text-right color-grey">{{managerConfiguration.auth.ssl_manager_cert}}</p>
+                    </div>
+                    <div layout="row" ng-if="managerConfiguration.auth.use_source_ip">
+                        <p class="manager-status-subtitle">Use source IP</p>
+                        <p class="text-right color-grey">{{managerConfiguration.auth.use_source_ip}}</p>
+                    </div>
+                    <div layout="row" ng-if="managerConfiguration.auth.use_password">
+                        <p class="manager-status-subtitle">Use password</p>
+                        <p class="text-right color-grey">{{managerConfiguration.auth.use_password}}</p>
+                    </div>
+                    <div layout="row" ng-if="managerConfiguration.auth.port">
+                        <p class="manager-status-subtitle">Port</p>
+                        <p class="text-right color-grey">{{managerConfiguration.auth.port}}</p>
+                    </div>
+                    <div layout="row" ng-if="managerConfiguration.auth.ssl_auto_negotiate">
+                        <p class="manager-status-subtitle">SSL auto negotiate</p>
+                        <p class="text-right color-grey">{{managerConfiguration.auth.ssl_auto_negotiate}}</p>
+                    </div>
+                    <div layout="row" ng-if="managerConfiguration.auth.ciphers">
+                        <p class="manager-status-subtitle">Ciphers</p>
+                        <p class="text-right color-grey">{{managerConfiguration.auth.ciphers}}</p>
+                    </div>
+                </md-card-content>
+            </md-card>
+            <!-- END AUTH -->
+
+            <!-- COMMAND -->
+            <md-card flex class="no-margin-left" ng-show="selectedItem === 'command'">
+                <md-card-content>
+                    <!-- Section title -->
+                    <h4><i class="fa fa-fw fa-terminal"></i> Command</h4>
+                    <md-divider></md-divider>
+                    <!-- Full details -->
+                    <div ng-repeat="item in managerConfiguration.command|orderBy:'name'">
+                        <div layout="row" ng-if="item.name">
+                            <p class="manager-status-subtitle">Name</p>
+                            <p class="text-right color-grey">{{item.name}}</p>
+                        </div>
+                        <div layout="row" ng-if="item.expect">
+                            <p class="manager-status-subtitle">Expect</p>
+                            <p class="text-right color-grey">{{item.expect}}</p>
+                        </div>
+                        <div layout="row" ng-if="item.executable">
+                            <p class="manager-status-subtitle">Executable</p>
+                            <p class="text-right color-grey">{{item.executable}}</p>
+                        </div>
+                        <div layout="row" ng-if="item.timeout_allowed">
+                            <p class="manager-status-subtitle">Timeout allowed</p>
+                            <p class="text-right color-grey">{{item.timeout_allowed}}</p>
+                        </div>
+                        <md-divider ng-if="!$last"></md-divider>
+                    </div>
+                </md-card-content>
+            </md-card>
+            <!-- END COMMAND -->
+
+            <!-- ACTIVE RESPONSE -->
+            <md-card flex class="no-margin-left" ng-show="selectedItem === 'active-response'">
+                <md-card-content>
+                    <!-- Section title -->
+                    <h4><i class="fa fa-fw fa-random"></i> Active response</h4>
+                    <md-divider></md-divider>
+                    <!-- Full details -->
+                    <div ng-repeat="item in managerConfiguration['active-response']|orderBy:'command'">
+                        <div layout="row" ng-if="item.command">
+                            <p class="manager-status-subtitle">Command</p>
+                            <p class="text-right color-grey">{{item.command}}</p>
+                        </div>
+                        <div layout="row" ng-if="item.location">
+                            <p class="manager-status-subtitle">Location</p>
+                            <p class="text-right color-grey">{{item.location}}</p>
+                        </div>
+                        <div layout="row" ng-if="item.agent_id">
+                            <p class="manager-status-subtitle">Agent ID(s)</p>
+                            <p class="text-right color-grey">{{item.agent_id}}</p>
+                        </div>
+                        <div layout="row" ng-if="item.level">
+                            <p class="manager-status-subtitle">Level</p>
+                            <p class="text-right color-grey">{{item.level}}</p>
+                        </div>
+                        <div layout="row" ng-if="item.timeout">
+                            <p class="manager-status-subtitle">Timeout</p>
+                            <p class="text-right color-grey">{{item.timeout}}</p>
+                        </div>
+                        <div layout="row" ng-if="item.rules_id">
+                            <p class="manager-status-subtitle">Rules ID(s)</p>
+                            <p class="text-right color-grey">{{item.rules_id}}</p>
+                        </div>
+                        <div layout="row" ng-if="item.repeated_offenders">
+                            <p class="manager-status-subtitle">Repeated offenders</p>
+                            <p class="text-right color-grey">{{item.repeated_offenders}}</p>
+                        </div>
+                        <md-divider ng-if="!$last"></md-divider>
+                    </div>
+                </md-card-content>
+            </md-card>
+            <!-- END ACTIVE RESPONSE -->
+
+            <!-- REMOTE -->
+            <md-card flex class="no-margin-left" ng-show="selectedItem === 'remote'">
+                <md-card-content>
+                    <!-- Section title -->
+                    <h4><i class="fa fa-fw fa-feed"></i> Remote</h4>
+                    <md-divider></md-divider>
+                    <!-- Full details -->
+                    <div ng-repeat="item in managerConfiguration.remote">
+                        <div layout="row" ng-if="item.connection">
+                            <p class="manager-status-subtitle">Connection</p>
+                            <p class="text-right color-grey">{{item.connection}}</p>
+                        </div>
+                        <div layout="row" ng-if="item.port">
+                            <p class="manager-status-subtitle">Port</p>
+                            <p class="text-right color-grey">{{item.port}}</p>
+                        </div>
+                        <div layout="row" ng-if="item.protocol">
+                            <p class="manager-status-subtitle">Protocol</p>
+                            <p class="text-right color-grey">{{item.protocol}}</p>
+                        </div>
+                        <md-divider ng-if="!$last"></md-divider>
+                    </div>
+                </md-card-content>
+            </md-card>
+            <!-- END REMOTE -->
+
+        </div>
+        <!-- End right column -->
+
     </div>
+
 </md-content>


### PR DESCRIPTION
Hello all,

Several weeks ago, a first approach was made to the *Manager/Configuration* tab. This time, I have a **new iteration with a new redesign**, in order to follow even more the Kibana guidelines.

## Example screenshot

![config1](https://user-images.githubusercontent.com/10928321/37045974-820cc3ea-2167-11e8-89a3-f711561e8d9a.png)

## Description
This design uses the ***Monitoring-like* boxes** to show relevant information about every specific Manager configuration. If you place the mouse pointer near the title, a **tooltip** will appear, indicating that you can click to see the complete configuration.

![config2](https://user-images.githubusercontent.com/10928321/37046054-b1e097e0-2167-11e8-9b9c-13568538deca.PNG)

## Additional notes
Furthermore, this PR adds two small bugfixes reported by @snaow:
* Fixed missing pointer when hovering the group in the *Agents/Configuration* tab.
* Now the Kibana filter search bar has the same shadow as the rest of app components.
![search2](https://user-images.githubusercontent.com/10928321/37046656-273dd6fa-2169-11e8-9729-475d4cb6107b.PNG)

I hope that you like this redesign. Every feedback is appreciated and will be taken into consideration.

Best regards,
Juanjo