### PR TITLE
Query size increased when fetching the index pattern list. 

### DIFF
--- a/server/api/wazuh-elastic.js
+++ b/server/api/wazuh-elastic.js
@@ -337,6 +337,7 @@ module.exports = (server, options) => {
                     index: '.kibana',
                     type: 'doc',
                     body: {
+                        "size": 999,
                         "query":{
                             "match":{
                               "type": "index-pattern"


### PR DESCRIPTION
Hi team,
this pr fix one bug:
* Query size increased when fetching the index pattern list. #338 

I saw this pr #339 but it only fix one query bug in `wazuh-kibana-app/server/api/wazuh-elastic.js`,
and the route `/get-list` also needs return all the index patterns more than 10 records(default by elasticsearch).

Thanks for your great work.
Best regards
