### PR TITLE
Logger fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,6 @@
         "pdfmake": "^0.1.37",
         "query-string": "5.1.1",
         "timsort": "^0.3.0",
-        "winston": "3.0.0-rc1"
+        "winston": "3.0.0"
     }
 }

--- a/server/logger.js
+++ b/server/logger.js
@@ -87,6 +87,12 @@ const checkFiles = () => {
                 path.join(__dirname, '../../../optimize/wazuh-logs/wazuhapp.log'),
                 path.join(__dirname, `../../../optimize/wazuh-logs/wazuhapp.${new Date().getTime()}.log`)
             );
+            fs.writeFileSync(path.join(__dirname, '../../../optimize/wazuh-logs/wazuhapp.log'),JSON.stringify({
+                date    : new Date(),
+                level   : 'info',
+                location: 'logger',
+                message : 'Rotated log file'
+            }) + '\n');
         }
     }
 };

--- a/server/logger.js
+++ b/server/logger.js
@@ -14,11 +14,32 @@ import fs      from 'fs';
 import path    from 'path';
 
 let allowed = false;
+let wazuhlogger = undefined;
+
+/**
+ * Here we create the logger
+ */
+const initLogger = () => {
+    wazuhlogger = winston.createLogger({
+        level     : 'info',
+        format    : winston.format.json(),
+        transports: [
+            new winston.transports.File({
+                filename: path.join(__dirname, '../../../optimize/wazuh-logs/wazuhapp.log')
+            })
+        ]
+    });
+    
+    /**
+     * Prevents from exit on error related to the logger.
+     */
+    wazuhlogger.exitOnError = false;  
+};
 
 /** 
  * Checks if wazuh-logs exists. If it doesn't exist, it will be created.
  */
-const initDirectory = () => {
+const initDirectory = async () => {
     try{
         if(!path.join(__dirname).includes('/usr/share/kibana') &&
             path.join(__dirname).includes('plugins') &&
@@ -30,31 +51,15 @@ const initDirectory = () => {
         if (!fs.existsSync(path.join(__dirname, '../../../optimize/wazuh-logs'))) {
             fs.mkdirSync(path.join(__dirname, '../../../optimize/wazuh-logs'));
         }
+        if(typeof wazuhlogger === 'undefined') initLogger();
         allowed = true;
         return;
     } catch (error) {
         allowed = false;
-        console.error(`Cannot create the logs directory due to:\n${error.message || error}`);
+        return Promise.reject(error);
     }
 }
 
-/**
- * Here we create the logger
- */
-const wazuhlogger = winston.createLogger({
-    level     : 'info',
-    format    : winston.format.json(),
-    transports: [
-        new winston.transports.File({
-            filename: path.join(__dirname, '../../../optimize/wazuh-logs/wazuhapp.log')
-        })
-    ]
-});
-
-/**
- * Prevents from exit on error related to the logger.
- */
-wazuhlogger.exitOnError = false;
 
 /**
  * Returns given file size in MB, if the file doesn't exist returns 0
@@ -81,10 +86,11 @@ const checkFiles = () => {
             fs.renameSync(
                 path.join(__dirname, '../../../optimize/wazuh-logs/wazuhapp.log'),
                 path.join(__dirname, `../../../optimize/wazuh-logs/wazuhapp.${new Date().getTime()}.log`)
-            )
+            );
         }
     }
 };
+
 
 /**
  * Main function to add a new log
@@ -93,14 +99,17 @@ const checkFiles = () => {
  * @param {*} level Optional, default is 'error'
  */
 export default (location, message, level) => {
-    initDirectory();
-    if(allowed){
-        checkFiles();
-        wazuhlogger.log({
-            date    : new Date(),
-            level   : level || 'error',
-            location: location || 'unknown',
-            message : message || 'An error occurred'
-        });
-    }
+    initDirectory()
+    .then(() => {
+        if(allowed){
+            checkFiles();
+            wazuhlogger.log({
+                date    : new Date(),
+                level   : level || 'error',
+                location: location || 'unknown',
+                message : message || 'An error occurred'
+            });
+        }
+    })
+    .catch(error => console.error(`Cannot create the logs directory due to:\n${error.message || error}`));
 };


### PR DESCRIPTION
Hello team, this PR fixes #618 

Brief summary:

- Wait until logs directory is created before try to write a new log entry
- Wait until log rotation finishes before try to write a new log entry
- Updated Winston library from 3.0.0-rc1 to 3.0.0 stable

Regards,
Jesús