### PR TITLE
Prevents get the agent key

### DIFF
--- a/server/controllers/wazuh-api.js
+++ b/server/controllers/wazuh-api.js
@@ -383,7 +383,13 @@ export default class WazuhApi {
                     return ErrorResponse('Allowed method: [GET]', 3023, 400, reply);
                 }
             }
-            if(req.payload.body.devTools) delete req.payload.body.devTools;
+            if(req.payload.body.devTools) {
+                delete req.payload.body.devTools;
+                const keyRegex = new RegExp(/.*agents\/\d*\/key.*/)
+                if(typeof req.payload.path === 'string' &&  keyRegex.test(req.payload.path)){
+                    return ErrorResponse('Forbidden route /agents/<id>/key', 3028, 400, reply);
+                }
+            }
             return this.makeRequest(req.payload.method, req.payload.path, req.payload.body, req.payload.id, reply);
         }
     }


### PR DESCRIPTION
Hello team, this pull request fixes https://github.com/wazuh/wazuh-kibana-app/issues/467

As @jesuslinares said, the Wazuh API route `GET /agents/<id>/key` could be harmful, so we are preventing a bad usage from the Dev tools.

Regards,
Jesús