### PR TITLE
 Changed colour palette for tables

### DIFF
--- a/public/controllers/settings.js
+++ b/public/controllers/settings.js
@@ -248,7 +248,6 @@ app.controller('settingsController', function ($scope, $rootScope, $http, $route
                     extensions  : tmpData.extensions
                 }
             };
-            console.log($scope.apiEntries)
             $scope.apiEntries.push(newEntry);
             $scope.apiEntries = $scope.apiEntries.sort(sortByTimestamp);
 

--- a/public/directives/wz-table/wz-table.less
+++ b/public/directives/wz-table/wz-table.less
@@ -1,3 +1,9 @@
+/* -------------------------------------------------------------------------- */
+/* ------------------------- Wazuh table stylesheet ------------------------- */
+/* -------------------------------------------------------------------------- */
+
+/* Layout */
+
 .wz-table-no-padding {
     padding: 0px;
 }
@@ -10,65 +16,12 @@
     padding-top: 10px;
 }
 
-.wz-table-size {
-    min-height: 34px;
-    height: auto;
-    align-items: center;
-}
-
-.wz-table-common {
-    height: auto;
-    min-height: 34px;
-    line-height: 20px;
-    padding-top: 0px;
-    padding-left: 15px;
-    align-items: center;
-    box-shadow: 0 1px 0px 2px rgba(0, 0, 0, 0.1);
-}
-
-.wz-table-common:hover {
-    background-color: rgb(0,121,165);
-    color: white;
-}
-
-.wz-table-scroll {
-    overflow: auto;
-    height: 400px;
-}
-
-.wz-table-even {
-    background-color: #fafafa;
-}
-
-.wz-table-odd {
-    background-color: white;
-}
-
-.wz-table-cursor-pointer {
-    cursor: pointer;
-}
-
-.wz-table-active {
-    background-color: rgb(0,121,165);
-    color: white;
-}
-
-.wz-table-ruleset-card-info {
-    background-color: rgb(0,121,165);
-    height: 100%;
-    padding: 0px;
-}
-
 .wz-padding-right-14 {
     padding-right: 14px !important;
 }
 
 .wz-padding-bottom-14 {
     padding-bottom: 14px !important;
-}
-
-.wz-cursor-default {
-    cursor: default !important;
 }
 
 .no-lateral-padding .md-padding {
@@ -81,17 +34,65 @@
     overflow: hidden;
 }
 
-.wz-table-card-active {
-    background-color: rgb(0,121,165) !important;
-    color: white !important;
-}
-
 .wz-table-agents {
     min-height: 34px;
     height: auto;
     padding-top: 10px;
 }
 
+.wz-table-scroll {
+    overflow: auto;
+    height: 400px;
+}
+
+.wz-table-size {
+    min-height: 34px;
+    height: auto;
+    align-items: center;
+}
+
+/* Table styles */
+
+.wz-table-common {
+    height: auto;
+    min-height: 34px;
+    line-height: 20px;
+    padding-top: 0px;
+    padding-left: 15px;
+    align-items: center;
+    box-shadow: 0 1px 0px 2px rgba(0, 0, 0, 0.1);
+}
+
+.wz-table-active,
+.wz-table-common:hover {
+    background-color: rgb(228, 242, 245);
+    color: rgba(0, 0, 0, 0.87);
+}
+
+.wz-table-even {
+    background-color: #fafafa;
+}
+
+.wz-table-odd {
+    background-color: white;
+}
+
+/* Others */
+
+.wz-table-cursor-pointer {
+    cursor: pointer;
+}
+
+.wz-cursor-default {
+    cursor: default !important;
+}
+
+/* Class to indicate the currently active button on Ruleset */
+.wz-ruleset-active {
+    background-color: rgb(0,121,165) !important;
+}
+
+/* Special fix to avoid flex issues on Firefox */
 @-moz-document url-prefix() {
     .mozilla-table-size-85 {max-height: 85vh !important;}
     .mozilla-table-size-99 {max-height: 99vh !important;}

--- a/public/directives/wz-table/wz-table.less
+++ b/public/directives/wz-table/wz-table.less
@@ -65,7 +65,7 @@
 
 .wz-table-active,
 .wz-table-common:hover {
-    background-color: rgb(228, 242, 245);
+    background-color: rgb(228, 242, 245) !important;
     color: rgba(0, 0, 0, 0.87);
 }
 

--- a/public/less/common.less
+++ b/public/less/common.less
@@ -273,7 +273,7 @@ div.uil-ring-css {
 }
 
 .wz-metric-color {
-    background-color: #e4f2f5 !important;
+    background-color: rgb(228, 242, 245);
 }
 
 .wz-background-transparent {

--- a/public/services/error-handler.js
+++ b/public/services/error-handler.js
@@ -7,8 +7,8 @@ app.service('errorHandler', function ( Notifier, appState, $location) {
         if(error.data && error.data.errorData && error.data.errorData.message) return error.data.errorData.message;
         if(error.errorData && error.errorData.message) return error.errorData.message;
         if(error.data && typeof error.data === 'string') return error.data;
-        if(error.data && error.data.message && error.data.message === 'string') return error.data.message;
-        if(error.data && error.data.message && error.data.message.msg && error.data.message.msg === 'string') return error.data.message.msg;
+        if(error.data && error.data.message && typeof error.data.message === 'string') return error.data.message;
+        if(error.data && error.data.message && error.data.message.msg && typeof error.data.message.msg === 'string') return error.data.message.msg;
         if(error.data && error.data.data && typeof error.data.data === 'string') return error.data.data;
         if(typeof error.message === 'string') return error.message;
         if(error.message && error.message.msg) return error.message.msg;

--- a/public/templates/manager/ruleset/ruleset-decoders.html
+++ b/public/templates/manager/ruleset/ruleset-decoders.html
@@ -37,11 +37,11 @@
                 </md-autocomplete>
             </span>
 
-            <md-button flex="10" ng-class="(globalsubmenuNavItem2 == 'rules') ? 'wz-table-card-active' : ''" ng-click="setRulesTab('rules')"
+            <md-button flex="10" ng-class="(globalsubmenuNavItem2 == 'rules') ? 'wz-ruleset-active' : ''" ng-click="setRulesTab('rules')"
                 class="wazuh-button md-raised md-primary manager-ruleset-btn" aria-label="Ruleset rules button">
                 Rules
             </md-button>
-            <md-button flex="10" ng-class="(globalsubmenuNavItem2 == 'decoders') ? 'wz-table-card-active' : ''" ng-click="setRulesTab('decoders')"
+            <md-button flex="10" ng-class="(globalsubmenuNavItem2 == 'decoders') ? 'wz-ruleset-active' : ''" ng-click="setRulesTab('decoders')"
                 class="wazuh-button md-raised md-primary manager-ruleset-btn" aria-label="Ruleset decoders button">
                 Decoders
             </md-button>

--- a/public/templates/manager/ruleset/ruleset-rules.html
+++ b/public/templates/manager/ruleset/ruleset-rules.html
@@ -72,11 +72,11 @@
                 </md-autocomplete>
             </span>
 
-            <md-button flex="10" ng-class="(globalsubmenuNavItem2 == 'rules') ? 'wz-table-card-active' : ''"
+            <md-button flex="10" ng-class="(globalsubmenuNavItem2 == 'rules') ? 'wz-ruleset-active' : ''"
                 ng-click="setRulesTab('rules')" class="wazuh-button md-raised md-primary manager-ruleset-btn" aria-label="Ruleset rules button">
                 Rules
             </md-button>
-            <md-button flex="10" ng-class="(globalsubmenuNavItem2 == 'decoders') ? 'wz-table-card-active' : ''"
+            <md-button flex="10" ng-class="(globalsubmenuNavItem2 == 'decoders') ? 'wz-ruleset-active' : ''"
                 ng-click="setRulesTab('decoders')" class="wazuh-button md-raised md-primary manager-ruleset-btn" aria-label="Ruleset decoders button">
                 Decoders
             </md-button>


### PR DESCRIPTION
Hello team.

This PR replaces the colour palette used in all the Wazuh app tables. Now uses a much more clearer blue, more relaxing to the eyes. It's the same colour as the used one on the metric ribbons.

Here's an example screenshot:
![colores](https://user-images.githubusercontent.com/10928321/38198457-38fa5bf0-368d-11e8-9b73-0ee2d94be7c8.PNG)

This PR also provides some CSS cleanup and reordering to the existing stylesheet files.

I hope you like this improvement to the Wazuh app.

Best regards,
Juanjo

**PST**: This PR will be added to the `3.2-xpack-rbac` development branch, which will be later merged into the `3.2` branch.