### PR TITLE
Added more Syscheck options to Manager/Agents configuration tabs

### DIFF
--- a/public/templates/agents/agents-configuration.html
+++ b/public/templates/agents/agents-configuration.html
@@ -297,6 +297,46 @@
                                 <span flex="25">Report changes</span>
                                 <span class="wz-text-right color-grey">{{item.report_changes}}</span>
                             </div>
+                            <div layout="row" class="wz-padding-top-10" ng-if="item.check_sum">
+                                <span flex="25">Check sum</span>
+                                <span class="wz-text-right color-grey">{{item.check_sum}}</span>
+                            </div>
+                            <div layout="row" class="wz-padding-top-10" ng-if="item.check_sha1sum">
+                                <span flex="25">Check SHA1sum</span>
+                                <span class="wz-text-right color-grey">{{item.check_sha1sum}}</span>
+                            </div>
+                            <div layout="row" class="wz-padding-top-10" ng-if="item.check_md5sum">
+                                <span flex="25">Check MD5sum</span>
+                                <span class="wz-text-right color-grey">{{item.check_md5sum}}</span>
+                            </div>
+                            <div layout="row" class="wz-padding-top-10" ng-if="item.check_size">
+                                <span flex="25">Check size</span>
+                                <span class="wz-text-right color-grey">{{item.check_size}}</span>
+                            </div>
+                            <div layout="row" class="wz-padding-top-10" ng-if="item.check_owner">
+                                <span flex="25">Check owner</span>
+                                <span class="wz-text-right color-grey">{{item.check_owner}}</span>
+                            </div>
+                            <div layout="row" class="wz-padding-top-10" ng-if="item.check_group">
+                                <span flex="25">Check group</span>
+                                <span class="wz-text-right color-grey">{{item.check_group}}</span>
+                            </div>
+                            <div layout="row" class="wz-padding-top-10" ng-if="item.check_perm">
+                                <span flex="25">Check permissions</span>
+                                <span class="wz-text-right color-grey">{{item.check_perm}}</span>
+                            </div>
+                            <div layout="row" class="wz-padding-top-10" ng-if="item.check_mtime">
+                                <span flex="25">Check modification time</span>
+                                <span class="wz-text-right color-grey">{{item.check_mtime}}</span>
+                            </div>
+                            <div layout="row" class="wz-padding-top-10" ng-if="item.check_inode">
+                                <span flex="25">Check inode</span>
+                                <span class="wz-text-right color-grey">{{item.check_inode}}</span>
+                            </div>
+                            <div layout="row" class="wz-padding-top-10" ng-if="item.restrict">
+                                <span flex="25">Restrict</span>
+                                <span class="wz-text-right color-grey">{{item.restrict}}</span>
+                            </div>
                             <md-divider class="wz-margin-top-10" ng-if="!$last"></md-divider>
                         </div>
 

--- a/public/templates/manager/manager-configuration.html
+++ b/public/templates/manager/manager-configuration.html
@@ -384,9 +384,57 @@
                             <span flex="25">Path</span>
                             <span class="wz-text-right color-grey">{{item.path}}</span>
                         </div>
+                        <div layout="row" class="wz-padding-top-10" ng-if="item.realtime">
+                            <span flex="25">Realtime</span>
+                            <span class="wz-text-right color-grey">{{item.realtime}}</span>
+                        </div>
+                        <div layout="row" class="wz-padding-top-10" ng-if="item.report_changes">
+                            <span flex="25">Report changes</span>
+                            <span class="wz-text-right color-grey">{{item.report_changes}}</span>
+                        </div>
                         <div layout="row" class="wz-padding-top-10" ng-if="item.check_all">
                             <span flex="25">Check all</span>
                             <span class="wz-text-right color-grey">{{item.check_all}}</span>
+                        </div>
+                        <div layout="row" class="wz-padding-top-10" ng-if="item.check_sum">
+                            <span flex="25">Check sum</span>
+                            <span class="wz-text-right color-grey">{{item.check_sum}}</span>
+                        </div>
+                        <div layout="row" class="wz-padding-top-10" ng-if="item.check_sha1sum">
+                            <span flex="25">Check SHA1sum</span>
+                            <span class="wz-text-right color-grey">{{item.check_sha1sum}}</span>
+                        </div>
+                        <div layout="row" class="wz-padding-top-10" ng-if="item.check_md5sum">
+                            <span flex="25">Check MD5sum</span>
+                            <span class="wz-text-right color-grey">{{item.check_md5sum}}</span>
+                        </div>
+                        <div layout="row" class="wz-padding-top-10" ng-if="item.check_size">
+                            <span flex="25">Check size</span>
+                            <span class="wz-text-right color-grey">{{item.check_size}}</span>
+                        </div>
+                        <div layout="row" class="wz-padding-top-10" ng-if="item.check_owner">
+                            <span flex="25">Check owner</span>
+                            <span class="wz-text-right color-grey">{{item.check_owner}}</span>
+                        </div>
+                        <div layout="row" class="wz-padding-top-10" ng-if="item.check_group">
+                            <span flex="25">Check group</span>
+                            <span class="wz-text-right color-grey">{{item.check_group}}</span>
+                        </div>
+                        <div layout="row" class="wz-padding-top-10" ng-if="item.check_perm">
+                            <span flex="25">Check permissions</span>
+                            <span class="wz-text-right color-grey">{{item.check_perm}}</span>
+                        </div>
+                        <div layout="row" class="wz-padding-top-10" ng-if="item.check_mtime">
+                            <span flex="25">Check modification time</span>
+                            <span class="wz-text-right color-grey">{{item.check_mtime}}</span>
+                        </div>
+                        <div layout="row" class="wz-padding-top-10" ng-if="item.check_inode">
+                            <span flex="25">Check inode</span>
+                            <span class="wz-text-right color-grey">{{item.check_inode}}</span>
+                        </div>
+                        <div layout="row" class="wz-padding-top-10" ng-if="item.restrict">
+                            <span flex="25">Restrict</span>
+                            <span class="wz-text-right color-grey">{{item.restrict}}</span>
                         </div>
                         <md-divider class="wz-margin-top-10" ng-if="!$last"></md-divider>
                     </div>


### PR DESCRIPTION
Hello team,

This pull request adds more attributes to the *Monitoring directories* section on Syscheck, for the *Manager/Agent Configuration* tabs on the Wazuh app.

In previous versions, we only showed two options, but now we show all the remaining according to the [documentation](https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html).

This closes #508.

![syscheck](https://user-images.githubusercontent.com/10928321/40723831-02cd694e-6420-11e8-84a9-52ba0507dc3e.PNG)

Best regards,
Juanjo