### PR TITLE
Fix x-pack bug when there is no security enabled

### DIFF
--- a/server/controllers/wazuh-elastic.js
+++ b/server/controllers/wazuh-elastic.js
@@ -226,15 +226,19 @@ export default class WazuhElastic {
         try {
             const xpack          = await this.wzWrapper.getPlugins();
             const isXpackEnabled = typeof xpack === 'string' && xpack.includes('x-pack');
-            const isSuperUser    = isXpackEnabled && req.auth.credentials.roles.includes('superuser');
-
+            const isSuperUser    = isXpackEnabled && 
+                                   req.auth && 
+                                   req.auth.credentials && 
+                                   req.auth.credentials.roles && 
+                                   req.auth.credentials.roles.includes('superuser');
+            
             const data = await this.wzWrapper.getAllIndexPatterns();
 
             if(data && data.hits && data.hits.hits.length === 0) throw new Error('There is no index pattern');
 
             if(data && data.hits && data.hits.hits){
                 const list = this.validateIndexPattern(data.hits.hits);
-
+                
                 return res({data: isXpackEnabled && !isSuperUser ? await this.filterAllowedIndexPatternList(list,req) : list});
             }
 

--- a/server/initialize.js
+++ b/server/initialize.js
@@ -72,9 +72,9 @@ export default (server, options) => {
     const checkKnownFields = async () => {
         try {
             const xpack = await wzWrapper.getPlugins();
-            log('[initialize][checkKnownFields]', `x-pack enabled: ${typeof xpack === 'string' && xpack.includes('x-pack') ? 'yes' : 'no'}`,'info')
-            server.log([blueWazuh, 'initialize', 'info'], `x-pack enabled: ${typeof xpack === 'string' && xpack.includes('x-pack') ? 'yes' : 'no'}`);
-
+            log('[initialize][checkKnownFields]', `x-pack enabled and using security: ${typeof xpack === 'string' && xpack.includes('x-pack') ? 'yes' : 'no'}`,'info')
+            server.log([blueWazuh, 'initialize', 'info'], `x-pack enabled and using security: ${typeof xpack === 'string' && xpack.includes('x-pack') ? 'yes' : 'no'}`);  
+                    
             const indexPatternList = await wzWrapper.getAllIndexPatterns();
 
             log('[initialize][checkKnownFields]', `Found ${indexPatternList.hits.total} index patterns`,'info')


### PR DESCRIPTION
Hello team, this pull request fixes a known bug (https://github.com/wazuh/wazuh-kibana-app/issues/400) on the Wazuh app related to using X-Pack without credentials which crashes the Wazuh app.

With this pull request we are checking if X-Pack is installed and security is enabled. The modification has been tested on the next environments:

- X-Pack enabled + security
- X-Pack enabled
- X-Pack disabled
- X-Pack enabled + security with no alerts indices

Regards,
Jesús