### PR TITLE
Resolve getIp before health check is fired

### DIFF
--- a/public/services/routes.js
+++ b/public/services/routes.js
@@ -33,6 +33,7 @@ routes
     .when('/health-check', {
         template: healthCheckTemplate,
         resolve: {
+            "ip": getIp,
             "checkAPI": settingsWizard
         }
     })


### PR DESCRIPTION
Hello team, this PR fixes https://github.com/wazuh/wazuh-kibana-app/issues/637

Also it would be nice if we cherry pick this fix to older versions such 6.2.4.

Regards,
Jesús