### PR TITLE
Fix empty vis being shown and frees listeners from Discover directive 

### DIFF
--- a/public/factories/vis-handlers.js
+++ b/public/factories/vis-handlers.js
@@ -25,6 +25,18 @@ app.factory('visHandlers', function() {
         return list;
     }
 
+    const hasData = () => {
+        for(const item of list) {
+            if(item && item._scope && item._scope.savedObj && item._scope.savedObj.searchSource && 
+                item._scope.savedObj.searchSource.rawResponse &&
+                item._scope.savedObj.searchSource.rawResponse.hits &&
+                item._scope.savedObj.searchSource.rawResponse.hits.total){
+                    return true;
+                }
+        }
+        return false;
+    }
+
     const removeAll = () => {
         for(const item of list){
             if(item && item._scope){
@@ -40,6 +52,7 @@ app.factory('visHandlers', function() {
     return {
       addItem    : addItem,
       getList    : getList,
-      removeAll  : removeAll
+      removeAll  : removeAll,
+      hasData    : hasData
     };
 });

--- a/public/kibana-integrations/kibana-discover.js
+++ b/public/kibana-integrations/kibana-discover.js
@@ -312,7 +312,7 @@ function discoverController(
 
             ////////////////////////////////////////////////////////////////////////////
             ///////////////////////////////  WAZUH   ///////////////////////////////////
-            ////////////////////////////////////////////////////////////////////////////            
+            ////////////////////////////////////////////////////////////////////////////    
             discoverPendingUpdates.removeAll()
             discoverPendingUpdates.addItem($state.query,queryFilter.getFilters());
             $rootScope.$broadcast('updateVis');
@@ -379,7 +379,7 @@ function discoverController(
             function pick(rows, oldRows, fetchStatus) {
               // initial state, pretend we are loading
               if (rows == null && oldRows == null) return status.LOADING;
-
+              
               const rowsEmpty = _.isEmpty(rows);
               // An undefined fetchStatus means the requests are still being
               // prepared to be sent. When all requests are completed,
@@ -404,7 +404,7 @@ function discoverController(
                 current.fetchStatus,
                 prev.fetchStatus
               );
-
+ 
               /////////////////////////////////////////////////////////////////
               // Copying it to the rootScope to access it from the Wazuh App //
               /////////////////////////////////////////////////////////////////
@@ -778,15 +778,20 @@ function discoverController(
     }
   }
 
-  $rootScope.$on('wzEventFilters', (evt,parameters) => {
+  const wzEventFiltersListener = $rootScope.$on('wzEventFilters', (evt,parameters) => {
     loadFilters(parameters.filters, parameters.localChange);
   });
 
 
   $scope.tabView = $location.search().tabView || 'panels'
-  $rootScope.$on('changeTabView',(evt,parameters) => {
+  const changeTabViewListener = $rootScope.$on('changeTabView',(evt,parameters) => {
     $scope.tabView = parameters.tabView || 'panels'
     $scope.updateQueryAndFetch($state.query);
+  })
+
+  $scope.$on('$destroy', () => {
+    wzEventFiltersListener()
+    changeTabViewListener()
   })
   ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
   ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/public/kibana-integrations/kibana-visualization.js
+++ b/public/kibana-integrations/kibana-visualization.js
@@ -79,7 +79,7 @@ const app = modules.get('apps/webinar_app', [])
                                 });
     
                                 visHandler = loader.embedVisualizationWithSavedObject($(`[vis-id="'${$scope.visID}'"]`), visualization, params); 
-                                
+          
                                 visHandlers.addItem(visHandler);
                                 visHandler.addRenderCompleteListener(renderComplete);
                             }).catch(error => {
@@ -137,8 +137,11 @@ const app = modules.get('apps/webinar_app', [])
                     $rootScope.loadingStatus = `Rendering visualizations... ${currentCompleted > 100 ? 100 : currentCompleted} %`;
 
                     if (currentCompleted >= 100) {
-
-                        if (!visTitle !== 'Wazuh App Overview General Agents status') $rootScope.rendered = true;
+                        if (!visTitle !== 'Wazuh App Overview General Agents status') { 
+                            const thereIsData   = visHandlers.hasData();
+                            $rootScope.rendered = thereIsData;
+                            if(!thereIsData) $rootScope.resultState = 'none'
+                        }
                         // Forcing a digest cycle
                         if(!$rootScope.$$phase) $rootScope.$digest();
                     }


### PR DESCRIPTION
Hello team, this pull request fixes https://github.com/wazuh/wazuh-kibana-app/issues/475

- Fix empty vis being shown
- Frees two remaining listeners once Discover directive is destroyed.

Regards,
Jesús