### PR TITLE
Fix false "not enough privileges" scenario

### DIFF
--- a/server/controllers/wazuh-elastic.js
+++ b/server/controllers/wazuh-elastic.js
@@ -189,13 +189,20 @@ export default class WazuhElastic {
     async filterAllowedIndexPatternList (list,req) {
         let finalList = [];
         for(let item of list){
+            let results = false, forbidden = false;
             try {
-                const allow = await this.wzWrapper.searchWazuhElementsByIndexWithRequest(req, item.title);
-                if(allow && allow.hits && allow.hits.total >= 1) finalList.push(item);
+                results = await this.wzWrapper.searchWazuhElementsByIndexWithRequest(req, item.title);
             } catch (error){
-                console.log(`Some user trys to fetch the index pattern ${item.title} without permissions`)
+                forbidden = true;
+                console.log(`Some user tried to fetch the index pattern ${item.title} without permissions.`)
             }
-
+            if((results && results.hits && results.hits.total >= 1) ||
+               (!forbidden && results && results.hits && results.hits.total === 0)
+            ) {
+               
+                finalList.push(item);
+            
+            }
         }
         return finalList;
     }


### PR DESCRIPTION
Hello team, this pull request fixes https://github.com/wazuh/wazuh-kibana-app/issues/414, read it to have a more in deep view about the problem.

Brief summary of the change:

Whenever `allow.hits.total >= 1` it means the user has enough privilege to use that index pattern. This is always true unless there is no indices matching that pattern. If `allow.hits.total === 0` but `!forbiden` the user still has enough privileges to use that pattern but no indices are being matched --> visualizations without results.

Regards,
Jesús