### PR TITLE
Fix gdpr

### DIFF
--- a/server/controllers/wazuh-api.js
+++ b/server/controllers/wazuh-api.js
@@ -279,6 +279,12 @@ export default class WazuhApi {
 
             if(!protectedRoute(req)) return ErrorResponse('Session expired', 3023, 401, reply);
 
+            // Prevents load GDPR if it's disabled
+            const configFile = getConfiguration();
+            if(configFile && typeof configFile['extensions.gdpr'] !== 'undefined' && !configFile['extensions.gdpr']) {
+                return reply({});
+            }
+
             let gdpr_description = '';
 
             if (req.params.requirement === 'all') {


### PR DESCRIPTION
Hello team, this pull request prevents from fetch data for GDPR using the Wazuh API if the extension is explicitly disabled on _config.yml_ file.

```
extensions.gdpr      : 0
```
Also valid:
```
extensions.gdpr      : false
```

This way, if it's disabled, you can activate it under Settings tab, but whenever you go GDPR tab you won't fetch data from the Wazuh API related to GDPR and won't see the requirements slider.

Regards,
Jesús