### PR TITLE
Improving wazuh-table usage

### DIFF
--- a/public/controllers/agents.js
+++ b/public/controllers/agents.js
@@ -15,10 +15,11 @@ import FilterHandler from '../utils/filter-handler'
 import generateMetric from '../utils/generate-metric'
 import TabNames       from '../utils/tab-names'
 import { metricsAudit, metricsVulnerability, metricsScap, metricsVirustotal } from '../utils/agents-metrics'
+import * as FileSaver from '../services/file-saver'
 
 const app = uiModules.get('app/wazuh', []);
 
-app.controller('agentsController', function ($timeout, $scope, $location, $rootScope, appState, apiReq, AgentsAutoComplete, errorHandler, tabVisualizations, vis2png, shareAgent, commonData, reportingService, visFactoryService) {
+app.controller('agentsController', function ($timeout, $scope, $location, $rootScope, appState, apiReq, AgentsAutoComplete, errorHandler, tabVisualizations, vis2png, shareAgent, commonData, reportingService, visFactoryService, csvReq) {
 
     $rootScope.reportStatus = false;
 
@@ -205,6 +206,23 @@ app.controller('agentsController', function ($timeout, $scope, $location, $rootS
             return $scope.agentsAutoComplete.items;
         } catch (error) {
             errorHandler.handle(error,'Agents');
+        }
+        return;
+    }
+
+    $scope.downloadCsv = async data_path => {
+        try {
+            errorHandler.info('Your download should begin automatically...', 'CSV')
+            const currentApi   = JSON.parse(appState.getCurrentAPI()).id;
+            const output       = await csvReq.fetch(data_path, currentApi, null);
+            const blob         = new Blob([output], {type: 'text/csv'});
+
+            FileSaver.saveAs(blob, 'packages.csv');
+            
+            return;
+
+        } catch (error) {
+            errorHandler.handle(error,'Download CSV');
         }
         return;
     }

--- a/public/directives/wazuh-table/controller.js
+++ b/public/directives/wazuh-table/controller.js
@@ -24,7 +24,8 @@ app.directive('wazuhTable', function() {
             path: '=path',
             keys: '=keys',
             allowClick: '=allowClick',
-            implicitFilter: '=implicitFilter'
+            implicitFilter: '=implicitFilter',
+            rowsPerPage: '=rowsPerPage'
         },
         controller: function($scope, apiReq, $timeout, shareAgent, $location, errorHandler) {            
             $scope.keyEquivalence = KeyEquivalenece;
@@ -52,7 +53,7 @@ app.directive('wazuhTable', function() {
 
             $scope.wazuh_table_loading = true;
             //// PAGINATION ////////////////////
-            $scope.itemsPerPage = 10;
+            $scope.itemsPerPage = $scope.rowsPerPage || 10;
             $scope.pagedItems = [];
             $scope.currentPage = 0;
             let items = [];
@@ -117,7 +118,9 @@ app.directive('wazuhTable', function() {
                     instance.addSorting(field.value || field);
                     $scope.sortValue = instance.sortValue;
                     $scope.sortDir   = instance.sortDir;
-                    items = await instance.fetch();
+                    const result = await instance.fetch();
+                    items = result.items;
+                    $scope.time = result.time;
                     $scope.totalItems = items.length;
                     $scope.items = items;
                     checkGap();
@@ -135,7 +138,9 @@ app.directive('wazuhTable', function() {
                     $scope.wazuh_table_loading = true;
                     if(removeFilters) instance.removeFilters();
                     instance.addFilter('search',term);
-                    items = await instance.fetch();
+                    const result = await instance.fetch();
+                    items = result.items;
+                    $scope.time = result.time;
                     $scope.totalItems = items.length;
                     $scope.items = items;
                     checkGap();
@@ -160,7 +165,9 @@ app.directive('wazuhTable', function() {
                         instance.addFilter(filter.name,filter.value);
                     }
                     
-                    items = await instance.fetch();
+                    const result = await instance.fetch();
+                    items = result.items;
+                    $scope.time = result.time;
                     $scope.totalItems = items.length;
                     $scope.items = items;
                     checkGap();
@@ -229,7 +236,9 @@ app.directive('wazuhTable', function() {
             const init = async () => {
                 try {
                     $scope.wazuh_table_loading = true;
-                    items = await instance.fetch();
+                    const result = await instance.fetch();
+                    items = result.items;
+                    $scope.time = result.time;
                     $scope.totalItems = items.length;
                     $scope.items = items;
                     checkGap();
@@ -243,6 +252,23 @@ app.directive('wazuhTable', function() {
             }
 
             init()
+
+            const splitArray = array => {
+                if(Array.isArray(array)){
+                    if(!array.length) return false;
+                    let str = '';
+                    for(const item of array) str += `${item}, `;
+                    str = str.substring(0, str.length - 2);
+                    return str;
+                }
+                return array;
+            }
+
+            $scope.checkIfArray = item => {
+                return typeof item === 'object' ? 
+                       splitArray(item) :
+                       item == 0 ? '0' : item;
+            }
 
             $scope.$on('$destroy',() => {
                 realTime = null;

--- a/public/directives/wazuh-table/template.html
+++ b/public/directives/wazuh-table/template.html
@@ -15,22 +15,31 @@
         </thead>
         <tbody>
             <tr ng-class="allowClick ? 'cursor-pointer' : ''" class="wz-word-wrap" ng-repeat="item in pagedItems[currentPage]" ng-click="clickAction(item)">
-                <td ng-repeat="key in keys" ng-if="path !== '/decoders'">{{ key === 'os.name' ? item.os.name || '---' : key === 'os.version' ? item.os.version || '---' : item[key.value || key] || '---' }}</td>
+                <td ng-repeat="key in keys" ng-if="path !== '/decoders'">
+                    {{ 
+                        key === 'os.name' ? 
+                        item.os.name || '---' : 
+                        key === 'os.version' ? 
+                        item.os.version || '---' : 
+                        checkIfArray(item[key.value || key]) || '---' 
+                    }}
+                </td>
                 <td ng-repeat="key in keys" ng-if="path === '/decoders'">
                     {{ 
                         key === 'details.program_name' || key.value === 'details.program_name' ? 
-                                                       item.details.program_name || '---' : 
+                        item.details.program_name || '---' : 
                         key === 'details.order' || key.value === 'details.order' ? 
-                                                              item.details.order || '---' : 
-                                                    item[key.value || key] || '---' 
+                        item.details.order || '---' : 
+                        checkIfArray(item[key.value || key]) || '---' 
                     }}
                 </td>
                 
             </tr>
         </tbody>
-        <tfoot ng-show="items.length >= itemsPerPage">
+        <tfoot >
             <td colspan="{{keys.length}}">
-                <div class="pagination pull-right" style="margin:0 !important">
+                <span ng-show="!wazuh_table_loading" class="color-grey">{{ totalItems }} items ({{time | number: 2}} seconds)</span>
+                <div ng-show="items.length >= itemsPerPage" class="pagination pull-right" style="margin:0 !important">
                     <ul layout="row">
                         <li ng-class="{disabled: currentPage == 0}" class="md-padding">
                             <a href ng-click="prevPage()">« Prev</a>
@@ -49,7 +58,4 @@
             </td>
         </tfoot>
     </table>
-</div>
-<div layout="row" ng-show="!wazuh_table_loading" class="md-padding">
-    Result: {{ totalItems }} items. 
 </div>

--- a/public/services/data-factory.js
+++ b/public/services/data-factory.js
@@ -56,6 +56,7 @@ export default class DataFactory {
     
     async fetch(options = {}) {
         try {     
+            const start = new Date();
             this.items       = [];       
             let offset       = 0;
             const limit      = options.limit || 2000;
@@ -69,7 +70,9 @@ export default class DataFactory {
             this.items.push(...firstPage.data.data.items)
             if(options.limit) {
                 if(this.path === '/agents') this.items = this.items.filter(item => item.id !== '000')
-                return this.items;   
+                const end = new Date();
+                const elapsed = (end - start) / 1000
+                return {items:this.items, time:elapsed};   
             }
 
             const totalItems = firstPage.data.data.totalItems;
@@ -89,7 +92,11 @@ export default class DataFactory {
             const remainingItems = await Promise.all(ops);
             remainingItems.map(page => this.items.push(...page.data.data.items))
             if(this.path === '/agents') this.items = this.items.filter(item => item.id !== '000')
-            return this.items;
+
+            const end = new Date();
+            const elapsed = (end - start) / 1000;
+
+            return {items:this.items, time:elapsed};
         
         } catch (error) {
             return Promise.reject(error);

--- a/public/templates/agents-prev/agents-prev.html
+++ b/public/templates/agents-prev/agents-prev.html
@@ -101,7 +101,12 @@
     </div>
 
     <div layout="row" class="margin-top-30">
-        <wazuh-table flex path="'/agents'" keys="['id','name','ip','status','group','os.name','os.version','version']" allow-click="true">
+        <wazuh-table 
+            flex 
+            path="'/agents'" 
+            keys="['id',{value:'name',size:2},'ip','status','group','os.name','os.version','version']" 
+            allow-click="true"
+            rows-per-page="17">
         </wazuh-table>
     </div>
 

--- a/public/templates/agents/agents-syscollector.html
+++ b/public/templates/agents/agents-syscollector.html
@@ -70,4 +70,10 @@
             keys="['name','architecture','version',{value:'vendor',size:3},{value:'description',size:3}]">
         </wazuh-table>
     </div>
+    <div layout="row" class="md-padding" ng-if="agent">
+        <span flex></span>
+        <a class="small" id="btnDownload" ng-click="downloadCsv('/syscollector/' + agent.id + '/packages')">Formatted
+            <i aria-hidden="true" class="fa fa-fw fa-download"></i>
+        </a>
+    </div>
 </md-content>

--- a/public/templates/manager/groups/groups-preview.html
+++ b/public/templates/manager/groups/groups-preview.html
@@ -63,7 +63,12 @@
 
         <!-- Groups table -->
         <div layout="row" ng-if="!lookingGroup" class="md-padding">
-            <wazuh-table flex path="'/agents/groups'" keys="['name','count','merged_sum']" allow-click="true">
+            <wazuh-table 
+                flex 
+                path="'/agents/groups'" 
+                keys="['name','count','merged_sum']" 
+                allow-click="true"
+                rows-per-page="19">
             </wazuh-table>
         </div>
         <!-- End groups table -->
@@ -79,8 +84,12 @@
 
         <!-- Group agents table -->
         <div layout="row" ng-if="lookingGroup && groupsSelectedTab==='agents' && currentGroup" class="md-padding">
-            <wazuh-table flex path="'/agents/groups/' + currentGroup.name" keys="['id','name','ip','status','os.name','os.version','version']"
-                allow-click="true">
+            <wazuh-table 
+                flex 
+                path="'/agents/groups/' + currentGroup.name" 
+                keys="['id','name','ip','status','os.name','os.version','version']"
+                allow-click="true"
+                rows-per-page="14">
             </wazuh-table>
         </div>
         <!-- End Group agents table -->
@@ -96,8 +105,12 @@
 
         <!-- Group files table -->
         <div layout="row" ng-if="lookingGroup && groupsSelectedTab==='files' && !fileViewer && currentGroup" class="md-padding">
-            <wazuh-table flex path="'/agents/groups/' + currentGroup.name + '/files'" keys="[{value:'filename',size:2},{value:'hash',size:6}]"
-                allow-click="true">
+            <wazuh-table 
+                flex 
+                path="'/agents/groups/' + currentGroup.name + '/files'" 
+                keys="[{value:'filename',size:2},{value:'hash',size:6}]"
+                allow-click="true"
+                rows-per-page="14">
             </wazuh-table>
         </div>
         <!-- End Group files table -->

--- a/public/templates/manager/manager-osseclog.html
+++ b/public/templates/manager/manager-osseclog.html
@@ -48,7 +48,12 @@
 
     <!-- Logs table section -->
     <div layout="row">
-        <wazuh-table flex path="'/manager/logs'" keys="['timestamp',{value:'tag',size:2},'level',{value:'description',size:4,nosortable:true}]"></wazuh-table>
+        <wazuh-table 
+            flex 
+            path="'/manager/logs'" 
+            keys="['timestamp',{value:'tag',size:2},'level',{value:'description',size:4,nosortable:true}]"
+            rows-per-page="19">
+        </wazuh-table>
     </div>
     <!-- End Logs table section -->
 

--- a/public/templates/manager/ruleset/decoders/decoders-list.html
+++ b/public/templates/manager/ruleset/decoders/decoders-list.html
@@ -47,13 +47,15 @@
             flex 
             path="'/decoders'" 
             keys="['name',{value:'details.program_name',size:2},{value:'details.order',size:2},'file']" 
-            allow-click="true">
+            allow-click="true"
+            rows-per-page="18">
         </wazuh-table> 
         <wazuh-table ng-if="!implicitFilterFromDetail"
                 flex 
                 path="'/decoders'" 
                 keys="['name',{value:'details.program_name',size:2,nosortable:true},{value:'details.order',size:2,nosortable:true},'file']" 
-                allow-click="true">
+                allow-click="true"
+                rows-per-page="18">
         </wazuh-table>
     </div>
 

--- a/public/templates/manager/ruleset/rules/rules-list.html
+++ b/public/templates/manager/ruleset/rules/rules-list.html
@@ -55,12 +55,16 @@
             implicit-filter="implicitFilterFromDetail"
             flex 
             path="'/rules'" 
-            keys="['id',{value:'file',size:2},{value:'description',size:2},{value:'groups',nosortable:true,size:2},{value:'pci',nosortable:true,size:2},{value:'gdpr',nosortable:true},'level']" allow-click="true">
+            keys="['id',{value:'file',size:2},{value:'description',size:2},{value:'groups',nosortable:true,size:2},{value:'pci',nosortable:true,size:2},{value:'gdpr',nosortable:true},'level']" 
+            allow-click="true"
+            rows-per-page="18">
         </wazuh-table>
         <wazuh-table ng-if="!implicitFilterFromDetail"
                 flex 
                 path="'/rules'" 
-                keys="['id',{value:'file',size:2},{value:'description',size:2},{value:'groups',nosortable:true,size:2},{value:'pci',nosortable:true,size:2},{value:'gdpr',nosortable:true},'level']" allow-click="true">
+                keys="['id',{value:'file',size:2},{value:'description',size:2},{value:'groups',nosortable:true,size:2},{value:'pci',nosortable:true,size:2},{value:'gdpr',nosortable:true},'level']" 
+                allow-click="true"
+                rows-per-page="18">
         </wazuh-table>
     </div>
 


### PR DESCRIPTION
Hello team, this PR fixes #587 

Brief summary:

- Array field such `["gpdr1","gdpr2"]` now looks like `gdpr1, gdpr2`
- Empty array field such `[ ]` now looks like `---`
- Added `Download CSV` to syscollector packages table
- Added optional parameter to `wazuh-table` directive named `rows-per-page`
- Added `elapsed` time to items count from the tables `Eg: 2313 items (0.32 seconds)`

Regards,
Jesús