### PR TITLE
Fix monitoring non-cluster filter

### DIFF
--- a/public/kibana-integrations/kibana-visualization.js
+++ b/public/kibana-integrations/kibana-visualization.js
@@ -64,8 +64,8 @@ const app = modules.get('apps/webinar_app', [])
                                     .set('filter',  discoverList.length > 1 ? discoverList[1] : {});
                                 } else {
                                     
-                                    // Get filter for cluster/manager regardless environment
-                                    const monitoringFilter = discoverList[1].filter(item => item && item.meta && item.meta.key && ['cluster.name','manager.name'].includes(item.meta.key));
+                                    // Checks for cluster.name filter existence 
+                                    const monitoringFilter = discoverList[1].filter(item => item && item.meta && item.meta.key && item.meta.key.includes('cluster.name'));
                                     
                                     // Applying specific filter to Agents status
                                     if(Array.isArray(monitoringFilter) && monitoringFilter.length) {
@@ -121,8 +121,8 @@ const app = modules.get('apps/webinar_app', [])
                                 .set('filter', discoverList.length > 1 ? discoverList[1] : {});
                             } else {
                                     
-                                // Get filter for cluster/manager regardless environment
-                                const monitoringFilter = discoverList[1].filter(item => item && item.meta && item.meta.key && ['cluster.name','manager.name'].includes(item.meta.key));
+                                // Checks for cluster.name filter existence 
+                                const monitoringFilter = discoverList[1].filter(item => item && item.meta && item.meta.key && item.meta.key.includes('cluster.name'));
                                 
                                 // Applying specific filter to Agents status
                                 if(Array.isArray(monitoringFilter) && monitoringFilter.length) {


### PR DESCRIPTION
Hello team, this pull request fixes https://github.com/wazuh/wazuh-kibana-app/issues/484

We only need to filter Agents status visualization if we are using a cluster, otherwise show all data.

Regards,
Jesús