### PR TITLE
Check if it's a local change cross tabs or same tab

### DIFF
--- a/public/controllers/agents.js
+++ b/public/controllers/agents.js
@@ -179,7 +179,7 @@ app.controller('agentsController', function ($timeout, $scope, $location, $rootS
     }
 
     // Switch subtab
-    $scope.switchSubtab = (subtab, force = false, onlyAgent = false) => {
+    $scope.switchSubtab = (subtab, force = false, onlyAgent = false, sameTab = false) => {
         if($scope.tabView === subtab && !force) return;
         if(!onlyAgent) visHandlers.removeAll();
         discoverPendingUpdates.removeAll();
@@ -187,8 +187,8 @@ app.controller('agentsController', function ($timeout, $scope, $location, $rootS
         loadedVisualizations.removeAll();
 
         $location.search('tabView', subtab);
-        const localChange = subtab === 'panels' && $scope.tabView === 'discover';
-        if(subtab === 'panels' && $scope.tabView === 'discover'){
+        const localChange = subtab === 'panels' && $scope.tabView === 'discover' && sameTab;
+        if(subtab === 'panels' && $scope.tabView === 'discover' && sameTab){
             $rootScope.$emit('changeTabView',{tabView:$scope.tabView})
         }
 
@@ -216,13 +216,14 @@ app.controller('agentsController', function ($timeout, $scope, $location, $rootS
         tabVisualizations.setTab(tab);
         if ($scope.tab === tab && !force) return;
         const onlyAgent = $scope.tab === tab && force;
+        const sameTab = $scope.tab === tab;
         $location.search('tab', tab);
         $scope.tab = tab;
 
         if($scope.tab === 'configuration'){
             firstLoad();
         } else {
-            $scope.switchSubtab('panels', true, onlyAgent);
+            $scope.switchSubtab('panels', true, onlyAgent, sameTab);
         }
     };
 

--- a/public/controllers/overview.js
+++ b/public/controllers/overview.js
@@ -212,7 +212,7 @@ app.controller('overviewController', function ($timeout, $scope, $location, $roo
     }
 
     // Switch subtab
-    $scope.switchSubtab = (subtab,force = false) => {
+    $scope.switchSubtab = (subtab, force = false, sameTab = false) => {
         if ($scope.tabView === subtab && !force) return;
         
         visHandlers.removeAll();
@@ -221,8 +221,8 @@ app.controller('overviewController', function ($timeout, $scope, $location, $roo
         loadedVisualizations.removeAll();
 
         $location.search('tabView', subtab);
-        const localChange = subtab === 'panels' && $scope.tabView === 'discover';
-        if(subtab === 'panels' && $scope.tabView === 'discover'){
+        const localChange = subtab === 'panels' && $scope.tabView === 'discover' && sameTab;
+        if(subtab === 'panels' && $scope.tabView === 'discover'  && sameTab){
             $rootScope.$emit('changeTabView',{tabView:$scope.tabView})
         }
 
@@ -249,11 +249,11 @@ app.controller('overviewController', function ($timeout, $scope, $location, $roo
     $scope.switchTab = (tab,force = false) => {
         tabVisualizations.setTab(tab);
         if ($scope.tab === tab && !force) return;
-
+        const sameTab = $scope.tab === tab;
         $location.search('tab', $scope.tab);
         $scope.tab = tab;
 
-        $scope.switchSubtab('panels',true);
+        $scope.switchSubtab('panels', true, sameTab);
     };
 
     $scope.$on('$destroy', () => {


### PR DESCRIPTION
Hello team, this pull request checks for different tab whenever we are on sub tab Discover and change the tab, was a missing condition but now it's fixed using a simple boolean variable.

Regards,
Jesús