### PR TITLE
Fix discover to panels preserve extra filters on filter-bar

### DIFF
--- a/public/controllers/agents.js
+++ b/public/controllers/agents.js
@@ -102,7 +102,7 @@ app.controller('agentsController', function ($timeout, $scope, $location, $rootS
     };
 
     let filters = []
-    const assignFilters = (tab,agent) => {
+    const assignFilters = (tab,agent,localChange) => {
         try {
             filters = [];
 
@@ -123,7 +123,7 @@ app.controller('agentsController', function ($timeout, $scope, $location, $rootS
             }
 
             filters.push(filterHandler.agentQuery(agent));
-            $rootScope.$emit('wzEventFilters',{filters});
+            $rootScope.$emit('wzEventFilters',{filters, localChange});
             if(!$rootScope.$$listenerCount['wzEventFilters']){
                 $timeout(100)
                 .then(() => assignFilters(tab,agent))
@@ -187,7 +187,7 @@ app.controller('agentsController', function ($timeout, $scope, $location, $rootS
         loadedVisualizations.removeAll();
 
         $location.search('tabView', subtab);
-
+        const localChange = subtab === 'panels' && $scope.tabView === 'discover';
         if(subtab === 'panels' && $scope.tabView === 'discover'){
             $rootScope.$emit('changeTabView',{tabView:$scope.tabView})
         }
@@ -199,7 +199,7 @@ app.controller('agentsController', function ($timeout, $scope, $location, $rootS
             genericReq.request('GET',`/api/wazuh-elastic/create-vis/agents-${$scope.tab}/${appState.getCurrentPattern()}`)
             .then(data => {
                 rawVisualizations.assignItems(data.data.raw);
-                assignFilters($scope.tab, $scope.agent.id);
+                assignFilters($scope.tab, $scope.agent.id, localChange);
                 $rootScope.$emit('changeTabView',{tabView:subtab})
                 $rootScope.$broadcast('updateVis');
                 checkMetrics($scope.tab, 'panels');

--- a/public/controllers/overview.js
+++ b/public/controllers/overview.js
@@ -127,7 +127,7 @@ app.controller('overviewController', function ($timeout, $scope, $location, $roo
 
     let filters = []
 
-    const assignFilters = tab => {
+    const assignFilters = (tab, localChange) => {
         try{
 
             filters = [];
@@ -147,7 +147,7 @@ app.controller('overviewController', function ($timeout, $scope, $location, $roo
                     filters.push(filterHandler.ruleGroupQuery(tabFilters[tab].group));
                 }
             }
-            $rootScope.$emit('wzEventFilters',{filters});
+            $rootScope.$emit('wzEventFilters',{filters, localChange});
             if(!$rootScope.$$listenerCount['wzEventFilters']){
                 $timeout(100)
                 .then(() => assignFilters(tab))
@@ -214,14 +214,14 @@ app.controller('overviewController', function ($timeout, $scope, $location, $roo
     // Switch subtab
     $scope.switchSubtab = (subtab,force = false) => {
         if ($scope.tabView === subtab && !force) return;
-
+        
         visHandlers.removeAll();
         discoverPendingUpdates.removeAll();
         rawVisualizations.removeAll();
         loadedVisualizations.removeAll();
 
         $location.search('tabView', subtab);
-
+        const localChange = subtab === 'panels' && $scope.tabView === 'discover';
         if(subtab === 'panels' && $scope.tabView === 'discover'){
             $rootScope.$emit('changeTabView',{tabView:$scope.tabView})
         }
@@ -233,7 +233,7 @@ app.controller('overviewController', function ($timeout, $scope, $location, $roo
             genericReq.request('GET',`/api/wazuh-elastic/create-vis/overview-${$scope.tab}/${appState.getCurrentPattern()}`)
             .then(data => {
                 rawVisualizations.assignItems(data.data.raw);
-                assignFilters($scope.tab);
+                assignFilters($scope.tab, localChange);
                 $rootScope.$emit('changeTabView',{tabView:subtab})
                 $rootScope.$broadcast('updateVis');
                 checkMetrics($scope.tab, 'panels');

--- a/public/kibana-integrations/kibana-discover.js
+++ b/public/kibana-integrations/kibana-discover.js
@@ -761,7 +761,7 @@ function discoverController(
   ////////////////////////////////////////////////////// WAZUH //////////////////////////////////////////////////////////
   ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-  const loadFilters = wzCurrentFilters => {
+  const loadFilters = (wzCurrentFilters, localChange) => {
     const appState = getAppState();
     if(!appState || !globalState){
       $timeout(100)
@@ -770,7 +770,7 @@ function discoverController(
         return loadFilters(wzCurrentFilters)
       })
     } else {
-      $state.filters = [];
+      $state.filters = localChange ? $state.filters : [];
 
       queryFilter.addFilters(wzCurrentFilters)
       .then(() => console.log('Filters loaded successfully'))
@@ -779,7 +779,7 @@ function discoverController(
   }
 
   $rootScope.$on('wzEventFilters', (evt,parameters) => {
-    loadFilters(parameters.filters);
+    loadFilters(parameters.filters, parameters.localChange);
   });
 
 


### PR DESCRIPTION
Hello team, this pull request fix a little non-desired behaviour whenever a user has a custom non-pinned filter on any overview/agent tab and goes to Discover sub tab then come back to Panels sub tab.

The trick here was to add a boolean variable to check if I'm on the same tab but come from Discover or if indeed I'm new for this tab. If `localChange` is true it means we are on that situation, otherwise it'll be false.

Finally, and using `localChange`, we can decide what to do on the right way:

```js
$state.filters = localChange ? $state.filters : [];
```

Best regards,
Jesús