### PR TITLE
Agents configuration tab redesign

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,19 @@
 # Change Log
 All notable changes to the Wazuh app project will be documented in this file.
 
+## Wazuh v3.2.1 - Kibana v6.2.2 - Revision 387
+### Added
+- **New logging system** ([#307](https://github.com/wazuh/wazuh-kibana-app/pull/307)):
+  - New module implemented to **write app logs**.
+  - Now **a trace is stored every time the app is re/started**.
+  - Currently, the `initialize.js` and `monitoring.js` files **works with this system**.
+  - **Note**: the logs will live under `/var/log/wazuh/wazuhapp.log` on Linux systems, on Windows systems they will live under `kibana/plugins/`. **It rotates the log whenever it reaches 100MB**.
+- **Better cookies handling** ([#308](https://github.com/wazuh/wazuh-kibana-app/pull/308)):
+  - New field on the `.wazuh-version` index to store the **last time the Kibana server was restarted**.
+  - This is used to **check if the cookies have consistency** with the current sever status.
+  - Now the app is clever and **takes decissions depending on new consistency checks**.
+- **New design for the *Agents/Configuration* tab** ([#309](https://github.com/wazuh/wazuh-kibana-app/pull/309)).
+
 ## Wazuh v3.2.1 - Kibana v6.2.2 - Revision 386
 ### Added
 - **New design for the *Manager/Groups* tab** ([#295](https://github.com/wazuh/wazuh-kibana-app/pull/295)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ All notable changes to the Wazuh app project will be documented in this file.
   - New field on the `.wazuh-version` index to store the **last time the Kibana server was restarted**.
   - This is used to **check if the cookies have consistency** with the current sever status.
   - Now the app is clever and **takes decissions depending on new consistency checks**.
-- **New design for the *Agents/Configuration* tab** ([#309](https://github.com/wazuh/wazuh-kibana-app/pull/309)).
+- **New design for the *Agents/Configuration* tab** ([#310](https://github.com/wazuh/wazuh-kibana-app/pull/310)).
 
 ## Wazuh v3.2.1 - Kibana v6.2.2 - Revision 386
 ### Added

--- a/public/controllers/agents.js
+++ b/public/controllers/agents.js
@@ -331,8 +331,8 @@ app.controller('agentsController',
         $scope.selectedIndex = 0;
 
         /** Agent configuration */
-        $scope.switchConfigTab = selected => {
-            $scope.configTab = selected;
+        $scope.switchConfigTab = item => {
+            $scope.selectedConfigTab = item;
             if(!$scope.$$phase) $scope.$digest();
         };
 

--- a/public/controllers/agents.js
+++ b/public/controllers/agents.js
@@ -330,12 +330,6 @@ app.controller('agentsController',
         $scope.tabs          = tabs;
         $scope.selectedIndex = 0;
 
-        /** Agent configuration */
-        $scope.switchConfigTab = item => {
-            $scope.selectedConfigTab = item;
-            if(!$scope.$$phase) $scope.$digest();
-        };
-
         $scope.isArray = angular.isArray;
 
         const getAgent = newAgentId => {

--- a/public/controllers/agents.js
+++ b/public/controllers/agents.js
@@ -33,7 +33,7 @@ app.controller('agentsController',
             auditModifiedFiles: '[vis-id="\'Wazuh-App-Agents-Audit-Modified-files-metric\'"]',
             auditRemovedFiles : '[vis-id="\'Wazuh-App-Agents-Audit-Removed-files-metric\'"]'
         }
-    
+
         // Metrics Vulnerability Detector
         const metricsVulnerability = {
             vulnCritical: '[vis-id="\'Wazuh-App-Overview-VULS-Metric-Critical-severity\'"]',
@@ -205,7 +205,7 @@ app.controller('agentsController',
             if(lastAgent && lastAgent !== id){
                 $rootScope.agentsAutoCompleteFired = true;
                 if(!$rootScope.$$phase) $rootScope.$digest();
-            }            
+            }
         }
 
         $scope.getAgent = async (newAgentId,fromAutocomplete) => {
@@ -332,7 +332,8 @@ app.controller('agentsController',
 
         /** Agent configuration */
         $scope.switchConfigTab = selected => {
-
+            $scope.configTab = selected;
+            if(!$scope.$$phase) $scope.$digest();
         };
 
         $scope.isArray = angular.isArray;

--- a/public/less/cleaned.less
+++ b/public/less/cleaned.less
@@ -321,7 +321,6 @@ kbn-vis .vis-container {
     margin: 0px !important;
 }
 
-.groupsFixPadding,
 .no-padding-top {
     padding-top: 0px !important;
 }

--- a/public/less/cleaned.less
+++ b/public/less/cleaned.less
@@ -300,10 +300,6 @@ kbn-vis .vis-container {
     margin-right: 10px;
 }
 
-.wz-margin-left-15 {
-    margin-left: 15px;
-}
-
 .wz-underline-config {
     text-decoration: underline !important;
 }

--- a/public/less/cleaned.less
+++ b/public/less/cleaned.less
@@ -90,7 +90,6 @@
     color: black !important;
 }
 
-
 /* ------------------------------------------------------------------- */
 /* ------------------- Wazuh stylesheet for buttons ------------------ */
 /* ------------------------------------------------------------------- */
@@ -142,7 +141,6 @@
 .kuiLocalNav {
     border-bottom: none !important;
 }
-
 
 kbn-vis,
 visualize,
@@ -240,8 +238,16 @@ kbn-vis .vis-container {
     background-color: rgb(49, 196, 113);
 }
 
+.color-green {
+    color: rgb(49, 196, 113) !important;
+}
+
 .red {
     background-color: #da534f;
+}
+
+.color-red {
+    color: #da534f !important;
 }
 
 .blue {
@@ -369,8 +375,6 @@ kbn-vis .vis-container {
 .wz-overflow-y-auto {
     overflow-y: auto;
 }
-
-
 
 .wz-margin-right-15 {
     margin-right: 15px;

--- a/public/less/cleaned.less
+++ b/public/less/cleaned.less
@@ -381,3 +381,7 @@ kbn-vis .vis-container {
     box-shadow: 0 2px 2px -1px rgba(0, 0, 0, 0.1) !important;
     border: 1px solid #D9D9D9;
 }
+
+.wz-md-switch {
+    margin: 0px !important;
+}

--- a/public/less/loader.js
+++ b/public/less/loader.js
@@ -1,6 +1,5 @@
 require('plugins/wazuh/less/common.less');
 require('plugins/wazuh/less/heights.less');
+require('plugins/wazuh/less/cleaned.less');
 require('plugins/wazuh/less/media-queries.less');
 import 'ui/styles/theme.less';
-
-require('plugins/wazuh/less/cleaned.less');

--- a/public/templates/agents-prev/agents-prev.head
+++ b/public/templates/agents-prev/agents-prev.head
@@ -4,4 +4,4 @@
         <wz-menu></wz-menu>
     </div>
 
-    <div flex layout="column" id="content" ng-class="tabView != 'discover' ? 'background-white' : ''" >
+    <div flex layout="column" id="content" ng-class="tabView != 'discover' ? 'background-white' : ''">

--- a/public/templates/agents-prev/agents-prev.html
+++ b/public/templates/agents-prev/agents-prev.html
@@ -26,7 +26,7 @@
                         </div>
                     </div>
                 </div>
-        </md-card-content>
+            </md-card-content>
         </md-card>
         <md-card flex class="no-margin-right wz-md-card">
             <md-card-content>

--- a/public/templates/agents/agents-configuration.html
+++ b/public/templates/agents/agents-configuration.html
@@ -2,31 +2,28 @@
 
     <!-- View: Panels -->
     <div layout="column" layout-align="start stretch">
-
         <md-card flex class="wz-md-card">
             <md-card-content>
-                <div layout="row">
-                    <div flex>
-                        <h4><i class="fa fa-warning"></i> This agent has never been connected, therefore no group has been assigned.</h4>
-                    </div>
+                <span class="wz-headline-title"><i class="fa fa-fw fa-warning"></i> Warning</span>
+                <md-divider class="wz-margin-top-10"></md-divider>
+                <div layout="row" class="wz-padding-top-10 wz-line-height">
+                    This agent has never been connected, therefore no group has been assigned.
                 </div>
-                <div layout="row">
-                    <div flex>
-                        <p>Use the following links to learn about the agent registration process and grouping of agents:
-                        </p>
-                        <ul>
-                            <li>
-                                <a href="https://documentation.wazuh.com/current/user-manual/registering/index.html">https://documentation.wazuh.com/current/user-manual/registering/index.html</a>
-                            </li>
-                            <li>
-                                <a href="https://documentation.wazuh.com/current/user-manual/agents/grouping-agents.html">https://documentation.wazuh.com/current/user-manual/agents/grouping-agents.html</a>
-                            </li>
-                        </ul>
-                    </div>
+                <div layout="row" class="wz-padding-top-10 wz-line-height">
+                    Use the following links to learn about the agent registration process and grouping of agents:
+                </div>
+                <div layout="row" class="wz-padding-top-10 wz-line-height">
+                    <ul>
+                        <li>
+                            <a href="https://documentation.wazuh.com/current/user-manual/registering/index.html">https://documentation.wazuh.com/current/user-manual/registering/index.html</a>
+                        </li>
+                        <li>
+                            <a href="https://documentation.wazuh.com/current/user-manual/agents/grouping-agents.html">https://documentation.wazuh.com/current/user-manual/agents/grouping-agents.html</a>
+                        </li>
+                    </ul>
                 </div>
             </md-card-content>
         </md-card>
-
     </div>
 
 </md-content>

--- a/public/templates/agents/agents-configuration.html
+++ b/public/templates/agents/agents-configuration.html
@@ -64,8 +64,13 @@
                         <!-- Section title -->
                         <span class="wz-headline-title cursor-pointer wz-table-hover" tooltip="Click to see more details" tooltip-placement="right" ng-click="selectedConfigTab='fim';toggleRAW=false" ng-class="selectedConfigTab === 'fim' ? 'wz-font-weight-bold' : ''">File Integrity</span>
                         <md-divider class="wz-margin-top-10"></md-divider>
-                        <div layout="row" class="wz-padding-top-10">
-                            <span flex>View File Integrity settings</span>
+                        <div layout="row" class="wz-padding-top-10" ng-if="groupConfiguration.config.syscheck.disabled">
+                            <span flex>Disabled</span>
+                            <span flex class="text-right color-grey">{{groupConfiguration.config.syscheck.disabled}}</span>
+                        </div>
+                        <div layout="row" class="wz-padding-top-10" ng-if="groupConfiguration.config.syscheck.frequency">
+                            <span flex>Frrequency</span>
+                            <span flex class="text-right color-grey">{{groupConfiguration.config.syscheck.frequency}}</span>
                         </div>
                     </md-card-content>
                 </md-card>
@@ -77,12 +82,35 @@
                         <!-- Section title -->
                         <span class="wz-headline-title cursor-pointer wz-table-hover" tooltip="Click to see more details" tooltip-placement="right" ng-click="selectedConfigTab='pm';toggleRAW=false" ng-class="selectedConfigTab === 'pm' ? 'wz-font-weight-bold' : ''">Policy Monitoring</span>
                         <md-divider class="wz-margin-top-10"></md-divider>
-                        <div layout="row" class="wz-padding-top-10">
-                            <span flex>View Policy Monitoring settings</span>
+                        <div layout="row" class="wz-padding-top-10" ng-if="groupConfiguration.config.rootcheck.disabled">
+                            <span flex>Disabled</span>
+                            <span flex class="text-right color-grey">{{groupConfiguration.config.rootcheck.disabled}}</span>
+                        </div>
+                        <div layout="row" class="wz-padding-top-10" ng-if="groupConfiguration.config.rootcheck.base_directory">
+                            <span flex>Base directory</span>
+                            <span flex class="text-right color-grey">{{groupConfiguration.config.rootcheck.frequency}}</span>
                         </div>
                     </md-card-content>
                 </md-card>
                 <!-- END POLICY MONITORING -->
+
+                <!-- OPENSCAP -->
+                <md-card flex class="wz-md-card" ng-show="groupConfiguration.config['open-scap']">
+                    <md-card-content>
+                        <!-- Section title -->
+                        <span class="wz-headline-title cursor-pointer wz-table-hover" tooltip="Click to see more details" tooltip-placement="right" ng-click="selectedConfigTab='scap';toggleRAW=false" ng-class="selectedConfigTab === 'scap' ? 'wz-font-weight-bold' : ''">OpenSCAP</span>
+                        <md-divider class="wz-margin-top-10"></md-divider>
+                        <div layout="row" class="wz-padding-top-10" ng-if="groupConfiguration.config['open-scap'].disabled">
+                            <span flex>Disabled</span>
+                            <span flex class="text-right color-grey">{{groupConfiguration.config['open-scap'].disabled}}</span>
+                        </div>
+                        <div layout="row" class="wz-padding-top-10" ng-if="groupConfiguration.config['open-scap'].interval">
+                            <span flex>Interval</span>
+                            <span flex class="text-right color-grey">{{groupConfiguration.config['open-scap'].interval}}</span>
+                        </div>
+                    </md-card-content>
+                </md-card>
+                <!-- END OPENSCAP -->
 
                 <!-- LOG COLLECTION -->
                 <md-card flex class="wz-md-card" ng-show="groupConfiguration.config['localfile']">
@@ -91,24 +119,11 @@
                         <span class="wz-headline-title cursor-pointer wz-table-hover" tooltip="Click to see more details" tooltip-placement="right" ng-click="selectedConfigTab='log';toggleRAW=false" ng-class="selectedConfigTab === 'log' ? 'wz-font-weight-bold' : ''">Log Collection</span>
                         <md-divider class="wz-margin-top-10"></md-divider>
                         <div layout="row" class="wz-padding-top-10">
-                            <span flex>Visualize all Log Collecting settings</span>
+                            <span flex>Visualize all Log Collection settings</span>
                         </div>
                     </md-card-content>
                 </md-card>
                 <!-- END LOG COLLECTION -->
-
-                <!-- OPENSCAP -->
-                <md-card flex class="wz-md-card" ng-show="groupConfiguration.config['open-scap']">
-                    <md-card-content>
-                        <!-- Section title -->
-                        <span class="wz-headline-title cursor-pointer wz-table-hover" tooltip="Click to see more details" tooltip-placement="right" ng-click="selectedConfigTab='scap';toggleRAW=false" ng-class="selectedConfigTab === 'scap' ? 'wz-font-weight-bold' : ''">OpenSCAP</span>
-                        <md-divider class="wz-margin-top-10"></md-divider>
-                        <div layout="row" class="wz-padding-top-10">
-                            <span flex>View OpenSCAP settings</span>
-                        </div>
-                    </md-card-content>
-                </md-card>
-                <!-- END OPENSCAP -->
 
             </div>
 
@@ -379,57 +394,6 @@
                 </md-card>
                 <!-- END POLICY MONITORING -->
 
-                <!-- LOG COLLECTION -->
-                <md-card flex class="wz-md-card" ng-show="selectedConfigTab === 'log' && !toggleRAW">
-                    <md-card-content>
-
-                        <!-- Section title -->
-                        <div layout="row" layout-align="start center">
-                            <span flex="85" class="wz-headline-title"><i class="fa fa-fw fa-reorder"></i> Log Collection</span>
-                            <md-switch flex="15" class="wz-md-switch" ng-model="toggleRAW">View JSON</md-switch>
-                        </div>
-
-                        <md-divider class="wz-margin-top-10"></md-divider>
-
-                        <!-- Log Files -->
-                        <div layout="row" class="wz-padding-top-10">
-                            <span class="wz-headline-title wz-padding-top-10">Log files</span>
-                        </div>
-                        <div ng-repeat="item in groupConfiguration.config['localfile']">
-                            <div ng-if="item.location" layout="row" class="wz-padding-top-10">
-                                <span flex>Location</span>
-                                <span flex class="text-right color-grey">{{item.location}}</span>
-                            </div>
-                            <div ng-if="item.log_format" layout="row" class="wz-padding-top-10">
-                                <span flex>Log format</span>
-                                <span flex class="text-right color-grey">{{item.log_format}}</span>
-                            </div>
-                            <div ng-if="item.frequency" layout="row" class="wz-padding-top-10">
-                                <span flex>Frequency</span>
-                                <span flex class="text-right color-grey">{{item.frequency}}</span>
-                            </div>
-                            <div ng-if="item.query" layout="row" class="wz-padding-top-10">
-                                <span flex>Query</span>
-                                <span flex class="text-right color-grey">{{item.query}}</span>
-                            </div>
-                            <div ng-if="item.command" layout="row" class="wz-padding-top-10">
-                                <span flex>Command</span>
-                                <span flex class="text-right color-grey">{{item.command}}</span>
-                            </div>
-                            <div ng-if="item.alias" layout="row" class="wz-padding-top-10">
-                                <span flex>Alias</span>
-                                <span flex class="text-right color-grey">{{item.alias}}</span>
-                            </div>
-                            <div ng-if="item.label" layout="row" class="wz-padding-top-10">
-                                <span flex>Label</span>
-                                <span flex class="text-right color-grey">{{item.label}}</span>
-                            </div>
-                            <md-divider class="wz-margin-top-10" ng-if="!$last"></md-divider>
-                        </div>
-                    </md-card-content>
-                </md-card>
-                <!-- END LOG COLLECTION -->
-
                 <!-- OPENSCAP -->
                 <md-card flex class="wz-md-card" ng-show="selectedConfigTab === 'scap' && !toggleRAW">
                     <md-card-content>
@@ -486,6 +450,54 @@
                     </md-card-content>
                 </md-card>
                 <!-- END OPENSCAP -->
+
+                <!-- LOG COLLECTION -->
+                <md-card flex class="wz-md-card" ng-show="selectedConfigTab === 'log' && !toggleRAW">
+                    <md-card-content>
+
+                        <!-- Section title -->
+                        <div layout="row" layout-align="start center">
+                            <span flex="85" class="wz-headline-title"><i class="fa fa-fw fa-reorder"></i> Log Collection</span>
+                            <md-switch flex="15" class="wz-md-switch" ng-model="toggleRAW">View JSON</md-switch>
+                        </div>
+
+                        <md-divider class="wz-margin-top-10"></md-divider>
+
+                        <!-- Log Files -->
+                        <div ng-repeat="item in groupConfiguration.config['localfile']">
+                            <div ng-if="item.location" layout="row" class="wz-padding-top-10">
+                                <span flex>Location</span>
+                                <span flex class="text-right color-grey">{{item.location}}</span>
+                            </div>
+                            <div ng-if="item.log_format" layout="row" class="wz-padding-top-10">
+                                <span flex>Log format</span>
+                                <span flex class="text-right color-grey">{{item.log_format}}</span>
+                            </div>
+                            <div ng-if="item.frequency" layout="row" class="wz-padding-top-10">
+                                <span flex>Frequency</span>
+                                <span flex class="text-right color-grey">{{item.frequency}}</span>
+                            </div>
+                            <div ng-if="item.query" layout="row" class="wz-padding-top-10">
+                                <span flex>Query</span>
+                                <span flex class="text-right color-grey">{{item.query}}</span>
+                            </div>
+                            <div ng-if="item.command" layout="row" class="wz-padding-top-10">
+                                <span flex>Command</span>
+                                <span flex class="text-right color-grey">{{item.command}}</span>
+                            </div>
+                            <div ng-if="item.alias" layout="row" class="wz-padding-top-10">
+                                <span flex>Alias</span>
+                                <span flex class="text-right color-grey">{{item.alias}}</span>
+                            </div>
+                            <div ng-if="item.label" layout="row" class="wz-padding-top-10">
+                                <span flex>Label</span>
+                                <span flex class="text-right color-grey">{{item.label}}</span>
+                            </div>
+                            <md-divider class="wz-margin-top-10" ng-if="!$last"></md-divider>
+                        </div>
+                    </md-card-content>
+                </md-card>
+                <!-- END LOG COLLECTION -->
 
                 <!-- JSON VIEWER -->
                 <md-card flex class="wz-md-card" ng-show="toggleRAW">

--- a/public/templates/agents/agents-configuration.html
+++ b/public/templates/agents/agents-configuration.html
@@ -41,9 +41,19 @@
     </div>
 
     <!-- The section container -->
-    <div flex layout="column" layout-align="start stretch" ng-init="showRaw=false" ng-show="!load">
+    <div flex layout="column" layout-align="start stretch" ng-init="showRaw = false; configTab = 'fim'" ng-show="!load">
 
         <!-- First row - Configuration status and other details -->
+        <div layout="row">
+            <md-card flex class="wz-metric-color wz-md-card">
+                <md-card-content layout="row" class="wz-padding-metric">
+                    <div flex>Group: <span ng-click="goGroup()" class="wz-font-weight-bold cursor-pointer" tooltip="Click to go to the group details" tooltip-placement="bottom">{{groupName}} <i class="fa fa-eye"></i></span></div>
+                    <div flex>Configuration status: <span class="wz-font-weight-bold" tooltip="The current synchronization status" tooltip-placement="bottom">{{isSynchronized ? 'SYNCHRONIZED' : 'NOT SYNCHRONIZED'}}</span></div>
+                    <div flex><md-switch flex="10" ng-model="toggleRAW">View JSON</md-switch></div>
+                </md-card-content>
+            </md-card>
+        </div>
+
         <div layout="row">
             <md-card flex class="wz-md-card">
                 <md-card-content>
@@ -65,465 +75,64 @@
         <div layout="row">
 
             <div flex="25">
+
+                <!-- FILE INTEGRITY -->
+                <md-card flex class="wz-md-card">
+                    <md-card-content>
+                        <!-- Section title -->
+                        <span class="wz-headline-title cursor-pointer" tooltip="Click to see more details" tooltip-placement="right" ng-click="switchConfigTab('fim')">
+                            File Integrity <i class="fa fa-eye"></i>
+                        </span>
+                        <md-divider class="wz-margin-top-10"></md-divider>
+                        <div layout="row" class="wz-padding-top-10">
+                            <span flex>View File Integrity settings</span>
+                        </div>
+                    </md-card-content>
+                </md-card>
+                <!-- END FILE INTEGRITY -->
+
+                <!-- POLICY MONITORING -->
+                <md-card flex class="wz-md-card">
+                    <md-card-content>
+                        <!-- Section title -->
+                        <span class="wz-headline-title cursor-pointer" tooltip="Click to see more details" tooltip-placement="right" ng-click="switchConfigTab('pm')">
+                            Policy Monitoring <i class="fa fa-eye"></i>
+                        </span>
+                        <md-divider class="wz-margin-top-10"></md-divider>
+                        <div layout="row" class="wz-padding-top-10">
+                            <span flex>View Policy Monitoring settings</span>
+                        </div>
+                    </md-card-content>
+                </md-card>
+                <!-- END POLICY MONITORING -->
+
             </div>
 
-            <div flex="75">
+            <div flex="75" layout="row" layout-align="start stretch">
+
+                <!-- FILE INTEGRITY -->
+                <md-card flex class="wz-md-card" ng-show="configTab === 'fim' && !toggleRAW">
+                    <md-card-content>
+                        <!-- Section title -->
+                        <span class="wz-headline-title"><i class="fa fa-fw fa-shield"></i> File Integrity</span>
+                        <md-divider class="wz-margin-top-10"></md-divider>
+                        <!-- No configuration panel -->
+                        <div layout="column" ng-show="groupConfiguration.config.syscheck && configTab === 'fim'">
+                            <h1 flex class="md-title text-center wz-padding-top-10">No FIM configuration available</h1>
+                            <p flex class="text-center wz-padding-top-10">There's no FIM group configuration used for this agent.</p>
+                        </div>
+                        <!-- Full details -->
+                        <div layout="row" class="wz-padding-top-10" ng-if="groupConfiguration.config.syscheck.disabled">
+                            <span flex>Disabled</span>
+                            <span flex class="text-right color-grey">{{groupConfiguration.config.syscheck.disabled}}</span>
+                        </div>
+                    </md-card-content>
+                </md-card>
+                <!-- END FILE INTEGRITY -->
+
             </div>
 
         </div>
 
-        <div flex layout="row">
-            <md-card flex class="wz-md-card">
-                <div layout="row" class="md-padding">
-                    <h1 flex="90" ng-show="!load" class="md-title">Current group:
-                        <span ng-click="goGroup()" class="agents-head-5 blue cursor-pointer" tooltip="Click to go to the group details" tooltip-placement="bottom">{{groupName}}</span>
-                        &nbsp;&ndash;&nbsp;Configuration status:
-                        <span ng-class="isSynchronized ? 'green' : 'red'" class="agents-head-5">{{isSynchronized ? 'SYNCHRONIZED' : 'NOT SYNCHRONIZED'}}</span>
-                    </h1>
-                    <md-switch flex="10" ng-model="toggleRAW">View JSON</md-switch>
-                </div>
-                <md-card-content ng-show="!toggleRAW" ng-init="configTab='fim'">
-                    <md-nav-bar md-selected-nav-item="configTab">
-                        <md-nav-item md-nav-click="switchConfigTab('fim')" name="fim">
-                            File Integrity
-                        </md-nav-item>
-                        <md-nav-item md-nav-click="switchConfigTab('pm')" name="pm">
-                            Policy Monitoring
-                        </md-nav-item>
-                        <md-nav-item md-nav-click="switchConfigTab('log')" name="log">
-                            Log Collection
-                        </md-nav-item>
-                        <md-nav-item md-nav-click="switchConfigTab('scap')" name="scap">
-                            OpenSCAP
-                        </md-nav-item>
-                    </md-nav-bar>
-                </md-card-content>
-
-                <!-- No config -->
-                <div layout="row" class="wz-margin-left-15" ng-show="!groupConfiguration.config.syscheck && configTab==='fim'">
-                    <div flex>
-                        <h1 class="md-title text-center">No FIM configuration available</h1>
-                        <p class="text-center">There's no FIM group configuration used for this agent.</p>
-                    </div>
-                </div>
-                <div layout="row" class="wz-margin-left-15" ng-show="!groupConfiguration.config.rootcheck && configTab==='pm'">
-                    <div flex>
-                        <h1 class="md-title text-center">No PM configuration available</h1>
-                        <p class="text-center">There's no PM group configuration used for this agent.</p>
-                    </div>
-                </div>
-                <div layout="row" class="wz-margin-left-15" ng-show="!groupConfiguration.config['localfile'] && configTab==='log'">
-                    <div flex>
-                        <h1 class="md-title text-center">No Log Collection configuration available</h1>
-                        <p class="text-center">There's no Log Collection group configuration used for this agent.</p>
-                    </div>
-                </div>
-                <div layout="row" class="wz-margin-left-15" ng-show="!groupConfiguration.config['active-response'] && configTab==='response'">
-                    <div flex>
-                        <h1 class="md-title text-center">No Active Response configuration available</h1>
-                        <p class="text-center">There's no Active Response group configuration used for this agent.</p>
-                    </div>
-                </div>
-                <div layout="row" class="wz-margin-left-15" ng-show="!groupConfiguration.config['open-scap'] && configTab==='scap'">
-                    <div flex>
-                        <h1 class="md-title text-center">No OpenSCAP configuration available</h1>
-                        <p class="text-center">There's no OpenSCAP group configuration used for this agent.</p>
-                    </div>
-                </div>
-                <!-- End no config -->
-
-                <!-- FIM -->
-                <div layout="row" class="wz-margin-left-15" ng-show="groupConfiguration.config.syscheck && configTab==='fim' && !toggleRAW">
-                    <md-card flex class="wz-md-card">
-                        <div layout="row" class="md-padding">
-                            <div flex>
-                                <h4>
-                                    <i class="fa fa-tasks"></i> Main Settings</h4>
-                                <md-divider></md-divider>
-                                <p ng-if="groupConfiguration.config.syscheck.disabled">
-                                    Disabled
-                                    <span class="md-secondary pull-right">{{groupConfiguration.config.syscheck.disabled}}</span>
-                                </p>
-                                <p ng-if="groupConfiguration.config.syscheck.frequency">
-                                    Frequency
-                                    <span class="md-secondary pull-right">{{groupConfiguration.config.syscheck.frequency}}</span>
-                                </p>
-                                <p ng-if="groupConfiguration.config.syscheck.alert_new_files">
-                                    Alert New Files
-                                    <span class="md-secondary pull-right">{{groupConfiguration.config.syscheck.alert_new_files}}</span>
-                                </p>
-                                <p ng-if="groupConfiguration.config.syscheck.skip_nfs">
-                                    Skip NFS
-                                    <span class="md-secondary pull-right">{{groupConfiguration.config.syscheck.skip_nfs}}</span>
-                                </p>
-                                <p ng-if="groupConfiguration.config.syscheck.scan_on_start">
-                                    Scan on Start
-                                    <span class="md-secondary pull-right">{{groupConfiguration.config.syscheck.scan_on_start}}</span>
-                                </p>
-                                <p ng-if="groupConfiguration.config.syscheck.scan_time">
-                                    Scan Time
-                                    <span class="md-secondary pull-right">{{groupConfiguration.config.syscheck.scan_time}}</span>
-                                </p>
-                                <p ng-if="groupConfiguration.config.syscheck.scan_day">
-                                    Scan Day
-                                    <span class="md-secondary pull-right">{{groupConfiguration.config.syscheck.scan_day}}</span>
-                                </p>
-                                <p ng-if="groupConfiguration.config.syscheck.auto_ignore">
-                                    Auto Ignore
-                                    <span class="md-secondary pull-right">{{groupConfiguration.config.syscheck.auto_ignore}}</span>
-                                </p>
-                            </div>
-                        </div>
-                    </md-card>
-                    <md-card flex class="wz-md-card">
-                        <div layout="row" class="md-padding">
-                            <div flex>
-                                <h4>
-                                    <i class="fa fa-clone"></i> No diff</h4>
-                                <md-divider></md-divider>
-                                <div ng-repeat="item in groupConfiguration.config.syscheck.nodiff">
-                                    <p ng-if="!item.type">
-                                        File
-                                        <span class="md-secondary pull-right">{{item}}</span>
-                                    </p>
-                                    <p ng-if="item.type">
-                                        File
-                                        <span class="md-secondary pull-right">{{item.item}}</span>
-                                    </p>
-                                    <p ng-if="item.type">
-                                        Type
-                                        <span class="md-secondary pull-right">{{item.type}}</span>
-                                    </p>
-                                    <md-divider ng-if="!$last"></md-divider>
-                                </div>
-                            </div>
-                        </div>
-                    </md-card>
-                </div>
-                <div layout="row" class="wz-margin-left-15" ng-show="groupConfiguration.config.syscheck && configTab==='fim' && !toggleRAW">
-                    <md-card flex class="wz-md-card">
-                        <div layout="row" class="md-padding">
-                            <div flex>
-                                <h4>
-                                    <i class="fa fa-file-o"></i> Monitored files</h4>
-                                <md-divider></md-divider>
-                                <div ng-repeat="item in groupConfiguration.config.syscheck.directories">
-                                    <p ng-if="item.path">
-                                        Path
-                                        <span class="md-secondary pull-right">{{item.path}}</span>
-                                    </p>
-                                    <p ng-if="item.check_all">
-                                        Check All
-                                        <span class="md-secondary pull-right">{{item.check_all}}</span>
-                                    </p>
-                                    <p ng-if="item.realtime">
-                                        Realtime
-                                        <span class="md-secondary pull-right">{{item.realtime}}</span>
-                                    </p>
-                                    <p ng-if="item.report_changes">
-                                        Report Changes
-                                        <span class="md-secondary pull-right">{{item.report_changes}}</span>
-                                    </p>
-                                    <md-divider ng-if="!$last"></md-divider>
-                                </div>
-                            </div>
-                        </div>
-                    </md-card>
-                    <md-card flex class="wz-md-card">
-                        <div layout="row" class="md-padding">
-                            <div flex>
-                                <h4>
-                                    <i class="fa fa-file"></i> Ignored files</h4>
-                                <md-divider></md-divider>
-                                <div ng-repeat="item in groupConfiguration.config.syscheck.ignore">
-                                    <p ng-if="!item.type">
-                                        File
-                                        <span class="md-secondary pull-right">{{item}}</span>
-                                    </p>
-                                    <p ng-if="item.type">
-                                        File
-                                        <span class="md-secondary pull-right">{{item.item}}</span>
-                                    </p>
-                                    <p ng-if="item.type">
-                                        Type
-                                        <span class="md-secondary pull-right">{{item.type}}</span>
-                                    </p>
-                                    <md-divider ng-if="!$last"></md-divider>
-                                </div>
-                            </div>
-                        </div>
-                    </md-card>
-
-                </div>
-                <!-- End FIM -->
-
-                <!-- PM -->
-                <div layout="row" class="wz-margin-left-15" ng-show="groupConfiguration.config.rootcheck && configTab==='pm' && !toggleRAW">
-                    <md-card flex class="wz-md-card">
-                        <div layout="row" class="md-padding">
-                            <div flex>
-                                <h4>
-                                    <i class="fa fa-tasks"></i> Main Settings</h4>
-                                <md-divider></md-divider>
-                                <p ng-if="groupConfiguration.config.rootcheck.disabled">
-                                    Disabled
-                                    <span class="md-secondary pull-right">{{groupConfiguration.config.rootcheck.disabled}}</span>
-                                </p>
-                                <p ng-if="groupConfiguration.config.rootcheck.base_directory">
-                                    Base directory
-                                    <span class="md-secondary pull-right">{{groupConfiguration.config.rootcheck.base_directory}}</span>
-                                </p>
-                                <p ng-if="groupConfiguration.config.rootcheck.frequency">
-                                    Frequency
-                                    <span class="md-secondary pull-right">{{groupConfiguration.config.rootcheck.frequency}}</span>
-                                </p>
-                                <p ng-if="groupConfiguration.config.rootcheck.scanall">
-                                    Scan All Files
-                                    <span class="md-secondary pull-right">{{groupConfiguration.config.rootcheck.scanall}}</span>
-                                </p>
-                                <p ng-if="groupConfiguration.config.rootcheck.skip_nfs">
-                                    Skip NFS
-                                    <span class="md-secondary pull-right">{{groupConfiguration.config.rootcheck.skip_nfs}}</span>
-                                </p>
-                            </div>
-                        </div>
-                    </md-card>
-                    <md-card flex class="wz-md-card">
-                        <div layout="row" class="md-padding">
-                            <div flex>
-                                <h4>
-                                    <i class="fa fa-check"></i> Checks</h4>
-                                <md-divider></md-divider>
-                                <p ng-if="groupConfiguration.config.rootcheck.check_unixaudit">
-                                    Check UNIX Audit
-                                    <span class="md-secondary pull-right">{{groupConfiguration.config.rootcheck.check_unixaudit}}</span>
-                                </p>
-                                <p ng-if="groupConfiguration.config.rootcheck.check_dev">
-                                    Check DEV
-                                    <span class="md-secondary pull-right">{{groupConfiguration.config.rootcheck.check_dev}}</span>
-                                </p>
-                                <p ng-if="groupConfiguration.config.rootcheck.check_files">
-                                    Check Files
-                                    <span class="md-secondary pull-right">{{groupConfiguration.config.rootcheck.check_files}}</span>
-                                </p>
-                                <p ng-if="groupConfiguration.config.rootcheck.check_if">
-                                    Check IF
-                                    <span class="md-secondary pull-right">{{groupConfiguration.config.rootcheck.check_if}}</span>
-                                </p>
-                                <p ng-if="groupConfiguration.config.rootcheck.check_pids">
-                                    Check PIDs
-                                    <span class="md-secondary pull-right">{{groupConfiguration.config.rootcheck.check_pids}}</span>
-                                </p>
-                                <p ng-if="groupConfiguration.config.rootcheck.check_policy">
-                                    Check Policy
-                                    <span class="md-secondary pull-right">{{groupConfiguration.config.rootcheck.check_policy}}</span>
-                                </p>
-                                <p ng-if="groupConfiguration.config.rootcheck.check_ports">
-                                    Check Ports
-                                    <span class="md-secondary pull-right">{{groupConfiguration.config.rootcheck.check_ports}}</span>
-                                </p>
-                                <p ng-if="groupConfiguration.config.rootcheck.check_sys">
-                                    Check SYS
-                                    <span class="md-secondary pull-right">{{groupConfiguration.config.rootcheck.check_sys}}</span>
-                                </p>
-                                <p ng-if="groupConfiguration.config.rootcheck.check_trojans">
-                                    Check Trojans
-                                    <span class="md-secondary pull-right">{{groupConfiguration.config.rootcheck.check_trojans}}</span>
-                                </p>
-                                <p ng-if="groupConfiguration.config.rootcheck.check_unixaudit">
-                                    Check UNIX Audit
-                                    <span class="md-secondary pull-right">{{groupConfiguration.config.rootcheck.check_unixaudit}}</span>
-                                </p>
-                            </div>
-                        </div>
-                    </md-card>
-                    <md-card flex class="wz-md-card">
-                        <div layout="row" class="md-padding">
-                            <div flex>
-                                <h4>
-                                    <i class="fa fa-windows"></i> Windows Settings</h4>
-                                <md-divider></md-divider>
-                                <p ng-if="groupConfiguration.config.rootcheck.check_winaudit">
-                                    Check Windows Audit
-                                    <span class="md-secondary pull-right">{{groupConfiguration.config.rootcheck.check_winaudit}}</span>
-                                </p>
-                                <p ng-if="groupConfiguration.config.rootcheck.check_winapps">
-                                    Check Windows Apps
-                                    <span class="md-secondary pull-right">{{groupConfiguration.config.rootcheck.check_winapps}}</span>
-                                </p>
-                                <p ng-if="groupConfiguration.config.rootcheck.check_winmalware">
-                                    Check Windows Malware
-                                    <span class="md-secondary pull-right">{{groupConfiguration.config.rootcheck.check_winmalware}}</span>
-                                </p>
-                            </div>
-                        </div>
-                    </md-card>
-                </div>
-                <div layout="row" class="wz-margin-left-15" ng-show="groupConfiguration.config.rootcheck && configTab==='pm' && !toggleRAW">
-
-                    <md-card flex class="wz-md-card">
-                        <div layout="row" class="md-padding">
-                            <div flex>
-                                <h4>
-                                    <i class="fa fa-shield"></i> Rootkit</h4>
-                                <md-divider></md-divider>
-                                <p ng-if="groupConfiguration.config.rootcheck.rootkit_trojans">
-                                    Trojans Path
-                                    <span class="md-secondary pull-right">{{groupConfiguration.config.rootcheck.rootkit_trojans[0]}}</span>
-                                </p>
-                                <p ng-if="groupConfiguration.config.rootcheck.rootkit_files">
-                                    Files Path
-                                    <span class="md-secondary pull-right">{{groupConfiguration.config.rootcheck.rootkit_files[0]}}</span>
-                                </p>
-                            </div>
-                        </div>
-                    </md-card>
-                    <md-card flex class="wz-md-card">
-                        <div layout="row" class="md-padding">
-                            <div flex>
-                                <h4>
-                                    <i class="fa fa-file-o"></i> System Audit Files</h4>
-                                <md-divider></md-divider>
-                                <div ng-repeat="item in groupConfiguration.config.rootcheck.system_audit">
-                                    <p>{{item}}</p>
-                                </div>
-                            </div>
-                        </div>
-                    </md-card>
-                </div>
-                <div layout="row" class="wz-margin-left-15" ng-show="groupConfiguration.config.rootcheck && configTab==='pm' && !toggleRAW">
-                    <md-card flex class="wz-md-card">
-                        <div layout="row" class="md-padding">
-                            <div flex>
-                                <h4>
-                                    <i class="fa fa-eye"></i> Windows Audit Files</h4>
-                                <md-divider></md-divider>
-                                <div ng-repeat="item in groupConfiguration.config.rootcheck.windows_audit">
-                                    <p>{{item}}</p>
-                                </div>
-                            </div>
-                        </div>
-                    </md-card>
-                    <md-card flex class="wz-md-card">
-                        <div layout="row" class="md-padding">
-                            <div flex>
-                                <h4>
-                                    <i class="fa fa-folder-o"></i> Windows Apps Files</h4>
-                                <md-divider></md-divider>
-                                <div ng-repeat="item in groupConfiguration.config.rootcheck.windows_apps">
-                                    <p>{{item}}</p>
-                                </div>
-                            </div>
-                        </div>
-                    </md-card>
-                    <md-card flex class="wz-md-card">
-                        <div layout="row" class="md-padding">
-                            <div flex>
-                                <h4>
-                                    <i class="fa fa-user-secret"></i> Windows Malware Files</h4>
-                                <md-divider></md-divider>
-                                <div ng-repeat="item in groupConfiguration.config.rootcheck.windows_malware">
-                                    <p>{{item}}</p>
-                                </div>
-                            </div>
-                        </div>
-                    </md-card>
-                </div>
-                <!-- End PM -->
-
-                <!-- Log -->
-                <div layout="row" class="wz-margin-left-15" ng-show="groupConfiguration.config['localfile'] && configTab==='log' && !toggleRAW">
-                    <md-card flex class="wz-md-card">
-                        <div layout="row" class="md-padding">
-                            <div flex>
-                                <h4>
-                                    <i class="fa fa-reorder"></i> Log Files</h4>
-                                <md-divider></md-divider>
-                                <div layout="column" ng-repeat="item in groupConfiguration.config['localfile']" class="md-subhead groupsFixPadding">
-                                    <div layout="row">
-                                        <span flex ng-if="item.location" class="md-headline">{{item.location}}</span>
-                                        <span flex ng-if="item.log_format" class="md-headline">{{item.log_format}}</span>
-                                        <span flex ng-if="item.frequency" class="md-headline">{{item.frequency}}</span>
-                                        <span flex ng-if="item.query" class="md-headline">{{item.query}}</span>
-                                        <span flex ng-if="item.command" class="md-headline">{{item.command}}</span>
-                                        <span flex ng-if="item.alias" class="md-headline">{{item.alias}}</span>
-
-                                        <span flex ng-if="item.label" class="md-headline">{{item.label}}</span>
-                                    </div>
-                                    <md-divider ng-if="!$last"></md-divider>
-                                </div>
-                            </div>
-                        </div>
-                    </md-card>
-                </div>
-                <!-- End Log -->
-
-                <!-- OpenScap -->
-                <div layout="row" class="wz-margin-left-15" ng-show="groupConfiguration.config['open-scap'] && configTab==='scap' && !toggleRAW">
-                    <md-card flex="40" class="wz-md-card">
-                        <div layout="row" class="md-padding">
-                            <div flex>
-                                <h4>
-                                    <i class="fa fa-tasks"></i> Main Settings
-                                </h4>
-                                <md-divider></md-divider>
-                                <p ng-if="groupConfiguration.config['open-scap'].disabled">
-                                    OpenSCAP disabled
-                                    <span class="md-secondary pull-right">{{groupConfiguration.config['open-scap'].disabled}}</span>
-                                </p>
-                                <p ng-if="groupConfiguration.config['open-scap'].interval">
-                                    Interval
-                                    <span class="md-secondary pull-right">{{groupConfiguration.config['open-scap'].interval}}</span>
-                                </p>
-                                <p ng-if="groupConfiguration.config['open-scap']['scan-on-start']">
-                                    Scan on start
-                                    <span class="md-secondary pull-right">{{groupConfiguration.config['open-scap']['scan-on-start']}}</span>
-                                </p>
-                                <p ng-if="groupConfiguration.config['open-scap'].ciscat_path">
-                                    CIS-CAT Path
-                                    <span class="md-secondary pull-right">{{groupConfiguration.config['open-scap'].ciscat_path}}</span>
-                                </p>
-                                <p ng-if="groupConfiguration.config['open-scap'].java_path">
-                                    Java Path
-                                    <span class="md-secondary pull-right">{{groupConfiguration.config['open-scap'].java_path}}</span>
-                                </p>
-                                <p ng-if="groupConfiguration.config['open-scap'].timeout">
-                                    Timeout
-                                    <span class="md-secondary pull-right">{{groupConfiguration.config['open-scap'].timeout}}</span>
-                                </p>
-                            </div>
-                        </div>
-                    </md-card>
-                    <md-card flex="40" class="wz-md-card">
-                        <div layout="row" class="md-padding">
-                            <div flex>
-                                <h4>
-                                    <i class="fa fa-reorder"></i> Content
-                                </h4>
-                                <md-divider></md-divider>
-                                <div ng-repeat="item in groupConfiguration.config['open-scap'].content">
-                                    <p ng-if="item.path">
-                                        Path
-                                        <span class="md-secondary pull-right">{{item.path}}</span>
-                                    </p>
-                                    <p ng-if="item.type">
-                                        Type
-                                        <span class="md-secondary pull-right">{{item.type}}</span>
-                                    </p>
-                                    <md-divider ng-if="!$last"></md-divider>
-                                </div>
-                            </div>
-                        </div>
-                    </md-card>
-                </div>
-                <!-- End OpenScap -->
-
-                <!-- JSON -->
-                <div layout="row" flex class="md-padding height-300 wz-margin-left-15" ng-show="toggleRAW">
-                    <pre flex layout-fill class="wz-pre json-beautifier"><code wz-dynamic="rawJSON"></code></pre>
-                </div>
-                <!-- End JSON -->
-            </md-card>
-        </div>
     </div>
 </md-content>

--- a/public/templates/agents/agents-configuration.html
+++ b/public/templates/agents/agents-configuration.html
@@ -62,7 +62,7 @@
                 <md-card flex class="wz-md-card">
                     <md-card-content>
                         <!-- Section title -->
-                        <span class="wz-headline-title cursor-pointer" tooltip="Click to see more details" tooltip-placement="right" ng-click="switchConfigTab('fim')">
+                        <span class="wz-headline-title cursor-pointer" tooltip="Click to see more details" tooltip-placement="right" ng-click="selectedConfigTab='fim'">
                             File Integrity <i class="fa fa-eye"></i>
                         </span>
                         <md-divider class="wz-margin-top-10"></md-divider>
@@ -77,7 +77,7 @@
                 <md-card flex class="wz-md-card">
                     <md-card-content>
                         <!-- Section title -->
-                        <span class="wz-headline-title cursor-pointer" tooltip="Click to see more details" tooltip-placement="right" ng-click="switchConfigTab('pm')">
+                        <span class="wz-headline-title cursor-pointer" tooltip="Click to see more details" tooltip-placement="right" ng-click="selectedConfigTab='pm'">
                             Policy Monitoring <i class="fa fa-eye"></i>
                         </span>
                         <md-divider class="wz-margin-top-10"></md-divider>
@@ -92,7 +92,7 @@
                 <md-card flex class="wz-md-card">
                     <md-card-content>
                         <!-- Section title -->
-                        <span class="wz-headline-title cursor-pointer" tooltip="Click to see more details" tooltip-placement="right" ng-click="switchConfigTab('log')">
+                        <span class="wz-headline-title cursor-pointer" tooltip="Click to see more details" tooltip-placement="right" ng-click="selectedConfigTab='log'">
                             Log Collection <i class="fa fa-eye"></i>
                         </span>
                         <md-divider class="wz-margin-top-10"></md-divider>
@@ -107,7 +107,7 @@
                 <md-card flex class="wz-md-card">
                     <md-card-content>
                         <!-- Section title -->
-                        <span class="wz-headline-title cursor-pointer" tooltip="Click to see more details" tooltip-placement="right" ng-click="switchConfigTab('scap')">
+                        <span class="wz-headline-title cursor-pointer" tooltip="Click to see more details" tooltip-placement="right" ng-click="selectedConfigTab='scap'">
                             OpenSCAP <i class="fa fa-eye"></i>
                         </span>
                         <md-divider class="wz-margin-top-10"></md-divider>

--- a/public/templates/agents/agents-configuration.html
+++ b/public/templates/agents/agents-configuration.html
@@ -59,12 +59,10 @@
             <div flex="25">
 
                 <!-- FILE INTEGRITY -->
-                <md-card flex class="wz-md-card">
+                <md-card flex class="wz-md-card" ng-if="groupConfiguration.config.syscheck">
                     <md-card-content>
                         <!-- Section title -->
-                        <span class="wz-headline-title cursor-pointer" tooltip="Click to see more details" tooltip-placement="right" ng-click="selectedConfigTab='fim'">
-                            File Integrity <i class="fa fa-eye"></i>
-                        </span>
+                        <span class="wz-headline-title cursor-pointer wz-table-hover" tooltip="Click to see more details" tooltip-placement="right" ng-click="selectedConfigTab='fim'">File Integrity</span>
                         <md-divider class="wz-margin-top-10"></md-divider>
                         <div layout="row" class="wz-padding-top-10">
                             <span flex>View File Integrity settings</span>
@@ -74,12 +72,10 @@
                 <!-- END FILE INTEGRITY -->
 
                 <!-- POLICY MONITORING -->
-                <md-card flex class="wz-md-card">
+                <md-card flex class="wz-md-card" ng-if="groupConfiguration.config.rootcheck">
                     <md-card-content>
                         <!-- Section title -->
-                        <span class="wz-headline-title cursor-pointer" tooltip="Click to see more details" tooltip-placement="right" ng-click="selectedConfigTab='pm'">
-                            Policy Monitoring <i class="fa fa-eye"></i>
-                        </span>
+                        <span class="wz-headline-title cursor-pointer wz-table-hover" tooltip="Click to see more details" tooltip-placement="right" ng-click="selectedConfigTab='pm'">Policy Monitoring</span>
                         <md-divider class="wz-margin-top-10"></md-divider>
                         <div layout="row" class="wz-padding-top-10">
                             <span flex>View Policy Monitoring settings</span>
@@ -89,12 +85,10 @@
                 <!-- END POLICY MONITORING -->
 
                 <!-- LOG COLLECTION -->
-                <md-card flex class="wz-md-card">
+                <md-card flex class="wz-md-card" ng-if="!groupConfiguration.config['localfile']">
                     <md-card-content>
                         <!-- Section title -->
-                        <span class="wz-headline-title cursor-pointer" tooltip="Click to see more details" tooltip-placement="right" ng-click="selectedConfigTab='log'">
-                            Log Collection <i class="fa fa-eye"></i>
-                        </span>
+                        <span class="wz-headline-title cursor-pointer wz-table-hover" tooltip="Click to see more details" tooltip-placement="right" ng-click="selectedConfigTab='log'">Log Collection</span>
                         <md-divider class="wz-margin-top-10"></md-divider>
                         <div layout="row" class="wz-padding-top-10">
                             <span flex>View Log Collection settings</span>
@@ -104,12 +98,10 @@
                 <!-- END LOG COLLECTION -->
 
                 <!-- OPENSCAP -->
-                <md-card flex class="wz-md-card">
+                <md-card flex class="wz-md-card" ng-if="!groupConfiguration.config['open-scap']">
                     <md-card-content>
                         <!-- Section title -->
-                        <span class="wz-headline-title cursor-pointer" tooltip="Click to see more details" tooltip-placement="right" ng-click="selectedConfigTab='scap'">
-                            OpenSCAP <i class="fa fa-eye"></i>
-                        </span>
+                        <span class="wz-headline-title cursor-pointer wz-table-hover" tooltip="Click to see more details" tooltip-placement="right" ng-click="selectedConfigTab='scap'">OpenSCAP</span>
                         <md-divider class="wz-margin-top-10"></md-divider>
                         <div layout="row" class="wz-padding-top-10">
                             <span flex>View OpenSCAP settings</span>
@@ -133,12 +125,6 @@
                         </div>
 
                         <md-divider class="wz-margin-top-10"></md-divider>
-
-                        <!-- No configuration panel -->
-                        <div layout="column" ng-show="!groupConfiguration.config.syscheck">
-                            <h1 flex class="md-title text-center wz-padding-top-10">No FIM configuration available</h1>
-                            <p flex class="text-center wz-padding-top-10">There's no FIM group configuration used for this agent.</p>
-                        </div>
 
                         <!-- Main settings -->
                         <div layout="row" class="wz-padding-top-10" ng-if="groupConfiguration.config.syscheck.disabled">
@@ -253,11 +239,6 @@
 
                         <md-divider class="wz-margin-top-10"></md-divider>
 
-                        <!-- No configuration panel -->
-                        <div layout="column" ng-show="!groupConfiguration.config.rootcheck">
-                            <h1 flex class="md-title text-center wz-padding-top-10">No PM configuration available</h1>
-                            <p flex class="text-center wz-padding-top-10">There's no PM group configuration used for this agent.</p>
-                        </div>
                     </md-card-content>
                 </md-card>
                 <!-- END POLICY MONITORING -->
@@ -274,11 +255,6 @@
 
                         <md-divider class="wz-margin-top-10"></md-divider>
 
-                        <!-- No configuration panel -->
-                        <div layout="column" ng-show="!groupConfiguration.config['localfile']">
-                            <h1 flex class="md-title text-center wz-padding-top-10">No Log Collection configuration available</h1>
-                            <p flex class="text-center wz-padding-top-10">There's no Log Collection group configuration used for this agent.</p>
-                        </div>
                     </md-card-content>
                 </md-card>
                 <!-- END LOG COLLECTION -->
@@ -295,11 +271,6 @@
 
                         <md-divider class="wz-margin-top-10"></md-divider>
 
-                        <!-- No configuration panel -->
-                        <div layout="column" ng-show="!groupConfiguration.config['open-scap']">
-                            <h1 flex class="md-title text-center wz-padding-top-10">No OpenSCAP configuration available</h1>
-                            <p flex class="text-center wz-padding-top-10">There's no OpenSCAP group configuration used for this agent.</p>
-                        </div>
                     </md-card-content>
                 </md-card>
                 <!-- END OPENSCAP -->

--- a/public/templates/agents/agents-configuration.html
+++ b/public/templates/agents/agents-configuration.html
@@ -101,7 +101,7 @@
                         <!-- Section title -->
                         <div layout="row" layout-align="start center">
                             <span flex="85" class="wz-headline-title"><i class="fa fa-fw fa-shield"></i> File Integrity</span>
-                            <md-switch flex="15" ng-model="toggleRAW" class="wz-md-switch">View JSON</md-switch>
+                            <md-switch flex="15" class="wz-md-switch" ng-model="toggleRAW">View JSON</md-switch>
                         </div>
 
                         <md-divider class="wz-margin-top-10"></md-divider>
@@ -208,6 +208,26 @@
                                 <span flex class="text-right color-grey">{{item.type}}</span>
                             </div>
                             <md-divider class="wz-margin-top-10" ng-if="!$last"></md-divider>
+                        </div>
+                    </md-card-content>
+                </md-card>
+                <!-- END FILE INTEGRITY -->
+
+                <!-- FILE INTEGRITY -->
+                <md-card flex class="wz-md-card" ng-show="toggleRAW">
+                    <md-card-content>
+
+                        <!-- Section title -->
+                        <div layout="row" layout-align="start center">
+                            <span flex="85" class="wz-headline-title"><i class="fa fa-fw fa-eye"></i> JSON viewer</span>
+                            <md-switch flex="15" class="wz-md-switch" ng-model="toggleRAW">View JSON</md-switch>
+                        </div>
+
+                        <md-divider class="wz-margin-top-10"></md-divider>
+
+                        <!-- JSON viewer -->
+                        <div flex class="wz-padding-top-10">
+                            <pre flex class="wz-pre json-beautifier jsonbeauty2 wz-overflow-y-auto"><code wz-dynamic="rawJSON"></code></pre>
                         </div>
                     </md-card-content>
                 </md-card>

--- a/public/templates/agents/agents-configuration.html
+++ b/public/templates/agents/agents-configuration.html
@@ -62,7 +62,7 @@
                 <md-card flex class="wz-md-card" ng-show="groupConfiguration.config.syscheck">
                     <md-card-content>
                         <!-- Section title -->
-                        <span class="wz-headline-title cursor-pointer wz-table-hover" tooltip="Click to see more details" tooltip-placement="right" ng-click="selectedConfigTab='fim';toggleRAW=false" ng-class="selectedConfigTab === 'fim' ? wz-font-weight-bold : ''">File Integrity</span>
+                        <span class="wz-headline-title cursor-pointer wz-table-hover" tooltip="Click to see more details" tooltip-placement="right" ng-click="selectedConfigTab='fim';toggleRAW=false" ng-class="selectedConfigTab === 'fim' ? 'wz-font-weight-bold' : ''">File Integrity</span>
                         <md-divider class="wz-margin-top-10"></md-divider>
                         <div layout="row" class="wz-padding-top-10">
                             <span flex>View File Integrity settings</span>
@@ -75,7 +75,7 @@
                 <md-card flex class="wz-md-card" ng-show="groupConfiguration.config.rootcheck">
                     <md-card-content>
                         <!-- Section title -->
-                        <span class="wz-headline-title cursor-pointer wz-table-hover" tooltip="Click to see more details" tooltip-placement="right" ng-click="selectedConfigTab='pm';toggleRAW=false" ng-class="selectedConfigTab === 'pm' ? wz-font-weight-bold : ''">Policy Monitoring</span>
+                        <span class="wz-headline-title cursor-pointer wz-table-hover" tooltip="Click to see more details" tooltip-placement="right" ng-click="selectedConfigTab='pm';toggleRAW=false" ng-class="selectedConfigTab === 'pm' ? 'wz-font-weight-bold' : ''">Policy Monitoring</span>
                         <md-divider class="wz-margin-top-10"></md-divider>
                         <div layout="row" class="wz-padding-top-10">
                             <span flex>View Policy Monitoring settings</span>
@@ -88,7 +88,7 @@
                 <md-card flex class="wz-md-card" ng-show="groupConfiguration.config['localfile']">
                     <md-card-content>
                         <!-- Section title -->
-                        <span class="wz-headline-title cursor-pointer wz-table-hover" tooltip="Click to see more details" tooltip-placement="right" ng-click="selectedConfigTab='log';toggleRAW=false" ng-class="selectedConfigTab === 'log' ? wz-font-weight-bold : ''">Log Collection</span>
+                        <span class="wz-headline-title cursor-pointer wz-table-hover" tooltip="Click to see more details" tooltip-placement="right" ng-click="selectedConfigTab='log';toggleRAW=false" ng-class="selectedConfigTab === 'log' ? 'wz-font-weight-bold' : ''">Log Collection</span>
                         <md-divider class="wz-margin-top-10"></md-divider>
                         <div layout="row" class="wz-padding-top-10">
                             <span flex>Visualize all Log Collecting settings</span>
@@ -101,7 +101,7 @@
                 <md-card flex class="wz-md-card" ng-show="groupConfiguration.config['open-scap']">
                     <md-card-content>
                         <!-- Section title -->
-                        <span class="wz-headline-title cursor-pointer wz-table-hover" tooltip="Click to see more details" tooltip-placement="right" ng-click="selectedConfigTab='scap';toggleRAW=false" ng-class="selectedConfigTab === 'scap' ? wz-font-weight-bold : ''">OpenSCAP</span>
+                        <span class="wz-headline-title cursor-pointer wz-table-hover" tooltip="Click to see more details" tooltip-placement="right" ng-click="selectedConfigTab='scap';toggleRAW=false" ng-class="selectedConfigTab === 'scap' ? 'wz-font-weight-bold' : ''">OpenSCAP</span>
                         <md-divider class="wz-margin-top-10"></md-divider>
                         <div layout="row" class="wz-padding-top-10">
                             <span flex>View OpenSCAP settings</span>
@@ -397,29 +397,35 @@
                         </div>
                         <div ng-repeat="item in groupConfiguration.config['localfile']">
                             <div ng-if="item.location" layout="row" class="wz-padding-top-10">
+                                <span flex>Location</span>
                                 <span flex class="text-right color-grey">{{item.location}}</span>
                             </div>
                             <div ng-if="item.log_format" layout="row" class="wz-padding-top-10">
+                                <span flex>Log format</span>
                                 <span flex class="text-right color-grey">{{item.log_format}}</span>
                             </div>
                             <div ng-if="item.frequency" layout="row" class="wz-padding-top-10">
+                                <span flex>Frequency</span>
                                 <span flex class="text-right color-grey">{{item.frequency}}</span>
                             </div>
                             <div ng-if="item.query" layout="row" class="wz-padding-top-10">
+                                <span flex>Query</span>
                                 <span flex class="text-right color-grey">{{item.query}}</span>
                             </div>
                             <div ng-if="item.command" layout="row" class="wz-padding-top-10">
+                                <span flex>Command</span>
                                 <span flex class="text-right color-grey">{{item.command}}</span>
                             </div>
                             <div ng-if="item.alias" layout="row" class="wz-padding-top-10">
+                                <span flex>Alias</span>
                                 <span flex class="text-right color-grey">{{item.alias}}</span>
                             </div>
                             <div ng-if="item.label" layout="row" class="wz-padding-top-10">
+                                <span flex>Label</span>
                                 <span flex class="text-right color-grey">{{item.label}}</span>
                             </div>
                             <md-divider class="wz-margin-top-10" ng-if="!$last"></md-divider>
                         </div>
-
                     </md-card-content>
                 </md-card>
                 <!-- END LOG COLLECTION -->
@@ -436,6 +442,47 @@
 
                         <md-divider class="wz-margin-top-10"></md-divider>
 
+                        <!-- Main settings -->
+                        <div layout="row" class="wz-padding-top-10" ng-if="groupConfiguration.config['open-scap'].disabled">
+                            <span flex>Disabled</span>
+                            <span flex class="text-right color-grey">{{groupConfiguration.config['open-scap'].disabled}}</span>
+                        </div>
+                        <div layout="row" class="wz-padding-top-10" ng-if="groupConfiguration.config['open-scap'].interval">
+                            <span flex>Interval</span>
+                            <span flex class="text-right color-grey">{{groupConfiguration.config['open-scap'].interval}}</span>
+                        </div>
+                        <div layout="row" class="wz-padding-top-10" ng-if="groupConfiguration.config['open-scap']['scan-on-start']">
+                            <span flex>Scan on start</span>
+                            <span flex class="text-right color-grey">{{groupConfiguration.config['open-scap']['scan-on-start']}}</span>
+                        </div>
+                        <div layout="row" class="wz-padding-top-10" ng-if="groupConfiguration.config['open-scap'].ciscat_path">
+                            <span flex>CIS-CAT path</span>
+                            <span flex class="text-right color-grey">{{groupConfiguration.config['open-scap'].ciscat_path}}</span>
+                        </div>
+                        <div layout="row" class="wz-padding-top-10" ng-if="groupConfiguration.config['open-scap'].java_path">
+                            <span flex>Java path</span>
+                            <span flex class="text-right color-grey">{{groupConfiguration.config['open-scap'].java_path}}</span>
+                        </div>
+                        <div layout="row" class="wz-padding-top-10" ng-if="groupConfiguration.config['open-scap'].timeout">
+                            <span flex>Timeout</span>
+                            <span flex class="text-right color-grey">{{groupConfiguration.config['open-scap'].timeout}}</span>
+                        </div>
+
+                        <!-- Content -->
+                        <div layout="row" class="wz-padding-top-10">
+                            <span class="wz-headline-title wz-padding-top-10">Content</span>
+                        </div>
+                        <div ng-repeat="item in groupConfiguration.config['open-scap'].content">
+                            <div ng-if="item.path" layout="row" class="wz-padding-top-10">
+                                <span flex>Path</span>
+                                <span flex class="text-right color-grey">{{item.path}}</span>
+                            </div>
+                            <div ng-if="item.type" layout="row" class="wz-padding-top-10">
+                                <span flex>Type</span>
+                                <span flex class="text-right color-grey">{{item.type}}</span>
+                            </div>
+                            <md-divider class="wz-margin-top-10" ng-if="!$last"></md-divider>
+                        </div>
                     </md-card-content>
                 </md-card>
                 <!-- END OPENSCAP -->

--- a/public/templates/agents/agents-configuration.html
+++ b/public/templates/agents/agents-configuration.html
@@ -469,7 +469,7 @@
                         </div>
 
                         <!-- Content -->
-                        <div layout="row" class="wz-padding-top-10">
+                        <div layout="row" class="wz-padding-top-10" ng-if="groupConfiguration.config['open-scap'].content">
                             <span class="wz-headline-title wz-padding-top-10">Content</span>
                         </div>
                         <div ng-repeat="item in groupConfiguration.config['open-scap'].content">

--- a/public/templates/agents/agents-configuration.html
+++ b/public/templates/agents/agents-configuration.html
@@ -41,7 +41,7 @@
     </div>
 
     <!-- The section container -->
-    <div flex layout="column" layout-align="start stretch" ng-init="showRaw = false; configTab = 'fim'" ng-show="!load">
+    <div flex layout="column" layout-align="start stretch" ng-init="showRaw=false; selectedConfigTab='fim'" ng-show="!load">
 
         <!-- First row - Configuration status and other details -->
         <div layout="row">
@@ -49,12 +49,11 @@
                 <md-card-content layout="row" class="wz-padding-metric">
                     <div flex>Group: <span ng-click="goGroup()" class="wz-font-weight-bold cursor-pointer" tooltip="Click to go to the group details" tooltip-placement="bottom">{{groupName}} <i class="fa fa-eye"></i></span></div>
                     <div flex>Configuration status: <span class="wz-font-weight-bold" tooltip="The current synchronization status" tooltip-placement="bottom">{{isSynchronized ? 'SYNCHRONIZED' : 'NOT SYNCHRONIZED'}}</span></div>
-                    <div flex><md-switch flex="10" ng-model="toggleRAW">View JSON</md-switch></div>
                 </md-card-content>
             </md-card>
         </div>
 
-        <div layout="row">
+        <!-- <div layout="row">
             <md-card flex class="wz-md-card">
                 <md-card-content>
                     <span class="wz-headline-title">Details</span>
@@ -69,7 +68,7 @@
                     </div>
                 </md-card-content>
             </md-card>
-        </div>
+        </div> -->
 
         <!-- Second row - The configuration section itself -->
         <div layout="row">
@@ -91,40 +90,124 @@
                 </md-card>
                 <!-- END FILE INTEGRITY -->
 
-                <!-- POLICY MONITORING -->
-                <md-card flex class="wz-md-card">
-                    <md-card-content>
-                        <!-- Section title -->
-                        <span class="wz-headline-title cursor-pointer" tooltip="Click to see more details" tooltip-placement="right" ng-click="switchConfigTab('pm')">
-                            Policy Monitoring <i class="fa fa-eye"></i>
-                        </span>
-                        <md-divider class="wz-margin-top-10"></md-divider>
-                        <div layout="row" class="wz-padding-top-10">
-                            <span flex>View Policy Monitoring settings</span>
-                        </div>
-                    </md-card-content>
-                </md-card>
-                <!-- END POLICY MONITORING -->
-
             </div>
 
             <div flex="75" layout="row" layout-align="start stretch">
 
                 <!-- FILE INTEGRITY -->
-                <md-card flex class="wz-md-card" ng-show="configTab === 'fim' && !toggleRAW">
+                <md-card flex class="wz-md-card" ng-show="selectedConfigTab === 'fim' && !toggleRAW">
                     <md-card-content>
+
                         <!-- Section title -->
-                        <span class="wz-headline-title"><i class="fa fa-fw fa-shield"></i> File Integrity</span>
+                        <div layout="row" layout-align="start center">
+                            <span flex="85" class="wz-headline-title"><i class="fa fa-fw fa-shield"></i> File Integrity</span>
+                            <md-switch flex="15" ng-model="toggleRAW" class="wz-md-switch">View JSON</md-switch>
+                        </div>
+
                         <md-divider class="wz-margin-top-10"></md-divider>
+
                         <!-- No configuration panel -->
-                        <div layout="column" ng-show="groupConfiguration.config.syscheck && configTab === 'fim'">
+                        <div layout="column" ng-show="!groupConfiguration.config.syscheck">
                             <h1 flex class="md-title text-center wz-padding-top-10">No FIM configuration available</h1>
                             <p flex class="text-center wz-padding-top-10">There's no FIM group configuration used for this agent.</p>
                         </div>
-                        <!-- Full details -->
+
+                        <!-- Main settings -->
                         <div layout="row" class="wz-padding-top-10" ng-if="groupConfiguration.config.syscheck.disabled">
                             <span flex>Disabled</span>
                             <span flex class="text-right color-grey">{{groupConfiguration.config.syscheck.disabled}}</span>
+                        </div>
+                        <div layout="row" class="wz-padding-top-10" ng-if="groupConfiguration.config.syscheck.frequency">
+                            <span flex>Frrequency</span>
+                            <span flex class="text-right color-grey">{{groupConfiguration.config.syscheck.frequency}}</span>
+                        </div>
+                        <div layout="row" class="wz-padding-top-10" ng-if="groupConfiguration.config.syscheck.alert_new_files">
+                            <span flex>Alert new files</span>
+                            <span flex class="text-right color-grey">{{groupConfiguration.config.syscheck.alert_new_files}}</span>
+                        </div>
+                        <div layout="row" class="wz-padding-top-10" ng-if="groupConfiguration.config.syscheck.skip_nfs">
+                            <span flex>Skip NFS</span>
+                            <span flex class="text-right color-grey">{{groupConfiguration.config.syscheck.skip_nfs}}</span>
+                        </div>
+                        <div layout="row" class="wz-padding-top-10" ng-if="groupConfiguration.config.syscheck.scan_on_start">
+                            <span flex>Scan on start</span>
+                            <span flex class="text-right color-grey">{{groupConfiguration.config.syscheck.scan_on_start}}</span>
+                        </div>
+                        <div layout="row" class="wz-padding-top-10" ng-if="groupConfiguration.config.syscheck.scan_time">
+                            <span flex>Scan time</span>
+                            <span flex class="text-right color-grey">{{groupConfiguration.config.syscheck.scan_time}}</span>
+                        </div>
+                        <div layout="row" class="wz-padding-top-10" ng-if="groupConfiguration.config.syscheck.scan_day">
+                            <span flex>Scan day</span>
+                            <span flex class="text-right color-grey">{{groupConfiguration.config.syscheck.scan_day}}</span>
+                        </div>
+                        <div layout="row" class="wz-padding-top-10" ng-if="groupConfiguration.config.syscheck.auto_ignore">
+                            <span flex>Auto ignore</span>
+                            <span flex class="text-right color-grey">{{groupConfiguration.config.syscheck.auto_ignore}}</span>
+                        </div>
+
+                        <!-- No diff settings -->
+                        <div layout="row" class="wz-padding-top-10" ng-if="groupConfiguration.config.syscheck.nodiff">
+                            <span class="wz-headline-title wz-padding-top-10">No diff</span>
+                        </div>
+                        <div ng-repeat="item in groupConfiguration.config.syscheck.nodiff">
+                            <div ng-if="!item.type" layout="row" class="wz-padding-top-10">
+                                <span flex>File</span>
+                                <span flex class="text-right color-grey">{{item}}</span>
+                            </div>
+                            <div ng-if="item.type" layout="row" class="wz-padding-top-10">
+                                <span flex>File</span>
+                                <span flex class="text-right color-grey">{{item.item}}</span>
+                            </div>
+                            <div ng-if="item.type" layout="row" class="wz-padding-top-10">
+                                <span flex>Type</span>
+                                <span flex class="text-right color-grey">{{item.type}}</span>
+                            </div>
+                            <md-divider class="wz-margin-top-10" ng-if="!$last"></md-divider>
+                        </div>
+
+                        <!-- Monitored files -->
+                        <div layout="row" class="wz-padding-top-10" ng-if="groupConfiguration.config.syscheck.directories">
+                            <span class="wz-headline-title wz-padding-top-10">Monitored files</span>
+                        </div>
+                        <div ng-repeat="item in groupConfiguration.config.syscheck.directories">
+                            <div ng-if="item.path" layout="row" class="wz-padding-top-10">
+                                <span flex>Path</span>
+                                <span flex class="text-right color-grey">{{item.path}}</span>
+                            </div>
+                            <div ng-if="item.check_all" layout="row" class="wz-padding-top-10">
+                                <span flex>Check all</span>
+                                <span flex class="text-right color-grey">{{item.check_all}}</span>
+                            </div>
+                            <div ng-if="item.realtime" layout="row" class="wz-padding-top-10">
+                                <span flex>Realtime</span>
+                                <span flex class="text-right color-grey">{{item.realtime}}</span>
+                            </div>
+                            <div ng-if="item.report_changes" layout="row" class="wz-padding-top-10">
+                                <span flex>Report changes</span>
+                                <span flex class="text-right color-grey">{{item.report_changes}}</span>
+                            </div>
+                            <md-divider class="wz-margin-top-10" ng-if="!$last"></md-divider>
+                        </div>
+
+                        <!-- Ignored files -->
+                        <div layout="row" class="wz-padding-top-10" ng-if="groupConfiguration.config.syscheck.ignore">
+                            <span class="wz-headline-title wz-padding-top-10">Ignored files</span>
+                        </div>
+                        <div ng-repeat="item in groupConfiguration.config.syscheck.ignore">
+                            <div ng-if="!item.type" layout="row" class="wz-padding-top-10">
+                                <span flex>File</span>
+                                <span flex class="text-right color-grey">{{item}}</span>
+                            </div>
+                            <div ng-if="item.type" layout="row" class="wz-padding-top-10">
+                                <span flex>File</span>
+                                <span flex class="text-right color-grey">{{item.item}}</span>
+                            </div>
+                            <div ng-if="item.type" layout="row" class="wz-padding-top-10">
+                                <span flex>Type</span>
+                                <span flex class="text-right color-grey">{{item.type}}</span>
+                            </div>
+                            <md-divider class="wz-margin-top-10" ng-if="!$last"></md-divider>
                         </div>
                     </md-card-content>
                 </md-card>

--- a/public/templates/agents/agents-configuration.html
+++ b/public/templates/agents/agents-configuration.html
@@ -47,28 +47,11 @@
         <div layout="row">
             <md-card flex class="wz-metric-color wz-md-card">
                 <md-card-content layout="row" class="wz-padding-metric">
-                    <div flex>Group: <span ng-click="goGroup()" class="wz-font-weight-bold cursor-pointer" tooltip="Click to go to the group details" tooltip-placement="bottom">{{groupName}} <i class="fa fa-eye"></i></span></div>
-                    <div flex>Configuration status: <span class="wz-font-weight-bold" tooltip="The current synchronization status" tooltip-placement="bottom">{{isSynchronized ? 'SYNCHRONIZED' : 'NOT SYNCHRONIZED'}}</span></div>
+                    <div flex>Group: <span ng-click="goGroup()" class="wz-font-weight-bold cursor-pointer" tooltip="Click to go to the group details" tooltip-placement="right">{{groupName}} <i class="fa fa-eye"></i></span></div>
+                    <div flex>Configuration status: <span class="wz-font-weight-bold" tooltip="The current synchronization status" tooltip-placement="right">{{isSynchronized ? 'SYNCHRONIZED' : 'NOT SYNCHRONIZED'}}</span></div>
                 </md-card-content>
             </md-card>
         </div>
-
-        <!-- <div layout="row">
-            <md-card flex class="wz-md-card">
-                <md-card-content>
-                    <span class="wz-headline-title">Details</span>
-                    <md-divider class="wz-margin-top-10"></md-divider>
-                    <div layout="row" class="wz-padding-top-10">
-                        <p flex="15" class="manager-status-subtitle">Configuration group</p>
-                        <p class="cursor-pointer color-pointer wz-table-hover" ng-click="goGroup()" tooltip="Click to go to the group details" tooltip-placement="right">{{groupName}} <i class="fa fa-eye"></i></p>
-                    </div>
-                    <div layout="row" class="wz-padding-top-10">
-                        <p flex="15" class="manager-status-subtitle">Configuration status</p>
-                        <p class="color-grey wz-font-weight-bold" ng-class="isSynchronized ? 'color-green' : 'color-red'" tooltip="The current synchronization status" tooltip-placement="right">{{isSynchronized ? 'SYNCHRONIZED' : 'NOT SYNCHRONIZED'}}</p>
-                    </div>
-                </md-card-content>
-            </md-card>
-        </div> -->
 
         <!-- Second row - The configuration section itself -->
         <div layout="row">
@@ -89,6 +72,51 @@
                     </md-card-content>
                 </md-card>
                 <!-- END FILE INTEGRITY -->
+
+                <!-- POLICY MONITORING -->
+                <md-card flex class="wz-md-card">
+                    <md-card-content>
+                        <!-- Section title -->
+                        <span class="wz-headline-title cursor-pointer" tooltip="Click to see more details" tooltip-placement="right" ng-click="switchConfigTab('pm')">
+                            Policy Monitoring <i class="fa fa-eye"></i>
+                        </span>
+                        <md-divider class="wz-margin-top-10"></md-divider>
+                        <div layout="row" class="wz-padding-top-10">
+                            <span flex>View Policy Monitoring settings</span>
+                        </div>
+                    </md-card-content>
+                </md-card>
+                <!-- END POLICY MONITORING -->
+
+                <!-- LOG COLLECTION -->
+                <md-card flex class="wz-md-card">
+                    <md-card-content>
+                        <!-- Section title -->
+                        <span class="wz-headline-title cursor-pointer" tooltip="Click to see more details" tooltip-placement="right" ng-click="switchConfigTab('log')">
+                            Log Collection <i class="fa fa-eye"></i>
+                        </span>
+                        <md-divider class="wz-margin-top-10"></md-divider>
+                        <div layout="row" class="wz-padding-top-10">
+                            <span flex>View Log Collection settings</span>
+                        </div>
+                    </md-card-content>
+                </md-card>
+                <!-- END LOG COLLECTION -->
+
+                <!-- OPENSCAP -->
+                <md-card flex class="wz-md-card">
+                    <md-card-content>
+                        <!-- Section title -->
+                        <span class="wz-headline-title cursor-pointer" tooltip="Click to see more details" tooltip-placement="right" ng-click="switchConfigTab('scap')">
+                            OpenSCAP <i class="fa fa-eye"></i>
+                        </span>
+                        <md-divider class="wz-margin-top-10"></md-divider>
+                        <div layout="row" class="wz-padding-top-10">
+                            <span flex>View OpenSCAP settings</span>
+                        </div>
+                    </md-card-content>
+                </md-card>
+                <!-- END OPENSCAP -->
 
             </div>
 
@@ -213,7 +241,70 @@
                 </md-card>
                 <!-- END FILE INTEGRITY -->
 
-                <!-- FILE INTEGRITY -->
+                <!-- POLICY MONITORING -->
+                <md-card flex class="wz-md-card" ng-show="selectedConfigTab === 'pm' && !toggleRAW">
+                    <md-card-content>
+
+                        <!-- Section title -->
+                        <div layout="row" layout-align="start center">
+                            <span flex="85" class="wz-headline-title"><i class="fa fa-fw fa-check"></i> Policy Monitoring</span>
+                            <md-switch flex="15" class="wz-md-switch" ng-model="toggleRAW">View JSON</md-switch>
+                        </div>
+
+                        <md-divider class="wz-margin-top-10"></md-divider>
+
+                        <!-- No configuration panel -->
+                        <div layout="column" ng-show="!groupConfiguration.config.rootcheck">
+                            <h1 flex class="md-title text-center wz-padding-top-10">No PM configuration available</h1>
+                            <p flex class="text-center wz-padding-top-10">There's no PM group configuration used for this agent.</p>
+                        </div>
+                    </md-card-content>
+                </md-card>
+                <!-- END POLICY MONITORING -->
+
+                <!-- LOG COLLECTION -->
+                <md-card flex class="wz-md-card" ng-show="selectedConfigTab === 'log' && !toggleRAW">
+                    <md-card-content>
+
+                        <!-- Section title -->
+                        <div layout="row" layout-align="start center">
+                            <span flex="85" class="wz-headline-title"><i class="fa fa-fw fa-check"></i> Log Collection</span>
+                            <md-switch flex="15" class="wz-md-switch" ng-model="toggleRAW">View JSON</md-switch>
+                        </div>
+
+                        <md-divider class="wz-margin-top-10"></md-divider>
+
+                        <!-- No configuration panel -->
+                        <div layout="column" ng-show="!groupConfiguration.config['localfile']">
+                            <h1 flex class="md-title text-center wz-padding-top-10">No Log Collection configuration available</h1>
+                            <p flex class="text-center wz-padding-top-10">There's no Log Collection group configuration used for this agent.</p>
+                        </div>
+                    </md-card-content>
+                </md-card>
+                <!-- END LOG COLLECTION -->
+
+                <!-- OPENSCAP -->
+                <md-card flex class="wz-md-card" ng-show="selectedConfigTab === 'scap' && !toggleRAW">
+                    <md-card-content>
+
+                        <!-- Section title -->
+                        <div layout="row" layout-align="start center">
+                            <span flex="85" class="wz-headline-title"><i class="fa fa-fw fa-check"></i> OpenSCAP</span>
+                            <md-switch flex="15" class="wz-md-switch" ng-model="toggleRAW">View JSON</md-switch>
+                        </div>
+
+                        <md-divider class="wz-margin-top-10"></md-divider>
+
+                        <!-- No configuration panel -->
+                        <div layout="column" ng-show="!groupConfiguration.config['open-scap']">
+                            <h1 flex class="md-title text-center wz-padding-top-10">No OpenSCAP configuration available</h1>
+                            <p flex class="text-center wz-padding-top-10">There's no OpenSCAP group configuration used for this agent.</p>
+                        </div>
+                    </md-card-content>
+                </md-card>
+                <!-- END OPENSCAP -->
+
+                <!-- JSON VIEWER -->
                 <md-card flex class="wz-md-card" ng-show="toggleRAW">
                     <md-card-content>
 
@@ -231,7 +322,7 @@
                         </div>
                     </md-card-content>
                 </md-card>
-                <!-- END FILE INTEGRITY -->
+                <!-- END JSON VIEWER -->
 
             </div>
 

--- a/public/templates/agents/agents-configuration.html
+++ b/public/templates/agents/agents-configuration.html
@@ -1,7 +1,12 @@
 <md-content flex layout="column" ng-if="tab === 'configuration' && configurationError" layout-align="start">
 
+    <!-- Loading ring -->
+    <div class='uil-ring-css' ng-show="load">
+        <div></div>
+    </div>
+
     <!-- View: Panels -->
-    <div layout="column" layout-align="start stretch">
+    <div layout="column" layout-align="start stretch" ng-show="!load">
         <md-card flex class="wz-md-card">
             <md-card-content>
                 <span class="wz-headline-title"><i class="fa fa-fw fa-warning"></i> Warning</span>
@@ -29,7 +34,44 @@
 </md-content>
 
 <md-content flex layout="column" ng-if="tab === 'configuration' && !configurationError" layout-align="start">
-    <div flex layout="column" layout-align="start stretch" ng-init="showRaw=false">
+
+    <!-- Loading ring -->
+    <div class='uil-ring-css' ng-show="load">
+        <div></div>
+    </div>
+
+    <!-- The section container -->
+    <div flex layout="column" layout-align="start stretch" ng-init="showRaw=false" ng-show="!load">
+
+        <!-- First row - Configuration status and other details -->
+        <div layout="row">
+            <md-card flex class="wz-md-card">
+                <md-card-content>
+                    <span class="wz-headline-title">Details</span>
+                    <md-divider class="wz-margin-top-10"></md-divider>
+                    <div layout="row" class="wz-padding-top-10">
+                        <p flex="15" class="manager-status-subtitle">Configuration group</p>
+                        <p class="cursor-pointer color-pointer wz-table-hover" ng-click="goGroup()" tooltip="Click to go to the group details" tooltip-placement="right">{{groupName}} <i class="fa fa-eye"></i></p>
+                    </div>
+                    <div layout="row" class="wz-padding-top-10">
+                        <p flex="15" class="manager-status-subtitle">Configuration status</p>
+                        <p class="color-grey wz-font-weight-bold" ng-class="isSynchronized ? 'color-green' : 'color-red'" tooltip="The current synchronization status" tooltip-placement="right">{{isSynchronized ? 'SYNCHRONIZED' : 'NOT SYNCHRONIZED'}}</p>
+                    </div>
+                </md-card-content>
+            </md-card>
+        </div>
+
+        <!-- Second row - The configuration section itself -->
+        <div layout="row">
+
+            <div flex="25">
+            </div>
+
+            <div flex="75">
+            </div>
+
+        </div>
+
         <div flex layout="row">
             <md-card flex class="wz-md-card">
                 <div layout="row" class="md-padding">

--- a/public/templates/agents/agents-configuration.html
+++ b/public/templates/agents/agents-configuration.html
@@ -41,7 +41,7 @@
     </div>
 
     <!-- The section container -->
-    <div flex layout="column" layout-align="start stretch" ng-init="showRaw=false; selectedConfigTab='fim'" ng-show="!load">
+    <div flex layout="column" layout-align="start stretch" ng-init="showRaw=false;selectedConfigTab='fim'" ng-show="!load">
 
         <!-- First row - Configuration status and other details -->
         <div layout="row">
@@ -59,7 +59,7 @@
             <div flex="25">
 
                 <!-- FILE INTEGRITY -->
-                <md-card flex class="wz-md-card" ng-if="groupConfiguration.config.syscheck">
+                <md-card flex class="wz-md-card" ng-show="groupConfiguration.config.syscheck">
                     <md-card-content>
                         <!-- Section title -->
                         <span class="wz-headline-title cursor-pointer wz-table-hover" tooltip="Click to see more details" tooltip-placement="right" ng-click="selectedConfigTab='fim'">File Integrity</span>
@@ -72,7 +72,7 @@
                 <!-- END FILE INTEGRITY -->
 
                 <!-- POLICY MONITORING -->
-                <md-card flex class="wz-md-card" ng-if="groupConfiguration.config.rootcheck">
+                <md-card flex class="wz-md-card" ng-show="groupConfiguration.config.rootcheck">
                     <md-card-content>
                         <!-- Section title -->
                         <span class="wz-headline-title cursor-pointer wz-table-hover" tooltip="Click to see more details" tooltip-placement="right" ng-click="selectedConfigTab='pm'">Policy Monitoring</span>
@@ -85,7 +85,7 @@
                 <!-- END POLICY MONITORING -->
 
                 <!-- LOG COLLECTION -->
-                <md-card flex class="wz-md-card" ng-if="!groupConfiguration.config['localfile']">
+                <md-card flex class="wz-md-card" ng-show="groupConfiguration.config['localfile']">
                     <md-card-content>
                         <!-- Section title -->
                         <span class="wz-headline-title cursor-pointer wz-table-hover" tooltip="Click to see more details" tooltip-placement="right" ng-click="selectedConfigTab='log'">Log Collection</span>
@@ -98,7 +98,7 @@
                 <!-- END LOG COLLECTION -->
 
                 <!-- OPENSCAP -->
-                <md-card flex class="wz-md-card" ng-if="!groupConfiguration.config['open-scap']">
+                <md-card flex class="wz-md-card" ng-show="groupConfiguration.config['open-scap']">
                     <md-card-content>
                         <!-- Section title -->
                         <span class="wz-headline-title cursor-pointer wz-table-hover" tooltip="Click to see more details" tooltip-placement="right" ng-click="selectedConfigTab='scap'">OpenSCAP</span>
@@ -239,6 +239,142 @@
 
                         <md-divider class="wz-margin-top-10"></md-divider>
 
+                        <!-- Main settings -->
+                        <div layout="row" class="wz-padding-top-10" ng-if="groupConfiguration.config.rootcheck.disabled">
+                            <span flex>Disabled</span>
+                            <span flex class="text-right color-grey">{{groupConfiguration.config.rootcheck.disabled}}</span>
+                        </div>
+                        <div layout="row" class="wz-padding-top-10" ng-if="groupConfiguration.config.rootcheck.base_directory">
+                            <span flex>Base directory</span>
+                            <span flex class="text-right color-grey">{{groupConfiguration.config.rootcheck.frequency}}</span>
+                        </div>
+                        <div layout="row" class="wz-padding-top-10" ng-if="groupConfiguration.config.rootcheck.frequency">
+                            <span flex>Frequency</span>
+                            <span flex class="text-right color-grey">{{groupConfiguration.config.rootcheck.frequency}}</span>
+                        </div>
+                        <div layout="row" class="wz-padding-top-10" ng-if="groupConfiguration.config.rootcheck.scanall">
+                            <span flex>Scan all files</span>
+                            <span flex class="text-right color-grey">{{groupConfiguration.config.rootcheck.scanall}}</span>
+                        </div>
+                        <div layout="row" class="wz-padding-top-10" ng-if="groupConfiguration.config.rootcheck.skip_nfs">
+                            <span flex>Skip NFS</span>
+                            <span flex class="text-right color-grey">{{groupConfiguration.config.rootcheck.skip_nfs}}</span>
+                        </div>
+
+                        <!-- Checks -->
+                        <div layout="row" class="wz-padding-top-10">
+                            <span class="wz-headline-title wz-padding-top-10">Checks</span>
+                        </div>
+                        <div layout="row" class="wz-padding-top-10" ng-if="groupConfiguration.config.rootcheck.check_unixaudit">
+                            <span flex>Check UNIX Audit</span>
+                            <span flex class="text-right color-grey">{{groupConfiguration.config.rootcheck.check_unixaudit}}</span>
+                        </div>
+                        <div layout="row" class="wz-padding-top-10" ng-if="groupConfiguration.config.rootcheck.check_dev">
+                            <span flex>Check /dev</span>
+                            <span flex class="text-right color-grey">{{groupConfiguration.config.rootcheck.check_dev}}</span>
+                        </div>
+                        <div layout="row" class="wz-padding-top-10" ng-if="groupConfiguration.config.rootcheck.check_files">
+                            <span flex>Check files</span>
+                            <span flex class="text-right color-grey">{{groupConfiguration.config.rootcheck.check_files}}</span>
+                        </div>
+                        <div layout="row" class="wz-padding-top-10" ng-if="groupConfiguration.config.rootcheck.check_if">
+                            <span flex>Check interfaces</span>
+                            <span flex class="text-right color-grey">{{groupConfiguration.config.rootcheck.check_if}}</span>
+                        </div>
+                        <div layout="row" class="wz-padding-top-10" ng-if="groupConfiguration.config.rootcheck.check_pids">
+                            <span flex>Check PIDs</span>
+                            <span flex class="text-right color-grey">{{groupConfiguration.config.rootcheck.check_pids}}</span>
+                        </div>
+                        <div layout="row" class="wz-padding-top-10" ng-if="groupConfiguration.config.rootcheck.check_policy">
+                            <span flex>Check policy</span>
+                            <span flex class="text-right color-grey">{{groupConfiguration.config.rootcheck.check_policy}}</span>
+                        </div>
+                        <div layout="row" class="wz-padding-top-10" ng-if="groupConfiguration.config.rootcheck.check_ports">
+                            <span flex>Check ports</span>
+                            <span flex class="text-right color-grey">{{groupConfiguration.config.rootcheck.check_ports}}</span>
+                        </div>
+                        <div layout="row" class="wz-padding-top-10" ng-if="groupConfiguration.config.rootcheck.check_sys">
+                            <span flex>Check SYSt</span>
+                            <span flex class="text-right color-grey">{{groupConfiguration.config.rootcheck.check_sys}}</span>
+                        </div>
+                        <div layout="row" class="wz-padding-top-10" ng-if="groupConfiguration.config.rootcheck.check_trojans">
+                            <span flex>Check Trojans</span>
+                            <span flex class="text-right color-grey">{{groupConfiguration.config.rootcheck.check_trojans}}</span>
+                        </div>
+
+                        <!-- Windows Settings -->
+                        <div layout="row" class="wz-padding-top-10">
+                            <span class="wz-headline-title wz-padding-top-10">Windows Settings</span>
+                        </div>
+                        <div layout="row" class="wz-padding-top-10" ng-if="groupConfiguration.config.rootcheck.check_winaudit">
+                            <span flex>Check Windows Audit</span>
+                            <span flex class="text-right color-grey">{{groupConfiguration.config.rootcheck.check_winaudit}}</span>
+                        </div>
+                        <div layout="row" class="wz-padding-top-10" ng-if="groupConfiguration.config.rootcheck.check_winapps">
+                            <span flex>Check Windows apps</span>
+                            <span flex class="text-right color-grey">{{groupConfiguration.config.rootcheck.check_winapps}}</span>
+                        </div>
+                        <div layout="row" class="wz-padding-top-10" ng-if="groupConfiguration.config.rootcheck.check_winmalware">
+                            <span flex>Check Windows malware</span>
+                            <span flex class="text-right color-grey">{{groupConfiguration.config.rootcheck.check_winmalware}}</span>
+                        </div>
+
+                        <!-- Rootkit -->
+                        <div layout="row" class="wz-padding-top-10">
+                            <span class="wz-headline-title wz-padding-top-10">Rootkit</span>
+                        </div>
+                        <div layout="row" class="wz-padding-top-10" ng-if="groupConfiguration.config.rootcheck.check_winaudit">
+                            <span flex>Trojans path</span>
+                            <span flex class="text-right color-grey">{{groupConfiguration.config.rootcheck.rootkit_trojans[0]}}</span>
+                        </div>
+                        <div layout="row" class="wz-padding-top-10" ng-if="groupConfiguration.config.rootcheck.check_winapps">
+                            <span flex>Files path</span>
+                            <span flex class="text-right color-grey">{{groupConfiguration.config.rootcheck.rootkit_files[0]}}</span>
+                        </div>
+
+                        <!-- System Audit Files -->
+                        <div layout="row" class="wz-padding-top-10" ng-if="groupConfiguration.config.rootcheck.system_audit">
+                            <span class="wz-headline-title wz-padding-top-10">System Audit Files</span>
+                        </div>
+                        <div ng-repeat="item in groupConfiguration.config.rootcheck.system_audit">
+                            <div ng-if="item" layout="row" class="wz-padding-top-10">
+                                <span flex class="color-grey">{{item}}</span>
+                            </div>
+                            <md-divider class="wz-margin-top-10" ng-if="!$last"></md-divider>
+                        </div>
+
+                        <!-- System Audit Files -->
+                        <div layout="row" class="wz-padding-top-10" ng-if="groupConfiguration.config.rootcheck.system_audit">
+                            <span class="wz-headline-title wz-padding-top-10">System Audit Files</span>
+                        </div>
+                        <div ng-repeat="item in groupConfiguration.config.rootcheck.system_audit">
+                            <div ng-if="item" layout="row" class="wz-padding-top-10">
+                                <span flex class="color-grey">{{item}}</span>
+                            </div>
+                            <md-divider class="wz-margin-top-10" ng-if="!$last"></md-divider>
+                        </div>
+
+                        <!-- Windows Apps Files -->
+                        <div layout="row" class="wz-padding-top-10" ng-if="groupConfiguration.config.rootcheck.windows_apps">
+                            <span class="wz-headline-title wz-padding-top-10">Windows Apps Files</span>
+                        </div>
+                        <div ng-repeat="item in groupConfiguration.config.rootcheck.windows_apps">
+                            <div ng-if="item" layout="row" class="wz-padding-top-10">
+                                <span flex class="color-grey">{{item}}</span>
+                            </div>
+                            <md-divider class="wz-margin-top-10" ng-if="!$last"></md-divider>
+                        </div>
+
+                        <!-- Windows Malware Files -->
+                        <div layout="row" class="wz-padding-top-10" ng-if="groupConfiguration.config.rootcheck.windows_malware">
+                            <span class="wz-headline-title wz-padding-top-10">Windows Malware Files</span>
+                        </div>
+                        <div ng-repeat="item in groupConfiguration.config.rootcheck.windows_malware">
+                            <div ng-if="item" layout="row" class="wz-padding-top-10">
+                                <span flex class="color-grey">{{item}}</span>
+                            </div>
+                            <md-divider class="wz-margin-top-10" ng-if="!$last"></md-divider>
+                        </div>
                     </md-card-content>
                 </md-card>
                 <!-- END POLICY MONITORING -->
@@ -249,7 +385,7 @@
 
                         <!-- Section title -->
                         <div layout="row" layout-align="start center">
-                            <span flex="85" class="wz-headline-title"><i class="fa fa-fw fa-check"></i> Log Collection</span>
+                            <span flex="85" class="wz-headline-title"><i class="fa fa-fw fa-reorder"></i> Log Collection</span>
                             <md-switch flex="15" class="wz-md-switch" ng-model="toggleRAW">View JSON</md-switch>
                         </div>
 
@@ -265,7 +401,7 @@
 
                         <!-- Section title -->
                         <div layout="row" layout-align="start center">
-                            <span flex="85" class="wz-headline-title"><i class="fa fa-fw fa-check"></i> OpenSCAP</span>
+                            <span flex="85" class="wz-headline-title"><i class="fa fa-fw fa-sliders"></i> OpenSCAP</span>
                             <md-switch flex="15" class="wz-md-switch" ng-model="toggleRAW">View JSON</md-switch>
                         </div>
 

--- a/public/templates/agents/agents-configuration.html
+++ b/public/templates/agents/agents-configuration.html
@@ -41,7 +41,7 @@
     </div>
 
     <!-- The section container -->
-    <div flex layout="column" layout-align="start stretch" ng-init="showRaw=false;selectedConfigTab='fim'" ng-show="!load">
+    <div flex layout="column" layout-align="start stretch" ng-init="toggleRAW=false;selectedConfigTab='fim'" ng-show="!load">
 
         <!-- First row - Configuration status and other details -->
         <div layout="row">
@@ -62,7 +62,7 @@
                 <md-card flex class="wz-md-card" ng-show="groupConfiguration.config.syscheck">
                     <md-card-content>
                         <!-- Section title -->
-                        <span class="wz-headline-title cursor-pointer wz-table-hover" tooltip="Click to see more details" tooltip-placement="right" ng-click="selectedConfigTab='fim'">File Integrity</span>
+                        <span class="wz-headline-title cursor-pointer wz-table-hover" tooltip="Click to see more details" tooltip-placement="right" ng-click="selectedConfigTab='fim';toggleRAW=false" ng-class="selectedConfigTab === 'fim' ? wz-font-weight-bold : ''">File Integrity</span>
                         <md-divider class="wz-margin-top-10"></md-divider>
                         <div layout="row" class="wz-padding-top-10">
                             <span flex>View File Integrity settings</span>
@@ -75,7 +75,7 @@
                 <md-card flex class="wz-md-card" ng-show="groupConfiguration.config.rootcheck">
                     <md-card-content>
                         <!-- Section title -->
-                        <span class="wz-headline-title cursor-pointer wz-table-hover" tooltip="Click to see more details" tooltip-placement="right" ng-click="selectedConfigTab='pm'">Policy Monitoring</span>
+                        <span class="wz-headline-title cursor-pointer wz-table-hover" tooltip="Click to see more details" tooltip-placement="right" ng-click="selectedConfigTab='pm';toggleRAW=false" ng-class="selectedConfigTab === 'pm' ? wz-font-weight-bold : ''">Policy Monitoring</span>
                         <md-divider class="wz-margin-top-10"></md-divider>
                         <div layout="row" class="wz-padding-top-10">
                             <span flex>View Policy Monitoring settings</span>
@@ -88,10 +88,10 @@
                 <md-card flex class="wz-md-card" ng-show="groupConfiguration.config['localfile']">
                     <md-card-content>
                         <!-- Section title -->
-                        <span class="wz-headline-title cursor-pointer wz-table-hover" tooltip="Click to see more details" tooltip-placement="right" ng-click="selectedConfigTab='log'">Log Collection</span>
+                        <span class="wz-headline-title cursor-pointer wz-table-hover" tooltip="Click to see more details" tooltip-placement="right" ng-click="selectedConfigTab='log';toggleRAW=false" ng-class="selectedConfigTab === 'log' ? wz-font-weight-bold : ''">Log Collection</span>
                         <md-divider class="wz-margin-top-10"></md-divider>
                         <div layout="row" class="wz-padding-top-10">
-                            <span flex>View Log Collection settings</span>
+                            <span flex>Visualize all Log Collecting settings</span>
                         </div>
                     </md-card-content>
                 </md-card>
@@ -101,7 +101,7 @@
                 <md-card flex class="wz-md-card" ng-show="groupConfiguration.config['open-scap']">
                     <md-card-content>
                         <!-- Section title -->
-                        <span class="wz-headline-title cursor-pointer wz-table-hover" tooltip="Click to see more details" tooltip-placement="right" ng-click="selectedConfigTab='scap'">OpenSCAP</span>
+                        <span class="wz-headline-title cursor-pointer wz-table-hover" tooltip="Click to see more details" tooltip-placement="right" ng-click="selectedConfigTab='scap';toggleRAW=false" ng-class="selectedConfigTab === 'scap' ? wz-font-weight-bold : ''">OpenSCAP</span>
                         <md-divider class="wz-margin-top-10"></md-divider>
                         <div layout="row" class="wz-padding-top-10">
                             <span flex>View OpenSCAP settings</span>
@@ -390,6 +390,35 @@
                         </div>
 
                         <md-divider class="wz-margin-top-10"></md-divider>
+
+                        <!-- Log Files -->
+                        <div layout="row" class="wz-padding-top-10">
+                            <span class="wz-headline-title wz-padding-top-10">Log files</span>
+                        </div>
+                        <div ng-repeat="item in groupConfiguration.config['localfile']">
+                            <div ng-if="item.location" layout="row" class="wz-padding-top-10">
+                                <span flex class="text-right color-grey">{{item.location}}</span>
+                            </div>
+                            <div ng-if="item.log_format" layout="row" class="wz-padding-top-10">
+                                <span flex class="text-right color-grey">{{item.log_format}}</span>
+                            </div>
+                            <div ng-if="item.frequency" layout="row" class="wz-padding-top-10">
+                                <span flex class="text-right color-grey">{{item.frequency}}</span>
+                            </div>
+                            <div ng-if="item.query" layout="row" class="wz-padding-top-10">
+                                <span flex class="text-right color-grey">{{item.query}}</span>
+                            </div>
+                            <div ng-if="item.command" layout="row" class="wz-padding-top-10">
+                                <span flex class="text-right color-grey">{{item.command}}</span>
+                            </div>
+                            <div ng-if="item.alias" layout="row" class="wz-padding-top-10">
+                                <span flex class="text-right color-grey">{{item.alias}}</span>
+                            </div>
+                            <div ng-if="item.label" layout="row" class="wz-padding-top-10">
+                                <span flex class="text-right color-grey">{{item.label}}</span>
+                            </div>
+                            <md-divider class="wz-margin-top-10" ng-if="!$last"></md-divider>
+                        </div>
 
                     </md-card-content>
                 </md-card>

--- a/public/templates/agents/agents-configuration.html
+++ b/public/templates/agents/agents-configuration.html
@@ -343,11 +343,11 @@
                             <md-divider class="wz-margin-top-10" ng-if="!$last"></md-divider>
                         </div>
 
-                        <!-- System Audit Files -->
-                        <div layout="row" class="wz-padding-top-10" ng-if="groupConfiguration.config.rootcheck.system_audit">
-                            <span class="wz-headline-title wz-padding-top-10">System Audit Files</span>
+                        <!-- Windows Audit Files -->
+                        <div layout="row" class="wz-padding-top-10" ng-if="groupConfiguration.config.rootcheck.windows_audit">
+                            <span class="wz-headline-title wz-padding-top-10">Windows Audit Files</span>
                         </div>
-                        <div ng-repeat="item in groupConfiguration.config.rootcheck.system_audit">
+                        <div ng-repeat="item in groupConfiguration.config.rootcheck.windows_audit">
                             <div ng-if="item" layout="row" class="wz-padding-top-10">
                                 <span flex class="color-grey">{{item}}</span>
                             </div>

--- a/public/templates/agents/agents.head
+++ b/public/templates/agents/agents.head
@@ -4,9 +4,9 @@
 		<wz-menu></wz-menu>
     </div>
 
-	<div layout="row" layout-align="space-between start">
-		<div class="md-toolbar-tools" layout="row" layout-align="space-between center">
-			<div flex class="layout-row" ng-if="agent">
+	<div layout="row">
+		<div class="md-toolbar-tools" layout="row">
+			<div flex layout-align="center center" class="layout-row" ng-if="agent">
 				<div class="flex">
 					<span> <i class="fa fa-desktop wz-margin-right-5" aria-hidden="true"></i>
 						{{agent.id}} - {{agent.name}}</span> <span ng-show="agent.id === '000'">(Manager)</span>

--- a/public/templates/agents/agents.head
+++ b/public/templates/agents/agents.head
@@ -4,7 +4,7 @@
 		<wz-menu></wz-menu>
     </div>
 
-	<div layout="row" layout-align="space-between start" class="height-50">
+	<div layout="row" layout-align="space-between start">
 		<div class="md-toolbar-tools" layout="row" layout-align="space-between center">
 			<div flex class="layout-row" ng-if="agent">
 				<div class="flex">
@@ -13,7 +13,7 @@
 
 					<span ng-show="agent.status" class="agents-head-5" ng-class="getAgentStatusClass(agent.status)" aria-hidden="false">{{formatAgentStatus(agent.status)}}</span>
 				</div>
-				
+
 				<span layout="row" class="padding-left-0" layout-align="space-between start" flex="40">
 					<md-autocomplete id="agentsAutocomplete" flex
 					md-no-cache="true"
@@ -73,7 +73,7 @@
 		</div>
 	</div>
 
-    <md-progress-linear class="md-accent" md-mode="indeterminate" ng-show="load"></md-progress-linear>
+    <!-- <md-progress-linear class="md-accent" md-mode="indeterminate" ng-show="load"></md-progress-linear> -->
 
 	<!-- View: Discover -->
     <kbn-dis ng-show="tab != 'configuration'"></kbn-dis>

--- a/public/templates/manager/manager-configuration.html
+++ b/public/templates/manager/manager-configuration.html
@@ -15,9 +15,7 @@
             <md-card flex class="no-margin-left wz-md-card" ng-if="managerConfiguration.global">
                 <md-card-content>
                     <!-- Section title -->
-                    <span class="wz-headline-title cursor-pointer" ng-click="switchItem('global')" tooltip="Click to see more details" tooltip-placement="right">
-                        Global <i class="fa fa-eye"></i>
-                    </span>
+                    <span class="wz-headline-title cursor-pointer wz-table-hover" ng-click="switchItem('global')" tooltip="Click to see more details" tooltip-placement="right">Global</span>
                     <md-divider class="wz-margin-top-10"></md-divider>
                     <!-- Summary -->
                     <div layout="row" class="wz-padding-top-10" ng-if="managerConfiguration.global.jsonout_output">
@@ -36,9 +34,7 @@
             <md-card flex class="no-margin-left wz-md-card" ng-if="managerConfiguration.cluster">
                 <md-card-content>
                     <!-- Section title -->
-                    <span class="wz-headline-title cursor-pointer" ng-click="switchItem('cluster')" tooltip="Click to see more details" tooltip-placement="right">
-                        Cluster <i class="fa fa-eye"></i>
-                    </span>
+                    <span class="wz-headline-title cursor-pointer wz-table-hover" ng-click="switchItem('cluster')" tooltip="Click to see more details" tooltip-placement="right">Cluster</span>
                     <md-divider class="wz-margin-top-10"></md-divider>
                     <!-- Summary -->
                     <div layout="row" class="wz-padding-top-10" ng-if="managerConfiguration.cluster.name">
@@ -57,9 +53,7 @@
             <md-card flex class="no-margin-left wz-md-card" ng-if="managerConfiguration.syscheck">
                 <md-card-content>
                     <!-- Section title -->
-                    <span class="wz-headline-title cursor-pointer" ng-click="switchItem('syscheck')" tooltip="Click to see more details" tooltip-placement="right">
-                        Syscheck <i class="fa fa-eye"></i>
-                    </span>
+                    <span class="wz-headline-title cursor-pointer wz-table-hover" ng-click="switchItem('syscheck')" tooltip="Click to see more details" tooltip-placement="right">Syscheck</span>
                     <md-divider class="wz-margin-top-10"></md-divider>
                     <!-- Summary -->
                     <div layout="row" class="wz-padding-top-10" ng-if="managerConfiguration.syscheck.frequency">
@@ -78,9 +72,7 @@
             <md-card flex class="no-margin-left wz-md-card" ng-if="managerConfiguration.rootcheck">
                 <md-card-content>
                     <!-- Section title -->
-                    <span class="wz-headline-title cursor-pointer" ng-click="switchItem('rootcheck')" tooltip="Click to see more details" tooltip-placement="right">
-                        Rootcheck <i class="fa fa-eye"></i>
-                    </span>
+                    <span class="wz-headline-title cursor-pointer wz-table-hover" ng-click="switchItem('rootcheck')" tooltip="Click to see more details" tooltip-placement="right">Rootcheck</span>
                     <md-divider class="wz-margin-top-10"></md-divider>
                     <!-- Summary -->
                     <div layout="row" class="wz-padding-top-10" ng-if="managerConfiguration.rootcheck.frequency">
@@ -99,9 +91,7 @@
             <md-card flex class="no-margin-left wz-md-card" ng-if="managerConfiguration.logcollector">
                 <md-card-content>
                     <!-- Section title -->
-                    <span class="wz-headline-title cursor-pointer" ng-click="switchItem('logcollector')" tooltip="Click to see more details" tooltip-placement="right">
-                        Logcollector <i class="fa fa-eye"></i>
-                    </span>
+                    <span class="wz-headline-title cursor-pointer wz-table-hover" ng-click="switchItem('logcollector')" tooltip="Click to see more details" tooltip-placement="right">Logcollector</span>
                     <md-divider class="wz-margin-top-10"></md-divider>
                     <div layout="row" class="wz-padding-top-10">
                         <span flex>Logcollector settings</span>
@@ -114,9 +104,7 @@
             <md-card flex class="no-margin-left wz-md-card" ng-if="managerConfiguration.email_alerts">
                 <md-card-content>
                     <!-- Section title -->
-                    <span class="wz-headline-title cursor-pointer" ng-click="switchItem('email_alerts')" tooltip="Click to see more details" tooltip-placement="right">
-                        E-mail alerts <i class="fa fa-eye"></i>
-                    </span>
+                    <span class="wz-headline-title cursor-pointer wz-table-hover" ng-click="switchItem('email_alerts')" tooltip="Click to see more details" tooltip-placement="right">E-mail alerts</span>
                     <md-divider class="wz-margin-top-10"></md-divider>
                     <!-- Summary -->
                     <div layout="row" class="wz-padding-top-10" ng-if="managerConfiguration.email_alerts.email_to">
@@ -135,9 +123,7 @@
             <md-card flex class="no-margin-left wz-md-card" ng-if="managerConfiguration.auth">
                 <md-card-content>
                     <!-- Section title -->
-                    <span class="wz-headline-title cursor-pointer" ng-click="switchItem('auth')" tooltip="Click to see more details" tooltip-placement="right">
-                        Auth <i class="fa fa-eye"></i>
-                    </span>
+                    <span class="wz-headline-title cursor-pointer wz-table-hover" ng-click="switchItem('auth')" tooltip="Click to see more details" tooltip-placement="right">Auth</span>
                     <md-divider class="wz-margin-top-10"></md-divider>
                     <!-- Summary -->
                     <div layout="row" class="wz-padding-top-10" ng-if="managerConfiguration.auth.purge">
@@ -156,9 +142,7 @@
             <md-card flex class="no-margin-left wz-md-card" ng-if="managerConfiguration.ruleset">
                 <md-card-content>
                     <!-- Section title -->
-                    <span class="wz-headline-title cursor-pointer" ng-click="switchItem('ruleset')" tooltip="Click to see more details" tooltip-placement="right">
-                        Ruleset <i class="fa fa-eye"></i>
-                    </span>
+                    <span class="wz-headline-title cursor-pointer wz-table-hover" ng-click="switchItem('ruleset')" tooltip="Click to see more details" tooltip-placement="right">Ruleset</span>
                     <md-divider class="wz-margin-top-10"></md-divider>
                     <div layout="row" class="wz-padding-top-10">
                         <span flex>Ruleset settings</span>
@@ -171,9 +155,7 @@
             <md-card flex class="no-margin-left wz-md-card" ng-if="managerConfiguration.command">
                 <md-card-content>
                     <!-- Section title -->
-                    <span class="wz-headline-title cursor-pointer" ng-click="switchItem('command')" tooltip="Click to see more details" tooltip-placement="right">
-                        Command <i class="fa fa-eye"></i>
-                    </span>
+                    <span class="wz-headline-title cursor-pointer wz-table-hover" ng-click="switchItem('command')" tooltip="Click to see more details" tooltip-placement="right">Command</span>
                     <md-divider class="wz-margin-top-10"></md-divider>
                     <div layout="row" class="wz-padding-top-10">
                         <span flex>Command settings</span>
@@ -186,9 +168,7 @@
             <md-card flex class="no-margin-left wz-md-card" ng-if="managerConfiguration['active-response'].length > 0">
                 <md-card-content>
                     <!-- Section title -->
-                    <span class="wz-headline-title cursor-pointer" ng-click="switchItem('active-response')" tooltip="Click to see more details" tooltip-placement="right">
-                        Active response <i class="fa fa-eye"></i>
-                    </span>
+                    <span class="wz-headline-title cursor-pointer wz-table-hover" ng-click="switchItem('active-response')" tooltip="Click to see more details" tooltip-placement="right">Active response</span>
                     <md-divider class="wz-margin-top-10"></md-divider>
                     <div layout="row" class="wz-padding-top-10">
                         <span flex>Active response settings</span>
@@ -201,9 +181,7 @@
             <md-card flex class="no-margin-left wz-md-card" ng-if="managerConfiguration.remote">
                 <md-card-content>
                     <!-- Section title -->
-                    <span class="wz-headline-title cursor-pointer" ng-click="switchItem('remote')" tooltip="Click to see more details" tooltip-placement="right">
-                        Remote <i class="fa fa-eye"></i>
-                    </span>
+                    <span class="wz-headline-title cursor-pointer wz-table-hover" ng-click="switchItem('remote')" tooltip="Click to see more details" tooltip-placement="right">Remote</span>
                     <md-divider class="wz-margin-top-10"></md-divider>
                     <div layout="row" class="wz-padding-top-10">
                         <span flex>Agents events listening settings</span>

--- a/public/templates/manager/manager-configuration.html
+++ b/public/templates/manager/manager-configuration.html
@@ -15,7 +15,7 @@
             <md-card flex class="no-margin-left wz-md-card" ng-if="managerConfiguration.global">
                 <md-card-content>
                     <!-- Section title -->
-                    <span class="wz-headline-title cursor-pointer wz-table-hover" ng-click="switchItem('global')" tooltip="Click to see more details" tooltip-placement="right">Global</span>
+                    <span class="wz-headline-title cursor-pointer wz-table-hover" ng-click="switchItem('global')" tooltip="Click to see more details" tooltip-placement="right" ng-class="selectedItem === 'global' ? 'wz-font-weight-bold' : ''">Global</span>
                     <md-divider class="wz-margin-top-10"></md-divider>
                     <!-- Summary -->
                     <div layout="row" class="wz-padding-top-10" ng-if="managerConfiguration.global.jsonout_output">
@@ -34,7 +34,7 @@
             <md-card flex class="no-margin-left wz-md-card" ng-if="managerConfiguration.cluster">
                 <md-card-content>
                     <!-- Section title -->
-                    <span class="wz-headline-title cursor-pointer wz-table-hover" ng-click="switchItem('cluster')" tooltip="Click to see more details" tooltip-placement="right">Cluster</span>
+                    <span class="wz-headline-title cursor-pointer wz-table-hover" ng-click="switchItem('cluster')" tooltip="Click to see more details" tooltip-placement="right" ng-class="selectedItem === 'cluster' ? 'wz-font-weight-bold' : ''">Cluster</span>
                     <md-divider class="wz-margin-top-10"></md-divider>
                     <!-- Summary -->
                     <div layout="row" class="wz-padding-top-10" ng-if="managerConfiguration.cluster.name">
@@ -53,7 +53,7 @@
             <md-card flex class="no-margin-left wz-md-card" ng-if="managerConfiguration.syscheck">
                 <md-card-content>
                     <!-- Section title -->
-                    <span class="wz-headline-title cursor-pointer wz-table-hover" ng-click="switchItem('syscheck')" tooltip="Click to see more details" tooltip-placement="right">Syscheck</span>
+                    <span class="wz-headline-title cursor-pointer wz-table-hover" ng-click="switchItem('syscheck')" tooltip="Click to see more details" tooltip-placement="right" ng-class="selectedItem === 'syscheck' ? 'wz-font-weight-bold' : ''">Syscheck</span>
                     <md-divider class="wz-margin-top-10"></md-divider>
                     <!-- Summary -->
                     <div layout="row" class="wz-padding-top-10" ng-if="managerConfiguration.syscheck.frequency">
@@ -72,7 +72,7 @@
             <md-card flex class="no-margin-left wz-md-card" ng-if="managerConfiguration.rootcheck">
                 <md-card-content>
                     <!-- Section title -->
-                    <span class="wz-headline-title cursor-pointer wz-table-hover" ng-click="switchItem('rootcheck')" tooltip="Click to see more details" tooltip-placement="right">Rootcheck</span>
+                    <span class="wz-headline-title cursor-pointer wz-table-hover" ng-click="switchItem('rootcheck')" tooltip="Click to see more details" tooltip-placement="right" ng-class="selectedItem === 'rootcheck' ? 'wz-font-weight-bold' : ''">Rootcheck</span>
                     <md-divider class="wz-margin-top-10"></md-divider>
                     <!-- Summary -->
                     <div layout="row" class="wz-padding-top-10" ng-if="managerConfiguration.rootcheck.frequency">
@@ -91,7 +91,7 @@
             <md-card flex class="no-margin-left wz-md-card" ng-if="managerConfiguration.logcollector">
                 <md-card-content>
                     <!-- Section title -->
-                    <span class="wz-headline-title cursor-pointer wz-table-hover" ng-click="switchItem('logcollector')" tooltip="Click to see more details" tooltip-placement="right">Logcollector</span>
+                    <span class="wz-headline-title cursor-pointer wz-table-hover" ng-click="switchItem('logcollector')" tooltip="Click to see more details" tooltip-placement="right" ng-class="selectedItem === 'logcollector' ? 'wz-font-weight-bold' : ''">Logcollector</span>
                     <md-divider class="wz-margin-top-10"></md-divider>
                     <div layout="row" class="wz-padding-top-10">
                         <span flex>Logcollector settings</span>
@@ -104,7 +104,7 @@
             <md-card flex class="no-margin-left wz-md-card" ng-if="managerConfiguration.email_alerts">
                 <md-card-content>
                     <!-- Section title -->
-                    <span class="wz-headline-title cursor-pointer wz-table-hover" ng-click="switchItem('email_alerts')" tooltip="Click to see more details" tooltip-placement="right">E-mail alerts</span>
+                    <span class="wz-headline-title cursor-pointer wz-table-hover" ng-click="switchItem('email_alerts')" tooltip="Click to see more details" tooltip-placement="right" ng-class="selectedItem === 'email_alerts' ? 'wz-font-weight-bold' : ''">E-mail alerts</span>
                     <md-divider class="wz-margin-top-10"></md-divider>
                     <!-- Summary -->
                     <div layout="row" class="wz-padding-top-10" ng-if="managerConfiguration.email_alerts.email_to">
@@ -123,7 +123,7 @@
             <md-card flex class="no-margin-left wz-md-card" ng-if="managerConfiguration.auth">
                 <md-card-content>
                     <!-- Section title -->
-                    <span class="wz-headline-title cursor-pointer wz-table-hover" ng-click="switchItem('auth')" tooltip="Click to see more details" tooltip-placement="right">Auth</span>
+                    <span class="wz-headline-title cursor-pointer wz-table-hover" ng-click="switchItem('auth')" tooltip="Click to see more details" tooltip-placement="right" ng-class="selectedItem === 'auth' ? 'wz-font-weight-bold' : ''">Auth</span>
                     <md-divider class="wz-margin-top-10"></md-divider>
                     <!-- Summary -->
                     <div layout="row" class="wz-padding-top-10" ng-if="managerConfiguration.auth.purge">
@@ -142,7 +142,7 @@
             <md-card flex class="no-margin-left wz-md-card" ng-if="managerConfiguration.ruleset">
                 <md-card-content>
                     <!-- Section title -->
-                    <span class="wz-headline-title cursor-pointer wz-table-hover" ng-click="switchItem('ruleset')" tooltip="Click to see more details" tooltip-placement="right">Ruleset</span>
+                    <span class="wz-headline-title cursor-pointer wz-table-hover" ng-click="switchItem('ruleset')" tooltip="Click to see more details" tooltip-placement="right" ng-class="selectedItem === 'ruleset' ? 'wz-font-weight-bold' : ''">Ruleset</span>
                     <md-divider class="wz-margin-top-10"></md-divider>
                     <div layout="row" class="wz-padding-top-10">
                         <span flex>Ruleset settings</span>
@@ -155,7 +155,7 @@
             <md-card flex class="no-margin-left wz-md-card" ng-if="managerConfiguration.command">
                 <md-card-content>
                     <!-- Section title -->
-                    <span class="wz-headline-title cursor-pointer wz-table-hover" ng-click="switchItem('command')" tooltip="Click to see more details" tooltip-placement="right">Command</span>
+                    <span class="wz-headline-title cursor-pointer wz-table-hover" ng-click="switchItem('command')" tooltip="Click to see more details" tooltip-placement="right" ng-class="selectedItem === 'command' ? 'wz-font-weight-bold' : ''">Command</span>
                     <md-divider class="wz-margin-top-10"></md-divider>
                     <div layout="row" class="wz-padding-top-10">
                         <span flex>Command settings</span>
@@ -168,7 +168,7 @@
             <md-card flex class="no-margin-left wz-md-card" ng-if="managerConfiguration['active-response'].length > 0">
                 <md-card-content>
                     <!-- Section title -->
-                    <span class="wz-headline-title cursor-pointer wz-table-hover" ng-click="switchItem('active-response')" tooltip="Click to see more details" tooltip-placement="right">Active response</span>
+                    <span class="wz-headline-title cursor-pointer wz-table-hover" ng-click="switchItem('active-response')" tooltip="Click to see more details" tooltip-placement="right" ng-class="selectedItem === 'active-response' ? 'wz-font-weight-bold' : ''">Active response</span>
                     <md-divider class="wz-margin-top-10"></md-divider>
                     <div layout="row" class="wz-padding-top-10">
                         <span flex>Active response settings</span>
@@ -181,7 +181,7 @@
             <md-card flex class="no-margin-left wz-md-card" ng-if="managerConfiguration.remote">
                 <md-card-content>
                     <!-- Section title -->
-                    <span class="wz-headline-title cursor-pointer wz-table-hover" ng-click="switchItem('remote')" tooltip="Click to see more details" tooltip-placement="right">Remote</span>
+                    <span class="wz-headline-title cursor-pointer wz-table-hover" ng-click="switchItem('remote')" tooltip="Click to see more details" tooltip-placement="right" ng-class="selectedItem === 'remote' ? 'wz-font-weight-bold' : ''">Remote</span>
                     <md-divider class="wz-margin-top-10"></md-divider>
                     <div layout="row" class="wz-padding-top-10">
                         <span flex>Agents events listening settings</span>

--- a/public/templates/overview/overview.head
+++ b/public/templates/overview/overview.head
@@ -31,7 +31,7 @@
         </div>
     </div>
 
-    <md-progress-linear class="md-accent" md-mode="indeterminate" ng-show="load"></md-progress-linear>
+    <!-- <md-progress-linear class="md-accent" md-mode="indeterminate" ng-show="load"></md-progress-linear> -->
 
     <!-- View: Discover -->
     <kbn-dis></kbn-dis>

--- a/public/templates/settings/settings.html
+++ b/public/templates/settings/settings.html
@@ -293,9 +293,7 @@
                     <md-divider class="wz-margin-top-10"></md-divider>
 
                     <div layout="row" class="wz-padding-top-10 wz-line-height">
-                        The Wazuh App brings together a new and useful web interface for managing and monitoring your Wazuh infrastructure. You can
-                        check agent status, alert evolution, most recent events, popular alerts, top alert groups, etc. You
-                        can also display configuration and logs of the manager.
+                        The Wazuh App brings together a new and useful web interface for managing and monitoring your Wazuh infrastructure. You can check agent status, alert evolution, most recent events, popular alerts, top alert groups, etc. You can also display configuration and logs of the manager.
                     </div>
                     <div layout="row" class="wz-padding-top-10">
                         In addition, make use of any or all of these extensions:


### PR DESCRIPTION
Hello all,

This PR brings a new redesign to the app. This time is for the **Agents configuration** tab.

### Description
This redesign is based on the same made for the **Manager configuration tab**. With this UI revamp, some modifications were made to the side nav cards and were applied to both tabs, providing consistency between them.

For example, the `fa-eye` icon was removed, and replaced by a bold-text active element indicator. When the user hovers the title, the font will turn bold, and also a tooltip will appear, indicating the possible actions.

The current group and sync status indicators were replaced by the new information ribbon, the same that we can see on other app sections.

In addition to this, this PR fixes some minor bugs on the UI, and also removes old CSS classes, continuing with the huge work done with the HTML & CSS removal and cleanup process.

### Sample screenshot
![rediseno](https://user-images.githubusercontent.com/10928321/37303189-fb9b65c0-262d-11e8-9ea2-8e410695835a.png)

![nogroup](https://user-images.githubusercontent.com/10928321/37303203-073a718c-262e-11e8-9fd7-bf956a99dd97.PNG)

This redesign is one more step into a better app design, achieving consistency between pages and a better overall look.

Best regards,
Juanjo