### PR TITLE
Initialize fix

### DIFF
--- a/server/initialize.js
+++ b/server/initialize.js
@@ -273,7 +273,7 @@ module.exports = (server, options) => {
             try{                
                 await wzWrapper.getWazuhVersionIndex();
             } catch (error) {
-                log('[initialize][checkWazuhVersionIndex]', error.message || error);
+                log('[initialize][checkWazuhVersionIndex]','.wazuh-version document does not exist. Initializating configuration...','info');
                 server.log([blueWazuh, 'initialize', 'info'], '.wazuh-version document does not exist. Initializating configuration...');
     
                 // Save Setup Info

--- a/server/initialize.js
+++ b/server/initialize.js
@@ -121,6 +121,7 @@ module.exports = (server, options) => {
             }
 
             for(const item of list){
+                if(item.title.includes('wazuh-monitoring-*') || item.id.includes('wazuh-monitoring-*')) continue;
                 log('[initialize][checkKnownFields]', `Refreshing known fields for "index-pattern:${item.title}"`,'info')
                 server.log([blueWazuh, 'initialize', 'info'], `Refreshing known fields for "index-pattern:${item.title}"`);
                 await wzWrapper.updateIndexPatternKnownFields('index-pattern:' + item.id);
@@ -534,8 +535,9 @@ module.exports = (server, options) => {
 
     const reachAPI = async config => {
         try {
+            const id = config._id;
             config = config._source;
-
+            config.id = id;
             log('[initialize][reachAPI]', `Reaching ${config.manager}`,'info')
             server.log([blueWazuh, 'reindex', 'info'], `Reaching ${config.manager}`);
 


### PR DESCRIPTION
Hello team, reviewing the 2.x to 3.x upgrading process I've catched two minor bugs. This pull request fix two minor bugs related to the recently merged branch, which changes all the server-side. 

- The first fix is related to this line ` const id = config._id;` before the fix, we were missing the `_id` value.
- The second fix is related to ignore the old `wazuh-monitoring` pattern to be refreshed.
- Additionally I've changed the error message `checkWazuhVersionIndex` because the .wazuh-version throws an error whenever it doesn't exists and its right, but not enough to generate an error.

Best,
Jesús