### PR TITLE
Allowing to show monitoring data without ingesting information

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -85,7 +85,10 @@
 # ------------------------------ wazuh-monitoring ------------------------------
 #
 # Custom setting to enable/disable wazuh-monitoring indices.
-# Default: enabled
+# Values: true, false, worker
+# If worker is given as value, the app will show the Agents status visualization but won't insert data 
+# on wazuh-monitoring indices
+# Default: true
 #wazuh.monitoring.enabled: true
 #
 # Custom setting to set the frequency for wazuh-monitoring indices cron task.

--- a/server/monitoring.js
+++ b/server/monitoring.js
@@ -30,7 +30,7 @@ export default (server, options) => {
         const configFile = getConfiguration();
 
         ENABLED   = configFile && typeof configFile['wazuh.monitoring.enabled'] !== 'undefined' ? 
-                    configFile['wazuh.monitoring.enabled'] : 
+                    configFile['wazuh.monitoring.enabled'] && configFile['wazuh.monitoring.enabled'] !== 'worker' : 
                     ENABLED;
         FREQUENCY = configFile && typeof configFile['wazuh.monitoring.frequency'] !== 'undefined' ? 
                     configFile['wazuh.monitoring.frequency'] : 


### PR DESCRIPTION
Hello team, this pull request fixes https://github.com/wazuh/wazuh-kibana-app/issues/482

The setting `wazuh.monitoring.enabled` now has three values:

- Any which evaluates `true` and it's not `worker` will ingest data and will show data
- Any which evaluates `false` won't ingest data and won't show data
- If `worker` is given as value, it won't ingest data but will show data

Regards,
Jesús