### PR TITLE
Configuration for Wazuh monitoring shards and replicas

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -56,13 +56,11 @@
 #
 # ------------------------------ Advanced indices ------------------------------
 #
-# Configure .wazuh, .wazuh-version, wazuh-monitoring-3.x-* indices shards and replicas.
+# Configure .wazuh and .wazuh-version indices shards and replicas.
 #wazuh.shards          : 1
 #wazuh.replicas        : 1
 #wazuh-version.shards  : 1
 #wazuh-version.replicas: 1
-#wazuh-monitoring.shards: 5
-#wazuh-monitoring.replicas: 1
 #
 # --------------------------- Index pattern selector ---------------------------
 #
@@ -90,3 +88,6 @@
 # Default: 3600 (s)
 #wazuh.monitoring.frequency: 3600
 #
+# Configure wazuh-monitoring-3.x-* indices shards and replicas.
+#wazuh.monitoring.shards: 5
+#wazuh.monitoring.replicas: 1

--- a/config.yml
+++ b/config.yml
@@ -56,11 +56,13 @@
 #
 # ------------------------------ Advanced indices ------------------------------
 #
-# Configure .wazuh and .wazuh-version indices shards and replicas.
+# Configure .wazuh, .wazuh-version, wazuh-monitoring-3.x-* indices shards and replicas.
 #wazuh.shards          : 1
 #wazuh.replicas        : 1
 #wazuh-version.shards  : 1
 #wazuh-version.replicas: 1
+#wazuh-monitoring.shards: 5
+#wazuh-monitoring.replicas: 1
 #
 # --------------------------- Index pattern selector ---------------------------
 #

--- a/public/services/resolves/get-config.js
+++ b/public/services/resolves/get-config.js
@@ -28,12 +28,14 @@ export default async ($q, genericReq, errorHandler, wazuhConfig) => {
         timeout                : 8000,
         'wazuh.shards'         : 1,
         'wazuh.replicas'       : 1,
+        'wazuh-version.shards'  : 1,
+        'wazuh-version.replicas': 1,   
         'ip.selector'          : true,
         'xpack.rbac.enabled'   : true,
-        'wazuh.wazuh-version.shards'  : 1,
-        'wazuh.wazuh-version.shards.replicas': 1,            
         'wazuh.monitoring.enabled'  : true,
-        'wazuh.monitoring.frequency': 3600
+        'wazuh.monitoring.frequency': 3600,
+        'wazuh.monitoring.shards'  : 5,
+        'wazuh.monitoring.replicas': 1
     };
 
     try {

--- a/server/lib/elastic-wrapper.js
+++ b/server/lib/elastic-wrapper.js
@@ -664,11 +664,18 @@ export default class ElasticWrapper {
          }
     }
 
-    async createIndexByName(name) {
+    async createIndexByName(name, configuration = null) {
         try {
             if(!name) return Promise.reject(new Error('No valid name given'));
+            
+            const raw = { 
+                index: name,
+                body: configuration
+            }
 
-            const data = await this.elasticRequest.callWithInternalUser('indices.create', { index: name });
+            if(!configuration) delete raw.body;
+
+            const data = await this.elasticRequest.callWithInternalUser('indices.create', raw);
 
             return data;
 

--- a/server/monitoring.js
+++ b/server/monitoring.js
@@ -234,7 +234,25 @@ export default (server, options) => {
     const createIndex = async (todayIndex,clusterName) => {
         try {
             if(!ENABLED) return;
-            await wzWrapper.createIndexByName(todayIndex);
+            const configFile = getConfiguration();
+
+            const shards = configFile && typeof configFile["wazuh-monitoring.shards"] !== 'undefined' ?
+                           configFile["wazuh-monitoring.shards"] : 5;
+
+            const replicas = configFile && typeof configFile["wazuh-monitoring.replicas"] !== 'undefined' ?
+                             configFile["wazuh-monitoring.replicas"] : 1;
+
+            const configuration = {
+                settings: {
+                    index: {
+                        number_of_shards: shards,
+                        number_of_replicas: replicas
+                    }
+                }
+            };
+
+            await wzWrapper.createIndexByName(todayIndex, configuration);
+
             log('[monitoring][createIndex]', 'Successfully created today index.', 'info');
             server.log([blueWazuh, 'monitoring', 'info'], 'Successfully created today index.');
             await insertDocument(todayIndex,clusterName);

--- a/server/monitoring.js
+++ b/server/monitoring.js
@@ -236,11 +236,11 @@ export default (server, options) => {
             if(!ENABLED) return;
             const configFile = getConfiguration();
 
-            const shards = configFile && typeof configFile["wazuh-monitoring.shards"] !== 'undefined' ?
-                           configFile["wazuh-monitoring.shards"] : 5;
+            const shards = configFile && typeof configFile['wazuh.monitoring.shards'] !== 'undefined' ?
+                           configFile['wazuh.monitoring.shards'] : 5;
 
-            const replicas = configFile && typeof configFile["wazuh-monitoring.replicas"] !== 'undefined' ?
-                             configFile["wazuh-monitoring.replicas"] : 1;
+            const replicas = configFile && typeof configFile['wazuh.monitoring.replicas'] !== 'undefined' ?
+                             configFile['wazuh.monitoring.replicas'] : 1;
 
             const configuration = {
                 settings: {


### PR DESCRIPTION
Hello team, this PR closes https://github.com/wazuh/wazuh-kibana-app/issues/801

Two new parameters have been added to our _config.yml_:

```yaml
wazuh.monitoring.shards: 5
wazuh.monitoring.replicas: 1
```

Just modify them to configure your shards and replicas for _wazuh-monitoring-3.x-*_ indices.

Regards,
Jesús