### PR TITLE
Added logs in critical catch statements

### DIFF
--- a/server/controllers/wazuh-api-elastic.js
+++ b/server/controllers/wazuh-api-elastic.js
@@ -12,6 +12,7 @@
 
 import ElasticWrapper from '../lib/elastic-wrapper';
 import ErrorResponse  from './error-response';
+import log            from '../logger';
 
 const userRegEx  = new RegExp(/^.{3,100}$/);
 const passRegEx  = new RegExp(/^.{3,100}$/);
@@ -42,6 +43,7 @@ export default class WazuhApiElastic {
             return reply(result);
 
         } catch(error){
+            log('GET /api/wazuh-api/apiEntries',error.message || error);
             return ErrorResponse(error.message || error, 2001, 500, reply);
         }
     }
@@ -53,6 +55,7 @@ export default class WazuhApiElastic {
             return reply(data);
 
         } catch(error){
+            log('DELETE /api/wazuh-api/apiEntries/{id}',error.message || error);
             return ErrorResponse(error.message || error, 2002, 500, reply);
         }
     }
@@ -72,6 +75,7 @@ export default class WazuhApiElastic {
             return reply({ statusCode: 200, message: 'ok' });
 
         }catch(error){
+            log('PUT /api/wazuh-api/apiEntries/{id}',error.message || error);
             return ErrorResponse(`Could not save data in elasticsearch due to ${error.message || error}`, 2003, 500, reply);
         }
     }
@@ -131,6 +135,7 @@ export default class WazuhApiElastic {
             return reply({ statusCode: 200, message: 'ok', response });
 
         } catch (error){
+            log('PUT /api/wazuh-api/settings',error.message || error);
             return ErrorResponse(`Could not save data in elasticsearch due to ${error.message || error}`, 2011, 500, reply);
         }
     }
@@ -143,6 +148,7 @@ export default class WazuhApiElastic {
             return reply({ statusCode: 200, message: 'ok' });
 
         } catch (error) {
+            log('PUT /api/wazuh-api/updateApiHostname/{id}',error.message || error);
             return ErrorResponse(`Could not save data in elasticsearch due to ${error.message || error}`, 2012, 500, reply);
         }
     }
@@ -163,6 +169,7 @@ export default class WazuhApiElastic {
             return reply({ statusCode: 200, message: 'ok' });
 
         } catch (error) {
+            log('PUT /api/wazuh-api/update-settings',error.message || error);
             return ErrorResponse(`Could not save data in elasticsearch due to ${error.message || error}`, 2014, 500, reply);
         }
     }

--- a/server/controllers/wazuh-api.js
+++ b/server/controllers/wazuh-api.js
@@ -24,8 +24,8 @@ import getConfiguration     from '../lib/get-configuration';
 import { totalmem }         from 'os';
 import simpleTail           from 'simple-tail';
 import path                 from 'path';
-
-import CsvKeys from '../../util/csv-key-equivalence';
+import log                  from '../logger';
+import CsvKeys              from '../../util/csv-key-equivalence';
 
 export default class WazuhApi {
     constructor(server){
@@ -124,6 +124,7 @@ export default class WazuhApi {
             }
         } catch(error){
             if(error.code === 'ECONNREFUSED'){
+                log('POST /api/wazuh-api/checkStoredAPI',error.message || error);
                 return reply({ statusCode: 200, data: {password: '****', apiIsDown: true } });
             } else {
                 // Check if we can connect to a different API
@@ -148,9 +149,11 @@ export default class WazuhApi {
                             } catch(error) {   } // eslint-disable-line                            
                         }
                     } catch (error) {
+                        log('POST /api/wazuh-api/checkStoredAPI',error.message || error);
                         return ErrorResponse(error.message || error, 3020, 500, reply);
                     }
                 }
+                log('POST /api/wazuh-api/checkStoredAPI',error.message || error);
                 return ErrorResponse(error.message || error, 3002, 500, reply);
             }
         }
@@ -282,6 +285,7 @@ export default class WazuhApi {
             throw new Error(tmpMsg)
 
         } catch(error) {
+            log('POST /api/wazuh-api/checkAPI',error.message || error);
             return ErrorResponse(error.message || error, 3005, 500, reply);
         }
     }

--- a/server/controllers/wazuh-elastic.js
+++ b/server/controllers/wazuh-elastic.js
@@ -10,9 +10,15 @@
  * Find more information about this on the LICENSE file.
  */
 import ElasticWrapper from '../lib/elastic-wrapper';
-import ErrorResponse  from './error-response'
+import ErrorResponse  from './error-response';
+import log            from '../logger';
 
-import { AgentsVisualizations, OverviewVisualizations, ClusterVisualizations }  from '../integration-files/visualizations'
+import { 
+    AgentsVisualizations, 
+    OverviewVisualizations, 
+    ClusterVisualizations 
+}  from '../integration-files/visualizations';
+
 
 export default class WazuhElastic {
     constructor(server){
@@ -66,6 +72,7 @@ export default class WazuhElastic {
                     reply({ statusCode: 200, status: false, data: `No template found for ${req.params.pattern}` });
             
         } catch (error){
+            log('GET /api/wazuh-elastic/template/{pattern}',error.message || error);
             return ErrorResponse(`Could not retrieve templates from Elasticsearch due to ${error.message || error}`, 4002, 500, reply);
         }
     }
@@ -81,6 +88,7 @@ export default class WazuhElastic {
                    reply({ statusCode: 500, status: false, error:10020, message: 'Index pattern not found' });
 
         } catch (error) {
+            log('GET /api/wazuh-elastic/pattern/{pattern}',error.message || error);
             return ErrorResponse(`Something went wrong retrieving index-patterns from Elasticsearch due to ${error.message || error}`, 4003, 500, reply);
         }
     }
@@ -143,6 +151,7 @@ export default class WazuhElastic {
                    reply({ statusCode: 200, data: data.hits.hits[0]._source });
 
         } catch (error) {
+            log('GET /api/wazuh-elastic/setup',error.message || error);
             return ErrorResponse(`Could not get data from elasticsearch due to ${error.message || error}`, 4005, 500, reply);
         }
     }
@@ -227,6 +236,7 @@ export default class WazuhElastic {
             throw new Error('The Elasticsearch request didn\'t fetch the expected data');
 
         } catch(error){
+            log('GET /get-list',error.message || error);
             return ErrorResponse(error.message || error, 4006, 500, reply);
         }
     }
@@ -386,6 +396,7 @@ export default class WazuhElastic {
             return reply({acknowledge: true, output: output });
 
         } catch(error){
+            log('GET /refresh-fields/{pattern}',error.message || error);
             return ErrorResponse(error.message || error, 4008, 500, reply);
         }
     }


### PR DESCRIPTION
Hello team, this PR closes https://github.com/wazuh/wazuh-kibana-app/issues/810.

Added some logs for specific routes when they fail in a critical way. This means, the log is only written when entering in a `catch(error) { ` block.

Affected routes are:

```
GET /api/wazuh-api/apiEntries
DELETE /api/wazuh-api/apiEntries/{id}
PUT /api/wazuh-api/apiEntries/{id}
PUT /api/wazuh-api/settings
PUT /api/wazuh-api/updateApiHostname/{id}
PUT /api/wazuh-api/update-settings
POST /api/wazuh-api/checkStoredAPI
POST /api/wazuh-api/checkAPI
GET /api/wazuh-elastic/template/{pattern}
GET /api/wazuh-elastic/pattern/{pattern}
GET /api/wazuh-elastic/setup
GET /get-list
GET /refresh-fields/{pattern}
```

Example when trying to save a Wazuh API entry from the app form using wrong port:

```js
// wazuhapp.log
{
"date":"2018-08-23T10:05:24.247Z",
"level":"error",
"location":"POST /api/wazuh-api/checkAPI",
"message":"connect ECONNREFUSED 192.168.1.193:5500"
}
```


Regards,
Jesús