### PR TITLE
Fixed flex layout on Ruleset tabs

### DIFF
--- a/public/templates/manager/ruleset/decoders/decoders-list.html
+++ b/public/templates/manager/ruleset/decoders/decoders-list.html
@@ -1,31 +1,27 @@
 <div ng-show="!loading && !viewingDetail" flex layout="column" class="md-padding">
     <div id="content" layout="row" layout-align="start start">
-        
-        <input flex="60" placeholder="Filter decoders..." ng-model="custom_search" type="text" class="kuiLocalSearchInput ng-empty ng-pristine ng-scope ng-touched ng-valid wz-margin-top-4 height-36"
+
+        <input flex placeholder="Filter decoders..." ng-model="custom_search" type="text" class="kuiLocalSearchInput ng-empty ng-pristine ng-scope ng-touched ng-valid wz-margin-top-4 height-36"
             aria-invalid="false" wz-enter="search(custom_search)">
         <button type="submit" aria-label="Search" class="kuiLocalSearchButton height-36 wz-margin-top-4 wz-margin-right-16" ng-click="search(custom_search)">
             <span class="fa fa-search" aria-hidden="true"></span>
-        </button>  
+        </button>
 
-        <div flex="15" layout="column" class="height-40 wz-select-input wz-margin-right-8">
+        <div layout="column" class="height-40 wz-select-input wz-margin-right-8">
             <select flex class="kuiSelect wz-border-none cursor-pointer" ng-model="typeFilter" ng-change="onlyParents(typeFilter)" aria-label="Filter by type" ng-init="'All decoders'">
                 <option value="all">All decoders</option>
                 <option value="parents">Parent decoders</option>
             </select>
         </div>
 
-        <div flex layout="column">
-            <md-button flex ng-class="(globalRulesetTab == 'rules') ? 'active' : ''" ng-click="setRulesTab('rules')"
-                class="wz-button md-raised md-primary manager-ruleset-btn" aria-label="Ruleset rules button">
-                <i class="fa fa-fw fa-file-text-o" aria-hidden="true"></i> Rules
-            </md-button>
-        </div>
-        <div flex layout="column">
-            <md-button flex ng-class="(globalRulesetTab == 'decoders') ? 'active' : ''" ng-click="setRulesTab('decoders')"
-                class="wz-button md-raised md-primary manager-ruleset-btn" aria-label="Ruleset decoders button">
-                <i class="fa fa-fw fa-search" aria-hidden="true"></i> Decoders
-            </md-button>
-        </div>
+        <md-button ng-class="(globalRulesetTab == 'rules') ? 'active' : ''" ng-click="setRulesTab('rules')"
+            class="wz-button md-raised md-primary manager-ruleset-btn" aria-label="Ruleset rules button">
+            <i class="fa fa-fw fa-file-text-o" aria-hidden="true"></i> Rules
+        </md-button>
+        <md-button ng-class="(globalRulesetTab == 'decoders') ? 'active' : ''" ng-click="setRulesTab('decoders')"
+            class="wz-button md-raised md-primary manager-ruleset-btn" aria-label="Ruleset decoders button">
+            <i class="fa fa-fw fa-search" aria-hidden="true"></i> Decoders
+        </md-button>
     </div>
 
     <md-chips readonly="true" ng-show="appliedFilters.length || implicitFilterFromDetail">
@@ -44,16 +40,16 @@
     <div layout="row">
         <wazuh-table ng-if="implicitFilterFromDetail"
             implicit-filter="implicitFilterFromDetail"
-            flex 
-            path="'/decoders'" 
-            keys="['name',{value:'details.program_name',size:2},{value:'details.order',size:2},'file']" 
+            flex
+            path="'/decoders'"
+            keys="['name',{value:'details.program_name',size:2},{value:'details.order',size:2},'file']"
             allow-click="true"
             rows-per-page="18">
-        </wazuh-table> 
+        </wazuh-table>
         <wazuh-table ng-if="!implicitFilterFromDetail"
-                flex 
-                path="'/decoders'" 
-                keys="['name',{value:'details.program_name',size:2,nosortable:true},{value:'details.order',size:2,nosortable:true},'file']" 
+                flex
+                path="'/decoders'"
+                keys="['name',{value:'details.program_name',size:2,nosortable:true},{value:'details.order',size:2,nosortable:true},'file']"
                 allow-click="true"
                 rows-per-page="18">
         </wazuh-table>

--- a/public/templates/manager/ruleset/rules/rules-list.html
+++ b/public/templates/manager/ruleset/rules/rules-list.html
@@ -1,17 +1,17 @@
 <div ng-if="!loading && !viewingDetail" flex layout="column" class="md-padding">
     <div id="content" layout="row">
-        <input flex="80" placeholder="Filter rules..." ng-model="custom_search" type="text" class="kuiLocalSearchInput ng-empty ng-pristine ng-scope ng-touched ng-valid wz-margin-top-4 height-36"
+
+        <input flex placeholder="Filter rules..." ng-model="custom_search" type="text" class="kuiLocalSearchInput ng-empty ng-pristine ng-scope ng-touched ng-valid wz-margin-top-4 height-36"
             aria-invalid="false" wz-enter="search(custom_search)">
         <button type="submit" aria-label="Search" class="kuiLocalSearchButton height-36 wz-margin-top-4" ng-click="search(custom_search)">
             <span class="fa fa-search" aria-hidden="true"></span>
-        </button>  
+        </button>
 
-
-        <md-button flex ng-class="(globalRulesetTab == 'rules') ? 'active' : ''"
+        <md-button ng-class="(globalRulesetTab == 'rules') ? 'active' : ''"
             ng-click="setRulesTab('rules')" class="wz-button md-raised md-primary manager-ruleset-btn" aria-label="Ruleset rules button">
             <i class="fa fa-fw fa-file-text-o" aria-hidden="true"></i> Rules
         </md-button>
-        <md-button flex ng-class="(globalRulesetTab == 'decoders') ? 'active' : ''"
+        <md-button ng-class="(globalRulesetTab == 'decoders') ? 'active' : ''"
             ng-click="setRulesTab('decoders')" class="wz-button md-raised md-primary manager-ruleset-btn" aria-label="Ruleset decoders button">
             <i class="fa fa-fw fa-search" aria-hidden="true"></i> Decoders
         </md-button>
@@ -53,16 +53,16 @@
     <div layout="row">
         <wazuh-table ng-if="implicitFilterFromDetail"
             implicit-filter="implicitFilterFromDetail"
-            flex 
-            path="'/rules'" 
-            keys="['id',{value:'file',size:2},{value:'description',size:2},{value:'groups',nosortable:true,size:2},{value:'pci',nosortable:true,size:2},{value:'gdpr',nosortable:true},'level']" 
+            flex
+            path="'/rules'"
+            keys="['id',{value:'file',size:2},{value:'description',size:2},{value:'groups',nosortable:true,size:2},{value:'pci',nosortable:true,size:2},{value:'gdpr',nosortable:true},'level']"
             allow-click="true"
             rows-per-page="18">
         </wazuh-table>
         <wazuh-table ng-if="!implicitFilterFromDetail"
-                flex 
-                path="'/rules'" 
-                keys="['id',{value:'file',size:2},{value:'description',size:2},{value:'groups',nosortable:true,size:2},{value:'pci',nosortable:true,size:2},{value:'gdpr',nosortable:true},'level']" 
+                flex
+                path="'/rules'"
+                keys="['id',{value:'file',size:2},{value:'description',size:2},{value:'groups',nosortable:true,size:2},{value:'pci',nosortable:true,size:2},{value:'gdpr',nosortable:true},'level']"
                 allow-click="true"
                 rows-per-page="18">
         </wazuh-table>


### PR DESCRIPTION
Hello team,

This pull request fixes #609.

Now the Ruleset buttons always take the needed space to not overflow the labels. The search bar and Decoders filter now are also taking the space properly, according to its component type.

Some example screenshots:
### Before:
![ruleset](https://user-images.githubusercontent.com/10928321/41835855-45fb5526-7859-11e8-8982-7dcf2029672f.PNG)
![ruleset2](https://user-images.githubusercontent.com/10928321/41835856-461575be-7859-11e8-9b3f-1d8f83b3f439.PNG)

### After:
![rules](https://user-images.githubusercontent.com/10928321/41835854-45e161f2-7859-11e8-8cb0-bf47df0fe963.PNG)
![decoders](https://user-images.githubusercontent.com/10928321/41835853-45c86c38-7859-11e8-86b3-8ecb15cb0a59.PNG)

Regards,
Juanjo