### PR TITLE
Added Syscollector to Manager and Agents configuration

### DIFF
--- a/public/templates/agents/agents-configuration.html
+++ b/public/templates/agents/agents-configuration.html
@@ -59,6 +59,7 @@
                 && !configurationError
                 && !groupConfiguration.config.syscheck
                 && !groupConfiguration.config.rootcheck
+                && !groupConfiguration.config.syscollector
                 && !groupConfiguration.config['open-scap']
                 && !groupConfiguration.config['cis-cat']
                 && !groupConfiguration.config['localfile']
@@ -100,7 +101,7 @@
                             <span flex class="wz-text-right color-grey">{{groupConfiguration.config.syscheck.disabled}}</span>
                         </div>
                         <div layout="row" class="wz-padding-top-10" ng-if="groupConfiguration.config.syscheck.frequency">
-                            <span flex>Frrequency</span>
+                            <span flex>Frequency</span>
                             <span flex class="wz-text-right color-grey">{{groupConfiguration.config.syscheck.frequency}}</span>
                         </div>
                     </md-card-content>
@@ -124,6 +125,24 @@
                     </md-card-content>
                 </md-card>
                 <!-- END POLICY MONITORING -->
+
+                <!-- SYSCOLLECTOR -->
+                <md-card flex class="wz-md-card" ng-show="groupConfiguration.config.syscollector">
+                    <md-card-content>
+                        <!-- Section title -->
+                        <span class="wz-headline-title wz-text-link" tooltip="Click to see more details" tooltip-placement="right" ng-click="selectedConfigTab='syscollector';toggleRAW=false">Syscollector</span>
+                        <md-divider class="wz-margin-top-10"></md-divider>
+                        <div layout="row" class="wz-padding-top-10" ng-if="groupConfiguration.config.syscollector.disabled">
+                            <span flex>Disabled</span>
+                            <span flex class="wz-text-right color-grey">{{groupConfiguration.config.syscollector.disabled}}</span>
+                        </div>
+                        <div layout="row" class="wz-padding-top-10" ng-if="groupConfiguration.config.syscollector.scan_on_start">
+                            <span flex>Scan on start</span>
+                            <span flex class="wz-text-right color-grey">{{groupConfiguration.config.syscollector.scan_on_start}}</span>
+                        </div>
+                    </md-card-content>
+                </md-card>
+                <!-- END SYSCOLLECTOR -->
 
                 <!-- OPENSCAP -->
                 <md-card flex class="wz-md-card" ng-show="groupConfiguration.config['open-scap']">
@@ -455,6 +474,47 @@
                     </md-card-content>
                 </md-card>
                 <!-- END POLICY MONITORING -->
+
+                <!-- SYSCOLLECTOR -->
+                <md-card flex class="wz-md-card" ng-show="selectedConfigTab === 'syscollector' && !toggleRAW && groupConfiguration.config.syscollector">
+                    <md-card-content>
+
+                        <!-- Section title -->
+                        <div layout="row" layout-align="start center">
+                            <span flex="85" class="wz-headline-title"><i class="fa fa-fw fa-laptop"></i> Syscollector</span>
+                            <md-switch flex="15" class="wz-md-switch" ng-model="toggleRAW">View JSON</md-switch>
+                        </div>
+
+                        <md-divider class="wz-margin-top-10"></md-divider>
+
+                        <!-- Main settings -->
+                        <div layout="row" class="wz-padding-top-10" ng-if="groupConfiguration.config.syscollector.disabled">
+                            <span flex="25">Disabled</span>
+                            <span class="wz-text-right color-grey">{{groupConfiguration.config.syscollector.disabled}}</span>
+                        </div>
+                        <div layout="row" class="wz-padding-top-10" ng-if="groupConfiguration.config.syscollector.interval">
+                            <span flex="25">Interval</span>
+                            <span class="wz-text-right color-grey">{{groupConfiguration.config.syscollector.interval}}</span>
+                        </div>
+                        <div layout="row" class="wz-padding-top-10" ng-if="groupConfiguration.config.syscollector.scan_on_start">
+                            <span flex="25">Scan on start</span>
+                            <span class="wz-text-right color-grey">{{groupConfiguration.config.syscollector.scan_on_start}}</span>
+                        </div>
+                        <div layout="row" class="wz-padding-top-10" ng-if="groupConfiguration.config.syscollector.hardware">
+                            <span flex="25">Hardware</span>
+                            <span class="wz-text-right color-grey">{{groupConfiguration.config.syscollector.hardware}}</span>
+                        </div>
+                        <div layout="row" class="wz-padding-top-10" ng-if="groupConfiguration.config.syscollector.os">
+                            <span flex="25">OS</span>
+                            <span class="wz-text-right color-grey">{{groupConfiguration.config.syscollector.os}}</span>
+                        </div>
+                        <div layout="row" class="wz-padding-top-10" ng-if="groupConfiguration.config.syscollector.packages">
+                            <span flex="25">Packages</span>
+                            <span class="wz-text-right color-grey">{{groupConfiguration.config.syscollector.packages}}</span>
+                        </div>
+                    </md-card-content>
+                </md-card>
+                <!-- END SYSCOLLECTOR -->
 
                 <!-- OPENSCAP -->
                 <md-card flex class="wz-md-card" ng-show="selectedConfigTab === 'scap' && !toggleRAW && groupConfiguration.config['open-scap']">

--- a/public/templates/manager/manager-configuration.html
+++ b/public/templates/manager/manager-configuration.html
@@ -87,6 +87,24 @@
             </md-card>
             <!-- END ROOTCHECK -->
 
+            <!-- SYSCOLLECTOR -->
+            <md-card flex class="no-margin-left wz-md-card" ng-show="managerConfiguration.syscollector">
+                <md-card-content>
+                    <!-- Section title -->
+                    <span class="wz-headline-title wz-text-link" ng-click="switchItem('syscollector')" tooltip="Click to see more details" tooltip-placement="right">Syscollector</span>
+                    <md-divider class="wz-margin-top-10"></md-divider>
+                    <div layout="row" class="wz-padding-top-10" ng-if="managerConfiguration.syscollector.disabled">
+                        <span flex>Disabled</span>
+                        <span flex class="wz-text-right color-grey">{{managerConfiguration.syscollector.disabled}}</span>
+                    </div>
+                    <div layout="row" class="wz-padding-top-10" ng-if="managerConfiguration.syscollector.scan_on_start">
+                        <span flex>Scan on start</span>
+                        <span flex class="wz-text-right color-grey">{{managerConfiguration.syscollector.scan_on_start}}</span>
+                    </div>
+                </md-card-content>
+            </md-card>
+            <!-- END SYSCOLLECTOR -->
+
             <!-- LOGCOLLECTOR -->
             <md-card flex class="no-margin-left wz-md-card" ng-if="managerConfiguration.logcollector">
                 <md-card-content>
@@ -529,6 +547,41 @@
                 </md-card-content>
             </md-card>
             <!-- END RULESET -->
+
+            <!-- SYSCOLLECTOR -->
+            <md-card flex class="no-margin-right wz-md-card" ng-show="selectedItem === 'syscollector'">
+                <md-card-content>
+                    <!-- Section title -->
+                    <span class="wz-headline-title"><i class="fa fa-fw fa-laptop"></i> Syscollector</span>
+                    <md-divider class="wz-margin-top-10"></md-divider>
+                    <!-- Main settings -->
+                    <div layout="row" class="wz-padding-top-10" ng-if="managerConfiguration.syscollector.disabled">
+                        <span flex="25">Disabled</span>
+                        <span class="wz-text-right color-grey">{{managerConfiguration.syscollector.disabled}}</span>
+                    </div>
+                    <div layout="row" class="wz-padding-top-10" ng-if="managerConfiguration.syscollector.interval">
+                        <span flex="25">Interval</span>
+                        <span class="wz-text-right color-grey">{{managerConfiguration.syscollector.interval}}</span>
+                    </div>
+                    <div layout="row" class="wz-padding-top-10" ng-if="managerConfiguration.syscollector.scan_on_start">
+                        <span flex="25">Scan on start</span>
+                        <span class="wz-text-right color-grey">{{managerConfiguration.syscollector.scan_on_start}}</span>
+                    </div>
+                    <div layout="row" class="wz-padding-top-10" ng-if="managerConfiguration.syscollector.hardware">
+                        <span flex="25">Hardware</span>
+                        <span class="wz-text-right color-grey">{{managerConfiguration.syscollector.hardware}}</span>
+                    </div>
+                    <div layout="row" class="wz-padding-top-10" ng-if="managerConfiguration.syscollector.os">
+                        <span flex="25">OS</span>
+                        <span class="wz-text-right color-grey">{{managerConfiguration.syscollector.os}}</span>
+                    </div>
+                    <div layout="row" class="wz-padding-top-10" ng-if="managerConfiguration.syscollector.packages">
+                        <span flex="25">Packages</span>
+                        <span class="wz-text-right color-grey">{{managerConfiguration.syscollector.packages}}</span>
+                    </div>
+                </md-card-content>
+            </md-card>
+            <!-- END SYSCOLLECTOR -->
 
             <!-- LOGCOLLECTOR -->
             <md-card flex class="no-margin-right wz-md-card" ng-show="selectedItem === 'logcollector'">


### PR DESCRIPTION
Hello team,

This pull request adds the **Syscollector** tab to both Manager and Agents configuration tabs. Now the user can see in a more friendly way what's the current `syscollector` configuration being applied to a group or the manager.

### Example screenshot
![syscollector](https://user-images.githubusercontent.com/10928321/38665643-2ed9e386-3e3d-11e8-9468-9873cfd40b8a.PNG)

Best regards,
Juanjo