### PR TITLE
Reduced vis tab checking to 2 elements

### DIFF
--- a/public/controllers/agents.js
+++ b/public/controllers/agents.js
@@ -43,7 +43,7 @@ app.controller('agentsController', function ($timeout, $scope, $location, $rootS
         $scope.tab = "general";
         $location.search("tab", "general");
     }
-    tabHistory.push($scope.tab)
+    if($scope.tab !== 'configuration' && $scope.tab !== 'welcome') tabHistory.push($scope.tab)
 
     // Metrics Audit
     const metricsAudit = {
@@ -214,14 +214,14 @@ app.controller('agentsController', function ($timeout, $scope, $location, $rootS
 
     // Switch tab
     $scope.switchTab = (tab, force = false) => {
-        tabHistory.push(tab)
-        if (tabHistory.length > 3) tabHistory = tabHistory.slice(-3);
+        if(tab !== 'configuration' && tab !== 'welcome') tabHistory.push(tab)
+        if (tabHistory.length > 2) tabHistory = tabHistory.slice(-2);
         tabVisualizations.setTab(tab);
         if ($scope.tab === tab && !force) return;
         const onlyAgent = $scope.tab === tab && force;
         const sameTab = $scope.tab === tab;
         $location.search('tab', tab);
-        const preserveDiscover = tabHistory.length === 3 && tabHistory[0] === tabHistory[2] && tabHistory[1] === 'configuration';
+        const preserveDiscover = tabHistory.length === 2 && tabHistory[0] === tabHistory[1];
         $scope.tab = tab;
 
         if($scope.tab === 'configuration'){


### PR DESCRIPTION
Since we'll have more than one agents tab without visualizations in further packages we've fixed the solution previously merged to be a bit more generic.

Now it only stores last two tabs only if their content includes visualizations. This way we can simply check `arr[0] === arr[1]` to detect if it's a local change.

Regards,
Jesús