### PR TITLE
Added errorHandler service to bs controller, better error parsing

### DIFF
--- a/public/controllers/blank-screen-controller.js
+++ b/public/controllers/blank-screen-controller.js
@@ -14,9 +14,15 @@ import * as modules from 'ui/modules'
 const app = modules.get('app/wazuh', []);
 
 // Logs controller
-app.controller('blankScreenController', function($scope, $rootScope, $location) {
+app.controller('blankScreenController', function($scope, $rootScope, $location, errorHandler) {
     if ($rootScope.blankScreenError) {
-        $scope.errorToShow = $rootScope.blankScreenError;
+        let parsed = null;
+        try {
+            parsed = errorHandler.handle($rootScope.blankScreenError,'',false,true);
+        } catch (error) {
+            // Do nothing (intended)
+        }
+        $scope.errorToShow = parsed ? parsed : $rootScope.blankScreenError;
         delete $rootScope.blankScreenError;
         if (!$scope.$$phase) $scope.$digest();
     }


### PR DESCRIPTION
Hello team, this pull request parses raw error objects from some scenarios on the blank screen controller, this way we can show the user the exactly message not the raw output. I'm using a try/catch block because this controller needs to be always avalaible, so if the parsing fails we can show the raw any way.

Regards,
Jesús