### PR TITLE
Added cluster.name to monitoring index

### DIFF
--- a/server/controllers/wazuh-elastic.js
+++ b/server/controllers/wazuh-elastic.js
@@ -275,8 +275,6 @@ class WazuhElastic {
                 
                 bulk_content["type"] = element._type;
                 bulk_content.visualization.description = timestamp;
-                if(clusterName && element._source.title.toLowerCase().includes('agents status')){
-                }
                 body += JSON.stringify(bulk_content) + "\n";
             }
             return body;

--- a/server/integration-files/monitoring-template.js
+++ b/server/integration-files/monitoring-template.js
@@ -25,6 +25,13 @@ module.exports = {
                 },
                 "id": {
                     "type": "keyword"
+                },
+                "cluster": {
+                    "properties": {
+                        "name": {
+                            "type": "keyword"
+                        }
+                    }
                 }
             }
         }

--- a/server/monitoring.js
+++ b/server/monitoring.js
@@ -208,12 +208,12 @@ module.exports = (server, options) => {
             let body = '';
             if (agentsArray.length > 0) {
                 let managerName = agentsArray[0].name;
-    
                 for(let element of agentsArray) {
                     body += '{ "index":  { "_index": "' + todayIndex + '", "_type": "wazuh-agent" } }\n';
                     let date              = new Date(Date.now()).toISOString();
-                    element["@timestamp"] = date;
-                    element["host"]       = managerName;
+                    element['@timestamp'] = date;
+                    element.host          = managerName;
+                    element.cluster       = { name: element.cluster && element.cluster.name ? element.cluster.name : 'disabled' } ;
                     body                 += JSON.stringify(element) + "\n";
                 }
                 if (body === '') return;


### PR DESCRIPTION
Hello team, this pull request ables the App to store the `cluster.name` property on the monitoring daily index. Assuming the agent from the `/agents` request comes with the field  `{ cluster: { name: 'wazuh-cluster-01' } }` we'll store it as it. If the agent doesn't come with that field, we'll store it as `{ cluster: { name: 'disabled' } }`. On the other hand, whenever we are on a non-cluster environment we'll still able to know it from the `.wazuh` index like on the other app packages.

This PR solves https://github.com/wazuh/wazuh-kibana-app/issues/375

Best,
Jesús