### PR TITLE
Added message for successful API removal

### DIFF
--- a/public/controllers/settings.js
+++ b/public/controllers/settings.js
@@ -80,10 +80,11 @@ app.controller('settingsController', function ($scope, $rootScope, $http, $route
             await genericReq.request('DELETE', `/api/wazuh-api/apiEntries/${$scope.apiEntries[index]._id}`);
             $scope.apiEntries.splice(index, 1);
             $rootScope.apiIsDown = null;
+            errorHandler.info('The API was removed successfully','Settings');
             if(!$scope.$$phase) $scope.$digest();
             return;
         } catch(error) {
-            errorHandler.handle('Could not remove manager','Settings');
+            errorHandler.handle('Could not remove the API','Settings');
             if(!$rootScope.$$phase) $rootScope.$digest();
         }
     };


### PR DESCRIPTION
Hello team,

This pull request adds a new message when the user deletes an API entry on the Settings tab:
![message](https://user-images.githubusercontent.com/10928321/39418647-ca86a9f0-4c5b-11e8-8395-d09b84082245.png)

Now not only the user will know if something went wrong, he'll also confirm that the deletion process was successful.

This PR closes #424.

Regards,
Juanjo