### PR TITLE
Added an intended empty catch statement when parsing current API

### DIFF
--- a/public/services/resolves/settings-wizard.js
+++ b/public/services/resolves/settings-wizard.js
@@ -80,9 +80,15 @@ export default ($rootScope, $location, $q, $window, testAPI, appState, genericRe
         const callCheckStored = () => {
             const config = wazuhConfig.getConfig();
 
-            const currentApi = appState.getCurrentAPI();
+            let currentApi = false;
+            
+            try {
+                currentApi = JSON.parse(appState.getCurrentAPI()).id;
+            } catch (error) {
+                // Intended empty catch
+            }
 
-            if(currentApi && !appState.getExtensions(JSON.parse(currentApi).id)){
+            if(currentApi && !appState.getExtensions(currentApi)){
                 const extensions = {
                     audit     : config['extensions.audit'],
                     pci       : config['extensions.pci'],
@@ -96,7 +102,7 @@ export default ($rootScope, $location, $q, $window, testAPI, appState, genericRe
             }
             
             checkTimestamp(appState,genericReq,errorHandler,$rootScope,$location)
-            .then(() => testAPI.check_stored(JSON.parse(appState.getCurrentAPI()).id))
+            .then(() => testAPI.check_stored(currentApi))
             .then(data => {
                 if(data && data === 'cookies_outdated'){
                     $location.search('tab','welcome');


### PR DESCRIPTION
Hello team, this PR fixes https://github.com/wazuh/wazuh-kibana-app/issues/709

The solution comes from add a new try/catch block because `JSON.parse` throws an exception if it fails, so our logic was just right but that exception was avoiding us to continue our standard execution.

Regards,
Jesús