### PR TITLE
Url regex validation now accepts custom dns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 
 ### Changed
 - Increased the query size when fetching the index pattern list ([#339](https://github.com/wazuh/wazuh-kibana-app/pull/339)).
+- Changed validation regex to accept URLs with non-numeric format ([#353](https://github.com/wazuh/wazuh-kibana-app/pull/353)).
 
 ### Fixed
 - Fixed a bug where several `agent.id` filters were created at the same time when navigating between *Agents* and *Groups* with different selected agents ([#342](https://github.com/wazuh/wazuh-kibana-app/pull/342)).

--- a/public/controllers/settings.js
+++ b/public/controllers/settings.js
@@ -37,7 +37,7 @@ app.controller('settingsController', function ($scope, $rootScope, $http, $route
 
     const userRegEx  = new RegExp(/^.{3,100}$/);
     const passRegEx  = new RegExp(/^.{3,100}$/);
-    const urlRegEx   = new RegExp(/^https?:\/\/[a-zA-Z0-9]{1,300}$/);
+    const urlRegEx   = new RegExp(/^https?:\/\/[a-zA-Z0-9-.]{1,300}$/);
     const urlRegExIP = new RegExp(/^https?:\/\/[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$/);
     const portRegEx  = new RegExp(/^[0-9]{2,5}$/);
 

--- a/server/api/wazuh-api-elastic.js
+++ b/server/api/wazuh-api-elastic.js
@@ -172,7 +172,7 @@ module.exports = (server, options) => {
 
         const userRegEx  = new RegExp(/^.{3,100}$/);
         const passRegEx  = new RegExp(/^.{3,100}$/); 
-        const urlRegEx   = new RegExp(/^https?:\/\/[a-zA-Z0-9]{1,300}$/); 
+        const urlRegEx   = new RegExp(/^https?:\/\/[a-zA-Z0-9-.]{1,300}$/); 
         const urlRegExIP = new RegExp(/^https?:\/\/[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$/); 
         const portRegEx  = new RegExp(/^[0-9]{2,5}$/); 
 
@@ -269,7 +269,7 @@ module.exports = (server, options) => {
 
         const userRegEx  = new RegExp(/^.{3,100}$/);
         const passRegEx  = new RegExp(/^.{3,100}$/); 
-        const urlRegEx   = new RegExp(/^https?:\/\/[a-zA-Z0-9]{1,300}$/); 
+        const urlRegEx   = new RegExp(/^https?:\/\/[a-zA-Z0-9-.]{1,300}$/); 
         const urlRegExIP = new RegExp(/^https?:\/\/[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$/); 
         const portRegEx  = new RegExp(/^[0-9]{2,5}$/); 
 


### PR DESCRIPTION
Hello team this pull request adds the requested feature to accept custom dns on url validation.

```js
const urlRegEx  = new RegExp(/^https?:\/\/[a-zA-Z0-9-.]{1,300}$/)

console.log(urlRegEx.test('http://mydns')); // true
console.log(urlRegEx.test('http://mydns.com')) // true
console.log(urlRegEx.test('http://mydns-mydns')) // true
console.log(urlRegEx.test('http://mydns-mydns.com') // true
console.log(urlRegEx.test('https://mydns')); // true
console.log(urlRegEx.test('https://mydns.com')) // true
console.log(urlRegEx.test('https://mydns-mydns')) // true
console.log(urlRegEx.test('https://mydns-mydns.com')) // true
```

Best,
Jesús