### PR TITLE
 Added new config for X-Pack index pattern filtering

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -61,3 +61,9 @@
 # Defines if the user is allowed to change the selected index
 # pattern directly from the Wazuh app top menu. Default: yes
 #ip.selector:            true
+#
+#---------------------------- RBAC X-Pack -------------------------------------
+#
+# Custom setting to enable/disable RBAC capabilities included on X-Pack (security)
+# Default: enabled
+#xpack.rbac.enabled:     true

--- a/server/controllers/wazuh-elastic.js
+++ b/server/controllers/wazuh-elastic.js
@@ -225,13 +225,18 @@ export default class WazuhElastic {
     async getlist (req,res) {
         try {
             const xpack          = await this.wzWrapper.getPlugins();
-            const isXpackEnabled = typeof xpack === 'string' && xpack.includes('x-pack');
+
+            const isXpackEnabled = typeof XPACK_RBAC_ENABLED !== 'undefined' && 
+                                   XPACK_RBAC_ENABLED && 
+                                   typeof xpack === 'string' && 
+                                   xpack.includes('x-pack');
+            
             const isSuperUser    = isXpackEnabled && 
                                    req.auth && 
                                    req.auth.credentials && 
                                    req.auth.credentials.roles && 
                                    req.auth.credentials.roles.includes('superuser');
-            
+
             const data = await this.wzWrapper.getAllIndexPatterns();
 
             if(data && data.hits && data.hits.hits.length === 0) throw new Error('There is no index pattern');

--- a/server/initialize.js
+++ b/server/initialize.js
@@ -28,18 +28,19 @@ export default (server, options) => {
     log('[initialize]', `Kibana index: ${wzWrapper.WZ_KIBANA_INDEX}`, 'info');
     server.log([blueWazuh, 'initialize', 'info'], `Kibana index: ${wzWrapper.WZ_KIBANA_INDEX}`);
 
+    log('[initialize]', `App revision: ${packageJSON.revision || 'missing revision'}`, 'info');
+
     let objects = {};
     let app_objects = {};
     let configurationFile = {};
     let pattern = null;
-    let forceDefaultPattern = true;
     // Read config from package.json and config.yml
     try {
         configurationFile = yml.load(fs.readFileSync(path.join(__dirname, '../config.yml'), { encoding: 'utf-8' }));
 
         global.loginEnabled = (configurationFile && typeof configurationFile['login.enabled'] !== 'undefined') ? configurationFile['login.enabled'] : false;
         pattern = (configurationFile && typeof configurationFile.pattern !== 'undefined') ? configurationFile.pattern : 'wazuh-alerts-3.x-*';
-        forceDefaultPattern = (configurationFile && typeof configurationFile['force.default'] !== 'undefined') ? configurationFile['force.default'] : true;
+        global.XPACK_RBAC_ENABLED = (configurationFile && typeof configurationFile['xpack.rbac.enabled'] !== 'undefined') ? configurationFile['xpack.rbac.enabled'] : true;
 
     } catch (e) {
         log('[initialize]', e.message || e);
@@ -107,7 +108,7 @@ export default (server, options) => {
             server.log([blueWazuh, 'initialize', 'info'], `Found ${list.length} valid index patterns for Wazuh alerts`);
             const defaultExists = list.filter(item => item.title === defaultIndexPattern);
 
-            if(defaultExists.length === 0 && forceDefaultPattern){
+            if(defaultExists.length === 0){
                 log('[initialize][checkKnownFields]', `Default index pattern not found, creating it...`,'info')
                 server.log([blueWazuh, 'initialize', 'info'], `Default index pattern not found, creating it...`);
                 await createIndexPattern();


### PR DESCRIPTION
Hello team, this pull request fixes https://github.com/wazuh/wazuh-kibana-app/issues/416, you could read that issue to get a more in deep description. 

Brief summary:

- This change adds a new feature designed to able us to ignore the X-Pack RBAC index pattern filtering capabilities. 
- By default, the filtering is still working like past packages but now we can disable it using the `config.yml` file.
- Also it could be used on next packages for other X-Pack related features.
- Extra: we are now logging the app revision on the internal logs.

Regards,
Jesús