### PR TITLE
Added more filters to Detail view in Ruleset

### DIFF
--- a/public/controllers/ruleset.js
+++ b/public/controllers/ruleset.js
@@ -70,12 +70,15 @@ app.controller('rulesController', function ($scope, $rootScope, Rules, RulesRela
      * This function takes back to the list but adding a group filter
      */
     $scope.addGroupFilter = (name) => {
+        // Remove all previous filters and then add it
+        $scope.rules.removeAllFilters();
+        $scope.rules.addFilter('group', name);
+
         // Clear the autocomplete component
         $scope.searchTerm = '';
         angular.element(document.querySelector('#autocomplete')).blur();
 
-        // Add the filter and go back to the list
-        $scope.rules.addFilter('group', name);
+        // Go back to the list
         $scope.closeDetailView();
     }
 
@@ -83,12 +86,15 @@ app.controller('rulesController', function ($scope, $rootScope, Rules, RulesRela
      * This function takes back to the list but adding a PCI filter
      */
     $scope.addPciFilter = (name) => {
+        // Remove all previous filters and then add it
+        $scope.rules.removeAllFilters();
+        $scope.rules.addFilter('pci', name);
+
         // Clear the autocomplete component
         $scope.searchTerm = '';
         angular.element(document.querySelector('#autocomplete')).blur();
 
-        // Add the filter and go back to the list
-        $scope.rules.addFilter('pci', name);
+        // Go back to the list
         $scope.closeDetailView();
     }
 
@@ -96,12 +102,16 @@ app.controller('rulesController', function ($scope, $rootScope, Rules, RulesRela
      * This function changes to the rule detail view
      */
     $scope.openDetailView = (rule) => {
+        // Clear current rule variable and assign the new one
+        $scope.currentRule = false;
         $scope.currentRule = rule;
 
+        // Create the related rules list, resetting it in first place
         $scope.rulesRelated.reset();
         $scope.rulesRelated.ruleID = $scope.currentRule.id;
         $scope.rulesRelated.addFilter('file', $scope.currentRule.file);
 
+        // Enable the Detail view
         $scope.viewingDetail = true;
         if(!$scope.$$phase) $scope.$digest();
     }
@@ -158,6 +168,7 @@ app.controller('rulesController', function ($scope, $rootScope, Rules, RulesRela
     //Destroy
     $scope.$on('$destroy', () => {
         $scope.rules.reset();
+        $scope.rulesRelated.reset();
         $scope.rulesAutoComplete.reset();
         $rootScope.rawVisualizations = null;
         if($rootScope.ownHandlers){
@@ -261,13 +272,17 @@ app.controller('decodersController', function ($scope, $rootScope, $sce, Decoder
      * This function changes to the decoder detail view
      */
     $scope.openDetailView = (decoder) => {
+        // Clear current decoder variable and assign the new one
+        $scope.currentDecoder = false;
         $scope.currentDecoder = decoder;
 
+        // Create the related decoders list, resetting it in first place
         $scope.decodersRelated.reset();
         $scope.decodersRelated.path = `/decoders/${$scope.currentDecoder.name}`;
         $scope.decodersRelated.decoderPosition = $scope.currentDecoder.position;
         $scope.decodersRelated.nextPage('');
 
+        // Enable the Detail view
         $scope.viewingDetail = true;
         if(!$scope.$$phase) $scope.$digest();
     }

--- a/public/controllers/ruleset.js
+++ b/public/controllers/ruleset.js
@@ -61,34 +61,20 @@ app.controller('rulesController', function ($scope, $rootScope, Rules, RulesRela
             $scope.rules.addFilter('pci',search.split('pci:')[1].trim());
         } else if(search.startsWith('file:') && search.split('file:')[1].trim()) {
             $scope.rules.addFilter('file',search.split('file:')[1].trim());
+        } else if(search.startsWith('path:') && search.split('path:')[1].trim()) {
+            $scope.rules.addFilter('path',search.split('path:')[1].trim());
         } else {
             $scope.rules.addFilter('search',search.trim());
         }
     };
 
     /**
-     * This function takes back to the list but adding a group filter
+     * This function takes back to the list but adding a filter from the detail view
      */
-    $scope.addGroupFilter = (name) => {
+    $scope.addDetailFilter = (name, value) => {
         // Remove all previous filters and then add it
         $scope.rules.removeAllFilters();
-        $scope.rules.addFilter('group', name);
-
-        // Clear the autocomplete component
-        $scope.searchTerm = '';
-        angular.element(document.querySelector('#autocomplete')).blur();
-
-        // Go back to the list
-        $scope.closeDetailView();
-    }
-
-    /**
-     * This function takes back to the list but adding a PCI filter
-     */
-    $scope.addPciFilter = (name) => {
-        // Remove all previous filters and then add it
-        $scope.rules.removeAllFilters();
-        $scope.rules.addFilter('pci', name);
+        $scope.rules.addFilter(name, value);
 
         // Clear the autocomplete component
         $scope.searchTerm = '';
@@ -266,6 +252,22 @@ app.controller('decodersController', function ($scope, $rootScope, $sce, Decoder
             errorHandler.handle(error,'Ruleset');
             if(!$rootScope.$$phase) $rootScope.$digest();
         }
+    }
+
+    /**
+     * This function takes back to the list but adding a filter from the detail view
+     */
+    $scope.addDetailFilter = (name, value) => {
+        // Remove all previous filters and then add it
+        $scope.decoders.removeAllFilters();
+        $scope.decoders.addFilter(name, value);
+
+        // Clear the autocomplete component
+        $scope.searchTerm = '';
+        angular.element(document.querySelector('#autocomplete')).blur();
+
+        // Go back to the list
+        $scope.closeDetailView();
     }
 
     /**

--- a/public/templates/manager/ruleset/decoders/decoders-detail.html
+++ b/public/templates/manager/ruleset/decoders/decoders-detail.html
@@ -13,10 +13,9 @@
     <div layout="row">
         <md-card flex class="wz-metric-color wz-md-card">
             <md-card-content layout="row" class="wz-padding-metric">
-                <div flex ng-if="currentDecoder.file" class="wz-text-truncatable">File: <span class="wz-text-bold">{{currentDecoder.file}}</span></div>
-                <div flex ng-if="currentDecoder.path" class="wz-text-truncatable">Path: <span class="wz-text-bold">{{currentDecoder.path}}</span></div>
-                <div flex="10" ng-if="currentDecoder.status" class="wz-text-truncatable">Status: <span class="wz-text-bold">{{currentDecoder.status}}</span></div>
-                <div flex="10" ng-if="currentDecoder.position || currentDecoder.position == 0" class="wz-text-truncatable">Position: <span class="wz-text-bold">{{currentDecoder.position}}</span></div>
+                <div flex="20" ng-if="currentDecoder.position || currentDecoder.position == 0" class="wz-text-truncatable">Position: <span class="wz-text-bold">{{currentDecoder.position}}</span></div>
+                <div flex="40" ng-if="currentDecoder.file" class="wz-text-truncatable">File: <span class="wz-text-bold wz-text-link" ng-click="addDetailFilter('file', currentRule.file)" tooltip="Filter by this file" tooltip-placement="bottom">{{currentDecoder.file}}</span></div>
+                <div flex="40" ng-if="currentDecoder.path" class="wz-text-truncatable">Path: <span class="wz-text-bold wz-text-link" ng-click="addDetailFilter('path', currentRule.path)" tooltip="Filter by this path" tooltip-placement="bottom">{{currentDecoder.path}}</span></div>
             </md-card-content>
         </md-card>
     </div>

--- a/public/templates/manager/ruleset/decoders/decoders-detail.html
+++ b/public/templates/manager/ruleset/decoders/decoders-detail.html
@@ -14,8 +14,8 @@
         <md-card flex class="wz-metric-color wz-md-card">
             <md-card-content layout="row" class="wz-padding-metric">
                 <div flex="20" ng-if="currentDecoder.position || currentDecoder.position == 0" class="wz-text-truncatable">Position: <span class="wz-text-bold">{{currentDecoder.position}}</span></div>
-                <div flex="40" ng-if="currentDecoder.file" class="wz-text-truncatable">File: <span class="wz-text-bold wz-text-link" ng-click="addDetailFilter('file', currentRule.file)" tooltip="Filter by this file" tooltip-placement="bottom">{{currentDecoder.file}}</span></div>
-                <div flex="40" ng-if="currentDecoder.path" class="wz-text-truncatable">Path: <span class="wz-text-bold wz-text-link" ng-click="addDetailFilter('path', currentRule.path)" tooltip="Filter by this path" tooltip-placement="bottom">{{currentDecoder.path}}</span></div>
+                <div flex="40" ng-if="currentDecoder.file" class="wz-text-truncatable">File: <span class="wz-text-bold wz-text-link" ng-click="addDetailFilter('file', currentDecoder.file)" tooltip="Filter by this file" tooltip-placement="bottom">{{currentDecoder.file}}</span></div>
+                <div flex="40" ng-if="currentDecoder.path" class="wz-text-truncatable">Path: <span class="wz-text-bold wz-text-link" ng-click="addDetailFilter('path', currentDecoder.path)" tooltip="Filter by this path" tooltip-placement="bottom">{{currentDecoder.path}}</span></div>
             </md-card-content>
         </md-card>
     </div>
@@ -152,7 +152,7 @@
         <!-- End prematch section -->
 
         <!-- Related decoders section -->
-        <h1 class="md-headline wz-headline"><i class="fa fa-fw fa-link" aria-hidden="true"></i> Related rules</h1>
+        <h1 class="md-headline wz-headline"><i class="fa fa-fw fa-link" aria-hidden="true"></i> Related decoders</h1>
         <wz-table-header
             class="wz-side-margin-8"
             layout="row"

--- a/public/templates/manager/ruleset/decoders/decoders-detail.html
+++ b/public/templates/manager/ruleset/decoders/decoders-detail.html
@@ -152,35 +152,37 @@
         <!-- End prematch section -->
 
         <!-- Related decoders section -->
-        <h1 class="md-headline wz-headline"><i class="fa fa-fw fa-link" aria-hidden="true"></i> Related decoders</h1>
-        <wz-table-header
-            class="wz-side-margin-8"
-            layout="row"
-            data="decodersRelated"
-            keys="[
-                {name:'Name',sortValue:'name',size:20},
-                {name:'Program name',size:20},
-                {name:'Fields',size:40},
-                {name:'File',sortValue:'file',size:20}
-            ]">
-        </wz-table-header>
-        <wz-table
-            layout="column"
-            flex
-            func="openDetailView(decoderRelated)"
-            data="decodersRelated"
-            full="'decoderRelated'"
-            activeitem="activeItem"
-            keys="[
-                {col:'name',size:20},
-                {col:'details.program_name',size:20},
-                {col:'details.order',size:40},
-                {col:'file',size:20}
-            ]"
-            isruleset="true"
-            isdecoders="true"
-            class="no-lateral-padding wz-side-margin-8">
-        </wz-table>
+        <div ng-show="(decodersRelated.items && decodersRelated.items.length > 0)">
+            <h1 class="md-headline wz-headline"><i class="fa fa-fw fa-link" aria-hidden="true"></i> Related decoders</h1>
+            <wz-table-header
+                class="wz-side-margin-8"
+                layout="row"
+                data="decodersRelated"
+                keys="[
+                    {name:'Name',sortValue:'name',size:20},
+                    {name:'Program name',size:20},
+                    {name:'Fields',size:40},
+                    {name:'File',sortValue:'file',size:20}
+                ]">
+            </wz-table-header>
+            <wz-table
+                layout="column"
+                flex
+                func="openDetailView(decoderRelated)"
+                data="decodersRelated"
+                full="'decoderRelated'"
+                activeitem="activeItem"
+                keys="[
+                    {col:'name',size:20},
+                    {col:'details.program_name',size:20},
+                    {col:'details.order',size:40},
+                    {col:'file',size:20}
+                ]"
+                isruleset="true"
+                isdecoders="true"
+                class="no-lateral-padding wz-side-margin-8">
+            </wz-table>
+        </div>
         <!-- End related decoders section -->
 
     </div>

--- a/public/templates/manager/ruleset/decoders/decoders-detail.html
+++ b/public/templates/manager/ruleset/decoders/decoders-detail.html
@@ -1,4 +1,4 @@
-<div ng-show="!loading && viewingDetail" flex layout="column">
+<div ng-if="!loading && viewingDetail" flex layout="column">
 
     <!-- Back button and title -->
     <div layout="row" layout-align="start center">

--- a/public/templates/manager/ruleset/rules/rules-detail.html
+++ b/public/templates/manager/ruleset/rules/rules-detail.html
@@ -174,39 +174,41 @@
         <!-- End prematch section -->
 
         <!-- Related rules section -->
-        <h1 class="md-headline wz-headline"><i class="fa fa-fw fa-link" aria-hidden="true"></i> Related rules</h1>
-        <wz-table-header
-            class="wz-side-margin-8"
-            layout="row"
-            data="rulesRelated"
-            keys="[
-                {name:'ID',sortValue:'id',size:5},
-                {name:'File',sortValue:'file',size:15},
-                {name:'Description',sortValue:'description',size:35},
-                {name:'Groups',size:25},
-                {name:'Requirement',size:15},
-                {name:'Level',sortValue:'level',size:5}
-            ]">
-        </wz-table-header>
-        <wz-table
-            layout="column"
-            flex
-            func="openDetailView(ruleRelated)"
-            data="rulesRelated"
-            full="'ruleRelated'"
-            activeitem="activeItem"
-            keys="[
-                {col:'id',size:5},
-                {col:'file',size:15},
-                {col:'description',size:35},
-                {col:'groups',size:25},
-                {col:'pci',size:15},
-                {col:'level',size:5}
-            ]"
-            isruleset="true"
-            isdecoders="false"
-            class="no-lateral-padding wz-side-margin-8">
-        </wz-table>
+        <div ng-show="(rulesRelated.items && rulesRelated.items.length > 0)">
+            <h1 class="md-headline wz-headline"><i class="fa fa-fw fa-link" aria-hidden="true"></i> Related rules</h1>
+            <wz-table-header
+                class="wz-side-margin-8"
+                layout="row"
+                data="rulesRelated"
+                keys="[
+                    {name:'ID',sortValue:'id',size:5},
+                    {name:'File',sortValue:'file',size:15},
+                    {name:'Description',sortValue:'description',size:35},
+                    {name:'Groups',size:25},
+                    {name:'Requirement',size:15},
+                    {name:'Level',sortValue:'level',size:5}
+                ]">
+            </wz-table-header>
+            <wz-table
+                layout="column"
+                flex
+                func="openDetailView(ruleRelated)"
+                data="rulesRelated"
+                full="'ruleRelated'"
+                activeitem="activeItem"
+                keys="[
+                    {col:'id',size:5},
+                    {col:'file',size:15},
+                    {col:'description',size:35},
+                    {col:'groups',size:25},
+                    {col:'pci',size:15},
+                    {col:'level',size:5}
+                ]"
+                isruleset="true"
+                isdecoders="false"
+                class="no-lateral-padding wz-side-margin-8">
+            </wz-table>
+        </div>
         <!-- End related rules section -->
 
     </div>

--- a/public/templates/manager/ruleset/rules/rules-detail.html
+++ b/public/templates/manager/ruleset/rules/rules-detail.html
@@ -1,4 +1,4 @@
-<div ng-show="!loading && viewingDetail" flex layout="column">
+<div ng-if="!loading && viewingDetail" flex layout="column">
 
     <!-- Back button and title -->
     <div layout="row" layout-align="start center">

--- a/public/templates/manager/ruleset/rules/rules-detail.html
+++ b/public/templates/manager/ruleset/rules/rules-detail.html
@@ -13,11 +13,11 @@
     <div layout="row">
         <md-card flex class="wz-metric-color wz-md-card">
             <md-card-content layout="row" class="wz-padding-metric">
-                <div flex ng-if="currentRule.file" class="wz-text-truncatable">File: <span class="wz-text-bold">{{currentRule.file}}</span></div>
-                <div flex ng-if="currentRule.path" class="wz-text-truncatable">Path: <span class="wz-text-bold">{{currentRule.path}}</span></div>
-                <div flex="10" ng-if="currentRule.id" class="wz-text-truncatable">ID: <span class="wz-text-bold">{{currentRule.id}}</span></div>
-                <div flex="10" ng-if="currentRule.level || currentRule.level == 0" class="wz-text-truncatable">Level: <span class="wz-text-bold">{{currentRule.level}}</span></div>
-                <div flex="10" ng-if="currentRule.status" class="wz-text-truncatable">Status: <span class="wz-text-bold">{{currentRule.status}}</span></div>
+                <div flex="15" ng-if="currentRule.id" class="wz-text-truncatable">ID: <span class="wz-text-bold">{{currentRule.id}}</span></div>
+                <div flex="15" ng-if="currentRule.level || currentRule.level == 0" class="wz-text-truncatable">Level: <span class="wz-text-bold wz-text-link" ng-click="addDetailFilter('level', currentRule.level)" tooltip="Filter by this level" tooltip-placement="bottom">{{currentRule.level}}</span></div>
+                <div flex="35" ng-if="currentRule.file" class="wz-text-truncatable">File: <span class="wz-text-bold wz-text-link" ng-click="addDetailFilter('file', currentRule.file)" tooltip="Filter by this file" tooltip-placement="bottom">{{currentRule.file}}</span></div>
+                <div flex="35" ng-if="currentRule.path" class="wz-text-truncatable">Path: <span class="wz-text-bold wz-text-link" ng-click="addDetailFilter('path', currentRule.path)" tooltip="Filter by this path" tooltip-placement="bottom">{{currentRule.path}}</span></div>
+
             </md-card-content>
         </md-card>
     </div>
@@ -32,7 +32,7 @@
                 <span class="wz-headline-title"><i class="fa fa-fw fa-tasks" aria-hidden="true"></i> Groups</span>
                 <md-divider class="wz-margin-top-10"></md-divider>
                 <div layout="row" layout-align="start start">
-                    <md-button class="md-primary wz-text-link" tooltip="Filter by this group" tooltip-placement="bottom" ng-repeat="item in currentRule.groups" ng-click="addGroupFilter(item)">
+                    <md-button class="md-primary wz-text-link" tooltip="Filter by this group" tooltip-placement="bottom" ng-repeat="item in currentRule.groups" ng-click="addDetailFilter('group', item)">
                         {{item}}
                     </md-button>
                 </div>
@@ -46,7 +46,7 @@
                 <span class="wz-headline-title"><i class="fa fa-fw fa-cogs" aria-hidden="true"></i> PCI</span>
                 <md-divider class="wz-margin-top-10"></md-divider>
                 <div layout="row" layout-align="start start">
-                    <md-button class="md-primary wz-text-link" tooltip="Filter by this requirement" tooltip-placement="bottom" ng-repeat="item in currentRule.pci" ng-click="addPciFilter(item)">
+                    <md-button class="md-primary wz-text-link" tooltip="Filter by this requirement" tooltip-placement="bottom" ng-repeat="item in currentRule.pci" ng-click="addDetailFilter('pci', item)">
                         {{item}}
                     </md-button>
                 </div>

--- a/public/templates/manager/ruleset/rules/rules-list.html
+++ b/public/templates/manager/ruleset/rules/rules-list.html
@@ -44,7 +44,7 @@
         </md-button>
     </div>
 
-    <md-chips readonly="true" ng-show="rules.hasFilter('level') || rules.hasFilter('search') || rules.hasFilter('file') || rules.hasFilter('group') || rules.hasFilter('pci')">
+    <md-chips readonly="true" ng-show="rules.hasFilter('level') || rules.hasFilter('search') || rules.hasFilter('file') || rules.hasFilter('path') || rules.hasFilter('group') || rules.hasFilter('pci')">
         <md-chip class="wz-chip" ng-if="rules.hasFilter('search') && rules.getFilter('search')">
             <span>Search: {{rules.getFilter('search')}}
                 <i class="fa fa-fw fa-times cursor-pointer" aria-hidden="true" ng-click="rules.removeFilter('search', true)"></i>
@@ -53,6 +53,11 @@
         <md-chip class="wz-chip" ng-if="rules.hasFilter('file')">
             <span>File: {{rules.getFilter('file')}}
                 <i class="fa fa-fw fa-times cursor-pointer" aria-hidden="true" ng-click="rules.removeFilter('file', true)"></i>
+            </span>
+        </md-chip>
+        <md-chip class="wz-chip" ng-if="rules.hasFilter('path')">
+            <span>File: {{rules.getFilter('path')}}
+                <i class="fa fa-fw fa-times cursor-pointer" aria-hidden="true" ng-click="rules.removeFilter('path', true)"></i>
             </span>
         </md-chip>
         <md-chip class="wz-chip" ng-if="rules.hasFilter('level')">


### PR DESCRIPTION
Hello team,

This pull request adds even more filters to the Detail view on the *Ruleset* tab.
![filtersrules](https://user-images.githubusercontent.com/10928321/39433162-7dc8d554-4c95-11e8-9242-ef1844cfd729.PNG)
![filtersdecoders](https://user-images.githubusercontent.com/10928321/39433160-7d997fc0-4c95-11e8-83e5-ac8b66a94a58.PNG)

Now the user can go back to the list and filter by **group**, **PCI**, **path**, **level** or **file** on the *Rules* tab. On the *Decoders* tab, the user can now filter by **file** or **path**.

This pull request closes #430.

In addition to this, this PR includes several bugfixes and enhancements to the related Rules/Decoders table, such as completely hiding it until the loading process is finished.

Regards,
Juanjo