### PR TITLE
Better checks

### DIFF
--- a/public/controllers/blank-screen-controller.js
+++ b/public/controllers/blank-screen-controller.js
@@ -1,11 +1,13 @@
 const app = require('ui/modules').get('app/wazuh', []);
-import $ from 'jquery';
+
 // Logs controller
-app.controller('blankScreenController', function ($scope, $rootScope, errorHandler) {
+app.controller('blankScreenController', function ($scope, $rootScope, errorHandler,$location) {
     if($rootScope.blankScreenError) {
-        $('#result').html(errorHandler.handle($rootScope.blankScreenError,'',false,true));
+        $scope.errorToShow = $rootScope.blankScreenError;
         delete $rootScope.blankScreenError;
-    } else {
-        $('#result').html('Something went wrong')
+        if(!$scope.$$phase) $scope.$digest();
+    } 
+    $scope.goOverview = () => {
+        $location.path('/overview'); 
     }
 });

--- a/public/controllers/settings.js
+++ b/public/controllers/settings.js
@@ -209,7 +209,6 @@ app.controller('settingsController', function ($scope, $rootScope, $http, $route
     // Save settings function
     const saveSettings = async () => {
         try {
-            $rootScope.comeFromSettings = true;
             const invalid = validator('formData');
 
             if(invalid) {

--- a/public/controllers/settings.js
+++ b/public/controllers/settings.js
@@ -209,6 +209,7 @@ app.controller('settingsController', function ($scope, $rootScope, $http, $route
     // Save settings function
     const saveSettings = async () => {
         try {
+            $rootScope.comeFromSettings = true;
             const invalid = validator('formData');
 
             if(invalid) {

--- a/public/services/api-tester.js
+++ b/public/services/api-tester.js
@@ -6,17 +6,23 @@ app.service('testAPI', function ($q, $http, $location, $rootScope, appState) {
         check_stored: data => {
             
             let defered = $q.defer();
-
+            
             const headers = {headers:{ "Content-Type": 'application/json' },timeout: $rootScope.userTimeout || 8000};
-            let timestamp = $rootScope.installationDate;
-   
-            const current = appState.getCreatedAt();
-            if(!$rootScope.comeFromSettings && current && timestamp && timestamp > current){
+            
+            /** Checks for outdated cookies */
+            const current     = appState.getCreatedAt();
+            const lastRestart = $rootScope.lastRestart;
+
+            if(current && lastRestart && lastRestart > current){
                 appState.removeCurrentPattern();
                 appState.removeCurrentAPI();
                 appState.removeClusterInfo();
-                return defered.resolve('cookies_outdated');
+                appState.removeCreatedAt();
+                defered.resolve('cookies_outdated');
+                delete $rootScope.lastRestart;
+                return defered.promise;
             }
+            /** End of checks for outdated cookies */
 
             if(appState.getUserCode()) headers.headers.code = appState.getUserCode();
                 

--- a/public/services/api-tester.js
+++ b/public/services/api-tester.js
@@ -8,23 +8,19 @@ app.service('testAPI', function ($q, $http, $location, $rootScope, appState) {
             let defered = $q.defer();
 
             const headers = {headers:{ "Content-Type": 'application/json' },timeout: $rootScope.userTimeout || 8000};
-            $http
-            .get(chrome.addBasePath('/api/wazuh-elastic/timestamp'))
-            .then(timestamp => {
-                const current = appState.getCreatedAt();
-                if(!$rootScope.comeFromSettings && current && timestamp.data && timestamp.data.installationDate && timestamp.data.installationDate > current){
-                    appState.removeCurrentPattern();
-                    appState.removeCurrentAPI();
-                    appState.removeClusterInfo();
-                    delete $rootScope.comeFromSettings;
-                    return defered.resolve('cookies_outdated');
-                }
-                delete $rootScope.comeFromSettings;
-                if(appState.getUserCode()) headers.headers.code = appState.getUserCode();
-                
-                return $http.post(chrome.addBasePath('/api/wazuh-api/checkStoredAPI'), data,headers)
+            let timestamp = $rootScope.installationDate;
+   
+            const current = appState.getCreatedAt();
+            if(!$rootScope.comeFromSettings && current && timestamp && timestamp > current){
+                appState.removeCurrentPattern();
+                appState.removeCurrentAPI();
+                appState.removeClusterInfo();
+                return defered.resolve('cookies_outdated');
+            }
 
-            })
+            if(appState.getUserCode()) headers.headers.code = appState.getUserCode();
+                
+            $http.post(chrome.addBasePath('/api/wazuh-api/checkStoredAPI'), data,headers)
             .then(response => {
                 if (response.error) {
                     defered.reject(response);

--- a/public/services/app-state.js
+++ b/public/services/app-state.js
@@ -59,6 +59,9 @@ require('ui/modules').get('app/wazuh', []).service('appState', function ($cookie
         getCreatedAt: () => {
             return $cookies.getObject('_createdAt');
         }, 
+        removeCreatedAt: () => {
+            return $cookies.remove('_createdAt');
+        }, 
         getCurrentAPI: () => {
             return $cookies.getObject('API');
         },

--- a/public/services/app-state.js
+++ b/public/services/app-state.js
@@ -19,7 +19,7 @@ require('ui/modules').get('app/wazuh', []).service('appState', function ($cookie
             return data;
         },
         setExtensions: extensions => {
-            var exp = new Date();
+            const exp = new Date();
             exp.setDate(exp.getDate() + 365);
             if (extensions) {
                 $cookies.putObject('extensions', extensions, { 'expires': exp });
@@ -28,8 +28,11 @@ require('ui/modules').get('app/wazuh', []).service('appState', function ($cookie
         getClusterInfo: () => {
             return $cookies.getObject('_clusterInfo');
         },
+        removeClusterInfo: () => {
+            return $cookies.remove('_clusterInfo');
+        },
         setClusterInfo: cluster_info => {
-            var exp = new Date();
+            const exp = new Date();
             exp.setDate(exp.getDate() + 365);
             if (cluster_info) {
                 $cookies.putObject('_clusterInfo', cluster_info, { 'expires': exp });
@@ -38,13 +41,24 @@ require('ui/modules').get('app/wazuh', []).service('appState', function ($cookie
         getCurrentPattern: () => {
             return $cookies.getObject('_currentPattern');
         },
+        setCreatedAt: date => {
+            const exp = new Date();
+            exp.setDate(exp.getDate() + 365);
+            $cookies.putObject('_createdAt',date,{ 'expires': exp });
+        },
         setCurrentPattern: newPattern => {
-            var exp = new Date();
+            const exp = new Date();
             exp.setDate(exp.getDate() + 365);
             if (newPattern) {
                 $cookies.putObject('_currentPattern', newPattern, { 'expires': exp });
             }
         },
+        removeCurrentPattern: () => {
+            return $cookies.remove('_currentPattern');
+        },
+        getCreatedAt: () => {
+            return $cookies.getObject('_createdAt');
+        }, 
         getCurrentAPI: () => {
             return $cookies.getObject('API');
         },
@@ -52,7 +66,7 @@ require('ui/modules').get('app/wazuh', []).service('appState', function ($cookie
             return $cookies.remove('API');
         },
         setCurrentAPI: API => {
-            var exp = new Date();
+            const exp = new Date();
             exp.setDate(exp.getDate() + 365);
             if (API) {
                 $cookies.putObject('API', API, { 'expires': exp});

--- a/public/services/routes.js
+++ b/public/services/routes.js
@@ -23,7 +23,7 @@ const checkTimestamp = async (appState,genericReq,errorHandler,$rootScope,$locat
             $rootScope.lastRestart = data.data.lastRestart;
             if(!$rootScope.$$phase) $rootScope.$digest();
         } else {
-            $rootScope.blankScreenError = 'Your .wazuh.version index is empty or corrupt'
+            $rootScope.blankScreenError = 'Your .wazuh-version index is empty or corrupt.'
             $location.search('tab',null);
             $location.path('/blank-screen');            
         }
@@ -38,8 +38,6 @@ const checkTimestamp = async (appState,genericReq,errorHandler,$rootScope,$locat
 //Installation wizard
 const settingsWizard = ($rootScope, $location, $q, $window, testAPI, appState, genericReq, errorHandler) => {
     let deferred = $q.defer();
-
-    
 
     // Save current location if we aren't performing a health-check, to later be able to come back to the same tab
     if (!$location.path().includes("/health-check")) {

--- a/public/services/routes.js
+++ b/public/services/routes.js
@@ -14,21 +14,24 @@ const healthCheck = ($window, $rootScope) => {
     }
 };
 
-const checkTimestamp = async (appState,genericReq,errorHandler,$rootScope) => {
+const checkTimestamp = async (appState,genericReq,errorHandler,$rootScope,$location) => {
     try {
         const data = await genericReq.request('GET', '/api/wazuh-elastic/timestamp');
         const current = appState.getCreatedAt();
-        if(data && data.data && data.data.installationDate){
-            $rootScope.installationDate = data.data.installationDate;
+        if(data && data.data){
+            if(!current) appState.setCreatedAt(data.data.lastRestart);
+            $rootScope.lastRestart = data.data.lastRestart;
             if(!$rootScope.$$phase) $rootScope.$digest();
+        } else {
+            $rootScope.blankScreenError = 'Your .wazuh.version index is empty or corrupt'
+            $location.search('tab',null);
+            $location.path('/blank-screen');            
         }
-        if(!current && data && data.data && data.data.installationDate) {
-            appState.setCreatedAt(data.data.installationDate);
-        }   
         return;
     } catch (err){
-        // IR AL BLANK SCREEN E INFORMAR
-        errorHandler.handle(err,'Routes - Check timestamp');
+        $rootScope.blankScreenError = err.message || err;
+        $location.search('tab',null);
+        $location.path('/blank-screen');  
     }
 }
 
@@ -59,10 +62,16 @@ const settingsWizard = ($rootScope, $location, $q, $window, testAPI, appState, g
         if(!fromElastic){
             $rootScope.comeFromWizard = true;
             if(!$rootScope.$$phase) $rootScope.$digest();
-            if(!$location.path().includes("/settings")) $location.path('/settings');
+            if(!$location.path().includes("/settings")) {
+                $location.search('_a', null);
+                $location.search('tab', 'api');
+                $location.path('/settings');
+            }
         } else {
             if(data && data.data && parseInt(data.data.statusCode) === 500 && parseInt(data.data.error) === 7 && data.data.message === '401 Unauthorized'){
                 errorHandler.handle('Wrong Wazuh API credentials, please add a new API and/or modify the existing one.','Routes');
+                $location.search('_a', null);
+                $location.search('tab', 'api');
                 $location.path('/settings');
             } else {
                 $location.path('/blank-screen');
@@ -92,19 +101,19 @@ const settingsWizard = ($rootScope, $location, $q, $window, testAPI, appState, g
     }
 
     const callCheckStored = () => {
-        checkTimestamp(appState,genericReq,errorHandler,$rootScope)
+        checkTimestamp(appState,genericReq,errorHandler,$rootScope,$location)
         .then(() => testAPI.check_stored(JSON.parse(appState.getCurrentAPI()).id))
         .then(data => {
-            if(data === 'cookies_outdated'){
-                $location.search('tab','panels');
-                $location.path('/overview');
-                return;
-            }
-            if (data.data.error || data.data.data.apiIsDown) {
-                checkResponse(data);
+            if(data && data === 'cookies_outdated'){
+                $location.search('tab','general');
+                $location.path('/overview')
             } else {
-                $rootScope.apiIsDown = null;
-                changeCurrentApi(data);
+                if (data.data.error || data.data.data.apiIsDown) {
+                    checkResponse(data);
+                } else {
+                    $rootScope.apiIsDown = null;
+                    changeCurrentApi(data);
+                }
             }
         })
         .catch(error => errorHandler.handle(error,'Routes'));
@@ -125,14 +134,22 @@ const settingsWizard = ($rootScope, $location, $q, $window, testAPI, appState, g
                 } else {
                     errorHandler.handle('Wazuh App: Please set up Wazuh API credentials.','Routes',true);
                     $rootScope.comeFromWizard = true;
-                    if(!$location.path().includes("/settings")) $location.path('/settings');
+                    if(!$location.path().includes("/settings")) {
+                        $location.search('_a', null);
+                        $location.search('tab', 'api');
+                        $location.path('/settings');
+                    }
                     deferred.reject();
                 }
             })
             .catch(error => {
                 errorHandler.handle(error,'Routes');
                 $rootScope.comeFromWizard = true;
-                if(!$location.path().includes("/settings")) $location.path('/settings');
+                if(!$location.path().includes("/settings")) {
+                    $location.search('_a', null);
+                    $location.search('tab', 'api');
+                    $location.path('/settings');
+                }
                 deferred.reject();
             });
         } else {

--- a/public/templates/error-handler/blank-screen.html
+++ b/public/templates/error-handler/blank-screen.html
@@ -4,16 +4,23 @@
     </div>
 
     <div class="checks-fail">
-        <div class="health-check-error">
-            
-            <center><span class="error-notify">Ups, something went wrong...</span></center>
-            <center class="wz-padding-top-10"><div id="result"></div></center>
-
-            <div layout="row" class="wz-padding-top-10 wz-line-height">
-                <p><a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/index.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/index.html</a>
-                <br>
-                <a href="https://documentation.wazuh.com/current/installation-guide/">https://documentation.wazuh.com/current/installation-guide/</a></p>
-            </div>
+            <md-divider></md-divider>
+        <div layout="row" class="wz-line-height layout-align-center-center"> 
+            <pre class="json-beautifier"><code>{{errorToShow || 'Something went wrong'}}</code></pre>
+        </div>
+        <md-divider></md-divider>
+        <div layout="row" class="wz-padding-top-10 wz-line-height layout-align-center-center">
+            <p><a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/index.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/index.html</a>
+            <br>
+            <a href="https://documentation.wazuh.com/current/installation-guide/">https://documentation.wazuh.com/current/installation-guide/</a></p>
+        </div>
+        <md-divider class="wz-margin-top-10"></md-divider>
+        <div layout="row" class="wz-padding-top-10 wz-line-height layout-align-center-center">
+            <p>Let me out of here!<br>
+            <md-button class="wazuh-button md-raised md-primary" ng-click="goOverview()" aria-label="Go overview">
+                <i class="fa fa-fw fa-sign-out"></i> Go app
+            </md-button>
+            </p>
         </div>
     </div>
 </div>

--- a/server/api/wazuh-elastic.js
+++ b/server/api/wazuh-elastic.js
@@ -7,15 +7,27 @@ module.exports = (server, options) => {
 
     const getTimeStamp = async (req,reply) => {
         try {
+
             const data = await elasticRequest.callWithInternalUser('search', {
                 index: '.wazuh-version',
-                type:  'wazuh-version'
+                type :  'wazuh-version'
             })
-            if(data.hits && data.hits.hits[0] && data.hits.hits[0]._source && data.hits.hits[0]._source.installationDate){
-                return reply({installationDate: data.hits.hits[0]._source.installationDate});
+
+            if(data.hits && 
+               data.hits.hits[0] && 
+               data.hits.hits[0]._source && 
+               data.hits.hits[0]._source.installationDate && 
+               data.hits.hits[0]._source.lastRestart){
+                
+                    return reply({
+                        installationDate: data.hits.hits[0]._source.installationDate,
+                        lastRestart     : data.hits.hits[0]._source.lastRestart
+                    });
+
             } else {
                 throw new Error('Could not fetch .wazuh-version index');
             }
+
         } catch (err) {
             reply({
                 'statusCode': 500,

--- a/server/initialize.js
+++ b/server/initialize.js
@@ -313,7 +313,6 @@ module.exports = (server, options) => {
         })
         .then(data => {
             server.log([blueWazuh, 'initialize', 'info'], '.wazuh-version document already exists. Updating version information and visualizations...');
-            server.log([blueWazuh, 'initialize', 'info'], 'FUUUUUCK');
             
             elasticRequest.callWithInternalUser('update', { 
                 index: '.wazuh-version', 

--- a/server/initialize.js
+++ b/server/initialize.js
@@ -220,12 +220,14 @@ module.exports = (server, options) => {
             body: shard_configuration
         })
         .then(() => {
+            const commonDate = new Date().toISOString();
 
-            let configuration = {
-                "name":             "Wazuh App",
-                "app-version":      packageJSON.version,
-                "revision":         packageJSON.revision,
-                "installationDate": new Date().toISOString()
+            const configuration = {
+                name            : 'Wazuh App',
+                'app-version'   : packageJSON.version,
+                revision        : packageJSON.revision,
+                installationDate: commonDate,
+                lastRestart     : commonDate
             };
 
             elasticRequest.callWithInternalUser('create', {
@@ -251,7 +253,7 @@ module.exports = (server, options) => {
         elasticRequest.callWithInternalUser('indices.exists', {
             index: '.wazuh'
         })
-        .then((result) => {
+        .then(result => {
             if (!result) {
 
                 let shards = 1;
@@ -309,17 +311,19 @@ module.exports = (server, options) => {
             type: "wazuh-version",
             id: "1"
         })
-        .then((data) => {
+        .then(data => {
             server.log([blueWazuh, 'initialize', 'info'], '.wazuh-version document already exists. Updating version information and visualizations...');
-
+            server.log([blueWazuh, 'initialize', 'info'], 'FUUUUUCK');
+            
             elasticRequest.callWithInternalUser('update', { 
                 index: '.wazuh-version', 
-                type: 'wazuh-version',
-                id: 1,
-                body: {
-                    'doc': {
-                        "app-version": packageJSON.version,
-                        "revision": packageJSON.revision
+                type : 'wazuh-version',
+                id   : 1,
+                body : {
+                    doc: {
+                        'app-version': packageJSON.version,
+                        revision     : packageJSON.revision,
+                        lastRestart: new Date().toISOString() // Indice exists so we update the lastRestarted date only
                     }
                 } 
             })


### PR DESCRIPTION
Hello team, this pull request add some improvments to the Wazuh App:

- Now we have a new field on the `.wazuh-version` index named `lastRestart`, it keeps the last kibana restart date.
- The citated field is used to check if the cookies have consistency with the current sever status. 
- Now the app is clever and take decissions depending on new consistency checks.

It will help to prevent weird situations on our users machines whenever they reinstall the app, reload Kibana, etc. It has been tested on several ways, hope it help us.

Best regards,
Jesús