### PR TITLE
Added check for new extensions

### DIFF
--- a/server/initialize.js
+++ b/server/initialize.js
@@ -266,8 +266,8 @@ export default (server, options) => {
                     
                 }
             } else {
-                log('[initialize][checkAPIEntriesExtensions]', 'There is no API entries, skipping extensions check','info')
-                server.log([blueWazuh, '[initialize][checkAPIEntriesExtensions]', 'info'], 'There is no API entries, skipping extensions check')
+                log('[initialize][checkAPIEntriesExtensions]', 'There are no API entries, skipping extensions check','info')
+                server.log([blueWazuh, '[initialize][checkAPIEntriesExtensions]', 'info'], 'There are no API entries, skipping extensions check')
             }
 
             return;

--- a/server/lib/default-ext.js
+++ b/server/lib/default-ext.js
@@ -1,0 +1,19 @@
+/*
+ * Wazuh app - Default extensions
+ * Copyright (C) 2018 Wazuh, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Find more information about this on the LICENSE file.
+ */
+export default {
+    audit     : true,
+    pci       : true,
+    oscap     : true,
+    aws       : false,
+    virustotal: false,
+    gdpr      : true
+}


### PR DESCRIPTION
Hello team, this pull request fix an inconsistency situation whenever we add a new extension to the App which is enabled by default.

The problem comes for old App packages, whose already have `.wazuh` documents created without the new extension. If the new extension is enabled on the `config.yml` file the App thinks it is disabled. 

With this pull request we are ensuring we have all the .wazuh documents with the proper extensions updated. If the document already had a extension, it is ignored, otherwise we update it adding the new extension using the default value.

To check the extensions the function reads the `config.yml` and compares it with `default-ext.js` extensions. If it's not found con `config.yml`, looks for it on `default-ext.js`. Finally looks if the current `.wazuh` document being analyzed has that extension, if it hasn't got it, the extension is added to its extensions with the default value, otherwise that extension is skipped for that `.wazuh` document.

From now and onwards we need to explicitly add any new extension to `default-ext.js` with its default value.

This PR fixes https://github.com/wazuh/wazuh-kibana-app/issues/455

Regards,
Jesús