### PR TITLE
Fix ignoring enter on main Discover

### DIFF
--- a/public/kibana-integrations/kibana-discover.js
+++ b/public/kibana-integrations/kibana-discover.js
@@ -476,9 +476,12 @@ function discoverController(
     ////////////////////////////////////////////////////////////////////////////
     ///////////////////////////////  WAZUH   ///////////////////////////////////
     ////////////////////////////////////////////////////////////////////////////
-    let filters = queryFilter.getFilters();
-    filters = Array.isArray(filters) ? filters.filter(item => item && item.$state && item.$state.store && item.$state.store === 'appState') : [];
-    if(!filters || !filters.length) return;
+    const currentUrlPath = $location.path();
+    if(currentUrlPath && !currentUrlPath.includes('wazuh-discover')){
+      let filters = queryFilter.getFilters();
+      filters = Array.isArray(filters) ? filters.filter(item => item && item.$state && item.$state.store && item.$state.store === 'appState') : [];
+      if(!filters || !filters.length) return;
+    }
     discoverPendingUpdates.removeAll()
     discoverPendingUpdates.addItem($state.query,queryFilter.getFilters());
     $rootScope.$broadcast('updateVis');


### PR DESCRIPTION
Hello team, this pull request fixes https://github.com/wazuh/wazuh-kibana-app/issues/487, the solution is to ignore our filter restrictions if we are on the main Discover cause we don't need it and they won't be satisfied never.

Regards,
Jesús