### PR TITLE
Prevents "000" agents in md-autocomplete

### DIFF
--- a/public/services/data-handler.js
+++ b/public/services/data-handler.js
@@ -88,6 +88,11 @@ app.factory('DataHandler', function ($q, apiReq,errorHandler) {
                     this.items.push(items[i]);
                     this.items[i].selected = false;
                 }
+                // Prevents from any manager
+                if (this.path === '/agents') {
+                    const filteredAgents = this.items.filter(item => item && item.id !== '000');
+                    this.items = filteredAgents;
+                }
                 this.offset += items.length;
                 if (this.offset >= this.totalItems) this.end = true;
                 if (data.data.data !== 0){
@@ -212,7 +217,11 @@ app.factory('DataHandler', function ($q, apiReq,errorHandler) {
                     const filteredRules = this.items.filter(item => item.id !== this.ruleID);
                     this.items = filteredRules;
                 }
-
+                // Prevents from any manager
+                if (this.path === '/agents') {
+                    const filteredAgents = this.items.filter(item => item && item.id !== '000');
+                    this.items = filteredAgents;
+                }
                 this.offset = items.length;
                 deferred.resolve(true);
                 this.busy = false;


### PR DESCRIPTION
Hello team, this PR fixes https://github.com/wazuh/wazuh-kibana-app/issues/492. The only one modification is in the data-handler factory. 

> If we are fetching agents, exclude any "000" agent before assign the array

It's useful for the whole app, and after think about it I concluded it's the best place to do the filtering.

Regards,
Jesús