### PR TITLE
Removed implicit filter from PCI 

### DIFF
--- a/public/controllers/agents.js
+++ b/public/controllers/agents.js
@@ -82,7 +82,7 @@ app.controller('agentsController',
             vuls      : { group: 'vulnerability-detector' },
             oscap     : { group: 'oscap' },
             audit     : { group: 'audit' },
-            pci       : { group: 'pci_dss' },
+            pci       : { group: '' },
             virustotal: { group: 'virustotal' }
         };
 

--- a/public/controllers/overview.js
+++ b/public/controllers/overview.js
@@ -105,7 +105,7 @@ app.controller('overviewController', function ($scope, $location, $rootScope, ap
         vuls      : { group: 'vulnerability-detector' },
         oscap     : { group: 'oscap' },
         audit     : { group: 'audit' },
-        pci       : { group: 'pci_dss' },
+        pci       : { group: '' },
         aws       : { group: 'amazon' },
         virustotal: { group: 'virustotal' }
     };

--- a/public/kibana-integrations/kibana-discover.js
+++ b/public/kibana-integrations/kibana-discover.js
@@ -897,28 +897,7 @@ function discoverController(
 
       // Build the full query using the implicit filter
       if ($rootScope.currentImplicitFilter !== "" && $rootScope.currentImplicitFilter !== null && angular.isUndefined($rootScope.currentImplicitFilter) !== true) {
-        if ($rootScope.currentImplicitFilter === "pci_dss") {
-          implicitFilter.push(
-            {
-              "meta":{
-                "removable":false,
-                "index":$scope.indexPattern.id,
-                "negate":false,
-                "disabled":false,
-                "alias":null,
-                "type":"exists",
-                "key":"rule.pci_dss",
-                "value":"exists"
-              },
-              "exists":{
-                "field":"rule.pci_dss"
-              },
-              "$state":{
-                "store":"appState"
-              }
-            }
-          );
-        } else {
+        if ($rootScope.currentImplicitFilter !== "pci_dss") {
           implicitFilter.push(
             {
               "meta":{
@@ -964,7 +943,7 @@ function discoverController(
         if(!tmp.length) cleaned.push(filter);
       }
 
-      queryFilter.addFilters(cleaned);
+      if(cleaned.length) queryFilter.addFilters(cleaned);
     }
   }
 


### PR DESCRIPTION
Hello team, this pull request removes the implicit filter from PCI to avoid a multi-search which crashes the very first time you enter Overview-PCI or Agent-PCI.

Since the visualizations from PCI has their own filter to check PCI related alerts, we don't need that filter which only causes overload to Elasticsearch.

Also adds this condition to not push empty arrays (it's not harmful but not needed to do it):

```js
if(cleaned.length) queryFilter.addFilters(cleaned);
``` 

Best,
Jesús