### PR TITLE
Refreshing known fields on settings while updating index pattern

### DIFF
--- a/public/controllers/settings.js
+++ b/public/controllers/settings.js
@@ -417,6 +417,7 @@ app.controller('settingsController', function ($scope, $rootScope, $http, $route
     $scope.changeIndexPattern = async newIndexPattern => {
         try {
             appState.setCurrentPattern(newIndexPattern);
+            await genericReq.request('GET',`/refresh-fields/${newIndexPattern}`,{})
             $scope.$emit('updatePattern', {});
             errorHandler.info('Successfully changed the default index-pattern','Settings');
             $scope.selectedIndexPattern = newIndexPattern;


### PR DESCRIPTION
Hello team, this pretty simple pull request fixes https://github.com/wazuh/wazuh-kibana-app/issues/458

It updates the known fields from an index pattern if it's being selected on Settings tab.

Regards,
Jesús