### PR TITLE
Accepting Kuery as new query language

### DIFF
--- a/public/factories/tab-visualizations.js
+++ b/public/factories/tab-visualizations.js
@@ -33,7 +33,7 @@ app.factory('tabVisualizations', function() {
     const overview = {
         welcome   : 0,
         general   : 11,
-        fim       : 9,
+        fim       : 10,
         pm        : 5,
         vuls      : 8,
         oscap     : 11,

--- a/public/factories/tab-visualizations.js
+++ b/public/factories/tab-visualizations.js
@@ -33,7 +33,7 @@ app.factory('tabVisualizations', function() {
     const overview = {
         welcome   : 0,
         general   : 11,
-        fim       : 10,
+        fim       : 9,
         pm        : 5,
         vuls      : 8,
         oscap     : 11,

--- a/public/kibana-integrations/kibana-visualization.js
+++ b/public/kibana-integrations/kibana-visualization.js
@@ -10,166 +10,119 @@
  * Find more information about this on the LICENSE file.
  */
 import $              from 'jquery';
-import { uiModules }   from 'ui/modules'
-import * as ownLoader from './loader/loader-import'
+import { uiModules }   from 'ui/modules';
+import * as ownLoader from './loader/loader-import';
 
-const app = uiModules.get('apps/webinar_app', [])
-    .directive('kbnVis', [function () {
-        return {
-            restrict: 'E',
-            scope: {
-                visID: '=visId',
-                specificTimeRange: '=specificTimeRange'
-            },
-            controller: function VisController($scope, $rootScope, $location, wzsavedVisualizations, genericReq, errorHandler, Private, rawVisualizations, loadedVisualizations, tabVisualizations, discoverPendingUpdates, visHandlers) {
+const app = uiModules.get('apps/webinar_app', []);
 
-                let originalImplicitFilter = '';
-                let implicitFilter         = '';
-                let rawFilters             = [];
-                let rendered               = false;
-                let visualization          = null;
-                let visHandler             = null;
-                let renderInProgress       = false;
+app.directive('kbnVis', [function () {
+    return {
+        restrict: 'E',
+        scope: {
+            visID: '=visId',
+            specificTimeRange: '=specificTimeRange'
+        },
+        controller: function VisController($scope, $rootScope, wzsavedVisualizations, errorHandler, rawVisualizations, loadedVisualizations, tabVisualizations, discoverPendingUpdates, visHandlers) {
 
-                const myRender = raw => {
+            let implicitFilter         = '';
+            let rawFilters             = [];
+            let rendered               = false;
+            let visualization          = null;
+            let visHandler             = null;
+            let renderInProgress       = false;
+
+            const setSearchSource = discoverList => {
+                // We don't want to filter that visualization as it uses another index-pattern
+                if ($scope.visID !== 'Wazuh-App-Overview-General-Agents-status' && !$scope.visID.includes('Cluster')) {
+                    visualization.searchSource
+                        .query({ language: discoverList[0].language || 'lucene', query: implicitFilter })
+                        .set('filter', discoverList.length > 1 ? [...discoverList[1], ...rawFilters] : rawFilters);
+                } else {
+                    // Checks for cluster.name filter existence 
+                    const monitoringFilter = discoverList[1].filter(item => item && item.meta && item.meta.key && item.meta.key.includes('cluster.name'));
+
+                    // Applying specific filter to Agents status
+                    if (Array.isArray(monitoringFilter) && monitoringFilter.length) {
+                        visualization.searchSource.filter(monitoringFilter[0]);
+                    }
+                }
+            };
+
+            const myRender = async raw => {
+                try {
                     if (raw && discoverPendingUpdates.getList().length) { // There are pending updates from the discover (which is the one who owns the true app state)
                         const discoverList = discoverPendingUpdates.getList();
-
+    
                         if(!visualization && !rendered && !renderInProgress) { // There's no visualization object -> create it with proper filters
                             renderInProgress = true;
+                            const rawVis     = raw.filter(item => item && item.id === $scope.visID);
+                            visualization    = await wzsavedVisualizations.get($scope.visID,rawVis[0]);
+                            rawFilters       = visualization.searchSource.get('filter');                           
 
-                            const rawVis = raw.filter(item => item && item.id === $scope.visID);
-                            wzsavedVisualizations.get($scope.visID,rawVis[0]).then(savedObj => {
-                                rawFilters = savedObj.searchSource.get('filter');
-                                originalImplicitFilter = savedObj.searchSource.get('query')['query'];
-                                visualization = savedObj;
-                                
-                                // There's an original filter
-                                if (originalImplicitFilter.length > 0 ) {
-                                    // And also a pending one -> concatenate them
-                                    if (typeof discoverList[0].query === 'string' && discoverList[0].query.length > 0) {
-                                        implicitFilter = originalImplicitFilter + ' AND ' + discoverList[0].query;
-                                    } else {
-                                        // Only the original filter
-                                        implicitFilter = originalImplicitFilter;
-                                    }
-                                } else {
-                                    // Other case, use the pending one, if it is empty, it won't matter
-                                    implicitFilter = discoverList ? discoverList[0].query : '';
-                                }
+                            // Other case, use the pending one, if it is empty, it won't matter
+                            implicitFilter = discoverList ? discoverList[0].query : '';
 
-                                if ($scope.visID !== 'Wazuh-App-Overview-General-Agents-status' && !$scope.visID.includes('Cluster')) { // We don't want to filter that visualization as it uses another index-pattern
-                                    visualization.searchSource
-                                    .query({ language: discoverList[0].language || 'lucene', query: implicitFilter })
-                                    .set('filter',  discoverList.length > 1 ? [...discoverList[1],...rawFilters] : rawFilters);
-                                } else {
-                                    
-                                    // Checks for cluster.name filter existence 
-                                    const monitoringFilter = discoverList[1].filter(item => item && item.meta && item.meta.key && item.meta.key.includes('cluster.name'));
-                                    
-                                    // Applying specific filter to Agents status
-                                    if(Array.isArray(monitoringFilter) && monitoringFilter.length) {
-                                        visualization.searchSource.filter(monitoringFilter[0]);
-                                    }
-                                }
+                            setSearchSource(discoverList);
 
-                                let params = {};
-
-                                if ($scope.specificTimeRange) {
-                                    const timeRange = {
-                                        from: 'now-1d/d',
-                                        to: 'now'
-                                    };
-                                    params = {timeRange: timeRange}
-                                }
-                                $(`[vis-id="'${$scope.visID}'"]`).on('renderStart', () => {
-                                //$("#"+$scope.visID).on('renderStart', () => {
-                                    // TBD: Use renderStart to couple it with renderComplete?
-                                });
-    
-                                visHandler = loader.embedVisualizationWithSavedObject($(`[vis-id="'${$scope.visID}'"]`), visualization, params); 
-          
-                                visHandlers.addItem(visHandler);
-                                visHandler.addRenderCompleteListener(renderComplete);
-                            }).catch(error => {
-                                if(error && error.message && error.message.includes('not locate that index-pattern-field')){
-                                    errorHandler.handle(`${error.message}, please restart Kibana and refresh this page once done`,'Visualize')
-                                } else {
-                                    errorHandler.handle(error,'Visualize')
-                                }
-                            });     
+                            visHandler = loader.embedVisualizationWithSavedObject($(`[vis-id="'${$scope.visID}'"]`), visualization, {}); 
+        
+                            visHandlers.addItem(visHandler);
+                            visHandler.addRenderCompleteListener(renderComplete);
                             
                         } else if (rendered) { // There's a visualization object -> just update its filters
-
-                            // There's an original filter
-                            if (originalImplicitFilter.length > 0 ) {
-                                // And also a pending one -> concatenate them
-                                if (discoverList[0].query === 'string' && discoverList[0].query.length > 0) {
-                                    implicitFilter = originalImplicitFilter + ' AND ' + discoverList[0].query;
-                                } else {
-                                    // Only the original filter
-                                    implicitFilter = originalImplicitFilter;
-                                }
-                            } else {
-                                // Other case, use the pending one, if it is empty, it won't matter
-                                implicitFilter = discoverList ? discoverList[0].query : '';
-                            }
+    
+                            // Use the pending one, if it is empty, it won't matter
+                            implicitFilter = discoverList ? discoverList[0].query : '';
                             
-                            if ($scope.visID !== 'Wazuh-App-Overview-General-Agents-status') { // We don't want to filter that visualization as it uses another index-pattern
-                                visualization.searchSource
-                                .query({ language: discoverList[0].language || 'lucene', query: implicitFilter })
-                                .set('filter', discoverList.length > 1 ? [...discoverList[1],...rawFilters] : rawFilters);
-                            } else {
-                                    
-                                // Checks for cluster.name filter existence 
-                                const monitoringFilter = discoverList[1].filter(item => item && item.meta && item.meta.key && item.meta.key.includes('cluster.name'));
-                                
-                                // Applying specific filter to Agents status
-                                if(Array.isArray(monitoringFilter) && monitoringFilter.length) {
-                                    visualization.searchSource.filter(monitoringFilter[0]);
-                                }
-                            }
+                            setSearchSource(discoverList);
                         }
                     }
-                };
+                } catch (error) {
+                    if(error && error.message && error.message.includes('not locate that index-pattern-field')){
+                        errorHandler.handle(`${error.message}, please restart Kibana and refresh this page once done`,'Visualize');
+                    } else {
+                        errorHandler.handle(error,'Visualize');
+                    }
+                }
 
-                // Listen for changes
-                const updateVisWatcher = $rootScope.$on('updateVis', () => {
+                return; 
+            };
+
+            // Listen for changes
+            const updateVisWatcher = $rootScope.$on('updateVis', () => {
+                if(!$rootScope.$$phase) $rootScope.$digest();
+                const rawVis = rawVisualizations.getList();
+                if(Array.isArray(rawVis) && rawVis.length){
+                    myRender(rawVis);
+                }
+            });
+
+            $scope.$on('$destroy',() => updateVisWatcher());
+
+            const renderComplete = () => {
+                rendered = true;
+
+                loadedVisualizations.addItem(true);
+
+                const currentCompleted = Math.round((loadedVisualizations.getList().length / tabVisualizations.getItem(tabVisualizations.getTab())) * 100);
+                $rootScope.loadingStatus = `Rendering visualizations... ${currentCompleted > 100 ? 100 : currentCompleted} %`;
+
+                if (currentCompleted >= 100) {
+                    
+                    if ($scope.visID !== 'Wazuh-App-Overview-General-Agents-status') { 
+                        const thereIsData   = visHandlers.hasData();
+                        $rootScope.rendered = thereIsData;
+                        if(!thereIsData) $rootScope.resultState = 'none';
+                        else $rootScope.resultState = 'ready';
+                    }
+                    // Forcing a digest cycle
                     if(!$rootScope.$$phase) $rootScope.$digest();
-                    const rawVis = rawVisualizations.getList();
-                    if(Array.isArray(rawVis) && rawVis.length){
-                        myRender(rawVis);
-                    }
-                });
+                }
+                else if ($scope.visID !== 'Wazuh-App-Overview-General-Agents-status') $rootScope.rendered = false;
+            };
 
-                $scope.$on('$destroy',() => {
-                    updateVisWatcher();
-                })
-
-                const renderComplete = () => {
-                    rendered = true;
-
-                    loadedVisualizations.addItem(true);
-
-                    const currentCompleted = Math.round((loadedVisualizations.getList().length / tabVisualizations.getItem(tabVisualizations.getTab())) * 100);
-                    $rootScope.loadingStatus = `Rendering visualizations... ${currentCompleted > 100 ? 100 : currentCompleted} %`;
-
-                    if (currentCompleted >= 100) {
-                        
-                        if ($scope.visID !== 'Wazuh-App-Overview-General-Agents-status') { 
-                            const thereIsData   = visHandlers.hasData();
-                            $rootScope.rendered = thereIsData;
-                            if(!thereIsData) $rootScope.resultState = 'none'
-                            else $rootScope.resultState = 'ready'
-                        }
-                        // Forcing a digest cycle
-                        if(!$rootScope.$$phase) $rootScope.$digest();
-                    }
-                    else if ($scope.visID !== 'Wazuh-App-Overview-General-Agents-status') $rootScope.rendered = false;
-                };
-
-                // Initializing the visualization
-                const loader = ownLoader.getVisualizeLoader();
-            }
+            // Initializing the visualization
+            const loader = ownLoader.getVisualizeLoader();
         }
-    }]);
+    };
+}]);

--- a/public/less/common.less
+++ b/public/less/common.less
@@ -397,10 +397,7 @@ kbn-vis .vis-container {
     margin-bottom: 30px;
 }
 
-.wz-always-top {
-    z-index: 9999 !important;
-}
-
+.wz-always-top,
 .kuiLocalSearchAssistedInput__assistance {
-    display: none !important;
+    z-index: 9999 !important;
 }

--- a/public/templates/manager/monitoring/main-timelions.html
+++ b/public/templates/manager/monitoring/main-timelions.html
@@ -14,14 +14,14 @@
         <md-card-content class="wazuh-column">
             <span class="wz-headline-title">Cluster alerts summary</span>
             <md-divider class="wz-margin-top-10"></md-divider>
-            <kbn-vis specific-time-range="true" vis-id="'Wazuh-App-Cluster-Overview-Manager'" id="Wazuh-App-Cluster-Overview-Manager"></kbn-vis>
+            <kbn-vis vis-id="'Wazuh-App-Cluster-Overview-Manager'" id="Wazuh-App-Cluster-Overview-Manager"></kbn-vis>
         </md-card-content>
     </md-card>
     <md-card flex class="wz-md-card">
         <md-card-content class="wazuh-column">
             <span class="wz-headline-title">Alerts by node summary</span>
             <md-divider class="wz-margin-top-10"></md-divider>
-            <kbn-vis specific-time-range="true" vis-id="'Wazuh-App-Cluster-Overview'" id="Wazuh-App-Cluster-Overview"></kbn-vis>
+            <kbn-vis vis-id="'Wazuh-App-Cluster-Overview'" id="Wazuh-App-Cluster-Overview"></kbn-vis>
         </md-card-content>
     </md-card>
 </div>

--- a/public/templates/overview/overview-fim.html
+++ b/public/templates/overview/overview-fim.html
@@ -62,14 +62,13 @@
                 <kbn-vis id="Wazuh-App-Overview-FIM-Root-user-file-changes" vis-id="'Wazuh-App-Overview-FIM-Root-user-file-changes'"></kbn-vis>
             </md-card-content>
         </md-card>
-        <!-- Temporary disabled due to Kuery researching -->
-        <!--<md-card flex class="wz-md-card">
+        <md-card flex class="wz-md-card">
             <md-card-content class="wazuh-column" >
                 <span class="wz-headline-title">World writable modified files</span>
                 <md-divider class="wz-margin-top-10"></md-divider>
                 <kbn-vis id="Wazuh-App-Overview-FIM-World-writable-modified-files" vis-id="'Wazuh-App-Overview-FIM-World-writable-modified-files'"></kbn-vis>
             </md-card-content>
-        </md-card>-->
+        </md-card>
     </div>
 
     <div layout="row" class="height-570">

--- a/public/templates/overview/overview-fim.html
+++ b/public/templates/overview/overview-fim.html
@@ -62,13 +62,14 @@
                 <kbn-vis id="Wazuh-App-Overview-FIM-Root-user-file-changes" vis-id="'Wazuh-App-Overview-FIM-Root-user-file-changes'"></kbn-vis>
             </md-card-content>
         </md-card>
-        <md-card flex class="wz-md-card">
+        <!-- Temporary disabled due to Kuery researching -->
+        <!--<md-card flex class="wz-md-card">
             <md-card-content class="wazuh-column" >
                 <span class="wz-headline-title">World writable modified files</span>
                 <md-divider class="wz-margin-top-10"></md-divider>
                 <kbn-vis id="Wazuh-App-Overview-FIM-World-writable-modified-files" vis-id="'Wazuh-App-Overview-FIM-World-writable-modified-files'"></kbn-vis>
             </md-card-content>
-        </md-card>
+        </md-card>-->
     </div>
 
     <div layout="row" class="height-570">

--- a/server/controllers/wazuh-elastic.js
+++ b/server/controllers/wazuh-elastic.js
@@ -257,7 +257,7 @@ export default class WazuhElastic {
             const visArray = [];
             let aux_source, bulk_content;
             for (let element of app_objects) {
-            	// Stringify and replace index-pattern for visualizations
+                // Stringify and replace index-pattern for visualizations
                 aux_source = JSON.stringify(element._source);
                 aux_source = aux_source.replace("wazuh-alerts", id);
                 aux_source = JSON.parse(aux_source);
@@ -293,7 +293,7 @@ export default class WazuhElastic {
             let aux_source, bulk_content;
 
             for (const element of app_objects) {
-            	// Stringify and replace index-pattern for visualizations
+                // Stringify and replace index-pattern for visualizations
                 aux_source = JSON.stringify(element._source);
                 aux_source = aux_source.replace("wazuh-alerts", id);
                 aux_source = JSON.parse(aux_source);
@@ -375,11 +375,6 @@ export default class WazuhElastic {
             ) {
                 throw new Error('Missing parameters creating visualizations');
             }
-
-            const tabPrefix = 'cluster';
-
-            const tabSplit = req.params.tab.split('-');
-            const tabSufix = tabSplit[1];
 
             const file        = ClusterVisualizations['monitoring'];
             const nodes       = req.payload.nodes.items;

--- a/server/integration-files/visualizations/agents/agents-audit.js
+++ b/server/integration-files/visualizations/agents/agents-audit.js
@@ -20,8 +20,38 @@ export default [
 			"description": "",
 			"version": 1,
 			"kibanaSavedObjectMeta": {
-				"searchSourceJSON":
-					"{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"rule.groups: audit AND rule.id : 80790\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": `{
+                    "index":"wazuh-alerts",
+                    "filter":[
+                        {
+                            "meta": {
+                                "index": "wazuh-alerts",
+                                "negate": false,
+                                "disabled": false,
+                                "alias": null,
+                                "type": "phrase",
+                                "key": "rule.id",
+                                "value": "80790",
+                                "params": {
+                                "query": "80790",
+                                "type": "phrase"
+                                }
+                            },
+                            "query": {
+                                "match": {
+                                "rule.id": {
+                                    "query": "80790",
+                                    "type": "phrase"
+                                }
+                                }
+                            },
+                            "$state": {
+                                "store": "appState"
+                            }
+                        }
+                    ],
+                    "query":{"query":"","language":"lucene"}
+                }`
 			}
 		},
 		"_type": "visualization"
@@ -35,7 +65,38 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"rule.groups: audit AND rule.id: 80784\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": `{
+                    "index":"wazuh-alerts",
+                    "filter":[
+                        {
+                            "meta": {
+                                "index": "wazuh-alerts",
+                                "negate": false,
+                                "disabled": false,
+                                "alias": null,
+                                "type": "phrase",
+                                "key": "rule.id",
+                                "value": "80784",
+                                "params": {
+                                "query": "80784",
+                                "type": "phrase"
+                                }
+                            },
+                            "query": {
+                                "match": {
+                                "rule.id": {
+                                    "query": "80784",
+                                    "type": "phrase"
+                                }
+                                }
+                            },
+                            "$state": {
+                                "store": "appState"
+                            }
+                        }
+                    ],
+                    "query":{"query":"","language":"lucene"}
+                }`
             }
         },
         "_type": "visualization"
@@ -49,7 +110,47 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"rule.groups: audit AND (rule.id: 80781 OR rule.id: 80787)\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": `{
+                    "index":"wazuh-alerts",
+                    "filter":[
+                        {
+                            "meta": {
+                              "index": "wazuh-alerts",
+                              "type": "phrases",
+                              "key": "rule.id",
+                              "value": "80781, 80787",
+                              "params": [
+                                "80781",
+                                "80787"
+                              ],
+                              "negate": false,
+                              "disabled": false,
+                              "alias": null
+                            },
+                            "query": {
+                              "bool": {
+                                "should": [
+                                  {
+                                    "match_phrase": {
+                                      "rule.id": "80781"
+                                    }
+                                  },
+                                  {
+                                    "match_phrase": {
+                                      "rule.id": "80787"
+                                    }
+                                  }
+                                ],
+                                "minimum_should_match": 1
+                              }
+                            },
+                            "$state": {
+                              "store": "appState"
+                            }
+                          }
+                    ],
+                    "query":{"query":"","language":"lucene"}
+                }`
             }
         },
         "_type": "visualization"
@@ -63,7 +164,38 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"rule.groups: audit AND rule.id: 80791\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": `{
+                    "index":"wazuh-alerts",
+                    "filter":[
+                        {
+                            "meta": {
+                                "index": "wazuh-alerts",
+                                "negate": false,
+                                "disabled": false,
+                                "alias": null,
+                                "type": "phrase",
+                                "key": "rule.id",
+                                "value": "80791",
+                                "params": {
+                                "query": "80791",
+                                "type": "phrase"
+                                }
+                            },
+                            "query": {
+                                "match": {
+                                "rule.id": {
+                                    "query": "80791",
+                                    "type": "phrase"
+                                }
+                                }
+                            },
+                            "$state": {
+                                "store": "appState"
+                            }
+                        }
+                    ],
+                    "query":{"query":"","language":"lucene"}
+                }`
             }
         },
         "_type": "visualization"
@@ -77,7 +209,7 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"rule.groups: audit\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"\",\"language\":\"lucene\"}}"
             }
         },
         "_type": "visualization"
@@ -91,7 +223,7 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"rule.groups: audit\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"\",\"language\":\"lucene\"}}"
             }
         },
         "_type": "visualization"
@@ -105,7 +237,7 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"rule.groups: audit\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"\",\"language\":\"lucene\"}}"
             }
         },
         "_type": "visualization"
@@ -119,7 +251,7 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"rule.groups: audit\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"\",\"language\":\"lucene\"}}"
             }
         },
         "_type": "visualization"
@@ -133,7 +265,7 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"rule.groups: audit\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"\",\"language\":\"lucene\"}}"
             }
         },
         "_type": "visualization"
@@ -147,7 +279,38 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"rule.groups: audit AND rule.id: 80784\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": `{
+                    "index":"wazuh-alerts",
+                    "filter":[
+                        {
+                            "meta": {
+                                "index": "wazuh-alerts",
+                                "negate": false,
+                                "disabled": false,
+                                "alias": null,
+                                "type": "phrase",
+                                "key": "rule.id",
+                                "value": "80784",
+                                "params": {
+                                "query": "80784",
+                                "type": "phrase"
+                                }
+                            },
+                            "query": {
+                                "match": {
+                                "rule.id": {
+                                    "query": "80784",
+                                    "type": "phrase"
+                                }
+                                }
+                            },
+                            "$state": {
+                                "store": "appState"
+                            }
+                        }
+                    ],
+                    "query":{"query":"","language":"lucene"}
+                }`
             }
         },
         "_type": "visualization"
@@ -161,7 +324,38 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"rule.groups: audit AND rule.id: 80781\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": `{
+                    "index":"wazuh-alerts",
+                    "filter":[
+                        {
+                            "meta": {
+                              "index": "wazuh-alerts",
+                              "negate": false,
+                              "disabled": false,
+                              "alias": null,
+                              "type": "phrase",
+                              "key": "rule.id",
+                              "value": "80781",
+                              "params": {
+                                "query": "80781",
+                                "type": "phrase"
+                              }
+                            },
+                            "query": {
+                              "match": {
+                                "rule.id": {
+                                  "query": "80781",
+                                  "type": "phrase"
+                                }
+                              }
+                            },
+                            "$state": {
+                              "store": "appState"
+                            }
+                          }
+                    ],
+                    "query":{"query":"","language":"lucene"}
+                }`
             }
         },
         "_type": "visualization"
@@ -175,7 +369,7 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"rule.groups: audit\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"\",\"language\":\"lucene\"}}"
             }
         },
         "_type": "visualization"
@@ -189,7 +383,38 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"rule.groups: audit AND rule.id: 80790\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": `{
+                    "index":"wazuh-alerts",
+                    "filter":[
+                        {
+                            "meta": {
+                              "index": "wazuh-alerts",
+                              "negate": false,
+                              "disabled": false,
+                              "alias": null,
+                              "type": "phrase",
+                              "key": "rule.id",
+                              "value": "80790",
+                              "params": {
+                                "query": "80790",
+                                "type": "phrase"
+                              }
+                            },
+                            "query": {
+                              "match": {
+                                "rule.id": {
+                                  "query": "80790",
+                                  "type": "phrase"
+                                }
+                              }
+                            },
+                            "$state": {
+                              "store": "appState"
+                            }
+                          }
+                    ],
+                    "query":{"query":"","language":"lucene"}
+                }`
             }
         },
         "_type": "visualization"
@@ -203,7 +428,38 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"rule.groups: audit AND rule.id: 80791\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": `{
+                    "index":"wazuh-alerts",
+                    "filter":[
+                        {
+                            "meta": {
+                              "index": "wazuh-alerts",
+                              "negate": false,
+                              "disabled": false,
+                              "alias": null,
+                              "type": "phrase",
+                              "key": "rule.id",
+                              "value": "80791",
+                              "params": {
+                                "query": "80791",
+                                "type": "phrase"
+                              }
+                            },
+                            "query": {
+                              "match": {
+                                "rule.id": {
+                                  "query": "80791",
+                                  "type": "phrase"
+                                }
+                              }
+                            },
+                            "$state": {
+                              "store": "appState"
+                            }
+                          }
+                    ],
+                    "query":{"query":"","language":"lucene"}
+                }`
             }
         },
         "_type": "visualization"
@@ -218,7 +474,7 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"rule.groups: audit\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"\",\"language\":\"lucene\"}}"
             }
         }
     }

--- a/server/integration-files/visualizations/agents/agents-ciscat.js
+++ b/server/integration-files/visualizations/agents/agents-ciscat.js
@@ -19,7 +19,7 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"rule.groups: ciscat\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"\",\"language\":\"lucene\"}}"
             }
         }
     },
@@ -33,7 +33,7 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"rule.groups: ciscat\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"\",\"language\":\"lucene\"}}"
             }
         }
     },
@@ -47,7 +47,7 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"rule.groups: ciscat\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"\",\"language\":\"lucene\"}}"
             }
         }
     },
@@ -61,7 +61,7 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"rule.groups: ciscat\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"\",\"language\":\"lucene\"}}"
             }
         }
     },
@@ -75,7 +75,7 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"rule.groups: ciscat\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"\",\"language\":\"lucene\"}}"
             }
         }
     },
@@ -89,7 +89,7 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"rule.groups: ciscat\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"\",\"language\":\"lucene\"}}"
             }
         }
     },
@@ -103,7 +103,7 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"rule.groups: ciscat\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"\",\"language\":\"lucene\"}}"
             }
         }
     },
@@ -117,7 +117,7 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"rule.groups: ciscat\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"\",\"language\":\"lucene\"}}"
             }
         }
     },
@@ -131,7 +131,7 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"rule.groups: ciscat\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"\",\"language\":\"lucene\"}}"
             }
         }
     },
@@ -145,7 +145,7 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"rule.groups: ciscat\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"\",\"language\":\"lucene\"}}"
             }
         }
     },
@@ -159,7 +159,7 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"rule.groups: ciscat\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"\",\"language\":\"lucene\"}}"
             }
         }
     }

--- a/server/integration-files/visualizations/agents/agents-fim.js
+++ b/server/integration-files/visualizations/agents/agents-fim.js
@@ -21,7 +21,7 @@ export default [
 			"version": 1,
 			"kibanaSavedObjectMeta": {
 				"searchSourceJSON":
-					"{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"rule.groups: syscheck\",\"language\":\"lucene\"}}"
+					"{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"\",\"language\":\"lucene\"}}"
 			}
 		},
 		"_type": "visualization"
@@ -35,7 +35,7 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"rule.groups: syscheck\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"\",\"language\":\"lucene\"}}"
             }
         },
         "_type": "visualization"
@@ -49,7 +49,7 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"rule.groups: syscheck\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"\",\"language\":\"lucene\"}}"
             }
         },
         "_type": "visualization"
@@ -63,7 +63,7 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"rule.groups: syscheck\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"\",\"language\":\"lucene\"}}"
             }
         },
         "_type": "visualization"
@@ -77,7 +77,47 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"rule.id: 554 AND NOT location: syscheck-registry\",\"language\":\"lucene\"}}"
+                "searchSourceJSON":`{
+                    "index":"wazuh-alerts",
+                    "filter":[
+                        {
+                            "meta": {
+                              "index": "wazuh-alerts",
+                              "type": "phrases",
+                              "key": "syscheck.event",
+                              "value": "added, readded",
+                              "params": [
+                                "added",
+                                "readded"
+                              ],
+                              "negate": false,
+                              "disabled": false,
+                              "alias": null
+                            },
+                            "query": {
+                              "bool": {
+                                "should": [
+                                  {
+                                    "match_phrase": {
+                                      "syscheck.event": "added"
+                                    }
+                                  },
+                                  {
+                                    "match_phrase": {
+                                      "syscheck.event": "readded"
+                                    }
+                                  }
+                                ],
+                                "minimum_should_match": 1
+                              }
+                            },
+                            "$state": {
+                              "store": "appState"
+                            }
+                          }
+                    ],
+                    "query":{"query":"","language":"lucene"}
+                }`
             }
         },
         "_type": "visualization"
@@ -91,7 +131,38 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"(rule.id: 550 OR rule.id: 551 OR rule.id: 552 OR rule.id: 555) AND NOT location: syscheck-registry\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": `{
+                    "index":"wazuh-alerts",
+                    "filter":[
+                        {
+                            "meta": {
+                              "index": "wazuh-alerts",
+                              "negate": false,
+                              "disabled": false,
+                              "alias": null,
+                              "type": "phrase",
+                              "key": "syscheck.event",
+                              "value": "modified",
+                              "params": {
+                                "query": "modified",
+                                "type": "phrase"
+                              }
+                            },
+                            "query": {
+                              "match": {
+                                "syscheck.event": {
+                                  "query": "modified",
+                                  "type": "phrase"
+                                }
+                              }
+                            },
+                            "$state": {
+                              "store": "appState"
+                            }
+                          }
+                    ],
+                    "query":{"query":"","language":"lucene"}
+                }`
             }
         },
         "_type": "visualization"
@@ -105,7 +176,38 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"rule.id: 553 AND NOT location: syscheck-registry\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": `{
+                    "index":"wazuh-alerts",
+                    "filter":[
+                        {
+                            "meta": {
+                              "index": "wazuh-alerts",
+                              "negate": false,
+                              "disabled": false,
+                              "alias": null,
+                              "type": "phrase",
+                              "key": "syscheck.event",
+                              "value": "deleted",
+                              "params": {
+                                "query": "deleted",
+                                "type": "phrase"
+                              }
+                            },
+                            "query": {
+                              "match": {
+                                "syscheck.event": {
+                                  "query": "deleted",
+                                  "type": "phrase"
+                                }
+                              }
+                            },
+                            "$state": {
+                              "store": "appState"
+                            }
+                          }
+                    ],
+                    "query":{"query":"","language":"lucene"}
+                }`
             }
         },
         "_type": "visualization"
@@ -120,7 +222,7 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"rule.groups: syscheck\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"\",\"language\":\"lucene\"}}"
             }
         }
     }

--- a/server/integration-files/visualizations/agents/agents-gdpr.js
+++ b/server/integration-files/visualizations/agents/agents-gdpr.js
@@ -11,8 +11,8 @@
  */
 export default [
     {
-	    "_id": "Wazuh-App-Agents-GDPR-Requirements",
-	    "_source": {
+        "_id": "Wazuh-App-Agents-GDPR-Requirements",
+        "_source": {
 			"title": "Requirements",
 			"visState": "{\"title\":\"Requirements\",\"type\":\"histogram\",\"params\":{\"type\":\"histogram\",\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"type\":\"category\",\"position\":\"bottom\",\"show\":true,\"style\":{},\"scale\":{\"type\":\"linear\"},\"labels\":{\"show\":true,\"truncate\":100,\"rotate\":0},\"title\":{}}],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"name\":\"LeftAxis-1\",\"type\":\"value\",\"position\":\"left\",\"show\":true,\"style\":{},\"scale\":{\"type\":\"linear\",\"mode\":\"normal\"},\"labels\":{\"show\":true,\"rotate\":0,\"filter\":false,\"truncate\":100},\"title\":{\"text\":\"Count\"}}],\"seriesParams\":[{\"show\":\"true\",\"type\":\"histogram\",\"mode\":\"stacked\",\"data\":{\"label\":\"Count\",\"id\":\"1\"},\"valueAxis\":\"ValueAxis-1\",\"drawLinesBetweenPoints\":true,\"showCircles\":true}],\"addTooltip\":true,\"addLegend\":true,\"legendPosition\":\"right\",\"times\":[],\"addTimeMarker\":false},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"3\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"group\",\"params\":{\"field\":\"rule.gdpr\",\"size\":5,\"order\":\"desc\",\"orderBy\":\"1\",\"customLabel\":\"\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"segment\",\"params\":{\"field\":\"rule.gdpr\",\"size\":10,\"order\":\"desc\",\"orderBy\":\"1\",\"customLabel\":\"GDPR Requirements\"}}]}",
 			"uiStateJSON": "{}",
@@ -20,10 +20,10 @@ export default [
 			"version": 1,
 			"kibanaSavedObjectMeta": {
 				"searchSourceJSON":
-					"{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"_exists_:rule.gdpr\",\"language\":\"lucene\"}}"
+					"{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"\",\"language\":\"lucene\"}}"
 			}
-	    },
-	    "_type": "visualization"
+        },
+        "_type": "visualization"
 	},
     {
         "_id": "Wazuh-App-Agents-GDPR-Groups",
@@ -34,7 +34,7 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"_exists_:rule.gdpr\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"\",\"language\":\"lucene\"}}"
             }
         },
         "_type": "visualization"
@@ -49,7 +49,7 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"_exists_:rule.gdpr\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"\",\"language\":\"lucene\"}}"
             }
         }
     }

--- a/server/integration-files/visualizations/agents/agents-oscap.js
+++ b/server/integration-files/visualizations/agents/agents-oscap.js
@@ -63,7 +63,38 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"data.oscap.check.result: fail AND rule.groups: oscap\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": `{
+                    "index":"wazuh-alerts",
+                    "filter":[
+                        {
+                            "meta": {
+                              "index": "wazuh-alerts",
+                              "negate": false,
+                              "disabled": false,
+                              "alias": null,
+                              "type": "phrase",
+                              "key": "data.oscap.check.result",
+                              "value": "fail",
+                              "params": {
+                                "query": "fail",
+                                "type": "phrase"
+                              }
+                            },
+                            "query": {
+                              "match": {
+                                "data.oscap.check.result": {
+                                  "query": "fail",
+                                  "type": "phrase"
+                                }
+                              }
+                            },
+                            "$state": {
+                              "store": "appState"
+                            }
+                        }
+                    ],
+                    "query":{"query":"","language":"lucene"}
+                }`
             }
         },
         "_type": "visualization"
@@ -91,7 +122,64 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"data.oscap.check.result: fail AND rule.groups:oscap AND NOT rule.groups: syslog\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": `{
+                    "index":"wazuh-alerts",
+                    "filter":[
+                        {
+                            "meta": {
+                              "index": "wazuh-alerts",
+                              "negate": false,
+                              "disabled": false,
+                              "alias": null,
+                              "type": "phrase",
+                              "key": "data.oscap.check.result",
+                              "value": "fail",
+                              "params": {
+                                "query": "fail",
+                                "type": "phrase"
+                              }
+                            },
+                            "query": {
+                              "match": {
+                                "data.oscap.check.result": {
+                                  "query": "fail",
+                                  "type": "phrase"
+                                }
+                              }
+                            },
+                            "$state": {
+                              "store": "appState"
+                            }
+                          },
+                          {
+                            "meta": {
+                              "index": "wazuh-alerts",
+                              "negate": true,
+                              "disabled": false,
+                              "alias": null,
+                              "type": "phrase",
+                              "key": "rule.groups",
+                              "value": "syslog",
+                              "params": {
+                                "query": "syslog",
+                                "type": "phrase"
+                              }
+                            },
+                            "query": {
+                              "match": {
+                                "rule.groups": {
+                                  "query": "syslog",
+                                  "type": "phrase"
+                                }
+                              }
+                            },
+                            "$state": {
+                              "store": "appState"
+                            }
+                          }
+                     ],
+                    "query":{"query":"","language":"lucene"}
+                }`
             }
         },
         "_type": "visualization"
@@ -105,7 +193,64 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"data.oscap.check.result: fail AND rule.groups:oscap AND NOT rule.groups: syslog\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": `{
+                    "index":"wazuh-alerts",
+                    "filter":[
+                        {
+                            "meta": {
+                              "index": "wazuh-alerts",
+                              "negate": false,
+                              "disabled": false,
+                              "alias": null,
+                              "type": "phrase",
+                              "key": "data.oscap.check.result",
+                              "value": "fail",
+                              "params": {
+                                "query": "fail",
+                                "type": "phrase"
+                              }
+                            },
+                            "query": {
+                              "match": {
+                                "data.oscap.check.result": {
+                                  "query": "fail",
+                                  "type": "phrase"
+                                }
+                              }
+                            },
+                            "$state": {
+                              "store": "appState"
+                            }
+                          },
+                          {
+                            "meta": {
+                              "index": "wazuh-alerts",
+                              "negate": true,
+                              "disabled": false,
+                              "alias": null,
+                              "type": "phrase",
+                              "key": "rule.groups",
+                              "value": "syslog",
+                              "params": {
+                                "query": "syslog",
+                                "type": "phrase"
+                              }
+                            },
+                            "query": {
+                              "match": {
+                                "rule.groups": {
+                                  "query": "syslog",
+                                  "type": "phrase"
+                                }
+                              }
+                            },
+                            "$state": {
+                              "store": "appState"
+                            }
+                          }
+                     ],
+                    "query":{"query":"","language":"lucene"}
+                }`
             }
         },
         "_type": "visualization"
@@ -119,7 +264,64 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"data.oscap.check.result: fail AND rule.groups:oscap AND NOT rule.groups: syslog\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": `{
+                    "index":"wazuh-alerts",
+                    "filter":[
+                        {
+                            "meta": {
+                              "index": "wazuh-alerts",
+                              "negate": false,
+                              "disabled": false,
+                              "alias": null,
+                              "type": "phrase",
+                              "key": "data.oscap.check.result",
+                              "value": "fail",
+                              "params": {
+                                "query": "fail",
+                                "type": "phrase"
+                              }
+                            },
+                            "query": {
+                              "match": {
+                                "data.oscap.check.result": {
+                                  "query": "fail",
+                                  "type": "phrase"
+                                }
+                              }
+                            },
+                            "$state": {
+                              "store": "appState"
+                            }
+                          },
+                          {
+                            "meta": {
+                              "index": "wazuh-alerts",
+                              "negate": true,
+                              "disabled": false,
+                              "alias": null,
+                              "type": "phrase",
+                              "key": "rule.groups",
+                              "value": "syslog",
+                              "params": {
+                                "query": "syslog",
+                                "type": "phrase"
+                              }
+                            },
+                            "query": {
+                              "match": {
+                                "rule.groups": {
+                                  "query": "syslog",
+                                  "type": "phrase"
+                                }
+                              }
+                            },
+                            "$state": {
+                              "store": "appState"
+                            }
+                          }
+                     ],
+                    "query":{"query":"","language":"lucene"}
+                }`
             }
         },
         "_type": "visualization"
@@ -133,7 +335,38 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"rule.groups: oscap AND data.oscap.check.result:fail\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": `{
+                    "index":"wazuh-alerts",
+                    "filter":[
+                        {
+                            "meta": {
+                              "index": "wazuh-alerts",
+                              "negate": false,
+                              "disabled": false,
+                              "alias": null,
+                              "type": "phrase",
+                              "key": "data.oscap.check.result",
+                              "value": "fail",
+                              "params": {
+                                "query": "fail",
+                                "type": "phrase"
+                              }
+                            },
+                            "query": {
+                              "match": {
+                                "data.oscap.check.result": {
+                                  "query": "fail",
+                                  "type": "phrase"
+                                }
+                              }
+                            },
+                            "$state": {
+                              "store": "appState"
+                            }
+                        }
+                    ],
+                    "query":{"query":"","language":"lucene"}
+                }`
             }
         },
         "_type": "visualization"
@@ -147,7 +380,38 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"data.oscap.check.result: fail AND rule.groups:oscap AND rule.groups: oscap-result AND data.oscap.check.result:fail\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": `{
+                    "index":"wazuh-alerts",
+                    "filter":[
+                        {
+                            "meta": {
+                              "index": "wazuh-alerts",
+                              "negate": false,
+                              "disabled": false,
+                              "alias": null,
+                              "type": "phrase",
+                              "key": "data.oscap.check.result",
+                              "value": "fail",
+                              "params": {
+                                "query": "fail",
+                                "type": "phrase"
+                              }
+                            },
+                            "query": {
+                              "match": {
+                                "data.oscap.check.result": {
+                                  "query": "fail",
+                                  "type": "phrase"
+                                }
+                              }
+                            },
+                            "$state": {
+                              "store": "appState"
+                            }
+                        }
+                    ],
+                    "query":{"query":"","language":"lucene"}
+                }`
             }
         },
         "_type": "visualization"
@@ -161,7 +425,64 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"data.oscap.check.severity: high AND data.oscap.check.result: fail AND rule.groups:oscap AND rule.groups: oscap-result AND data.oscap.check.result:fail\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": `{
+                    "index":"wazuh-alerts",
+                    "filter":[
+                        {
+                            "meta": {
+                              "index": "wazuh-alerts",
+                              "negate": false,
+                              "disabled": false,
+                              "alias": null,
+                              "type": "phrase",
+                              "key": "data.oscap.check.result",
+                              "value": "fail",
+                              "params": {
+                                "query": "fail",
+                                "type": "phrase"
+                              }
+                            },
+                            "query": {
+                              "match": {
+                                "data.oscap.check.result": {
+                                  "query": "fail",
+                                  "type": "phrase"
+                                }
+                              }
+                            },
+                            "$state": {
+                              "store": "appState"
+                            }
+                        },
+                        {
+                            "meta": {
+                              "index": "wazuh-alerts",
+                              "negate": false,
+                              "disabled": false,
+                              "alias": null,
+                              "type": "phrase",
+                              "key": "data.oscap.check.severity",
+                              "value": "high",
+                              "params": {
+                                "query": "high",
+                                "type": "phrase"
+                              }
+                            },
+                            "query": {
+                              "match": {
+                                "data.oscap.check.severity": {
+                                  "query": "high",
+                                  "type": "phrase"
+                                }
+                              }
+                            },
+                            "$state": {
+                              "store": "appState"
+                            }
+                        }
+                    ],
+                    "query":{"query":"","language":"lucene"}
+                }`
             }
         },
         "_type": "visualization"
@@ -175,7 +496,38 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"data.oscap.check.result: fail AND rule.groups:oscap\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": `{
+                    "index":"wazuh-alerts",
+                    "filter":[
+                        {
+                            "meta": {
+                              "index": "wazuh-alerts",
+                              "negate": false,
+                              "disabled": false,
+                              "alias": null,
+                              "type": "phrase",
+                              "key": "data.oscap.check.result",
+                              "value": "fail",
+                              "params": {
+                                "query": "fail",
+                                "type": "phrase"
+                              }
+                            },
+                            "query": {
+                              "match": {
+                                "data.oscap.check.result": {
+                                  "query": "fail",
+                                  "type": "phrase"
+                                }
+                              }
+                            },
+                            "$state": {
+                              "store": "appState"
+                            }
+                        }
+                    ],
+                    "query":{"query":"","language":"lucene"}
+                }`
             }
         },
         "_type": "visualization"
@@ -189,7 +541,7 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"rule.groups: oscap\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"\",\"language\":\"lucene\"}}"
             }
         }
     }

--- a/server/integration-files/visualizations/agents/agents-pci.js
+++ b/server/integration-files/visualizations/agents/agents-pci.js
@@ -20,7 +20,7 @@ export default [
 			"version": 1,
 			"kibanaSavedObjectMeta": {
 				"searchSourceJSON":
-					"{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"_exists_:rule.pci_dss\",\"language\":\"lucene\"}}"
+					"{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"\",\"language\":\"lucene\"}}"
 			}
 	    },
 	    "_type": "visualization"
@@ -34,7 +34,7 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"_exists_:rule.pci_dss\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"\",\"language\":\"lucene\"}}"
             }
         },
         "_type": "visualization"
@@ -49,7 +49,7 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"_exists_:rule.pci_dss\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"\",\"language\":\"lucene\"}}"
             }
         }
     }

--- a/server/integration-files/visualizations/agents/agents-pm.js
+++ b/server/integration-files/visualizations/agents/agents-pm.js
@@ -21,7 +21,7 @@ export default [
 			"version": 1,
 			"kibanaSavedObjectMeta": {
 				"searchSourceJSON":
-					"{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"rule.groups: rootcheck\",\"language\":\"lucene\"}}"
+					"{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"\",\"language\":\"lucene\"}}"
 			}
 		},
 		"_type": "visualization"
@@ -35,7 +35,7 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"rule.groups: rootcheck\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"\",\"language\":\"lucene\"}}"
             }
         },
         "_type": "visualization"
@@ -49,7 +49,7 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"rule.groups: rootcheck\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"\",\"language\":\"lucene\"}}"
             }
         },
         "_type": "visualization"
@@ -64,7 +64,7 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"rule.groups: rootcheck\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"\",\"language\":\"lucene\"}}"
             }
         }
     }

--- a/server/integration-files/visualizations/agents/agents-virustotal.js
+++ b/server/integration-files/visualizations/agents/agents-virustotal.js
@@ -14,14 +14,14 @@ export default [
 		"_id": "Wazuh-App-Agents-Virustotal-Last-Files-Pie",
 		"_type": "visualization",
 		"_source": {
-		  "title": "Last files",
-		  "visState": "{\"title\":\"Last files\",\"type\":\"pie\",\"params\":{\"type\":\"pie\",\"addTooltip\":true,\"addLegend\":true,\"legendPosition\":\"right\",\"isDonut\":true,\"labels\":{\"show\":false,\"values\":true,\"last_level\":true,\"truncate\":100}},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{\"customLabel\":\"Files\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"segment\",\"params\":{\"field\":\"data.virustotal.source.file\",\"size\":5,\"order\":\"desc\",\"orderBy\":\"1\"}}]}",
-		  "uiStateJSON": "{\"vis\":{\"legendOpen\":true}}",
-		  "description": "",
-		  "version": 1,
-		  "kibanaSavedObjectMeta": {
+            "title": "Last files",
+            "visState": "{\"title\":\"Last files\",\"type\":\"pie\",\"params\":{\"type\":\"pie\",\"addTooltip\":true,\"addLegend\":true,\"legendPosition\":\"right\",\"isDonut\":true,\"labels\":{\"show\":false,\"values\":true,\"last_level\":true,\"truncate\":100}},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{\"customLabel\":\"Files\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"segment\",\"params\":{\"field\":\"data.virustotal.source.file\",\"size\":5,\"order\":\"desc\",\"orderBy\":\"1\"}}]}",
+            "uiStateJSON": "{\"vis\":{\"legendOpen\":true}}",
+            "description": "",
+            "version": 1,
+            "kibanaSavedObjectMeta": {
 			"searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"\",\"language\":\"lucene\"}}"
-		  }
+            }
 		}
     },
     {
@@ -48,7 +48,38 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"data.virustotal.malicious: 1\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": `{
+                    "index":"wazuh-alerts",
+                    "filter":[
+                        {
+                            "meta": {
+                              "index": "wazuh-alerts",
+                              "negate": false,
+                              "disabled": false,
+                              "alias": null,
+                              "type": "phrase",
+                              "key": "data.virustotal.malicious",
+                              "value": "1",
+                              "params": {
+                                "query": "1",
+                                "type": "phrase"
+                              }
+                            },
+                            "query": {
+                              "match": {
+                                "data.virustotal.malicious": {
+                                  "query": "1",
+                                  "type": "phrase"
+                                }
+                              }
+                            },
+                            "$state": {
+                              "store": "appState"
+                            }
+                          }
+                    ],
+                    "query":{"query":"","language":"lucene"}
+                }`
             }
         }
     },
@@ -62,7 +93,55 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"_exists_:data.virustotal.positives AND NOT data.virustotal.positives: 0\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": `{
+                    "index":"wazuh-alerts",
+                    "filter":[
+                        {
+                            "meta": {
+                              "index": "wazuh-alerts",
+                              "negate": false,
+                              "disabled": false,
+                              "alias": null,
+                              "type": "exists",
+                              "key": "data.virustotal.positives",
+                              "value": "exists"
+                            },
+                            "exists": {
+                              "field": "data.virustotal.positives"
+                            },
+                            "$state": {
+                              "store": "appState"
+                            }
+                          },
+                          {
+                            "meta": {
+                              "index": "wazuh-alerts",
+                              "negate": true,
+                              "disabled": false,
+                              "alias": null,
+                              "type": "phrase",
+                              "key": "data.virustotal.positives",
+                              "value": "0",
+                              "params": {
+                                "query": 0,
+                                "type": "phrase"
+                              }
+                            },
+                            "query": {
+                              "match": {
+                                "data.virustotal.positives": {
+                                  "query": 0,
+                                  "type": "phrase"
+                                }
+                              }
+                            },
+                            "$state": {
+                              "store": "appState"
+                            }
+                          }
+                    ],
+                    "query":{"query":"","language":"lucene"}
+                }`
             }
         }
     },
@@ -76,7 +155,55 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"_exists_:data.virustotal.malicious AND NOT data.virustotal.malicious: 0\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": `{
+                    "index":"wazuh-alerts",
+                    "filter":[
+                        {
+                            "meta": {
+                              "index": "wazuh-alerts",
+                              "negate": false,
+                              "disabled": false,
+                              "alias": null,
+                              "type": "exists",
+                              "key": "data.virustotal.positives",
+                              "value": "exists"
+                            },
+                            "exists": {
+                              "field": "data.virustotal.positives"
+                            },
+                            "$state": {
+                              "store": "appState"
+                            }
+                          },
+                          {
+                            "meta": {
+                              "index": "wazuh-alerts",
+                              "negate": true,
+                              "disabled": false,
+                              "alias": null,
+                              "type": "phrase",
+                              "key": "data.virustotal.positives",
+                              "value": "0",
+                              "params": {
+                                "query": 0,
+                                "type": "phrase"
+                              }
+                            },
+                            "query": {
+                              "match": {
+                                "data.virustotal.positives": {
+                                  "query": 0,
+                                  "type": "phrase"
+                                }
+                              }
+                            },
+                            "$state": {
+                              "store": "appState"
+                            }
+                          }
+                    ],
+                    "query":{"query":"","language":"lucene"}
+                }`
             }
         }
     },
@@ -90,50 +217,28 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"_exists_:data.virustotal\",\"language\":\"lucene\"}}"
-            }
-        }
-    },
-    {
-        "_id": "Wazuh-App-Agents-Virustotal-Malicious-Per-Agent-Table",
-        "_type": "visualization",
-        "_source": {
-            "title": "Malicious Per Agent Table",
-            "visState": "{\"title\":\"Malicious Per Agent Table\",\"type\":\"table\",\"params\":{\"perPage\":10,\"showPartialRows\":false,\"showMeticsAtAllLevels\":false,\"sort\":{\"columnIndex\":null,\"direction\":null},\"showTotal\":false,\"totalFunc\":\"sum\"},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"cardinality\",\"schema\":\"metric\",\"params\":{\"field\":\"data.virustotal.source.md5\",\"customLabel\":\"Malicious detected files\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"bucket\",\"params\":{\"field\":\"agent.name\",\"size\":16,\"order\":\"desc\",\"orderBy\":\"1\",\"customLabel\":\"Agent\"}}]}",
-            "uiStateJSON": "{\"vis\":{\"params\":{\"sort\":{\"columnIndex\":null,\"direction\":null}}}}",
-            "description": "",
-            "version": 1,
-            "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"NOT data.virustotal.malicious: 0\",\"language\":\"lucene\"}}"
-            }
-        }
-    },
-    {
-        "_id": "Wazuh-App-Agents-Virustotal-Malicious-Per-Agent",
-        "_type": "visualization",
-        "_source": {
-            "title": "Malicious Per Agent",
-            "visState": "{\"title\":\"Malicious Per Agent\",\"type\":\"pie\",\"params\":{\"type\":\"pie\",\"addTooltip\":true,\"addLegend\":true,\"legendPosition\":\"right\",\"isDonut\":true,\"labels\":{\"show\":false,\"values\":true,\"last_level\":true,\"truncate\":100}},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"cardinality\",\"schema\":\"metric\",\"params\":{\"field\":\"data.virustotal.source.md5\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"segment\",\"params\":{\"field\":\"agent.name\",\"size\":5,\"order\":\"desc\",\"orderBy\":\"1\"}}]}",
-            "uiStateJSON": "{}",
-            "description": "",
-            "version": 1,
-            "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"NOT data.virustotal.malicious: 0\",\"language\":\"lucene\"}}"
-            }
-        }
-    },
-    {
-        "_id": "Wazuh-App-Agents-Virustotal-Positives-Heatmap",
-        "_type": "visualization",
-        "_source": {
-            "title": "Positives Heatmap",
-            "visState": "{\"title\":\"Positives Heatmap\",\"type\":\"heatmap\",\"params\":{\"type\":\"heatmap\",\"addTooltip\":true,\"addLegend\":true,\"enableHover\":false,\"legendPosition\":\"right\",\"times\":[],\"colorsNumber\":7,\"colorSchema\":\"Blues\",\"setColorRange\":false,\"colorsRange\":[],\"invertColors\":false,\"percentageMode\":false,\"valueAxes\":[{\"show\":false,\"id\":\"ValueAxis-1\",\"type\":\"value\",\"scale\":{\"type\":\"linear\",\"defaultYExtents\":false},\"labels\":{\"show\":false,\"rotate\":0,\"color\":\"#555\"}}]},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{\"customLabel\":\"Positives\"}},{\"id\":\"3\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"segment\",\"params\":{\"field\":\"agent.name\",\"size\":10,\"order\":\"desc\",\"orderBy\":\"1\",\"customLabel\":\"Agent\"}},{\"id\":\"4\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"group\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"auto\",\"customInterval\":\"2h\",\"min_doc_count\":1,\"extended_bounds\":{},\"customLabel\":\"Date\"}}]}",
-            "uiStateJSON": "{\"vis\":{\"defaultColors\":{\"0 - 7\":\"rgb(247,251,255)\",\"7 - 13\":\"rgb(219,233,246)\",\"13 - 20\":\"rgb(187,214,235)\",\"20 - 26\":\"rgb(137,190,220)\",\"26 - 33\":\"rgb(83,158,205)\",\"33 - 39\":\"rgb(42,123,186)\",\"39 - 45\":\"rgb(11,85,159)\"},\"legendOpen\":true}}",
-            "description": "",
-            "version": 1,
-            "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"_exists_:data.virustotal AND NOT data.virustotal.positives: 0\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": `{
+                    "index":"wazuh-alerts",
+                    "filter":[{
+                        "meta": {
+                        "index": "wazuh-alerts",
+                        "negate": false,
+                        "disabled": false,
+                        "alias": null,
+                        "type": "exists",
+                        "key": "data.virustotal",
+                        "value": "exists"
+                        },
+                        "exists": {
+                        "field": "data.virustotal"
+                        },
+                        "$state": {
+                        "store": "appState"
+                        }
+                    }],
+                    "query":{"query":"","language":"lucene"}
+                }`
             }
         }
     }
-]
+];

--- a/server/integration-files/visualizations/agents/agents-vuls.js
+++ b/server/integration-files/visualizations/agents/agents-vuls.js
@@ -20,7 +20,7 @@ export default [
 			"description": "",
 			"version": 1,
 			"kibanaSavedObjectMeta": {
-				"searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"rule.groups: vulnerability-detector\",\"language\":\"lucene\"}}"
+				"searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"\",\"language\":\"lucene\"}}"
 			}
 		}
 	},
@@ -34,7 +34,7 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"rule.groups: vulnerability-detector\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"\",\"language\":\"lucene\"}}"
             }
         }
     },
@@ -48,7 +48,7 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"rule.groups: vulnerability-detector\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"\",\"language\":\"lucene\"}}"
             }
         }
     },
@@ -62,7 +62,38 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"rule.groups: vulnerability-detector AND data.vulnerability.severity: Critical\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": `{
+                    "index":"wazuh-alerts",
+                    "filter":[
+                        {
+                            "meta": {
+                              "index": "wazuh-alerts",
+                              "negate": false,
+                              "disabled": false,
+                              "alias": null,
+                              "type": "phrase",
+                              "key": "data.vulnerability.severity",
+                              "value": "Critical",
+                              "params": {
+                                "query": "Critical",
+                                "type": "phrase"
+                              }
+                            },
+                            "query": {
+                              "match": {
+                                "data.vulnerability.severity": {
+                                  "query": "Critical",
+                                  "type": "phrase"
+                                }
+                              }
+                            },
+                            "$state": {
+                              "store": "appState"
+                            }
+                        }
+                    ],
+                    "query":{"query":"","language":"lucene"}
+                }`
             }
         }
     },
@@ -76,7 +107,38 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"rule.groups: vulnerability-detector AND data.vulnerability.severity: High\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": `{
+                    "index":"wazuh-alerts",
+                    "filter":[
+                        {
+                            "meta": {
+                              "index": "wazuh-alerts",
+                              "negate": false,
+                              "disabled": false,
+                              "alias": null,
+                              "type": "phrase",
+                              "key": "data.vulnerability.severity",
+                              "value": "High",
+                              "params": {
+                                "query": "High",
+                                "type": "phrase"
+                              }
+                            },
+                            "query": {
+                              "match": {
+                                "data.vulnerability.severity": {
+                                  "query": "High",
+                                  "type": "phrase"
+                                }
+                              }
+                            },
+                            "$state": {
+                              "store": "appState"
+                            }
+                        }
+                    ],
+                    "query":{"query":"","language":"lucene"}
+                }`
             }
         }
     },
@@ -90,7 +152,38 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"rule.groups: vulnerability-detector AND data.vulnerability.severity: Medium\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": `{
+                    "index":"wazuh-alerts",
+                    "filter":[
+                        {
+                            "meta": {
+                              "index": "wazuh-alerts",
+                              "negate": false,
+                              "disabled": false,
+                              "alias": null,
+                              "type": "phrase",
+                              "key": "data.vulnerability.severity",
+                              "value": "Medium",
+                              "params": {
+                                "query": "Medium",
+                                "type": "phrase"
+                              }
+                            },
+                            "query": {
+                              "match": {
+                                "data.vulnerability.severity": {
+                                  "query": "Medium",
+                                  "type": "phrase"
+                                }
+                              }
+                            },
+                            "$state": {
+                              "store": "appState"
+                            }
+                        }
+                    ],
+                    "query":{"query":"","language":"lucene"}
+                }`
             }
         }
     },
@@ -104,7 +197,38 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"rule.groups: vulnerability-detector AND data.vulnerability.severity: Low\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": `{
+                    "index":"wazuh-alerts",
+                    "filter":[
+                        {
+                            "meta": {
+                              "index": "wazuh-alerts",
+                              "negate": false,
+                              "disabled": false,
+                              "alias": null,
+                              "type": "phrase",
+                              "key": "data.vulnerability.severity",
+                              "value": "Low",
+                              "params": {
+                                "query": "Low",
+                                "type": "phrase"
+                              }
+                            },
+                            "query": {
+                              "match": {
+                                "data.vulnerability.severity": {
+                                  "query": "Low",
+                                  "type": "phrase"
+                                }
+                              }
+                            },
+                            "$state": {
+                              "store": "appState"
+                            }
+                        }
+                    ],
+                    "query":{"query":"","language":"lucene"}
+                }`
             }
         }
     },
@@ -118,7 +242,7 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"rule.groups: vulnerability-detector\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"\",\"language\":\"lucene\"}}"
             }
         }
     }

--- a/server/integration-files/visualizations/overview/overview-audit.js
+++ b/server/integration-files/visualizations/overview/overview-audit.js
@@ -20,8 +20,38 @@ export default [
 			"description": "",
 			"version": 1,
 			"kibanaSavedObjectMeta": {
-				"searchSourceJSON":
-					"{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"rule.groups: audit AND rule.id : 80790\",\"language\":\"lucene\"}}"
+				"searchSourceJSON": `{
+                    "index":"wazuh-alerts",
+                    "filter":[
+                        {
+                            "meta": {
+                              "index": "wazuh-alerts",
+                              "negate": false,
+                              "disabled": false,
+                              "alias": null,
+                              "type": "phrase",
+                              "key": "rule.id",
+                              "value": "80790",
+                              "params": {
+                                "query": "80790",
+                                "type": "phrase"
+                              }
+                            },
+                            "query": {
+                              "match": {
+                                "rule.id": {
+                                  "query": "80790",
+                                  "type": "phrase"
+                                }
+                              }
+                            },
+                            "$state": {
+                              "store": "appState"
+                            }
+                          }
+                    ],
+                    "query":{"query":"","language":"lucene"}
+                }`
 			}
 		},
 		"_type": "visualization"
@@ -35,7 +65,38 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"rule.groups: audit AND rule.id: 80784\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": `{
+                    "index":"wazuh-alerts",
+                    "filter":[
+                        {
+                            "meta": {
+                              "index": "wazuh-alerts",
+                              "negate": false,
+                              "disabled": false,
+                              "alias": null,
+                              "type": "phrase",
+                              "key": "rule.id",
+                              "value": "80784",
+                              "params": {
+                                "query": "80784",
+                                "type": "phrase"
+                              }
+                            },
+                            "query": {
+                              "match": {
+                                "rule.id": {
+                                  "query": "80784",
+                                  "type": "phrase"
+                                }
+                              }
+                            },
+                            "$state": {
+                              "store": "appState"
+                            }
+                          }
+                    ],
+                    "query":{"query":"","language":"lucene"}
+                }`
             }
         },
         "_type": "visualization"
@@ -49,7 +110,47 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"rule.groups: audit AND (rule.id: 80781 OR rule.id: 80787)\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": `{
+                    "index":"wazuh-alerts",
+                    "filter":[
+                        {
+                            "meta": {
+                              "index": "wazuh-alerts",
+                              "type": "phrases",
+                              "key": "rule.id",
+                              "value": "80781, 80787",
+                              "params": [
+                                "80781",
+                                "80787"
+                              ],
+                              "negate": false,
+                              "disabled": false,
+                              "alias": null
+                            },
+                            "query": {
+                              "bool": {
+                                "should": [
+                                  {
+                                    "match_phrase": {
+                                      "rule.id": "80781"
+                                    }
+                                  },
+                                  {
+                                    "match_phrase": {
+                                      "rule.id": "80787"
+                                    }
+                                  }
+                                ],
+                                "minimum_should_match": 1
+                              }
+                            },
+                            "$state": {
+                              "store": "appState"
+                            }
+                          }
+                    ],
+                    "query":{"query":"","language":"lucene"}
+                }`
             }
         },
         "_type": "visualization"
@@ -63,21 +164,38 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"rule.groups: audit AND rule.id : 80791\",\"language\":\"lucene\"}}"
-            }
-        },
-        "_type": "visualization"
-    },
-    {
-        "_id": "Wazuh-App-Overview-Audit-Latest-alert",
-        "_source": {
-            "title": "Latest alert",
-            "visState": "{\"title\":\"Latest alert\",\"type\":\"table\",\"params\":{\"perPage\":10,\"showPartialRows\":false,\"showMeticsAtAllLevels\":false,\"sort\":{\"columnIndex\":null,\"direction\":null},\"showTotal\":false,\"totalFunc\":\"sum\"},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"max\",\"schema\":\"metric\",\"params\":{\"field\":\"@timestamp\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"bucket\",\"params\":{\"field\":\"rule.description\",\"size\":1,\"order\":\"desc\",\"orderBy\":\"1\"}}]}",
-            "uiStateJSON": "{\"vis\":{\"params\":{\"sort\":{\"columnIndex\":null,\"direction\":null}}}}",
-            "description": "",
-            "version": 1,
-            "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"rule.groups: audit\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": `{
+                    "index":"wazuh-alerts",
+                    "filter":[
+                        {
+                            "meta": {
+                              "index": "wazuh-alerts",
+                              "negate": false,
+                              "disabled": false,
+                              "alias": null,
+                              "type": "phrase",
+                              "key": "rule.id",
+                              "value": "80791",
+                              "params": {
+                                "query": "80791",
+                                "type": "phrase"
+                              }
+                            },
+                            "query": {
+                              "match": {
+                                "rule.id": {
+                                  "query": "80791",
+                                  "type": "phrase"
+                                }
+                              }
+                            },
+                            "$state": {
+                              "store": "appState"
+                            }
+                          }
+                    ],
+                    "query":{"query":"","language":"lucene"}
+                }`
             }
         },
         "_type": "visualization"
@@ -91,7 +209,7 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"rule.groups: audit\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"\",\"language\":\"lucene\"}}"
             }
         },
         "_type": "visualization"
@@ -105,7 +223,7 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"rule.groups: audit\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"\",\"language\":\"lucene\"}}"
             }
         },
         "_type": "visualization"
@@ -119,7 +237,7 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"rule.groups: audit\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"\",\"language\":\"lucene\"}}"
             }
         },
         "_type": "visualization"
@@ -133,7 +251,7 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"rule.groups: audit\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"\",\"language\":\"lucene\"}}"
             }
         },
         "_type": "visualization"
@@ -147,7 +265,7 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"rule.groups: audit\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"\",\"language\":\"lucene\"}}"
             }
         },
         "_type": "visualization"
@@ -162,7 +280,38 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"rule.groups: audit AND rule.id: 80784\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": `{
+                    "index":"wazuh-alerts",
+                    "filter":[
+                        {
+                            "meta": {
+                              "index": "wazuh-alerts",
+                              "negate": false,
+                              "disabled": false,
+                              "alias": null,
+                              "type": "phrase",
+                              "key": "rule.id",
+                              "value": "80784",
+                              "params": {
+                                "query": "80784",
+                                "type": "phrase"
+                              }
+                            },
+                            "query": {
+                              "match": {
+                                "rule.id": {
+                                  "query": "80784",
+                                  "type": "phrase"
+                                }
+                              }
+                            },
+                            "$state": {
+                              "store": "appState"
+                            }
+                          }
+                    ],
+                    "query":{"query":"","language":"lucene"}
+                }`
             }
         }
     },
@@ -176,7 +325,38 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"rule.groups: audit AND rule.id: 80781\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": `{
+                    "index":"wazuh-alerts",
+                    "filter":[
+                        {
+                            "meta": {
+                              "index": "wazuh-alerts",
+                              "negate": false,
+                              "disabled": false,
+                              "alias": null,
+                              "type": "phrase",
+                              "key": "rule.id",
+                              "value": "80781",
+                              "params": {
+                                "query": "80781",
+                                "type": "phrase"
+                              }
+                            },
+                            "query": {
+                              "match": {
+                                "rule.id": {
+                                  "query": "80781",
+                                  "type": "phrase"
+                                }
+                              }
+                            },
+                            "$state": {
+                              "store": "appState"
+                            }
+                          }
+                    ],
+                    "query":{"query":"","language":"lucene"}
+                }`
             }
         }
     },
@@ -189,7 +369,7 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"rule.groups: audit\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"\",\"language\":\"lucene\"}}"
             }
         },
         "_type": "visualization"
@@ -204,7 +384,38 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"rule.groups: audit AND rule.id: 80790\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": `{
+                    "index":"wazuh-alerts",
+                    "filter":[
+                        {
+                            "meta": {
+                              "index": "wazuh-alerts",
+                              "negate": false,
+                              "disabled": false,
+                              "alias": null,
+                              "type": "phrase",
+                              "key": "rule.id",
+                              "value": "80790",
+                              "params": {
+                                "query": "80790",
+                                "type": "phrase"
+                              }
+                            },
+                            "query": {
+                              "match": {
+                                "rule.id": {
+                                  "query": "80790",
+                                  "type": "phrase"
+                                }
+                              }
+                            },
+                            "$state": {
+                              "store": "appState"
+                            }
+                          }
+                    ],
+                    "query":{"query":"","language":"lucene"}
+                }`
             }
         }
     },
@@ -218,7 +429,38 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"rule.groups: audit AND rule.id: 80791\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": `{
+                    "index":"wazuh-alerts",
+                    "filter":[
+                        {
+                            "meta": {
+                              "index": "wazuh-alerts",
+                              "negate": false,
+                              "disabled": false,
+                              "alias": null,
+                              "type": "phrase",
+                              "key": "rule.id",
+                              "value": "80791",
+                              "params": {
+                                "query": "80791",
+                                "type": "phrase"
+                              }
+                            },
+                            "query": {
+                              "match": {
+                                "rule.id": {
+                                  "query": "80791",
+                                  "type": "phrase"
+                                }
+                              }
+                            },
+                            "$state": {
+                              "store": "appState"
+                            }
+                          }
+                    ],
+                    "query":{"query":"","language":"lucene"}
+                }`
             }
         }
     },
@@ -232,7 +474,7 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"rule.groups: audit\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"\",\"language\":\"lucene\"}}"
             }
         }
     }

--- a/server/integration-files/visualizations/overview/overview-aws.js
+++ b/server/integration-files/visualizations/overview/overview-aws.js
@@ -37,7 +37,7 @@ export default [
                               "alias": null,
                               "type": "custom",
                               "key": "query",
-                              "value": "{"regexp":{"rule.description":{"value":".*AuthorizeSecurity.*"}}}"
+                              "value": {"regexp":{"rule.description":".*AuthorizeSecurity.*"}}
                             },
                             "$state": {
                               "store": "appState"
@@ -77,7 +77,7 @@ export default [
                               "alias": null,
                               "type": "custom",
                               "key": "query",
-                              "value": "{"regexp":{"rule.description":{"value":".*RevokeSecurity.*"}}}"
+                              "value": {"regexp":{"rule.description":".*RevokeSecurity.*"}}
                             },
                             "$state": {
                               "store": "appState"
@@ -117,7 +117,7 @@ export default [
                               "alias": null,
                               "type": "custom",
                               "key": "query",
-                              "value": "{"regexp":{"data.aws.eventName":{"value":".*Instances.*"}}}"
+                              "value": {"regexp":{"data.aws.eventName":".*Instances.*"}}
                             },
                             "$state": {
                               "store": "appState"
@@ -157,7 +157,7 @@ export default [
                               "alias": null,
                               "type": "custom",
                               "key": "query",
-                              "value": "{"regexp":{"rule.description":{"value":".*Login?Success.*"}}}"
+                              "value": {"regexp":{"rule.description":".*Login?Success.*"}}
                             },
                             "$state": {
                               "store": "appState"
@@ -211,7 +211,7 @@ export default [
                               "alias": null,
                               "type": "custom",
                               "key": "query",
-                              "value": "{"regexp":{"rule.description":{"value":".*Security.*"}}}"
+                              "value": {"regexp":{"rule.description":".*Security.*"}}
                             },
                             "$state": {
                               "store": "appState"
@@ -251,7 +251,7 @@ export default [
                               "alias": null,
                               "type": "custom",
                               "key": "query",
-                              "value": "{"regexp":{"rule.description":{"value":".*Login?Success.*"}}}"
+                              "value": {"regexp":{"rule.description":".*Login?Success.*"}}
                             },
                             "$state": {
                               "store": "appState"

--- a/server/integration-files/visualizations/overview/overview-aws.js
+++ b/server/integration-files/visualizations/overview/overview-aws.js
@@ -19,8 +19,34 @@ export default [
 			"description": "",
 			"version": 1,
 			"kibanaSavedObjectMeta": {
-				"searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"rule.groups: amazon AND rule.description: *AuthorizeSecurity*\",\"language\":\"lucene\"}}"
-			}
+                "searchSourceJSON": `{
+                    "index":"wazuh-alerts",
+                    "filter":[
+                        {
+                            "query": {
+                              "regexp": {
+                                "rule.description": {
+                                  "value": ".*AuthorizeSecurity.*"
+                                }
+                              }
+                            },
+                            "meta": {
+                              "negate": false,
+                              "index": "wazuh-alerts",
+                              "disabled": false,
+                              "alias": null,
+                              "type": "custom",
+                              "key": "query",
+                              "value": "{"regexp":{"rule.description":{"value":".*AuthorizeSecurity.*"}}}"
+                            },
+                            "$state": {
+                              "store": "appState"
+                            }
+                          }
+                    ],
+                    "query":{"query":"","language":"lucene"}
+                }` 
+            }
 		},
 		"_type": "visualization"
 	},
@@ -33,7 +59,33 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"rule.groups: amazon AND rule.description: *RevokeSecurity*\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": `{
+                    "index":"wazuh-alerts",
+                    "filter":[
+                        {
+                            "query": {
+                              "regexp": {
+                                "rule.description": {
+                                  "value": ".*RevokeSecurity.*"
+                                }
+                              }
+                            },
+                            "meta": {
+                              "negate": false,
+                              "index": "wazuh-alerts",
+                              "disabled": false,
+                              "alias": null,
+                              "type": "custom",
+                              "key": "query",
+                              "value": "{"regexp":{"rule.description":{"value":".*RevokeSecurity.*"}}}"
+                            },
+                            "$state": {
+                              "store": "appState"
+                            }
+                          }
+                    ],
+                    "query":{"query":"","language":"lucene"}
+                }` 
             }
         },
         "_type": "visualization"
@@ -47,7 +99,33 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"rule.groups: amazon AND data.aws.eventName: *Instances*\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": `{
+                    "index":"wazuh-alerts",
+                    "filter":[
+                        {
+                            "query": {
+                              "regexp": {
+                                "data.aws.eventName": {
+                                  "value": ".*Instances.*"
+                                }
+                              }
+                            },
+                            "meta": {
+                              "negate": false,
+                              "index": "wazuh-alerts",
+                              "disabled": false,
+                              "alias": null,
+                              "type": "custom",
+                              "key": "query",
+                              "value": "{"regexp":{"data.aws.eventName":{"value":".*Instances.*"}}}"
+                            },
+                            "$state": {
+                              "store": "appState"
+                            }
+                          }
+                    ],
+                    "query":{"query":"","language":"lucene"}
+                }`
             }
         },
         "_type": "visualization"
@@ -61,7 +139,33 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"rule.groups: amazon AND rule.description: *Login?Success*\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": `{
+                    "index":"wazuh-alerts",
+                    "filter":[
+                        {
+                            "query": {
+                              "regexp": {
+                                "rule.description": {
+                                  "value": ".*Login?Success.*"
+                                }
+                              }
+                            },
+                            "meta": {
+                              "negate": false,
+                              "index": "wazuh-alerts",
+                              "disabled": false,
+                              "alias": null,
+                              "type": "custom",
+                              "key": "query",
+                              "value": "{"regexp":{"rule.description":{"value":".*Login?Success.*"}}}"
+                            },
+                            "$state": {
+                              "store": "appState"
+                            }
+                          }
+                    ],
+                    "query":{"query":"","language":"lucene"}
+                }`
             }
         },
         "_type": "visualization"
@@ -89,7 +193,33 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"rule.groups: amazon AND rule.description: *Security*\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": `{
+                    "index":"wazuh-alerts",
+                    "filter":[
+                        {
+                            "query": {
+                              "regexp": {
+                                "rule.description": {
+                                  "value": ".*Security.*"
+                                }
+                              }
+                            },
+                            "meta": {
+                              "negate": false,
+                              "index": "wazuh-alerts",
+                              "disabled": false,
+                              "alias": null,
+                              "type": "custom",
+                              "key": "query",
+                              "value": "{"regexp":{"rule.description":{"value":".*Security.*"}}}"
+                            },
+                            "$state": {
+                              "store": "appState"
+                            }
+                          }
+                    ],
+                    "query":{"query":"","language":"lucene"}
+                }`
             }
         },
         "_type": "visualization"
@@ -103,7 +233,33 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"rule.groups: amazon AND rule.description: *Login?Success*\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": `{
+                    "index":"wazuh-alerts",
+                    "filter":[
+                        {
+                            "query": {
+                              "regexp": {
+                                "rule.description": {
+                                  "value": ".*Login?Success.*"
+                                }
+                              }
+                            },
+                            "meta": {
+                              "negate": false,
+                              "index": "wazuh-alerts",
+                              "disabled": false,
+                              "alias": null,
+                              "type": "custom",
+                              "key": "query",
+                              "value": "{"regexp":{"rule.description":{"value":".*Login?Success.*"}}}"
+                            },
+                            "$state": {
+                              "store": "appState"
+                            }
+                          }
+                    ],
+                    "query":{"query":"","language":"lucene"}
+                }`
             }
         },
         "_type": "visualization"
@@ -117,7 +273,7 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"rule.groups: amazon\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"\",\"language\":\"lucene\"}}"
             }
         },
         "_type": "visualization"
@@ -131,7 +287,7 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"rule.groups: amazon\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"\",\"language\":\"lucene\"}}"
             }
         },
         "_type": "visualization"
@@ -146,7 +302,7 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"rule.groups: amazon\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"\",\"language\":\"lucene\"}}"
             }
         }
     }

--- a/server/integration-files/visualizations/overview/overview-ciscat.js
+++ b/server/integration-files/visualizations/overview/overview-ciscat.js
@@ -20,7 +20,7 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"rule.groups: ciscat\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"\",\"language\":\"lucene\"}}"
             }
         }
     },
@@ -34,7 +34,7 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"rule.groups: ciscat\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"\",\"language\":\"lucene\"}}"
             }
         }
     },
@@ -48,7 +48,7 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"rule.groups: ciscat\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"\",\"language\":\"lucene\"}}"
             }
         }
     },
@@ -62,7 +62,7 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"rule.groups: ciscat\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"\",\"language\":\"lucene\"}}"
             }
         }
     },
@@ -76,7 +76,7 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"rule.groups: ciscat\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"\",\"language\":\"lucene\"}}"
             }
         }
     },
@@ -90,7 +90,7 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"rule.groups: ciscat\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"\",\"language\":\"lucene\"}}"
             }
         }
     },
@@ -104,7 +104,7 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"rule.groups: ciscat\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"\",\"language\":\"lucene\"}}"
             }
         }
     },
@@ -118,7 +118,7 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"rule.groups: ciscat\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"\",\"language\":\"lucene\"}}"
             }
         }
     },
@@ -132,7 +132,7 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"rule.groups: ciscat\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"\",\"language\":\"lucene\"}}"
             }
         }
     },
@@ -146,7 +146,7 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"rule.groups: ciscat\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"\",\"language\":\"lucene\"}}"
             }
         }
     },
@@ -160,7 +160,7 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"rule.groups: ciscat\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"\",\"language\":\"lucene\"}}"
             }
         }
     }

--- a/server/integration-files/visualizations/overview/overview-fim.js
+++ b/server/integration-files/visualizations/overview/overview-fim.js
@@ -20,46 +20,46 @@ export default [
 			"version": 1,
 			"kibanaSavedObjectMeta": {
 				"searchSourceJSON":`{
-                    "index":"wazuh-alerts",
-                    "filter":[
-                        {
-                            "meta": {
-                              "index": "wazuh-alerts",
-                              "type": "phrases",
-                              "key": "syscheck.event",
-                              "value": "added, readded",
-                              "params": [
-                                "added",
-                                "readded"
-                              ],
-                              "negate": false,
-                              "disabled": false,
-                              "alias": null
-                            },
-                            "query": {
-                              "bool": {
-                                "should": [
-                                  {
-                                    "match_phrase": {
-                                      "syscheck.event": "added"
-                                    }
-                                  },
-                                  {
-                                    "match_phrase": {
-                                      "syscheck.event": "readded"
-                                    }
-                                  }
-                                ],
-                                "minimum_should_match": 1
-                              }
-                            },
-                            "$state": {
-                              "store": "appState"
+            "index":"wazuh-alerts",
+            "filter":[
+                {
+                    "meta": {
+                      "index": "wazuh-alerts",
+                      "type": "phrases",
+                      "key": "syscheck.event",
+                      "value": "added, readded",
+                      "params": [
+                        "added",
+                        "readded"
+                      ],
+                      "negate": false,
+                      "disabled": false,
+                      "alias": null
+                    },
+                    "query": {
+                      "bool": {
+                        "should": [
+                          {
+                            "match_phrase": {
+                              "syscheck.event": "added"
+                            }
+                          },
+                          {
+                            "match_phrase": {
+                              "syscheck.event": "readded"
                             }
                           }
-                    ],
-                    "query":{"query":"","language":"lucene"}
-                }`
+                        ],
+                        "minimum_should_match": 1
+                      }
+                    },
+                    "$state": {
+                      "store": "appState"
+                    }
+                  }
+            ],
+            "query":{"query":"","language":"lucene"}
+        }`
 			}
 		},
 		"_type": "visualization"

--- a/server/integration-files/visualizations/overview/overview-fim.js
+++ b/server/integration-files/visualizations/overview/overview-fim.js
@@ -245,7 +245,7 @@ export default [
         "_id": "Wazuh-App-Overview-FIM-Root-user-file-changes",
         "_source": {
             "title": "Root user file changes",
-            "visState": "{\"title\":\"Root user file changes\",\"type\":\"pie\",\"params\":{\"isDonut\":false,\"shareYAxis\":true,\"addTooltip\":true,\"addLegend\":true,\"type\":\"pie\",\"legendPosition\":\"right\",\"labels\":{\"show\":false,\"values\":true,\"last_level\":true,\"truncate\":100}},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"segment\",\"params\":{\"field\":\"syscheck.path\",\"otherBucket\":false,\"otherBucketLabel\":\"Other\",\"missingBucket\":false,\"missingBucketLabel\":\"Missing\",\"size\":10,\"order\":\"desc\",\"orderBy\":\"1\"}}]}",
+            "visState": "{\"title\":\"Root user file changes\",\"type\":\"pie\",\"params\":{\"isDonut\":false,\"shareYAxis\":true,\"addTooltip\":true,\"addLegend\":true,\"type\":\"pie\",\"legendPosition\":\"right\",\"labels\":{\"show\":false,\"values\":true,\"last_level\":true,\"truncate\":100}},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"segment\",\"params\":{\"field\":\"syscheck.path\",\"otherBucket\":false,\"otherBucketLabel\":\"Other\",\"missingBucket\":false,\"missingBucketLabel\":\"Missing\",\"size\":5,\"order\":\"desc\",\"orderBy\":\"1\"}}]}",
             "uiStateJSON": "{}",
             "description": "",
             "version": 1,
@@ -287,7 +287,7 @@ export default [
                           {
                             "query": {
                               "regexp": {
-                                "syscheck.perm_after": "[0-7]{5}([2367]).*"
+                                "syscheck.perm_after": "[0-7]{5}([2367])"                                
                               }
                             },
                             "meta": {
@@ -297,7 +297,7 @@ export default [
                               "alias": null,
                               "type": "custom",
                               "key": "query",
-                              "value": "{"regexp":{"syscheck.perm_after":"[0-7]{5}([2367]).*"}}"
+                              "value": {"regexp":{"syscheck.perm_after": "[0-7]{5}([2367])" }}
                             },
                             "$state": {
                               "store": "appState"

--- a/server/integration-files/visualizations/overview/overview-fim.js
+++ b/server/integration-files/visualizations/overview/overview-fim.js
@@ -19,8 +19,47 @@ export default [
 			"description": "",
 			"version": 1,
 			"kibanaSavedObjectMeta": {
-				"searchSourceJSON":
-					"{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"rule.groups: \\\"syscheck\\\" AND syscheck.event: (added OR readded)\",\"language\":\"lucene\"}}"
+				"searchSourceJSON":`{
+                    "index":"wazuh-alerts",
+                    "filter":[
+                        {
+                            "meta": {
+                              "index": "wazuh-alerts",
+                              "type": "phrases",
+                              "key": "syscheck.event",
+                              "value": "added, readded",
+                              "params": [
+                                "added",
+                                "readded"
+                              ],
+                              "negate": false,
+                              "disabled": false,
+                              "alias": null
+                            },
+                            "query": {
+                              "bool": {
+                                "should": [
+                                  {
+                                    "match_phrase": {
+                                      "syscheck.event": "added"
+                                    }
+                                  },
+                                  {
+                                    "match_phrase": {
+                                      "syscheck.event": "readded"
+                                    }
+                                  }
+                                ],
+                                "minimum_should_match": 1
+                              }
+                            },
+                            "$state": {
+                              "store": "appState"
+                            }
+                          }
+                    ],
+                    "query":{"query":"","language":"lucene"}
+                }`
 			}
 		},
 		"_type": "visualization"
@@ -34,7 +73,38 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"rule.groups: \\\"syscheck\\\" syscheck.event: \\\"modified\\\"\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": `{
+                    "index":"wazuh-alerts",
+                    "filter":[
+                        {
+                            "meta": {
+                              "index": "wazuh-alerts",
+                              "negate": false,
+                              "disabled": false,
+                              "alias": null,
+                              "type": "phrase",
+                              "key": "syscheck.event",
+                              "value": "modified",
+                              "params": {
+                                "query": "modified",
+                                "type": "phrase"
+                              }
+                            },
+                            "query": {
+                              "match": {
+                                "syscheck.event": {
+                                  "query": "modified",
+                                  "type": "phrase"
+                                }
+                              }
+                            },
+                            "$state": {
+                              "store": "appState"
+                            }
+                          }
+                    ],
+                    "query":{"query":"","language":"lucene"}
+                }`
             }
         },
         "_type": "visualization"
@@ -48,7 +118,38 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"rule.groups: \\\"syscheck\\\" AND syscheck.event: \\\"deleted\\\"\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": `{
+                    "index":"wazuh-alerts",
+                    "filter":[
+                        {
+                            "meta": {
+                              "index": "wazuh-alerts",
+                              "negate": false,
+                              "disabled": false,
+                              "alias": null,
+                              "type": "phrase",
+                              "key": "syscheck.event",
+                              "value": "deleted",
+                              "params": {
+                                "query": "deleted",
+                                "type": "phrase"
+                              }
+                            },
+                            "query": {
+                              "match": {
+                                "syscheck.event": {
+                                  "query": "deleted",
+                                  "type": "phrase"
+                                }
+                              }
+                            },
+                            "$state": {
+                              "store": "appState"
+                            }
+                          }
+                    ],
+                    "query":{"query":"","language":"lucene"}
+                }`
             }
         },
         "_type": "visualization"
@@ -62,7 +163,7 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"rule.groups: syscheck\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"\",\"language\":\"lucene\"}}"
             }
         },
         "_type": "visualization"
@@ -77,7 +178,7 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"rule.groups:\\\"syscheck\\\"\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"\",\"language\":\"lucene\"}}"
             }
         }
     },
@@ -91,51 +192,9 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"rule.groups:\\\"syscheck\\\"\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"\",\"language\":\"lucene\"}}"
             }
         }
-    },
-    {
-        "_id": "Wazuh-App-Overview-FIM-Last-file-modified",
-        "_source": {
-            "title": "Last file modified",
-            "visState": "{\"title\":\"Last file modified\",\"type\":\"table\",\"params\":{\"perPage\":10,\"showPartialRows\":false,\"showMeticsAtAllLevels\":false,\"sort\":{\"columnIndex\":null,\"direction\":null},\"showTotal\":false,\"totalFunc\":\"sum\"},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"bucket\",\"params\":{\"field\":\"syscheck.path\",\"size\":1,\"order\":\"desc\",\"orderBy\":\"_term\"}}]}",
-            "uiStateJSON": "{\"vis\":{\"params\":{\"sort\":{\"columnIndex\":2,\"direction\":\"desc\"}}}}",
-            "description": "",
-            "version": 1,
-            "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"syscheck.event: modified AND location: syscheck\",\"language\":\"lucene\"}}"
-            }
-        },
-        "_type": "visualization"
-    },
-    {
-        "_id": "Wazuh-App-Overview-FIM-Last-file-added",
-        "_source": {
-            "title": "Last file added",
-            "visState": "{\"title\":\"Last file added\",\"type\":\"table\",\"params\":{\"perPage\":10,\"showPartialRows\":false,\"showMeticsAtAllLevels\":false,\"sort\":{\"columnIndex\":null,\"direction\":null},\"showTotal\":false,\"totalFunc\":\"sum\"},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"bucket\",\"params\":{\"field\":\"syscheck.path\",\"size\":1,\"order\":\"desc\",\"orderBy\":\"_term\"}}]}",
-            "uiStateJSON": "{\"vis\":{\"params\":{\"sort\":{\"columnIndex\":2,\"direction\":\"desc\"}}}}",
-            "description": "",
-            "version": 1,
-            "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"syscheck.event: added AND location: syscheck\",\"language\":\"lucene\"}}"
-            }
-        },
-        "_type": "visualization"
-    },
-    {
-        "_id": "Wazuh-App-Overview-FIM-Last-file-deleted",
-        "_source": {
-            "title": "Last file deleted",
-            "visState": "{\"title\":\"Last file deleted\",\"type\":\"table\",\"params\":{\"perPage\":10,\"showPartialRows\":false,\"showMeticsAtAllLevels\":false,\"sort\":{\"columnIndex\":null,\"direction\":null},\"showTotal\":false,\"totalFunc\":\"sum\"},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"bucket\",\"params\":{\"field\":\"syscheck.path\",\"size\":1,\"order\":\"desc\",\"orderBy\":\"_term\"}}]}",
-            "uiStateJSON": "{\"vis\":{\"params\":{\"sort\":{\"columnIndex\":2,\"direction\":\"desc\"}}}}",
-            "description": "",
-            "version": 1,
-            "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"syscheck.event: deleted AND location: syscheck\",\"language\":\"lucene\"}}"
-            }
-        },
-        "_type": "visualization"
     },
     {
         "_id": "Wazuh-App-Overview-FIM-Top-file-changes",
@@ -146,7 +205,38 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"rule.groups:\\\"syscheck\\\" AND syscheck.event: \\\"modified\\\"\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": `{
+                    "index":"wazuh-alerts",
+                    "filter":[
+                        {
+                            "meta": {
+                              "index": "wazuh-alerts",
+                              "negate": false,
+                              "disabled": false,
+                              "alias": null,
+                              "type": "phrase",
+                              "key": "syscheck.event",
+                              "value": "modified",
+                              "params": {
+                                "query": "modified",
+                                "type": "phrase"
+                              }
+                            },
+                            "query": {
+                              "match": {
+                                "syscheck.event": {
+                                  "query": "modified",
+                                  "type": "phrase"
+                                }
+                              }
+                            },
+                            "$state": {
+                              "store": "appState"
+                            }
+                          }
+                    ],
+                    "query":{"query":"","language":"lucene"}
+                }`
             }
         },
         "_type": "visualization"
@@ -174,63 +264,48 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"rule.groups:\\\"syscheck\\\" AND _exists_:syscheck.perm_after AND (syscheck.perm_after:/[0-7]{5}([2367]).*/)\",\"language\":\"lucene\"}}"
-            }
-        },
-        "_type": "visualization"
-    },
-    {
-        "_id": "Wazuh-App-Overview-FIM-Top-agent",
-        "_source": {
-            "title": "Top agent",
-            "visState": "{\"title\":\"Top agent\",\"type\":\"table\",\"params\":{\"perPage\":10,\"showPartialRows\":false,\"showMeticsAtAllLevels\":false,\"sort\":{\"columnIndex\":null,\"direction\":null},\"showTotal\":false,\"totalFunc\":\"sum\"},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"bucket\",\"params\":{\"field\":\"agent.name\",\"size\":1,\"order\":\"desc\",\"orderBy\":\"1\"}}]}",
-            "uiStateJSON": "{\"vis\":{\"params\":{\"sort\":{\"columnIndex\":2,\"direction\":\"desc\"}}}}",
-            "description": "",
-            "version": 1,
-            "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"location: syscheck\",\"language\":\"lucene\"}}"
-            }
-        },
-        "_type": "visualization"
-    },
-    {
-        "_id": "Wazuh-App-Overview-FIM-Top-PCI-requirement",
-        "_source": {
-            "title": "Top PCI requirement",
-            "visState": "{\"title\":\"Top PCI requirement\",\"type\":\"table\",\"params\":{\"perPage\":10,\"showPartialRows\":false,\"showMeticsAtAllLevels\":false,\"sort\":{\"columnIndex\":null,\"direction\":null},\"showTotal\":false,\"totalFunc\":\"sum\"},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"bucket\",\"params\":{\"field\":\"rule.pci_dss\",\"size\":1,\"order\":\"desc\",\"orderBy\":\"1\"}}]}",
-            "uiStateJSON": "{\"vis\":{\"params\":{\"sort\":{\"columnIndex\":null,\"direction\":null}}}}",
-            "description": "",
-            "version": 1,
-            "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"location: syscheck\",\"language\":\"lucene\"}}"
-            }
-        },
-        "_type": "visualization"
-    },
-    {
-        "_id": "Wazuh-App-Overview-FIM-Most-common-permissions",
-        "_source": {
-            "title": "Most common permissions",
-            "visState": "{\"title\":\"Most common permissions\",\"type\":\"table\",\"params\":{\"perPage\":10,\"showPartialRows\":false,\"showMeticsAtAllLevels\":false,\"sort\":{\"columnIndex\":null,\"direction\":null},\"showTotal\":false,\"totalFunc\":\"sum\"},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"bucket\",\"params\":{\"field\":\"syscheck.perm_after\",\"size\":1,\"order\":\"desc\",\"orderBy\":\"1\"}}]}",
-            "uiStateJSON": "{\"vis\":{\"params\":{\"sort\":{\"columnIndex\":null,\"direction\":null}}}}",
-            "description": "",
-            "version": 1,
-            "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"location: syscheck\",\"language\":\"lucene\"}}"
-            }
-        },
-        "_type": "visualization"
-    },
-    {
-        "_id": "Wazuh-App-Overview-FIM-Most-modified-file",
-        "_source": {
-            "title": "Most modified file",
-            "visState": "{\"title\":\"Most modified file\",\"type\":\"table\",\"params\":{\"perPage\":10,\"showPartialRows\":false,\"showMeticsAtAllLevels\":false,\"sort\":{\"columnIndex\":null,\"direction\":null},\"showTotal\":false,\"totalFunc\":\"sum\"},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"bucket\",\"params\":{\"field\":\"syscheck.path\",\"size\":1,\"order\":\"desc\",\"orderBy\":\"1\"}}]}",
-            "uiStateJSON": "{\"vis\":{\"params\":{\"sort\":{\"columnIndex\":null,\"direction\":null}}}}",
-            "description": "",
-            "version": 1,
-            "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"location: syscheck\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": `{
+                    "index":"wazuh-alerts",
+                    "filter":[
+                          {
+                            "meta": {
+                              "index": "wazuh-alerts",
+                              "negate": false,
+                              "disabled": false,
+                              "alias": null,
+                              "type": "exists",
+                              "key": "syscheck.perm_after",
+                              "value": "exists"
+                            },
+                            "exists": {
+                              "field": "syscheck.perm_after"
+                            },
+                            "$state": {
+                              "store": "appState"
+                            }
+                          },
+                          {
+                            "query": {
+                              "regexp": {
+                                "syscheck.perm_after": "[0-7]{5}([2367]).*"
+                              }
+                            },
+                            "meta": {
+                              "negate": false,
+                              "index": "wazuh-alerts",
+                              "disabled": false,
+                              "alias": null,
+                              "type": "custom",
+                              "key": "query",
+                              "value": "{"regexp":{"syscheck.perm_after":"[0-7]{5}([2367]).*"}}"
+                            },
+                            "$state": {
+                              "store": "appState"
+                            }
+                          }
+                    ],
+                    "query":{"query":"","language":"lucene"}
+                }`
             }
         },
         "_type": "visualization"
@@ -245,7 +320,7 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"rule.groups: syscheck\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"\",\"language\":\"lucene\"}}"
             }
         }
     }

--- a/server/integration-files/visualizations/overview/overview-gdpr.js
+++ b/server/integration-files/visualizations/overview/overview-gdpr.js
@@ -33,7 +33,7 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"_exists_:rule.gdpr\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"\",\"language\":\"lucene\"}}"
             }
         },
         "_type": "visualization"
@@ -61,7 +61,7 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"_exists_:rule.gdpr\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"\",\"language\":\"lucene\"}}"
             }
         },
         "_type": "visualization"
@@ -75,7 +75,7 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"_exists_:rule.gdpr\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"\",\"language\":\"lucene\"}}"
             }
         },
         "_type": "visualization"
@@ -90,7 +90,7 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"_exists_:rule.gdpr\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"\",\"language\":\"lucene\"}}"
             }
         }
     }

--- a/server/integration-files/visualizations/overview/overview-general.js
+++ b/server/integration-files/visualizations/overview/overview-general.js
@@ -45,13 +45,41 @@ export default [
 		"_source": {
 			"title": "Level 12 alerts",
 			"visState":
-				"{\"title\":\"Count Level 12 Alerts\",\"type\":\"metric\",\"params\":{\"addTooltip\":true,\"addLegend\":false,\"type\":\"gauge\",\"gauge\":{\"verticalSplit\":false,\"autoExtend\":false,\"percentageMode\":false,\"gaugeType\":\"Metric\",\"gaugeStyle\":\"Full\",\"backStyle\":\"Full\",\"orientation\":\"vertical\",\"colorSchema\":\"Green to Red\",\"gaugeColorMode\":\"None\",\"useRange\":false,\"colorsRange\":[{\"from\":0,\"to\":100}],\"invertColors\":false,\"labels\":{\"show\":true,\"color\":\"black\"},\"scale\":{\"show\":false,\"labels\":false,\"color\":\"#333\",\"width\":2},\"type\":\"simple\",\"style\":{\"fontSize\":20,\"bgColor\":false,\"labelColor\":false,\"subText\":\"\"}}},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{\"customLabel\":\"Level 12 or above alerts\"}}]}",
-			"uiStateJSON": "{\"vis\":{\"defaultColors\":{\"0 - 100\":\"rgb(0,104,55)\"}}}",
+				'{"title":"Count Level 12 Alerts","type":"metric","params":{"addTooltip":true,"addLegend":false,"type":"gauge","gauge":{"verticalSplit":false,"autoExtend":false,"percentageMode":false,"gaugeType":"Metric","gaugeStyle":"Full","backStyle":"Full","orientation":"vertical","colorSchema":"Green to Red","gaugeColorMode":"None","useRange":false,"colorsRange":[{"from":0,"to":100}],"invertColors":false,"labels":{"show":true,"color":"black"},"scale":{"show":false,"labels":false,"color":"#333","width":2},"type":"simple","style":{"fontSize":20,"bgColor":false,"labelColor":false,"subText":""}}},"aggs":[{"id":"1","enabled":true,"type":"count","schema":"metric","params":{"customLabel":"Level 12 or above alerts"}}]}',
+			"uiStateJSON": '{"vis":{"defaultColors":{"0 - 100":"rgb(0,104,55)"}}}',
 			"description": "",
 			"version": 1,
 			"kibanaSavedObjectMeta": {
-				"searchSourceJSON":
-					"{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"rule.level:[12 TO *]\",\"language\":\"lucene\"}}"
+				"searchSourceJSON": `{
+                    "index":"wazuh-alerts",
+                    "filter":[
+                        {
+                        "$state": {
+                          "store": "appState"
+                        },
+                        "meta": {
+                          "alias": null,
+                          "disabled": false,
+                          "index": "wazuh-alerts",
+                          "key": "rule.level",
+                          "negate": false,
+                          "params": {
+                            "gte": 12,
+                            "lt": null
+                          },
+                          "type": "range",
+                          "value": "12 to +∞"
+                        },
+                        "range": {
+                          "rule.level": {
+                            "gte": 12,
+                            "lt": null
+                          }
+                        }
+                      }
+                    ],
+                    "query":{ "query": "", "language": "lucene" } 
+                }`
 			}
 		},
 		"_type": "visualization"
@@ -66,8 +94,47 @@ export default [
 			"description": "",
 			"version": 1,
 			"kibanaSavedObjectMeta": {
-				"searchSourceJSON":
-					"{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"rule.groups: authentication_failed OR rule.groups: authentication_failures\",\"language\":\"lucene\"}}"
+				"searchSourceJSON": `{
+                    "index":"wazuh-alerts",
+                    "filter":[
+                        {
+                            "meta": {
+                              "index": "wazuh-alerts",
+                              "type": "phrases",
+                              "key": "rule.groups",
+                              "value": "authentication_failed, authentication_failures",
+                              "params": [
+                                "authentication_failed",
+                                "authentication_failures"
+                              ],
+                              "negate": false,
+                              "disabled": false,
+                              "alias": null
+                            },
+                            "query": {
+                              "bool": {
+                                "should": [
+                                  {
+                                    "match_phrase": {
+                                      "rule.groups": "authentication_failed"
+                                    }
+                                  },
+                                  {
+                                    "match_phrase": {
+                                      "rule.groups": "authentication_failures"
+                                    }
+                                  }
+                                ],
+                                "minimum_should_match": 1
+                              }
+                            },
+                            "$state": {
+                              "store": "appState"
+                            }
+                          }
+                    ],
+                    "query":{"query":"","language":"lucene"}
+                }`
 			}
 		},
 		"_type": "visualization"
@@ -82,8 +149,38 @@ export default [
 			"description": "",
 			"version": 1,
 			"kibanaSavedObjectMeta": {
-				"searchSourceJSON":
-					"{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"rule.groups: authentication_success\",\"language\":\"lucene\"}}"
+				"searchSourceJSON": `{
+                    "index":"wazuh-alerts",
+                    "filter":[
+                        {
+                            "meta": {
+                              "index": "wazuh-alerts",
+                              "negate": false,
+                              "disabled": false,
+                              "alias": null,
+                              "type": "phrase",
+                              "key": "rule.groups",
+                              "value": "authentication_success",
+                              "params": {
+                                "query": "authentication_success",
+                                "type": "phrase"
+                              }
+                            },
+                            "query": {
+                              "match": {
+                                "rule.groups": {
+                                  "query": "authentication_success",
+                                  "type": "phrase"
+                                }
+                              }
+                            },
+                            "$state": {
+                              "store": "appState"
+                            }
+                          }
+                    ],
+                    "query":{"query":"","language":"lucene"}
+                }`
 			}
 		},
 		"_type": "visualization"

--- a/server/integration-files/visualizations/overview/overview-oscap.js
+++ b/server/integration-files/visualizations/overview/overview-oscap.js
@@ -35,7 +35,38 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"data.oscap.check.result: fail AND rule.groups:oscap\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": `{
+                    "index":"wazuh-alerts",
+                    "filter":[
+                        {
+                            "meta": {
+                              "index": "wazuh-alerts",
+                              "negate": false,
+                              "disabled": false,
+                              "alias": null,
+                              "type": "phrase",
+                              "key": "data.oscap.check.result",
+                              "value": "fail",
+                              "params": {
+                                "query": "fail",
+                                "type": "phrase"
+                              }
+                            },
+                            "query": {
+                              "match": {
+                                "data.oscap.check.result": {
+                                  "query": "fail",
+                                  "type": "phrase"
+                                }
+                              }
+                            },
+                            "$state": {
+                              "store": "appState"
+                            }
+                          }
+                    ],
+                    "query":{"query":"","language":"lucene"}
+                }`
             }
         },
         "_type": "visualization"
@@ -63,7 +94,38 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"rule.groups:\\\"oscap\\\" AND NOT rule.groups:\\\"syslog\\\"\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": `{
+                    "index":"wazuh-alerts",
+                    "filter":[
+                        {
+                            "meta": {
+                              "index": "wazuh-alerts",
+                              "negate": true,
+                              "disabled": false,
+                              "alias": null,
+                              "type": "phrase",
+                              "key": "rule.groups",
+                              "value": "syslog",
+                              "params": {
+                                "query": "syslog",
+                                "type": "phrase"
+                              }
+                            },
+                            "query": {
+                              "match": {
+                                "rule.groups": {
+                                  "query": "syslog",
+                                  "type": "phrase"
+                                }
+                              }
+                            },
+                            "$state": {
+                              "store": "appState"
+                            }
+                          }
+                    ],
+                    "query":{"query":"","language":"lucene"}
+                }`
             }
         },
         "_type": "visualization"
@@ -77,7 +139,39 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"rule.groups:\\\"oscap\\\" AND NOT rule.groups:\\\"syslog\\\"\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": `{
+                    "index":"wazuh-alerts",
+                    "filter":[
+                        {
+                            "meta": {
+                              "index": "wazuh-alerts",
+                              "negate": true,
+                              "disabled": false,
+                              "alias": null,
+                              "type": "phrase",
+                              "key": "rule.groups",
+                              "value": "syslog",
+                              "params": {
+                                "query": "syslog",
+                                "type": "phrase"
+                              }
+                            },
+                            "query": {
+                              "match": {
+                                "rule.groups": {
+                                  "query": "syslog",
+                                  "type": "phrase"
+                                }
+                              }
+                            },
+                            "$state": {
+                              "store": "appState"
+                            }
+                          }
+                    ],
+                    "query":{"query":"","language":"lucene"}
+                }`
+                
             }
         },
         "_type": "visualization"
@@ -91,7 +185,38 @@ export default [
             "version": 1,
             "description": "",
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"rule.groups:\\\"oscap\\\" AND NOT rule.groups:\\\"syslog\\\"\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": `{
+                    "index":"wazuh-alerts",
+                    "filter":[
+                        {
+                            "meta": {
+                              "index": "wazuh-alerts",
+                              "negate": true,
+                              "disabled": false,
+                              "alias": null,
+                              "type": "phrase",
+                              "key": "rule.groups",
+                              "value": "syslog",
+                              "params": {
+                                "query": "syslog",
+                                "type": "phrase"
+                              }
+                            },
+                            "query": {
+                              "match": {
+                                "rule.groups": {
+                                  "query": "syslog",
+                                  "type": "phrase"
+                                }
+                              }
+                            },
+                            "$state": {
+                              "store": "appState"
+                            }
+                          }
+                    ],
+                    "query":{"query":"","language":"lucene"}
+                }`
             }
         },
         "_type": "visualization"
@@ -105,7 +230,64 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"data.oscap.check.result: fail AND rule.groups:oscap AND NOT rule.groups: syslog\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": `{
+                    "index":"wazuh-alerts",
+                    "filter":[
+                        {
+                            "meta": {
+                              "index": "wazuh-alerts",
+                              "negate": false,
+                              "disabled": false,
+                              "alias": null,
+                              "type": "phrase",
+                              "key": "data.oscap.check.result",
+                              "value": "fail",
+                              "params": {
+                                "query": "fail",
+                                "type": "phrase"
+                              }
+                            },
+                            "query": {
+                              "match": {
+                                "data.oscap.check.result": {
+                                  "query": "fail",
+                                  "type": "phrase"
+                                }
+                              }
+                            },
+                            "$state": {
+                              "store": "appState"
+                            }
+                          },
+                          {
+                            "meta": {
+                              "index": "wazuh-alerts",
+                              "negate": true,
+                              "disabled": false,
+                              "alias": null,
+                              "type": "phrase",
+                              "key": "rule.groups",
+                              "value": "syslog",
+                              "params": {
+                                "query": "syslog",
+                                "type": "phrase"
+                              }
+                            },
+                            "query": {
+                              "match": {
+                                "rule.groups": {
+                                  "query": "syslog",
+                                  "type": "phrase"
+                                }
+                              }
+                            },
+                            "$state": {
+                              "store": "appState"
+                            }
+                          }
+                     ],
+                    "query":{"query":"","language":"lucene"}
+                }`
             }
         },
         "_type": "visualization"
@@ -119,7 +301,38 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"rule.groups: oscap AND data.oscap.check.severity: high\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": `{
+                    "index":"wazuh-alerts",
+                    "filter":[
+                        {
+                            "meta": {
+                              "index": "wazuh-alerts",
+                              "negate": false,
+                              "disabled": false,
+                              "alias": null,
+                              "type": "phrase",
+                              "key": "data.oscap.check.severity",
+                              "value": "high",
+                              "params": {
+                                "query": "high",
+                                "type": "phrase"
+                              }
+                            },
+                            "query": {
+                              "match": {
+                                "data.oscap.check.severity": {
+                                  "query": "high",
+                                  "type": "phrase"
+                                }
+                              }
+                            },
+                            "$state": {
+                              "store": "appState"
+                            }
+                        }
+                     ],
+                    "query":{"query":"","language":"lucene"}
+                }`
             }
         },
         "_type": "visualization"
@@ -133,7 +346,38 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"data.oscap.check.result: fail AND rule.groups:oscap AND rule.groups: oscap-result AND data.oscap.check.result:fail\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": `{
+                    "index":"wazuh-alerts",
+                    "filter":[
+                        {
+                            "meta": {
+                              "index": "wazuh-alerts",
+                              "negate": false,
+                              "disabled": false,
+                              "alias": null,
+                              "type": "phrase",
+                              "key": "data.oscap.check.result",
+                              "value": "fail",
+                              "params": {
+                                "query": "fail",
+                                "type": "phrase"
+                              }
+                            },
+                            "query": {
+                              "match": {
+                                "data.oscap.check.result": {
+                                  "query": "fail",
+                                  "type": "phrase"
+                                }
+                              }
+                            },
+                            "$state": {
+                              "store": "appState"
+                            }
+                        }
+                    ],
+                    "query":{"query":"","language":"lucene"}
+                }`
             }
         },
         "_type": "visualization"
@@ -147,7 +391,64 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"data.oscap.check.severity: high AND data.oscap.check.result: fail AND rule.groups:oscap AND rule.groups: oscap-result AND data.oscap.check.result:fail\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": `{
+                    "index":"wazuh-alerts",
+                    "filter":[
+                        {
+                            "meta": {
+                              "index": "wazuh-alerts",
+                              "negate": false,
+                              "disabled": false,
+                              "alias": null,
+                              "type": "phrase",
+                              "key": "data.oscap.check.result",
+                              "value": "fail",
+                              "params": {
+                                "query": "fail",
+                                "type": "phrase"
+                              }
+                            },
+                            "query": {
+                              "match": {
+                                "data.oscap.check.result": {
+                                  "query": "fail",
+                                  "type": "phrase"
+                                }
+                              }
+                            },
+                            "$state": {
+                              "store": "appState"
+                            }
+                        },
+                        {
+                            "meta": {
+                              "index": "wazuh-alerts",
+                              "negate": false,
+                              "disabled": false,
+                              "alias": null,
+                              "type": "phrase",
+                              "key": "data.oscap.check.severity",
+                              "value": "high",
+                              "params": {
+                                "query": "high",
+                                "type": "phrase"
+                              }
+                            },
+                            "query": {
+                              "match": {
+                                "data.oscap.check.severity": {
+                                  "query": "high",
+                                  "type": "phrase"
+                                }
+                              }
+                            },
+                            "$state": {
+                              "store": "appState"
+                            }
+                        }
+                    ],
+                    "query":{"query":"","language":"lucene"}
+                }`
             }
         },
         "_type": "visualization"
@@ -189,7 +490,38 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"data.oscap.check.result: fail AND rule.groups:oscap AND rule.groups: oscap-result AND data.oscap.check.result:fail\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": `{
+                    "index":"wazuh-alerts",
+                    "filter":[
+                        {
+                            "meta": {
+                              "index": "wazuh-alerts",
+                              "negate": false,
+                              "disabled": false,
+                              "alias": null,
+                              "type": "phrase",
+                              "key": "data.oscap.check.result",
+                              "value": "fail",
+                              "params": {
+                                "query": "fail",
+                                "type": "phrase"
+                              }
+                            },
+                            "query": {
+                              "match": {
+                                "data.oscap.check.result": {
+                                  "query": "fail",
+                                  "type": "phrase"
+                                }
+                              }
+                            },
+                            "$state": {
+                              "store": "appState"
+                            }
+                        }
+                    ],
+                    "query":{"query":"","language":"lucene"}
+                }`
             }
         },
         "_type": "visualization"
@@ -203,7 +535,7 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"rule.groups: oscap\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"\",\"language\":\"lucene\"}}"
             }
         }
     }

--- a/server/integration-files/visualizations/overview/overview-pci.js
+++ b/server/integration-files/visualizations/overview/overview-pci.js
@@ -33,7 +33,7 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"_exists_:rule.pci_dss\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"\",\"language\":\"lucene\"}}"
             }
         },
         "_type": "visualization"
@@ -61,7 +61,7 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"_exists_:rule.pci_dss\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"\",\"language\":\"lucene\"}}"
             }
         },
         "_type": "visualization"
@@ -75,7 +75,7 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"_exists_:rule.pci_dss\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"\",\"language\":\"lucene\"}}"
             }
         },
         "_type": "visualization"
@@ -90,7 +90,7 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"_exists_:rule.pci_dss\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"\",\"language\":\"lucene\"}}"
             }
         }
     }

--- a/server/integration-files/visualizations/overview/overview-pm.js
+++ b/server/integration-files/visualizations/overview/overview-pm.js
@@ -21,7 +21,7 @@ export default [
 		"version": 1,
 			"kibanaSavedObjectMeta": {
 				"searchSourceJSON": 
-					"{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"rule.groups:\\\"rootcheck\\\"\",\"language\":\"lucene\"}}"
+					"{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"\",\"language\":\"lucene\"}}"
 			}
 		}
 	},
@@ -34,7 +34,7 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"rule.groups:\\\"rootcheck\\\"\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"\",\"language\":\"lucene\"}}"
             }
         },
         "_type": "visualization"
@@ -48,7 +48,7 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"rule.groups:\\\"rootcheck\\\"\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"\",\"language\":\"lucene\"}}"
             }
         },
         "_type": "visualization"
@@ -62,7 +62,7 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"rule.groups:\\\"rootcheck\\\"\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"\",\"language\":\"lucene\"}}"
             }
         },
         "_type": "visualization"
@@ -77,7 +77,7 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"language\":\"lucene\",\"query\":\"rule.groups:\\\"rootcheck\\\"\"}}"
+                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"language\":\"lucene\",\"query\":\"\"}}"
             }
         }
     }

--- a/server/integration-files/visualizations/overview/overview-virustotal.js
+++ b/server/integration-files/visualizations/overview/overview-virustotal.js
@@ -48,7 +48,38 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"data.virustotal.malicious: 1\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": `{
+                    "index":"wazuh-alerts",
+                    "filter":[
+                        {
+                            "meta": {
+                              "index": "wazuh-alerts",
+                              "negate": false,
+                              "disabled": false,
+                              "alias": null,
+                              "type": "phrase",
+                              "key": "data.virustotal.malicious",
+                              "value": "1",
+                              "params": {
+                                "query": "1",
+                                "type": "phrase"
+                              }
+                            },
+                            "query": {
+                              "match": {
+                                "data.virustotal.malicious": {
+                                  "query": "1",
+                                  "type": "phrase"
+                                }
+                              }
+                            },
+                            "$state": {
+                              "store": "appState"
+                            }
+                          }
+                    ],
+                    "query":{"query":"","language":"lucene"}
+                }`
             }
         }
     },
@@ -62,7 +93,55 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"_exists_:data.virustotal.positives AND NOT data.virustotal.positives: 0\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": `{
+                    "index":"wazuh-alerts",
+                    "filter":[
+                        {
+                            "meta": {
+                              "index": "wazuh-alerts",
+                              "negate": false,
+                              "disabled": false,
+                              "alias": null,
+                              "type": "exists",
+                              "key": "data.virustotal.positives",
+                              "value": "exists"
+                            },
+                            "exists": {
+                              "field": "data.virustotal.positives"
+                            },
+                            "$state": {
+                              "store": "appState"
+                            }
+                          },
+                          {
+                            "meta": {
+                              "index": "wazuh-alerts",
+                              "negate": true,
+                              "disabled": false,
+                              "alias": null,
+                              "type": "phrase",
+                              "key": "data.virustotal.positives",
+                              "value": "0",
+                              "params": {
+                                "query": 0,
+                                "type": "phrase"
+                              }
+                            },
+                            "query": {
+                              "match": {
+                                "data.virustotal.positives": {
+                                  "query": 0,
+                                  "type": "phrase"
+                                }
+                              }
+                            },
+                            "$state": {
+                              "store": "appState"
+                            }
+                          }
+                    ],
+                    "query":{"query":"","language":"lucene"}
+                }`
             }
         }
     },
@@ -76,7 +155,55 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"_exists_:data.virustotal.malicious AND NOT data.virustotal.malicious: 0\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": `{
+                    "index":"wazuh-alerts",
+                    "filter":[
+                        {
+                            "meta": {
+                              "index": "wazuh-alerts",
+                              "negate": false,
+                              "disabled": false,
+                              "alias": null,
+                              "type": "exists",
+                              "key": "data.virustotal.malicious",
+                              "value": "exists"
+                            },
+                            "exists": {
+                              "field": "data.virustotal.malicious"
+                            },
+                            "$state": {
+                              "store": "appState"
+                            }
+                          },
+                          {
+                            "meta": {
+                              "index": "wazuh-alerts",
+                              "negate": true,
+                              "disabled": false,
+                              "alias": null,
+                              "type": "phrase",
+                              "key": "data.virustotal.malicious",
+                              "value": "0",
+                              "params": {
+                                "query": 0,
+                                "type": "phrase"
+                              }
+                            },
+                            "query": {
+                              "match": {
+                                "data.virustotal.malicious": {
+                                  "query": 0,
+                                  "type": "phrase"
+                                }
+                              }
+                            },
+                            "$state": {
+                              "store": "appState"
+                            }
+                          }
+                    ],
+                    "query":{"query":"","language":"lucene"}
+                }`
             }
         }
     },
@@ -90,7 +217,27 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"_exists_:data.virustotal\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": `{
+                    "index":"wazuh-alerts",
+                    "filter":[{
+                        "meta": {
+                        "index": "wazuh-alerts",
+                        "negate": false,
+                        "disabled": false,
+                        "alias": null,
+                        "type": "exists",
+                        "key": "data.virustotal",
+                        "value": "exists"
+                        },
+                        "exists": {
+                        "field": "data.virustotal"
+                        },
+                        "$state": {
+                        "store": "appState"
+                        }
+                    }],
+                    "query":{"query":"","language":"lucene"}
+                }`
             }
         }
     },
@@ -104,7 +251,38 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"NOT data.virustotal.malicious: 0\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": `{
+                    "index":"wazuh-alerts",
+                    "filter":[
+                        {
+                            "meta": {
+                              "index": "wazuh-alerts",
+                              "negate": true,
+                              "disabled": false,
+                              "alias": null,
+                              "type": "phrase",
+                              "key": "data.virustotal.malicious",
+                              "value": "0",
+                              "params": {
+                                "query": "0",
+                                "type": "phrase"
+                              }
+                            },
+                            "query": {
+                              "match": {
+                                "data.virustotal.malicious": {
+                                  "query": "0",
+                                  "type": "phrase"
+                                }
+                              }
+                            },
+                            "$state": {
+                              "store": "appState"
+                            }
+                          }
+                    ],
+                    "query":{"query":"","language":"lucene"}
+                }`
             }
         }
     },
@@ -118,7 +296,38 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"NOT data.virustotal.malicious: 0\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": `{
+                    "index":"wazuh-alerts",
+                    "filter":[
+                        {
+                            "meta": {
+                              "index": "wazuh-alerts",
+                              "negate": true,
+                              "disabled": false,
+                              "alias": null,
+                              "type": "phrase",
+                              "key": "data.virustotal.malicious",
+                              "value": "0",
+                              "params": {
+                                "query": "0",
+                                "type": "phrase"
+                              }
+                            },
+                            "query": {
+                              "match": {
+                                "data.virustotal.malicious": {
+                                  "query": "0",
+                                  "type": "phrase"
+                                }
+                              }
+                            },
+                            "$state": {
+                              "store": "appState"
+                            }
+                          }
+                    ],
+                    "query":{"query":"","language":"lucene"}
+                }`
             }
         }
     },
@@ -132,7 +341,55 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"_exists_:data.virustotal AND NOT data.virustotal.positives: 0\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": `{
+                    "index":"wazuh-alerts",
+                    "filter":[
+                        {
+                            "meta": {
+                              "index": "wazuh-alerts",
+                              "negate": false,
+                              "disabled": false,
+                              "alias": null,
+                              "type": "exists",
+                              "key": "data.virustotal",
+                              "value": "exists"
+                            },
+                            "exists": {
+                              "field": "data.virustotal"
+                            },
+                            "$state": {
+                              "store": "appState"
+                            }
+                          },
+                          {
+                            "meta": {
+                              "index": "wazuh-alerts",
+                              "negate": true,
+                              "disabled": false,
+                              "alias": null,
+                              "type": "phrase",
+                              "key": "data.virustotal.positives",
+                              "value": "0",
+                              "params": {
+                                "query": 0,
+                                "type": "phrase"
+                              }
+                            },
+                            "query": {
+                              "match": {
+                                "data.virustotal.positives": {
+                                  "query": 0,
+                                  "type": "phrase"
+                                }
+                              }
+                            },
+                            "$state": {
+                              "store": "appState"
+                            }
+                          }
+                    ],
+                    "query":{"query":"","language":"lucene"}
+                }`
             }
         }
     }

--- a/server/integration-files/visualizations/overview/overview-virustotal.js
+++ b/server/integration-files/visualizations/overview/overview-virustotal.js
@@ -11,18 +11,18 @@
  */
 export default [
     {
-		"_id": "Wazuh-App-Overview-Virustotal-Last-Files-Pie",
-		"_type": "visualization",
-		"_source": {
-		  "title": "Last files",
-		  "visState": "{\"title\":\"Last files\",\"type\":\"pie\",\"params\":{\"type\":\"pie\",\"addTooltip\":true,\"addLegend\":true,\"legendPosition\":\"right\",\"isDonut\":true,\"labels\":{\"show\":false,\"values\":true,\"last_level\":true,\"truncate\":100}},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{\"customLabel\":\"Files\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"segment\",\"params\":{\"field\":\"data.virustotal.source.file\",\"size\":5,\"order\":\"desc\",\"orderBy\":\"1\"}}]}",
-		  "uiStateJSON": "{\"vis\":{\"legendOpen\":true}}",
-		  "description": "",
-		  "version": 1,
-		  "kibanaSavedObjectMeta": {
-			"searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"\",\"language\":\"lucene\"}}"
-		  }
-		}
+      "_id": "Wazuh-App-Overview-Virustotal-Last-Files-Pie",
+      "_type": "visualization",
+      "_source": {
+        "title": "Last files",
+        "visState": "{\"title\":\"Last files\",\"type\":\"pie\",\"params\":{\"type\":\"pie\",\"addTooltip\":true,\"addLegend\":true,\"legendPosition\":\"right\",\"isDonut\":true,\"labels\":{\"show\":false,\"values\":true,\"last_level\":true,\"truncate\":100}},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{\"customLabel\":\"Files\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"segment\",\"params\":{\"field\":\"data.virustotal.source.file\",\"size\":5,\"order\":\"desc\",\"orderBy\":\"1\"}}]}",
+        "uiStateJSON": "{\"vis\":{\"legendOpen\":true}}",
+        "description": "",
+        "version": 1,
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"\",\"language\":\"lucene\"}}"
+        }
+      }
     },
     {
         "_id": "Wazuh-App-Overview-Virustotal-Files-Table",

--- a/server/integration-files/visualizations/overview/overview-vuls.js
+++ b/server/integration-files/visualizations/overview/overview-vuls.js
@@ -20,7 +20,7 @@ export default [
 			"description": "",
 			"version": 1,
 			"kibanaSavedObjectMeta": {
-				"searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"rule.groups: vulnerability-detector\",\"language\":\"lucene\"}}"
+				"searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"\",\"language\":\"lucene\"}}"
 			}
 		}
 	},
@@ -34,7 +34,7 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"rule.groups: vulnerability-detector\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"\",\"language\":\"lucene\"}}"
             }
         }
     },
@@ -48,7 +48,7 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"rule.groups: vulnerability-detector\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"\",\"language\":\"lucene\"}}"
             }
         }
     },
@@ -62,7 +62,38 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"rule.groups: vulnerability-detector AND data.vulnerability.severity: Critical\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": `{
+                    "index":"wazuh-alerts",
+                    "filter":[
+                        {
+                            "meta": {
+                              "index": "wazuh-alerts",
+                              "negate": false,
+                              "disabled": false,
+                              "alias": null,
+                              "type": "phrase",
+                              "key": "data.vulnerability.severity",
+                              "value": "Critical",
+                              "params": {
+                                "query": "Critical",
+                                "type": "phrase"
+                              }
+                            },
+                            "query": {
+                              "match": {
+                                "data.vulnerability.severity": {
+                                  "query": "Critical",
+                                  "type": "phrase"
+                                }
+                              }
+                            },
+                            "$state": {
+                              "store": "appState"
+                            }
+                        }
+                    ],
+                    "query":{"query":"","language":"lucene"}
+                }`
             }
         }
     },
@@ -76,7 +107,38 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"rule.groups: vulnerability-detector AND data.vulnerability.severity: High\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": `{
+                    "index":"wazuh-alerts",
+                    "filter":[
+                        {
+                            "meta": {
+                              "index": "wazuh-alerts",
+                              "negate": false,
+                              "disabled": false,
+                              "alias": null,
+                              "type": "phrase",
+                              "key": "data.vulnerability.severity",
+                              "value": "High",
+                              "params": {
+                                "query": "High",
+                                "type": "phrase"
+                              }
+                            },
+                            "query": {
+                              "match": {
+                                "data.vulnerability.severity": {
+                                  "query": "High",
+                                  "type": "phrase"
+                                }
+                              }
+                            },
+                            "$state": {
+                              "store": "appState"
+                            }
+                        }
+                    ],
+                    "query":{"query":"","language":"lucene"}
+                }`
             }
         }
     },
@@ -90,7 +152,38 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"rule.groups: vulnerability-detector AND data.vulnerability.severity: Medium\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": `{
+                    "index":"wazuh-alerts",
+                    "filter":[
+                        {
+                            "meta": {
+                              "index": "wazuh-alerts",
+                              "negate": false,
+                              "disabled": false,
+                              "alias": null,
+                              "type": "phrase",
+                              "key": "data.vulnerability.severity",
+                              "value": "Medium",
+                              "params": {
+                                "query": "Medium",
+                                "type": "phrase"
+                              }
+                            },
+                            "query": {
+                              "match": {
+                                "data.vulnerability.severity": {
+                                  "query": "Medium",
+                                  "type": "phrase"
+                                }
+                              }
+                            },
+                            "$state": {
+                              "store": "appState"
+                            }
+                        }
+                    ],
+                    "query":{"query":"","language":"lucene"}
+                }`
             }
         }
     },
@@ -104,7 +197,38 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"rule.groups: vulnerability-detector AND data.vulnerability.severity: Low\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": `{
+                    "index":"wazuh-alerts",
+                    "filter":[
+                        {
+                            "meta": {
+                              "index": "wazuh-alerts",
+                              "negate": false,
+                              "disabled": false,
+                              "alias": null,
+                              "type": "phrase",
+                              "key": "data.vulnerability.severity",
+                              "value": "Low",
+                              "params": {
+                                "query": "Low",
+                                "type": "phrase"
+                              }
+                            },
+                            "query": {
+                              "match": {
+                                "data.vulnerability.severity": {
+                                  "query": "Low",
+                                  "type": "phrase"
+                                }
+                              }
+                            },
+                            "$state": {
+                              "store": "appState"
+                            }
+                        }
+                    ],
+                    "query":{"query":"","language":"lucene"}
+                }`
             }
         }
     },
@@ -118,7 +242,7 @@ export default [
             "description": "",
             "version": 1,
             "kibanaSavedObjectMeta": {
-                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"rule.groups: vulnerability-detector\",\"language\":\"lucene\"}}"
+                "searchSourceJSON": "{\"index\":\"wazuh-alerts\",\"filter\":[],\"query\":{\"query\":\"\",\"language\":\"lucene\"}}"
             }
         }
     }


### PR DESCRIPTION
Hello team, this PR fixes https://github.com/wazuh/wazuh-kibana-app/issues/654

Brief summary:

- All visualizations have been refactored. They are now using filters instead queries.
- The kbn-vis has been refactored. It's now switching between Lucene and Kuery depending on the user input.
- Discover directive doesn't need changes because it's already adapted by the Elastic team.

_Note: this feature is experimental for Kibana, even more for the Wazuh App. It needs lot of testing._

Regards,
Jesús