### PR TITLE
Remove rule.id filter before entering Management

### DIFF
--- a/public/services/common-data.js
+++ b/public/services/common-data.js
@@ -25,6 +25,18 @@ class CommonData {
         this.globalState  = globalState;
     }
 
+    removeRuleId() {
+        if(!this.globalState || !this.globalState.filters) return;
+        const arr = [];
+        for(const item of this.globalState.filters){
+            if(item.query && item.query.match && item.query.match["rule.id"] && item.query.match["rule.id"].query) {
+                continue;
+            }
+            arr.push(item);
+        }
+        this.globalState.filters = arr;
+    }
+
     removeDuplicateRuleGroups(group) {
         if(!this.globalState || !this.globalState.filters) return;
         const globalRuleGroupFilters = this.globalState.filters.map(item => {

--- a/public/services/routes.js
+++ b/public/services/routes.js
@@ -64,6 +64,10 @@ function wzKibana($location, $window, $rootScope) {
     return goToKibana($location, $window);
 }
 
+function clearRuleId(commonData) {
+    commonData.removeRuleId()
+    return Promise.resolve()
+}
 
 //Routes
 routes.enable();
@@ -82,7 +86,7 @@ routes
     })
     .when('/manager/:tab?/', {
         template: managementTemplate,
-        resolve: { nestedResolve, ip, savedSearch }
+        resolve: { nestedResolve, ip, savedSearch, clearRuleId }
     })
     .when('/overview/', {
         template: overviewTemplate,


### PR DESCRIPTION
Hello team, this PR prevents from having a global `rule.id` filter if we are in Management > Monitoring

Regards