### PR TITLE
Several index pattern improvements

### DIFF
--- a/public/controllers/settings.js
+++ b/public/controllers/settings.js
@@ -43,26 +43,6 @@ app.controller('settingsController', function ($scope, $rootScope, $http, $route
 
     $scope.indexPatterns = [];
 
-    // Getting the index pattern list into the scope, but selecting only "valid" ones
-    for (let i = 0; i < $route.current.locals.ips.list.length; i ++) {
-        courier.indexPatterns.get($route.current.locals.ips.list[i].id)
-        .then((data) => {
-            let minimum = ["@timestamp", "full_log", "manager.name", "agent.id"];
-            let minimumCount = 0;
-
-            for (let j = 0; j < data.fields.length; j++) {
-                if (minimum.includes(data.fields[j].name)) {
-                    minimumCount++;
-                }
-            }
-
-            if (minimumCount == minimum.length) {
-                $scope.indexPatterns.push($route.current.locals.ips.list[i]);
-            }
-
-        });
-    }
-
     if ($routeParams.tab){
         $scope.submenuNavItem = $routeParams.tab;
     }
@@ -147,6 +127,8 @@ app.controller('settingsController', function ($scope, $rootScope, $http, $route
     // Get settings function
     const getSettings = async () => {
         try {
+            const patternList = await genericReq.request('GET','/get-list',{});
+            $scope.indexPatterns = patternList.data.data;
             const data = await genericReq.request('GET', '/api/wazuh-api/apiEntries');
             for(const entry of data.data) $scope.showEditForm[entry._id] = false;
             

--- a/public/directives/wz-menu/wz-menu.html
+++ b/public/directives/wz-menu/wz-menu.html
@@ -11,7 +11,7 @@
         <div ng-show="!theresAPI" layout layout-align="center center" tooltip="Selected API" tooltip-placement="bottom"><i class="fa fa-star fa-fw wz-color-orange" aria-hidden="true"></i>No API <span ng-if="showSelector">&nbsp;&ndash;&nbsp;</span></div>
         <div ng-if="showSelector" ng-show="theresPattern && patternList && patternList.length > 1" layout layout-align="center center">
             <md-select ng-model="currentSelectedPattern" ng-change="changePattern(currentSelectedPattern)" placeholder="Index pattern" class="wz-menu-select md-no-underline wz-border-none" aria-label="Select index pattern" tooltip="Selected index pattern" tooltip-placement="bottom">
-                <md-option ng-repeat="pattern in patternList" value="{{ pattern.id }}">{{ pattern.attributes.title }}</md-option>
+                <md-option ng-repeat="pattern in patternList" value="{{ pattern.id }}">{{ pattern.title }}</md-option>
             </md-select>
         </div>
         <div ng-if="showSelector" ng-show="theresPattern && patternList && patternList.length === 1" layout layout-align="center center" tooltip="Selected index pattern" tooltip-placement="bottom"> {{ patternList[0].attributes.title }}</div>

--- a/public/services/pattern-handler.js
+++ b/public/services/pattern-handler.js
@@ -3,25 +3,8 @@ require('ui/modules').get('app/wazuh', [])
     return {
         getPatternList: async () => {
             try {
-                let patternList = [];
-
-                // Getting the index pattern list into the array,
-                // but selecting only "valid" ones
-                const len = $route.current.locals.ips.list.length;
-                let data;
-                for (let i = 0; i < len; i ++) {
-                    data = await courier.indexPatterns.get($route.current.locals.ips.list[i].id)
-                    
-                    let minimum = ["@timestamp", "full_log", "manager.name", "agent.id"];
-                    let minimumCount = 0;
-                    data.fields.filter(element => minimumCount += (minimum.includes(element.name)) ? 1 : 0);
-
-                    if (minimumCount === minimum.length) {
-                        patternList.push($route.current.locals.ips.list[i]);
-                    }
-                }
-    
-                return patternList;
+                const patternList = await genericReq.request('GET','/get-list',{});
+                return patternList.data.data;
             } catch (error) {
                 errorHandler.handle(error,'Pattern Handler (getPatternList)');
                 if(!$rootScope.$$phase) $rootScope.$digest();

--- a/public/templates/settings/settings.html
+++ b/public/templates/settings/settings.html
@@ -286,7 +286,7 @@
 
                 <div flex="20" layout="column" class="height-41 md-block wz-margin-top-17 wz-margin-right-15 wz-select-input">
                     <select flex class="kuiSelect wz-border-none cursor-pointer" ng-model="selectedIndexPattern" ng-change="changeIndexPattern(selectedIndexPattern)" aria-label="Select index pattern">
-                        <option ng-repeat="indexPattern in indexPatterns" value="{{indexPattern.id}}">{{indexPattern.attributes.title}}</option>
+                        <option ng-repeat="indexPattern in indexPatterns" value="{{indexPattern.id}}">{{indexPattern.title}}</option>
                     </select>
                 </div>
             </md-card-content>

--- a/server/api/wazuh-elastic.js
+++ b/server/api/wazuh-elastic.js
@@ -346,23 +346,28 @@ module.exports = (server, options) => {
                     
             });
             
-            const minimum = ["@timestamp", "full_log", "manager.name", "agent.id"];
-            let list = [];
-            for(const index of data.hits.hits){
-                let valid = JSON.parse(index._source['index-pattern'].fields).filter(item => minimum.includes(item.name));
-                if(valid.length === 4){
-                    list.push({
-                        id: index._id.split('index-pattern:')[1],
-                        title: index._source['index-pattern'].title
-                    })
+            if(data && data.hits && data.hits.hits){
+                const minimum = ["@timestamp", "full_log", "manager.name", "agent.id"];
+                let list = [];
+                if(data.hits.hits.length === 0) throw new Error('There is no index pattern');
+                for(const index of data.hits.hits){
+                    let valid = JSON.parse(index._source['index-pattern'].fields).filter(item => minimum.includes(item.name));
+                    if(valid.length === 4){
+                        list.push({
+                            id: index._id.split('index-pattern:')[1],
+                            title: index._source['index-pattern'].title
+                        })
+                    }
+           
                 }
-       
+                
+                return res({data: list});
             }
             
-            return res({data: list});
+            throw new Error('The Elasticsearch request didn\'t fetch the expected data');
 
         } catch(error){
-            return res({error: error.message})
+            return res({error: error.message}).code(500)
         }
     }
 

--- a/server/initialize.js
+++ b/server/initialize.js
@@ -147,7 +147,13 @@ module.exports = (server, options) => {
                         .callWithInternalUser('search', {
                             index: '.kibana',
                             type: 'doc',
-                            q: `index-pattern.title:"${id}"`
+                            body: {
+                                "query": {
+                                    "match": {
+                                        "_id":"index-pattern:" + id 
+                                    }
+                                }
+                            }
                         });
             return data;
         } catch (error) {


### PR DESCRIPTION
Hello team, this pull request adds several improvements:

- Adds a new route named `/get-list` to fetch the index pattern list

```js
GET /get-list
{
   data: [
     { id: 'index-pattern:wazuh-alerts-3.x-*', title: 'wazuh-alerts-3.x-*' },
     { id: 'index-pattern:aaaa-aaaa-aaaa-aaaa', title: 'wazuh*' },
     ...
  ]
}
```

- Removed index pattern loop from `settings` controller and `pattern-handler` controller (no longer needed)
- Removed `getAllIp` function from the whole app (no longer needed)
- Modified the function who fetchs an index pattern, now it searches for index pattern `id` instead `title`

```js
{
 "query": {
      "match": {
             "_id":"index-pattern:" + id 
          }
    }
 }
```
Best regards,
Jesús