### PR TITLE
Fix cluster.name filter

### DIFF
--- a/public/controllers/agents.js
+++ b/public/controllers/agents.js
@@ -106,10 +106,12 @@ app.controller('agentsController', function ($timeout, $scope, $location, $rootS
         try {
             filters = [];
 
+            const isCluster = appState.getClusterInfo().status == 'enabled';
             filters.push(filterHandler.managerQuery(
-                appState.getClusterInfo().status == 'enabled' ?
+                isCluster ?
                 appState.getClusterInfo().cluster :
-                appState.getClusterInfo().manager
+                appState.getClusterInfo().manager,
+                isCluster
             ))
 
             if(tab !== 'general'){

--- a/public/controllers/overview.js
+++ b/public/controllers/overview.js
@@ -131,11 +131,12 @@ app.controller('overviewController', function ($timeout, $scope, $location, $roo
         try{
 
             filters = [];
-
+            const isCluster = appState.getClusterInfo().status == 'enabled';
             filters.push(filterHandler.managerQuery(
-                appState.getClusterInfo().status == 'enabled' ?
+                isCluster ?
                 appState.getClusterInfo().cluster :
-                appState.getClusterInfo().manager
+                appState.getClusterInfo().manager,
+                isCluster
             ))
 
             if(tab !== 'general'){


### PR DESCRIPTION
Hello team, this pull request fixes https://github.com/wazuh/wazuh-kibana-app/issues/473, now the App uses the right `manager.name` or `cluster.name` filter.

Regards,
Jesús