### PR TITLE
Fix searching index pattern

### DIFF
--- a/public/controllers/agents-preview.js
+++ b/public/controllers/agents-preview.js
@@ -74,9 +74,11 @@ app.controller('agentsPreviewController', function ($scope, $routeParams, generi
             const firstUrlParam  = clusterInfo.status === 'enabled' ? 'cluster' : 'manager';
             const secondUrlParam = clusterInfo[firstUrlParam];
 
+            const pattern = appState.getCurrentPattern();
+            
             const data = await Promise.all([
                 genericReq.request('GET', '/api/wazuh-api/agents-unique/' + api, {}),
-                genericReq.request('GET', `/api/wazuh-elastic/top/${firstUrlParam}/${secondUrlParam}/agent.name`)                
+                genericReq.request('GET', `/api/wazuh-elastic/top/${firstUrlParam}/${secondUrlParam}/agent.name/${pattern}`)                
             ]);
             
             const unique = data[0].data.result;
@@ -97,7 +99,7 @@ app.controller('agentsPreviewController', function ($scope, $routeParams, generi
                 $scope.mostActiveAgent.id   = '000';
             } else {
                 $scope.mostActiveAgent.name = data[1].data.data;
-                const info = await genericReq.request('GET', `/api/wazuh-elastic/top/${firstUrlParam}/${secondUrlParam}/agent.id`);
+                const info = await genericReq.request('GET', `/api/wazuh-elastic/top/${firstUrlParam}/${secondUrlParam}/agent.id/${pattern}`);
                 if (info.data.data === '' && $scope.mostActiveAgent.name !== '') {
                     $scope.mostActiveAgent.id = '000';
                 } else {

--- a/public/services/resolves/get-config.js
+++ b/public/services/resolves/get-config.js
@@ -28,7 +28,7 @@ export default ($q, genericReq, errorHandler, wazuhConfig) => {
         timeout                : 8000,
         'wazuh.shards'         : 1,
         'wazuh.replicas'       : 1,
-        selector               : true,
+        'ip.selector'          : true,
         'xpack.rbac.enabled'   : true,
         'wazuh.wazuh-version.shards'  : 1,
         'wazuh.wazuh-version.shards.replicas': 1,            

--- a/server/controllers/wazuh-elastic.js
+++ b/server/controllers/wazuh-elastic.js
@@ -138,7 +138,7 @@ export default class WazuhElastic {
             );
 
             payload.aggs['2'].terms.field = req.params.field;
-
+            payload.pattern = req.params.pattern;
             const data = await this.wzWrapper.searchWazuhAlertsWithPayload(payload);
 
             return (data.hits.total === 0 || typeof data.aggregations['2'].buckets[0] === 'undefined') ?

--- a/server/lib/elastic-wrapper.js
+++ b/server/lib/elastic-wrapper.js
@@ -366,9 +366,19 @@ export default class ElasticWrapper {
         try {
 
             if(!payload) return Promise.reject(new Error('No valid payload given'));
+            const pattern = payload.pattern;
+            delete payload.pattern;
+            const fullPattern = await this.getIndexPatternUsingGet(pattern);
 
+            const title = fullPattern &&
+                          fullPattern._source && 
+                          fullPattern._source['index-pattern'] &&
+                          fullPattern._source['index-pattern'].title ?
+                          fullPattern._source['index-pattern'].title :
+                          false;
+            
             const data = await this.elasticRequest.callWithInternalUser('search', {
-                index: 'wazuh-alerts-3.x-*',
+                index: title || 'wazuh-alerts-3.x-*',
                 type:  'wazuh',
                 body:  payload
             });
@@ -378,7 +388,7 @@ export default class ElasticWrapper {
         } catch (error) {
             return Promise.reject(error);
         }
-    };
+    }
 
     /**
      * Search for the Wazuh API configuration document using its own id (usually it's a timestamp)

--- a/server/routes/wazuh-elastic.js
+++ b/server/routes/wazuh-elastic.js
@@ -32,7 +32,7 @@ export default (server, options) => {
     server.route({ method: 'GET', path: '/api/wazuh-elastic/pattern/{pattern}', handler: (req,res) => ctrl.checkPattern(req,res) });
 
     // Returns the agent with most alerts
-    server.route({ method: 'GET', path: '/api/wazuh-elastic/top/{mode}/{cluster}/{field}', handler: (req,res) => ctrl.getFieldTop(req,res) });
+    server.route({ method: 'GET', path: '/api/wazuh-elastic/top/{mode}/{cluster}/{field}/{pattern}', handler: (req,res) => ctrl.getFieldTop(req,res) });
 
     // Return Wazuh Appsetup info
     server.route({ method: 'GET', path: '/api/wazuh-elastic/setup', handler: (req,res) => ctrl.getSetupInfo(req,res) });


### PR DESCRIPTION
Hello team, this PR fixes https://github.com/wazuh/wazuh-kibana-app/issues/699. I've found a wrong function in our server side. That function is currently being used to get the top active agent in Elasticsearch and it had the _wazuh-alerts-3.x-*_ pattern hardcoded. 

The bug was not so harmful but since we are going to use that function with the reporting module in further packages, it must accept dynamic index patterns. 

Regards,
Jesús