### PR TITLE
Pagination improvements

### DIFF
--- a/public/directives/wazuh-table/controller.js
+++ b/public/directives/wazuh-table/controller.js
@@ -93,11 +93,11 @@ app.directive('wazuhTable', function() {
                 return ret;
             };
         
-            $scope.prevPage = () => {
+            $scope.prevPage = function () {
                 if ($scope.currentPage > 0) {
                     $scope.currentPage--;
                 }
-                $scope.nextPage(true);
+                $scope.nextPage($scope.currentPage);
             };
             
             const fetch = async options => {
@@ -115,12 +115,12 @@ app.directive('wazuhTable', function() {
                 }
             };
 
-            $scope.nextPage = async ignore_increment => {
+            $scope.nextPage = async currentPage => {
                 try {
-                    if (!ignore_increment && ($scope.currentPage < $scope.pagedItems.length - 1)) {
+                    if (!currentPage && ($scope.currentPage < $scope.pagedItems.length - 1)) {
                         $scope.currentPage++;
                     }
-                    if($scope.pagedItems[$scope.currentPage].includes(null)){
+                    if($scope.pagedItems[currentPage || $scope.currentPage].includes(null)){
                         const copy = $scope.currentPage;
                         $scope.wazuh_table_loading = true;
                         const currentNonNull = $scope.items.filter(item => !!item);
@@ -136,9 +136,9 @@ app.directive('wazuhTable', function() {
 
             };
             
-            $scope.setPage = () => {
+            $scope.setPage = function () {
                 $scope.currentPage = this.n;
-                $scope.nextPage(true);
+                $scope.nextPage(this.n);
             };
             ////////////////////////////////////
 

--- a/public/services/data-factory.js
+++ b/public/services/data-factory.js
@@ -74,7 +74,7 @@ export default class DataFactory {
             const totalItems = firstPage.data.data.totalItems;
 
             const remaining  = this.items.length === totalItems ? 0 :
-                               totalItems-firstPage.data.data.items.length-this.items.length;
+                               totalItems-this.items.length;
 
             // Ignore manager as an agent, once the team solves this issue, review this line
             if(this.path === '/agents') this.items = this.items.filter(item => item.id !== '000');

--- a/server/controllers/wazuh-api.js
+++ b/server/controllers/wazuh-api.js
@@ -578,7 +578,7 @@ export default class WazuhApi {
             const url = `${config.url}:${config.port}/agents`;
 
             const params = {
-                limit : 2000,
+                limit : 500,
                 offset: 0,
                 sort  :'-dateAdd'
             }

--- a/server/monitoring.js
+++ b/server/monitoring.js
@@ -65,12 +65,12 @@ export default (server, options) => {
     const checkStatus = async (apiEntry, maxSize) => {
         try {
             if (!maxSize) {
-                throw new Error('You must provide a max size')
+                throw new Error('You must provide a max size');
             }
 
             const payload = {
                 offset: 0,
-                limit : 1000
+                limit : 500
             };
 
             const options = {


### PR DESCRIPTION
Hello team, this PR fixes https://github.com/wazuh/wazuh-kibana-app/issues/645

Brief summary:

- Monitoring module is now paginating agents by 500 items per request in order to fit new Wazuh API limits (https://github.com/wazuh/wazuh/issues/875)
- Wazuh table directive has been improved:
  - Single request has a 500 items limit
  - If we are in an empty page, it fetchs 500 more items and so on
  - Already fetched items are not re-fetched each time we are requesting data
  - Tables works the same way, this modification doesn't modify their behaviour, it only modifies the internal pagination
  - Some duplicated code has been placed into a common function

Regards,
Jesús

