### PR TITLE
Truncated text for tables and metric ribbons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ All notable changes to the Wazuh app project will be documented in this file.
   - Cleaned and refactored code
   - Revamped design, smaller and with minor details to follow the rest of Wazuh app guidelines.
 - **New design for the wz-chip component** to follow the new Wazuh app guidelines ([#323](https://github.com/wazuh/wazuh-kibana-app/pull/323)).
+- Added **more descriptive error messages** when the user inserts bad credentials on the *Add new API* form in the *Settings* tab ([#331](https://github.com/wazuh/wazuh-kibana-app/pull/331)).
+- Added a new CSS class to **truncate overflowing text** on tables and metric ribbons ([#332](https://github.com/wazuh/wazuh-kibana-app/pull/332)).
 
 ### Changed
 - **Improved the initialization system** ([#317](https://github.com/wazuh/wazuh-kibana-app/pull/317)):

--- a/public/directives/wz-table-header/wz-table-header.html
+++ b/public/directives/wz-table-header/wz-table-header.html
@@ -1,5 +1,5 @@
 <md-toolbar layout="row" class="md-toolbar-tools wz-theader-toolbar" ng-show="(!noscroll && data.items && data.items.length > 0) || (noscroll && data)">
-    <div ng-repeat="key in keys" flex="{{key.size || ''}}">
+    <div class="wz-text-truncatable" ng-repeat="key in keys" flex="{{key.size || ''}}">
         <span ng-if="key.sortValue" class="wz-theader-color" ng-click="data.sort(key.sortValue)">{{key.name}}
             <i class="fa wz-theader-sort-icon" ng-class="data.sortValue === key.sortValue ? (data.sortDir ? 'fa-sort-asc' : 'fa-sort-desc') : 'fa-sort'"
                 aria-hidden="true"></i>

--- a/public/directives/wz-table/wz-table.html
+++ b/public/directives/wz-table/wz-table.html
@@ -1,43 +1,46 @@
 <div flex ng-if="!isruleset && !isdecoders" layout="column" class="wz-table-no-padding" ng-show="(!noscroll && data.items && data.items.length > 0) || (noscroll && data)">
+    <!-- Manager/Logs table -->
     <div ng-if="!isagents && !noscroll" flex class="wz-table-scroll" when-scrolled="data.nextPage('')">
         <div layout="row" ng-class-odd="'wz-table-odd'" ng-class-even="'wz-table-even'" ng-repeat="item in data.items | filter : searchTerm"
             class="wz-table-common" ng-class="!nopointer ? 'wz-table-cursor-pointer' : '' "
             ng-click="clickAction(full ? item : $index)">
-            <div ng-repeat="key in keys" flex="{{key.size || ''}}">
+            <div class="wz-text-truncatable" ng-repeat="key in keys" flex="{{key.size || ''}}">
                 <span>{{parseItem(item,key) || '---'}}</span>
             </div>
         </div>
     </div>
+    <!-- Manager/Logs table on realtime -->
     <div ng-if="!isagents && noscroll" flex class="wz-table-scroll">
         <div layout="row" ng-class-odd="'wz-table-odd'" ng-class-even="'wz-table-even'" ng-repeat="item in data" class="wz-table-common"
             ng-class="!nopointer ? 'wz-table-cursor-pointer' : '' " ng-click="clickAction($index)">
-            <div ng-repeat="key in keys" flex="{{key.size || ''}}">
+            <div class="wz-text-truncatable" ng-repeat="key in keys" flex="{{key.size || ''}}">
                 <span>{{parseItem(item,key) || '---'}}</span>
             </div>
         </div>
     </div>
+    <!-- Agents preview table -->
     <div ng-if="!noscroll && isagents" flex class="wz-table-scroll" when-scrolled="data.nextPage('')">
         <div layout="row" ng-class-odd="'wz-table-odd'" ng-class-even="'wz-table-even'" ng-repeat="item in data.items | filter : searchTerm"
-            class="wz-table-common" ng-class="!nopointer ? 'wz-table-cursor-pointer' : '' "
-            >
-            <div class="wz-table-agents" ng-repeat="key in keys" flex="{{key.size || ''}}" ng-click="clickAction(full ? item : $index,key)">
+            class="wz-table-common" ng-class="!nopointer ? 'wz-table-cursor-pointer' : '' ">
+            <div class="wz-table-agents wz-text-truncatable" ng-repeat="key in keys" flex="{{key.size || ''}}" ng-click="clickAction(full ? item : $index,key)">
                 <span>{{parseItem(item,key) || '---'}}</span>
             </div>
         </div>
     </div>
 </div>
 
+<!-- Manager/Ruleset/Rules tab -->
 <div flex ng-if="isruleset" layout="column" class="wz-table-no-padding" ng-show="(!noscroll && data.items && data.items.length > 0) || (noscroll && data)">
     <div ng-if="!noscroll" flex class="wz-table-scroll" when-scrolled="data.nextPage('')">
         <div layout="row" ng-class-odd="'wz-table-odd'" ng-class-even="'wz-table-even'" ng-repeat="item in data.items | filter : searchTerm"
             class="wz-table-common" ng-class="!nopointer && activeitem !== item.id ? 'wz-table-cursor-pointer' : !nopointer && activeitem === item.id ? 'wz-table-cursor-pointer wz-table-active' : ''"
             ng-click="clickAction(full ? item : $index)">
-            <div ng-show="activeitem !== item.id" ng-repeat="key in keys" flex="{{key.size || ''}}">
+            <div class="wz-text-truncatable" ng-show="activeitem !== item.id" ng-repeat="key in keys" flex="{{key.size || ''}}">
                 <span>{{parseItem(item,key) || '---'}}</span>
             </div>
             <div flex ng-show="activeitem === item.id" class="wz-table-height-fixed">
                 <div layout="row" class="wz-table-size">
-                    <div ng-repeat="key in keys" flex="{{key.size || ''}}">
+                    <div class="wz-text-truncatable" ng-repeat="key in keys" flex="{{key.size || ''}}">
                         <span>{{parseItem(item,key) || '---'}}</span>
                     </div>
                 </div>
@@ -106,17 +109,18 @@
     </div>
 </div>
 
+<!-- Manager/Ruleset/Decoders tab -->
 <div flex ng-if="isdecoders" layout="column" class="md-padding wz-table-no-padding wz-table-no-padding-bottom" ng-show="(!noscroll && data.items && data.items.length > 0) || (noscroll && data)">
     <div ng-if="!noscroll" flex class="wz-table-scroll" when-scrolled="data.nextPage('')">
         <div layout="row" ng-class-odd="'wz-table-odd'" ng-class-even="'wz-table-even'" ng-repeat="decoder in data.items | filter : searchTerm"
             class="wz-table-common" ng-class="!nopointer && activeitem !== decoder.name+decoder.file+decoder.position ? 'wz-table-cursor-pointer' : !nopointer && activeitem === decoder.name+decoder.file+decoder.position ? 'wz-table-cursor-pointer wz-table-active' : ''"
             ng-click="clickAction(full ? decoder : $index)">
-            <div ng-show="activeitem !== decoder.name+decoder.file+decoder.position" class="wz-word-wrap" ng-repeat="key in keys" flex="{{key.size || ''}}">
+            <div ng-show="activeitem !== decoder.name+decoder.file+decoder.position" class="wz-text-truncatable" ng-repeat="key in keys" flex="{{key.size || ''}}">
                 <span>{{parseItem(decoder,key) || '---'}}</span>
             </div>
             <div flex ng-show="activeitem === decoder.name+decoder.file+decoder.position" class="wz-table-height-fixed">
                 <div layout="row" class="wz-table-size">
-                    <div ng-repeat="key in keys" flex="{{key.size || ''}}" class="wz-word-wrap">
+                    <div ng-repeat="key in keys" flex="{{key.size || ''}}" class="wz-text-truncatable">
                         <span>{{parseItem(decoder,key) || '---'}}</span>
                     </div>
                 </div>

--- a/public/directives/wz-table/wz-table.html
+++ b/public/directives/wz-table/wz-table.html
@@ -4,7 +4,7 @@
         <div layout="row" ng-class-odd="'wz-table-odd'" ng-class-even="'wz-table-even'" ng-repeat="item in data.items | filter : searchTerm"
             class="wz-table-common" ng-class="!nopointer ? 'wz-table-cursor-pointer' : '' "
             ng-click="clickAction(full ? item : $index)">
-            <div class="wz-text-truncatable" ng-repeat="key in keys" flex="{{key.size || ''}}">
+            <div ng-class="key.truncatable === 'true' ? 'wz-text-truncatable' : ''" ng-repeat="key in keys" flex="{{key.size || ''}}">
                 <span>{{parseItem(item,key) || '---'}}</span>
             </div>
         </div>
@@ -13,7 +13,7 @@
     <div ng-if="!isagents && noscroll" flex class="wz-table-scroll">
         <div layout="row" ng-class-odd="'wz-table-odd'" ng-class-even="'wz-table-even'" ng-repeat="item in data" class="wz-table-common"
             ng-class="!nopointer ? 'wz-table-cursor-pointer' : '' " ng-click="clickAction($index)">
-            <div class="wz-text-truncatable" ng-repeat="key in keys" flex="{{key.size || ''}}">
+            <div ng-class="key.truncatable === 'true' ? 'wz-text-truncatable' : ''" ng-repeat="key in keys" flex="{{key.size || ''}}">
                 <span>{{parseItem(item,key) || '---'}}</span>
             </div>
         </div>

--- a/public/directives/wz-table/wz-table.js
+++ b/public/directives/wz-table/wz-table.js
@@ -6,18 +6,18 @@ app.directive('wzTable',function(){
     return {
         restrict: 'E',
         scope: {
-            data      : '=data',
-            keys      : '=keys',
-            func      : '&',
-            noscroll  : '=noscroll',
-            nopointer : '=nopointer',
-            full      : '=full',
-            noheight  : '=noheight',
-            isruleset : '=isruleset',
-            isdecoders: '=isdecoders',
-            activeitem: '=activeitem',
-            isagents  : '=isagents',
-            specialfunc: '&'
+            data        : '=data',
+            keys        : '=keys',
+            func        : '&',
+            noscroll    : '=noscroll',
+            nopointer   : '=nopointer',
+            full        : '=full',
+            noheight    : '=noheight',
+            isruleset   : '=isruleset',
+            isdecoders  : '=isdecoders',
+            activeitem  : '=activeitem',
+            isagents    : '=isagents',
+            specialfunc : '&'
         },
         link: function(scope,ele,attrs){
             scope.clickAction = (index,special) => {
@@ -27,10 +27,10 @@ app.directive('wzTable',function(){
                 } else {
                     obj.index = index;
                 }
-                
+
                 if(scope.isagents && special && special.col && special.col === 'group') scope.specialfunc(obj)
                 else scope.func(obj);
-            }   
+            }
             scope.parseItem = (item,key) => {
                 if(scope.isruleset && key.col === 'level' && item.level === 0) return '0';
                 let tmp = key;

--- a/public/directives/wz-table/wz-table.less
+++ b/public/directives/wz-table/wz-table.less
@@ -16,17 +16,13 @@
     align-items: center;
 }
 
-.wz-word-wrap {
-    word-wrap: break-word;
-}
-
 .wz-table-common {
-    padding-left: 15px;
-    min-height: 34px;
     height: auto;
-    align-items: center;
+    min-height: 34px;
+    line-height: 20px;
     padding-top: 0px;
-    word-wrap: break-word;
+    padding-left: 15px;
+    align-items: center;
     box-shadow: 0 1px 0px 2px rgba(0, 0, 0, 0.1);
 }
 

--- a/public/less/layout.less
+++ b/public/less/layout.less
@@ -83,6 +83,7 @@
 }
 
 .wz-padding-metric {
+    line-height: 16px;
     padding-top: 10px;
     padding-bottom: 10px;
 }

--- a/public/less/typography.less
+++ b/public/less/typography.less
@@ -12,10 +12,6 @@ html, body, button:not(.fa):not(.fa-times), textarea, input, select, .wz-chip {
     font-size: 17px;
 }
 
-.wz-font-weight-bold {
-    font-weight: bold !important;
-}
-
 .color-grey {
     color: grey !important;
 }
@@ -42,6 +38,16 @@ html, body, button:not(.fa):not(.fa-times), textarea, input, select, .wz-chip {
 
 .wz-text-right {
     text-align: right;
+}
+
+.wz-text-bold {
+    font-weight: bold !important;
+}
+
+.wz-text-truncatable {
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
 }
 
 .font-size-16-pt {

--- a/public/templates/agents/agents-audit.html
+++ b/public/templates/agents/agents-audit.html
@@ -5,10 +5,10 @@
         <div layout="row">
             <md-card flex class="wz-metric-color wz-md-card">
                 <md-card-content layout="row" class="wz-padding-metric">
-                    <div flex>New files: <span class="wz-font-weight-bold">{{auditNewFiles}}</span></div>
-                    <div flex>Read files: <span class="wz-font-weight-bold">{{auditReadFiles}}</span></div>
-                    <div flex>Modified files: <span class="wz-font-weight-bold">{{auditModifiedFiles}}</span></div>
-                    <div flex>Removed files: <span class="wz-font-weight-bold">{{auditRemovedFiles}}</span></div>
+                    <div class="wz-text-truncatable" flex>New files: <span class="wz-text-bold">{{auditNewFiles}}</span></div>
+                    <div class="wz-text-truncatable" flex>Read files: <span class="wz-text-bold">{{auditReadFiles}}</span></div>
+                    <div class="wz-text-truncatable" flex>Modified files: <span class="wz-text-bold">{{auditModifiedFiles}}</span></div>
+                    <div class="wz-text-truncatable" flex>Removed files: <span class="wz-text-bold">{{auditRemovedFiles}}</span></div>
                 </md-card-content>
             </md-card>
         </div>

--- a/public/templates/agents/agents-configuration.html
+++ b/public/templates/agents/agents-configuration.html
@@ -47,8 +47,8 @@
         <div layout="row">
             <md-card flex class="wz-metric-color wz-md-card">
                 <md-card-content layout="row" class="wz-padding-metric">
-                    <div flex>Group: <span ng-click="goGroup()" class="wz-font-weight-bold wz-text-link" tooltip="Click to go to the group details" tooltip-placement="right">{{groupName}}</span></div>
-                    <div flex>Configuration status: <span class="wz-font-weight-bold" tooltip="The current synchronization status" tooltip-placement="right">{{isSynchronized ? 'SYNCHRONIZED' : 'NOT SYNCHRONIZED'}}</span></div>
+                    <div class="wz-text-truncatable" flex>Group: <span ng-click="goGroup()" class="wz-text-bold wz-text-link" tooltip="Click to go to the group details" tooltip-placement="right">{{groupName}}</span></div>
+                    <div class="wz-text-truncatable" flex>Configuration status: <span class="wz-text-bold" tooltip="The current synchronization status" tooltip-placement="right">{{isSynchronized ? 'SYNCHRONIZED' : 'NOT SYNCHRONIZED'}}</span></div>
                 </md-card-content>
             </md-card>
         </div>

--- a/public/templates/agents/agents-general.html
+++ b/public/templates/agents/agents-general.html
@@ -5,25 +5,25 @@
         <div layout="row">
             <md-card flex class="wz-metric-color wz-md-card">
                 <md-card-content layout="row" class="wz-padding-metric">
-                    <div flex="20">
-                        Name: <span class="wz-font-weight-bold">{{ agent.name | limitTo: 25 }}{{ agent.name.length > 25 ? '&hellip;' : '' }}</span>
+                    <div class="wz-text-truncatable" flex>
+                        Name: <span class="wz-text-bold">{{ agent.name }}</span>
                         <md-tooltip ng-if="agent.name.length > 25" md-direction="bottom" class="wz-tooltip">
-                            Full name: {{agent.name}}
+                            Full name: {{ agent.name }}
                         </md-tooltip>
                     </div>
-                    <div flex="20">
-                        IP: <span class="wz-font-weight-bold">{{agent.ip}}</span>
+                    <div class="wz-text-truncatable" flex>
+                        IP: <span class="wz-text-bold">{{ agent.ip }}</span>
                     </div>
-                    <div flex="20" ng-if="agent.group">
-                        Group: <span class="wz-font-weight-bold">{{ agent.group }}</span>
+                    <div class="wz-text-truncatable" flex ng-if="agent.group">
+                        Group: <span class="wz-text-bold">{{ agent.group }}</span>
                     </div>
-                    <div flex="20" ng-if="agent.version">
-                        Version: <span class="wz-font-weight-bold">{{ agent.version }}</span>
+                    <div class="wz-text-truncatable" flex ng-if="agent.version">
+                        Version: <span class="wz-text-bold">{{ agent.version }}</span>
                     </div>
-                    <div flex>
-                        OS: <span class="wz-font-weight-bold">{{ agentOS | limitTo: 25 }}{{ agentOS.length > 25 ? '&hellip;' : '' }}</span>
+                    <div class="wz-text-truncatable" flex>
+                        OS: <span class="wz-text-bold">{{ agentOS }}</span>
                         <md-tooltip ng-if="agentOS.length > 25" md-direction="bottom" class="wz-tooltip">
-                            Full OS name: {{agentOS}}
+                            Full OS name: {{ agentOS }}
                         </md-tooltip>
                     </div>
                 </md-card-content>
@@ -33,18 +33,18 @@
         <div layout="row">
             <md-card flex class="wz-metric-color wz-md-card">
                 <md-card-content layout="row" class="wz-padding-metric">
-                    <div flex="25">Last keep alive:<span class="wz-font-weight-bold"> {{agent.lastKeepAlive || 'Unknown' }}</span></div>
-                    <div flex="25">Registration date:<span class="wz-font-weight-bold"> {{agent.dateAdd}}</span></div>
-                    <div flex="25" ng-if="agent.syscheck.inProgress">Last syscheck scan:<span class="wz-font-weight-bold"> Scan in progress</span></div>
-                    <div flex="25" ng-if="!agent.syscheck.inProgress">Last syscheck scan:<span class="wz-font-weight-bold"> {{agent.syscheck.end || 'Unknown'}}</span>
+                    <div class="wz-text-truncatable" flex>Last keep alive:<span class="wz-text-bold"> {{agent.lastKeepAlive || 'Unknown' }}</span></div>
+                    <div class="wz-text-truncatable" flex>Registration date:<span class="wz-text-bold"> {{agent.dateAdd}}</span></div>
+                    <div class="wz-text-truncatable" flex ng-if="agent.syscheck.inProgress">Last syscheck scan:<span class="wz-text-bold"> Scan in progress</span></div>
+                    <div class="wz-text-truncatable" flex ng-if="!agent.syscheck.inProgress">Last syscheck scan:<span class="wz-text-bold"> {{agent.syscheck.end || 'Unknown'}}</span>
                         <md-tooltip ng-if="!agent.syscheck.inProgress && agent.syscheck.start && agent.syscheck.end" md-direction="bottom" class="wz-tooltip">
                             Start time: {{ agent.syscheck.start || 'Unknown'}} <br>
                             End time: {{ agent.syscheck.end || 'Unknown'}} <br>
                             Duration time: {{ agent.syscheck.duration +' minutes' || 'Unknown'}}
                         </md-tooltip>
                     </div>
-                    <div flex ng-if="agent.rootcheck.inProgress">Last rootcheck scan:<span class="wz-font-weight-bold"> Scan in progress</span></div>
-                    <div flex ng-if="!agent.rootcheck.inProgress">Last rootcheck scan:<span class="wz-font-weight-bold"> {{agent.rootcheck.end || 'Unknown'}}</span>
+                    <div class="wz-text-truncatable" flex ng-if="agent.rootcheck.inProgress">Last rootcheck scan:<span class="wz-text-bold"> Scan in progress</span></div>
+                    <div class="wz-text-truncatable" flex ng-if="!agent.rootcheck.inProgress">Last rootcheck scan:<span class="wz-text-bold"> {{agent.rootcheck.end || 'Unknown'}}</span>
                         <md-tooltip ng-if="!agent.rootcheck.inProgress && agent.rootcheck.start && agent.rootcheck.end" md-direction="bottom" class="wz-tooltip">
                             Start time: {{ agent.rootcheck.start || 'Unknown'}} <br>
                             End time: {{ agent.rootcheck.end || 'Unknown'}} <br>

--- a/public/templates/agents/agents-oscap.html
+++ b/public/templates/agents/agents-oscap.html
@@ -5,9 +5,9 @@
         <div layout="row">
             <md-card flex class="wz-metric-color wz-md-card">
                 <md-card-content layout="row" class="wz-padding-metric">
-                    <div flex>Last score: <span class="wz-font-weight-bold">{{scapLastScore}}</span></div>
-                    <div flex>Highest score: <span class="wz-font-weight-bold">{{scapHighestScore}}</span></div>
-                    <div flex>Lowest score: <span class="wz-font-weight-bold">{{scapLowestScore}}</span></div>
+                    <div flex>Last score: <span class="wz-text-bold">{{scapLastScore}}</span></div>
+                    <div flex>Highest score: <span class="wz-text-bold">{{scapHighestScore}}</span></div>
+                    <div flex>Lowest score: <span class="wz-text-bold">{{scapLowestScore}}</span></div>
                 </md-card-content>
             </md-card>
         </div>

--- a/public/templates/agents/agents-virustotal.html
+++ b/public/templates/agents/agents-virustotal.html
@@ -6,9 +6,9 @@
         <div layout="row">
             <md-card flex class="wz-metric-color wz-md-card">
                 <md-card-content layout="row" class="wz-padding-metric">
-                    <div flex>Total malicious: <span class="wz-font-weight-bold">{{virusMalicious}}</span></div>
-                    <div flex>Total positives: <span class="wz-font-weight-bold">{{virusPositives}}</span></div>
-                    <div flex>Total: <span class="wz-font-weight-bold">{{virusTotal}}</span></div>                    
+                    <div flex>Total malicious: <span class="wz-text-bold">{{virusMalicious}}</span></div>
+                    <div flex>Total positives: <span class="wz-text-bold">{{virusPositives}}</span></div>
+                    <div flex>Total: <span class="wz-text-bold">{{virusTotal}}</span></div>                    
                 </md-card-content>
             </md-card>
         </div>

--- a/public/templates/agents/agents-vuls.html
+++ b/public/templates/agents/agents-vuls.html
@@ -6,10 +6,10 @@
         <div layout="row">
             <md-card flex class="wz-metric-color wz-md-card">
                 <md-card-content layout="row" class="wz-padding-metric">
-                    <div flex>Critical severity alerts: <span class="wz-font-weight-bold">{{vulnCritical}}</span></div>
-                    <div flex>High severity alerts: <span class="wz-font-weight-bold">{{vulnHigh}}</span></div>
-                    <div flex>Medium severity alerts: <span class="wz-font-weight-bold">{{vulnMedium}}</span></div>
-                    <div flex>Low severity alerts: <span class="wz-font-weight-bold">{{vulnLow}}</span></div>
+                    <div flex>Critical severity alerts: <span class="wz-text-bold">{{vulnCritical}}</span></div>
+                    <div flex>High severity alerts: <span class="wz-text-bold">{{vulnHigh}}</span></div>
+                    <div flex>Medium severity alerts: <span class="wz-text-bold">{{vulnMedium}}</span></div>
+                    <div flex>Low severity alerts: <span class="wz-text-bold">{{vulnLow}}</span></div>
                 </md-card-content>
             </md-card>
         </div>

--- a/public/templates/manager/manager-osseclog.html
+++ b/public/templates/manager/manager-osseclog.html
@@ -64,7 +64,7 @@
             layout="column"
             flex
             data="logs"
-            keys="[{col:'timestamp',size:15},{col:'tag',size:25},{col:'level',size:10},{col:'description'}]"
+            keys="[{col:'timestamp',size:15,truncatable:'true'},{col:'tag',size:25,truncatable:'true'},{col:'level',size:10,truncatable:'true'},{col:'description',truncatable:'false'}]"
             ng-if="!realtime"
             class="no-lateral-padding"
             nopointer="true"
@@ -76,7 +76,7 @@
             layout="column"
             flex
             data="realLogs"
-            keys="[{col:'timestamp',size:15},{col:'tag',size:25},{col:'level',size:10},{col:'description'}]"
+            keys="[{col:'timestamp',size:15,truncatable:'true'},{col:'tag',size:25,truncatable:'true'},{col:'level',size:10,truncatable:'true'},{col:'description',truncatable:'false'}]"
             ng-if="realtime"
             class="no-lateral-padding",
             noscroll="true"

--- a/public/templates/manager/manager-status.html
+++ b/public/templates/manager/manager-status.html
@@ -20,19 +20,19 @@
             <md-card flex class="wz-metric-color wz-md-card">
                 <md-card-content layout="row" class="wz-padding-metric">
                     <div flex>Total agents:
-                        <span class="wz-font-weight-bold">{{agentsCountTotal}}</span>
+                        <span class="wz-text-bold">{{agentsCountTotal}}</span>
                     </div>
                     <div flex>Active:
-                        <span class="wz-font-weight-bold">{{agentsCountActive}}</span>
+                        <span class="wz-text-bold">{{agentsCountActive}}</span>
                     </div>
                     <div flex>Disconnected:
-                        <span class="wz-font-weight-bold">{{agentsCountDisconnected}}</span>
+                        <span class="wz-text-bold">{{agentsCountDisconnected}}</span>
                     </div>
                     <div flex>Never connected:
-                        <span class="wz-font-weight-bold">{{agentsCountNeverConnected}}</span>
+                        <span class="wz-text-bold">{{agentsCountNeverConnected}}</span>
                     </div>
                     <div flex>Agents coverage:
-                        <span class="wz-font-weight-bold">{{(agentsCoverity | number:2)}}%</span>
+                        <span class="wz-text-bold">{{(agentsCoverity | number:2)}}%</span>
                     </div>
                 </md-card-content>
             </md-card>

--- a/public/templates/overview/overview-audit.html
+++ b/public/templates/overview/overview-audit.html
@@ -2,16 +2,18 @@
 
     <!-- View: Panels -->
     <div ng-if="resultState === 'ready' && tabView === 'panels'">
+
         <div layout="row">
             <md-card flex class="wz-metric-color wz-md-card">
                 <md-card-content layout="row" class="wz-padding-metric">
-                    <div flex>New files: <span class="wz-font-weight-bold">{{auditNewFiles}}</span></div>
-                    <div flex>Read files: <span class="wz-font-weight-bold">{{auditReadFiles}}</span></div>
-                    <div flex>Modified files: <span class="wz-font-weight-bold">{{auditModifiedFiles}}</span></div>
-                    <div flex>Removed files: <span class="wz-font-weight-bold">{{auditRemovedFiles}}</span></div>
+                    <div class="wz-text-truncatable" flex>New files: <span class="wz-text-bold">{{auditNewFiles}}</span></div>
+                    <div class="wz-text-truncatable" flex>Read files: <span class="wz-text-bold">{{auditReadFiles}}</span></div>
+                    <div class="wz-text-truncatable" flex>Modified files: <span class="wz-text-bold">{{auditModifiedFiles}}</span></div>
+                    <div class="wz-text-truncatable" flex>Removed files: <span class="wz-text-bold">{{auditRemovedFiles}}</span></div>
                 </md-card-content>
             </md-card>
         </div>
+
         <div class="wz-no-display">
             <kbn-vis vis-id="'Wazuh-App-Overview-Audit-New-files'"></kbn-vis>
             <kbn-vis vis-id="'Wazuh-App-Overview-Audit-Read-files'"></kbn-vis>

--- a/public/templates/overview/overview-aws.html
+++ b/public/templates/overview/overview-aws.html
@@ -6,10 +6,10 @@
         <div layout="row">
             <md-card flex class="wz-metric-color wz-md-card">
                 <md-card-content layout="row" class="wz-padding-metric">
-                    <div flex>Successful logins: <span class="wz-font-weight-bold">{{awsLogins}}</span></div>
-                    <div flex>Most active user: <span class="wz-font-weight-bold">{{awsMostActiveUser}}</span></div>
-                    <div flex>Authorized security groups: <span class="wz-font-weight-bold">{{awsAuthorized}}</span></div>    
-                    <div flex>Revoked security groups: <span class="wz-font-weight-bold">{{awsRevoked}}</span></div>                  
+                    <div class="wz-text-truncatable" flex>Successful logins: <span class="wz-text-bold">{{awsLogins}}</span></div>
+                    <div class="wz-text-truncatable" flex>Most active user: <span class="wz-text-bold">{{awsMostActiveUser}}</span></div>
+                    <div class="wz-text-truncatable" flex>Authorized security groups: <span class="wz-text-bold">{{awsAuthorized}}</span></div>    
+                    <div class="wz-text-truncatable" flex>Revoked security groups: <span class="wz-text-bold">{{awsRevoked}}</span></div>
                 </md-card-content>
             </md-card>
         </div>

--- a/public/templates/overview/overview-fim.html
+++ b/public/templates/overview/overview-fim.html
@@ -6,9 +6,9 @@
         <div layout="row">
             <md-card flex class="wz-metric-color wz-md-card">
                 <md-card-content layout="row" class="wz-padding-metric">
-                    <div flex>Files added: <span class="wz-font-weight-bold">{{fimAdded}}</span></div>
-                    <div flex>Files modified: <span class="wz-font-weight-bold">{{fimModified}}</span></div>
-                    <div flex>Files deleted: <span class="wz-font-weight-bold">{{fimDeleted}}</span></div>
+                    <div class="wz-text-truncatable" flex>Files added: <span class="wz-text-bold">{{fimAdded}}</span></div>
+                    <div class="wz-text-truncatable" flex>Files modified: <span class="wz-text-bold">{{fimModified}}</span></div>
+                    <div class="wz-text-truncatable" flex>Files deleted: <span class="wz-text-bold">{{fimDeleted}}</span></div>
                 </md-card-content>
             </md-card>
         </div>

--- a/public/templates/overview/overview-general.html
+++ b/public/templates/overview/overview-general.html
@@ -6,10 +6,10 @@
         <div layout="row">
             <md-card flex class="wz-metric-color wz-md-card">
                 <md-card-content layout="row" class="wz-padding-metric">
-                    <div flex>Alerts: <span class="wz-font-weight-bold">{{totalAlerts}}</span></div>
-                    <div flex>Level 12 or above alerts: <span class="wz-font-weight-bold">{{level12}}</span></div>
-                    <div flex>Authentication failure: <span class="wz-font-weight-bold">{{authFailure}}</span></div>
-                    <div flex>Authentication success: <span class="wz-font-weight-bold">{{authSuccess}}</span></div>
+                    <div class="wz-text-truncatable" flex>Alerts: <span class="wz-text-bold">{{totalAlerts}}</span></div>
+                    <div class="wz-text-truncatable" flex>Level 12 or above alerts: <span class="wz-text-bold">{{level12}}</span></div>
+                    <div class="wz-text-truncatable" flex>Authentication failure: <span class="wz-text-bold">{{authFailure}}</span></div>
+                    <div class="wz-text-truncatable" flex>Authentication success: <span class="wz-text-bold">{{authSuccess}}</span></div>
                 </md-card-content>
             </md-card>
         </div>

--- a/public/templates/overview/overview-oscap.html
+++ b/public/templates/overview/overview-oscap.html
@@ -6,9 +6,9 @@
         <div layout="row">
             <md-card flex class="wz-metric-color wz-md-card">
                 <md-card-content layout="row" class="wz-padding-metric">
-                    <div flex>Last score: <span class="wz-font-weight-bold">{{scapLastScore}}</span></div>
-                    <div flex>Highest score: <span class="wz-font-weight-bold">{{scapHighestScore}}</span></div>
-                    <div flex>Lowest score: <span class="wz-font-weight-bold">{{scapLowestScore}}</span></div>
+                    <div class="wz-text-truncatable" flex>Last score: <span class="wz-text-bold">{{scapLastScore}}</span></div>
+                    <div class="wz-text-truncatable" flex>Highest score: <span class="wz-text-bold">{{scapHighestScore}}</span></div>
+                    <div class="wz-text-truncatable" flex>Lowest score: <span class="wz-text-bold">{{scapLowestScore}}</span></div>
                 </md-card-content>
             </md-card>
         </div>

--- a/public/templates/overview/overview-virustotal.html
+++ b/public/templates/overview/overview-virustotal.html
@@ -1,11 +1,13 @@
 <md-content flex layout="column" ng-if="tab === 'virustotal'" layout-align="start">
+
     <div ng-if="resultState === 'ready' && tabView === 'panels'">
+
         <div layout="row">
             <md-card flex class="wz-metric-color wz-md-card">
                 <md-card-content layout="row" class="wz-padding-metric">
-                    <div flex>Total malicious: <span class="wz-font-weight-bold">{{virusMalicious}}</span></div>
-                    <div flex>Total positives: <span class="wz-font-weight-bold">{{virusPositives}}</span></div>
-                    <div flex>Total: <span class="wz-font-weight-bold">{{virusTotal}}</span></div>                    
+                    <div class="wz-text-truncatable" flex>Total malicious: <span class="wz-text-bold">{{virusMalicious}}</span></div>
+                    <div class="wz-text-truncatable" flex>Total positives: <span class="wz-text-bold">{{virusPositives}}</span></div>
+                    <div class="wz-text-truncatable" flex>Total: <span class="wz-text-bold">{{virusTotal}}</span></div>
                 </md-card-content>
             </md-card>
         </div>

--- a/public/templates/overview/overview-vuls.html
+++ b/public/templates/overview/overview-vuls.html
@@ -6,10 +6,10 @@
         <div layout="row">
             <md-card flex class="wz-metric-color wz-md-card">
                 <md-card-content layout="row" class="wz-padding-metric">
-                    <div flex>Critical severity alerts: <span class="wz-font-weight-bold">{{vulnCritical}}</span></div>
-                    <div flex>High severity alerts: <span class="wz-font-weight-bold">{{vulnHigh}}</span></div>
-                    <div flex>Medium severity alerts: <span class="wz-font-weight-bold">{{vulnMedium}}</span></div>
-                    <div flex>Low severity alerts: <span class="wz-font-weight-bold">{{vulnLow}}</span></div>
+                    <div class="wz-text-truncatable" flex>Critical severity alerts: <span class="wz-text-bold">{{vulnCritical}}</span></div>
+                    <div class="wz-text-truncatable" flex>High severity alerts: <span class="wz-text-bold">{{vulnHigh}}</span></div>
+                    <div class="wz-text-truncatable" flex>Medium severity alerts: <span class="wz-text-bold">{{vulnMedium}}</span></div>
+                    <div class="wz-text-truncatable" flex>Low severity alerts: <span class="wz-text-bold">{{vulnLow}}</span></div>
                 </md-card-content>
             </md-card>
         </div>

--- a/public/templates/settings/settings.html
+++ b/public/templates/settings/settings.html
@@ -88,12 +88,12 @@
 
                 <!-- API list headings row -->
                 <div layout="row" layout-align="start start" class="wz-padding-top-10 wz-padding-bottom-14">
-                    <p flex="15" class="wz-font-weight-bold">Cluster</p>
-                    <p flex="20" class="wz-font-weight-bold">Manager</p>
-                    <p flex="15" class="wz-font-weight-bold">API URL</p>
-                    <p flex="15" class="wz-font-weight-bold">API Port</p>
-                    <p flex="15" class="wz-font-weight-bold">User</p>
-                    <p flex="20" class="wz-font-weight-bold">Actions</p>
+                    <p flex="15" class="wz-text-bold">Cluster</p>
+                    <p flex="20" class="wz-text-bold">Manager</p>
+                    <p flex="15" class="wz-text-bold">API URL</p>
+                    <p flex="15" class="wz-text-bold">API Port</p>
+                    <p flex="15" class="wz-text-bold">User</p>
+                    <p flex="20" class="wz-text-bold">Actions</p>
                 </div>
 
                 <div ng-repeat="entry in apiEntries">
@@ -199,7 +199,7 @@
                 <div layout="row" class="wz-padding-top-10">Enable or disable extensions according to your needs. The extension includes: Panels and Discover, for Overview / Agents tabs.</div>
 
                 <div class="wz-padding-top-10">
-                    <div layout="row" layout-align="space-between center" class="wz-font-weight-bold">PCI DSS</div>
+                    <div layout="row" layout-align="space-between center" class="wz-text-bold">PCI DSS</div>
                     <div layout="row" class="wz-padding-top-10 wz-line-height">
                         The Payment Card Industry Data Security Standard (PCI DSS) is a proprietary information security standard for organizations
                         that handle branded credit cards from the major card schemes including Visa, MasterCard, American Express,
@@ -214,7 +214,7 @@
                 </div>
 
                 <div class="wz-padding-top-10">
-                    <div layout="row" layout-align="space-between center" class="wz-font-weight-bold">OpenSCAP</div>
+                    <div layout="row" layout-align="space-between center" class="wz-text-bold">OpenSCAP</div>
                     <div layout="row" class="wz-padding-top-10 wz-line-height">
                         OVAL (Open Vulnerability Assessment Language) interpreter used to check system configuration and detect vulnerable applications.
                         <br> It is recognized as a standardized compliance and hardening checking solution for enterprise-level infrastructure.
@@ -226,7 +226,7 @@
                 </div>
 
                 <div class="wz-padding-top-10">
-                    <div layout="row" layout-align="space-between center" class="wz-font-weight-bold">Audit</div>
+                    <div layout="row" layout-align="space-between center" class="wz-text-bold">Audit</div>
                     <div layout="row" class="wz-padding-top-10 wz-line-height">
                         The Linux Audit system provides a way to track security-relevant information on your system. Based on pre-configured rules,
                         Audit generates log entries to record as much information about the events that are happening on your
@@ -239,7 +239,7 @@
                 </div>
 
                 <div class="wz-padding-top-10">
-                    <div layout="row" class="wz-font-weight-bold">Amazon Web Services (AWS)</div>
+                    <div layout="row" class="wz-text-bold">Amazon Web Services (AWS)</div>
                     <div layout="row" class="wz-padding-top-10 wz-line-height">
                         Wazuh provides a way to collect alerts from your AWS machines and store them to an agent. Once the agent reads the message,
                         it sends it to the Wazuh manager which analyses it with decoders and rules. When a rule matches, an alert
@@ -253,7 +253,7 @@
                 </div>
 
                 <div class="wz-padding-top-10">
-                    <div layout="row" layout-align="space-between center" class="wz-font-weight-bold">VirusTotal</div>
+                    <div layout="row" layout-align="space-between center" class="wz-text-bold">VirusTotal</div>
                     <div layout="row" class="wz-padding-top-10 wz-line-height">
                         VirusTotal is an online service that analyzes files and URLs enabling the detection of viruses, worms, trojans and other
                         kinds of malicious content using antivirus engines and website scanners. It also can be used to detect


### PR DESCRIPTION
Greetings,

This pull request adds truncatable text to the app. Specifically, to the metric ribbons and the tables. We've implemented a new CSS class, `wz-text-truncatable`, used for text containers (not the text element itself):
```CSS
.wz-text-truncatable {
    overflow: hidden;
    white-space: nowrap;
    text-overflow: ellipsis;
}
```
In addition, the table from *Manager Logs* is configured to not truncate the **Description** column, so the user won't miss the complete log.

### Example screenshots
![overflow1](https://user-images.githubusercontent.com/10928321/37781278-a99077f0-2df0-11e8-8c52-38da148e609d.png)
![overflow2](https://user-images.githubusercontent.com/10928321/37781280-a9b72eb8-2df0-11e8-9715-0b0f14e7ede0.png)

Regards,
Juanjo