### PR TITLE
Fix extensions wrong situation

### DIFF
--- a/public/controllers/settings.js
+++ b/public/controllers/settings.js
@@ -399,7 +399,8 @@ app.controller('settingsController', function ($scope, $rootScope, $http, $route
     // Toggle extension
     $scope.toggleExtension = async (extension, state) => {
         try{
-            if (['oscap','audit','pci','gdpr','aws','virustotal'].includes(extension)) {
+            getCurrentAPIIndex()
+            if ($scope.apiEntries && $scope.apiEntries.length && ['oscap','audit','pci','gdpr','aws','virustotal'].includes(extension)) {
                 await genericReq.request('PUT', `/api/wazuh-api/extension/toggle/${$scope.apiEntries[currentApiEntryIndex]._id}/${extension}/${state}`);
                 $scope.apiEntries[currentApiEntryIndex]._source.extensions[extension] = state;
                 appState.setExtensions($scope.apiEntries[currentApiEntryIndex]._source.extensions);

--- a/public/templates/settings/settings.html
+++ b/public/templates/settings/settings.html
@@ -6,7 +6,7 @@
     <div layout="row" layout-align="center start">
         <md-nav-bar flex class="padding-right-0 wz-md-navbar" md-selected-nav-item="submenuNavItem" nav-bar-aria-label="navigation submenu">
             <md-nav-item md-nav-click="submenuNavItem = 'api'" name="api">API</md-nav-item>
-            <md-nav-item md-nav-click="submenuNavItem = 'extensions'" name="extensions">Extensions</md-nav-item>
+            <md-nav-item md-nav-click="submenuNavItem = 'extensions'" ng-if="apiEntries && apiEntries.length" name="extensions">Extensions</md-nav-item>
             <md-nav-item md-nav-click="submenuNavItem = 'pattern'" name="pattern">Pattern</md-nav-item>
             <md-nav-item md-nav-click="submenuNavItem = 'about'" name="about">About</md-nav-item>
         </md-nav-bar>


### PR DESCRIPTION
Hello team, this pull request fix a bug related to Settings and the Wazuh API extensions.

- Keeps the current API entry index updated any time you toggle an extension
- Extensions tab is hidden if there are no API entries
- Any case if you are on extensions tab but there are no API entries on the controller, the function returns empty

Regards,
Jesús