### PR TITLE
Disable auto-refresh on configuration tab

### DIFF
--- a/public/templates/agents/agents.head
+++ b/public/templates/agents/agents.head
@@ -74,7 +74,7 @@
     <!-- <md-progress-linear class="md-accent" md-mode="indeterminate" ng-show="load"></md-progress-linear> -->
 
 	<!-- View: Discover -->
-    <kbn-dis ng-show="tab != 'configuration'"></kbn-dis>
+    <kbn-dis ng-if="tab != 'configuration'"></kbn-dis>
 
     <div class="wazuh-loading" layout="column" layout-align="center center" ng-show="resultState === 'ready' && tabView === 'panels' && tab !== 'configuration' && !rendered">
         <div class="percentage"><i class="fa fa-spinner fa-spin fa-fw" aria-hidden="true"></i></div>


### PR DESCRIPTION
Hello team, this pull request fixes https://github.com/wazuh/wazuh-kibana-app/issues/418

There is only one change, a `ng-show` statement has been replaced by a `ng-if` statement, this way we are removing the Discover directive from agent / configuration. 

Regards,
Jesús