### PR TITLE
Safer access to filter properties

### DIFF
--- a/public/kibana-integrations/kibana-discover.js
+++ b/public/kibana-integrations/kibana-discover.js
@@ -952,9 +952,15 @@ function discoverController(
       }
       const cleaned = [];
       for(const filter of implicitFilter){
-        const tmp = queryFilter.getFilters().filter(item => item.meta.params.query === filter.meta.params.query && 
-                                                item.meta.params.type === filter.meta.params.type &&
-                                                item.meta.key === filter.meta.key );
+        const tmp = queryFilter
+                    .getFilters()
+                    .filter(item => 
+                            item.meta && item.meta.params && item.meta.params.query &&
+                            filter.meta && filter.meta.params && filter.meta.params.query &&
+                            item.meta.params.query === filter.meta.params.query && 
+                            item.meta.params.type  === filter.meta.params.type &&
+                            item.meta.key          === filter.meta.key 
+                    );
         if(!tmp.length) cleaned.push(filter);
       }
 


### PR DESCRIPTION
Hello team, this pull request only prevents from weird situations where we are comparing some properties without any validation before accessing the properties.

With this addition we are safer whenever we access them:

```js
...
item.meta && item.meta.params && item.meta.params.query &&
filter.meta && filter.meta.params && filter.meta.params.query &&
...
```

Best,
Jesús