### PR TITLE
Replaced `needle` request to Elastic by `callWithInteralUser`

### DIFF
--- a/server/lib/elastic-wrapper.js
+++ b/server/lib/elastic-wrapper.js
@@ -10,7 +10,6 @@
  * Find more information about this on the LICENSE file.
  */
 import knownFields from '../integration-files/known-fields';
-import needle      from 'needle'
 
 export default class ElasticWrapper {
     constructor(server){
@@ -523,17 +522,13 @@ export default class ElasticWrapper {
 
     async usingCredentials() {
         try {
-            const response = await needle('get', `${this.elasticRequest._config.url}/_xpack`, {}, {
-                username: this.elasticRequest._config.username,
-                password:  this.elasticRequest._config.password
-            })
+            const data = await this.elasticRequest.callWithInternalUser('cluster.getSettings', { includeDefaults: true });
 
-
-            return response && 
-                   response.body && 
-                   response.body.features && 
-                   response.body.features.security && 
-                   response.body.features.security.enabled;
+            return data && 
+                   data.defaults && 
+                   data.defaults.xpack && 
+                   data.defaults.xpack.security && 
+                   data.defaults.xpack.security.enabled;
 
         } catch (error) {
             return Promise.reject(error);


### PR DESCRIPTION
Hello team, this pull request is a fix for https://github.com/wazuh/wazuh-kibana-app/pull/401. Now we are not using `needle` to fetch Elasticsearch. Now we are using the proper Elastic client and parsing the information needed from the cluster settings. This avoids https problems or cross-cluster related problems.

Regards,
Jesús