### PR TITLE
Node selector for Management > Status

### DIFF
--- a/public/controllers/management/status.js
+++ b/public/controllers/management/status.js
@@ -19,9 +19,12 @@ class StatusController {
     this.errorHandler = errorHandler;
     this.apiReq = apiReq;
     this.$scope.load = true;
-
+    this.$scope.nodes = [];
+    this.$scope.selectedNode = false;
+    this.$scope.clusterError = false;
     this.$scope.getDaemonStatusClass = daemonStatus =>
       this.getDaemonStatusClass(daemonStatus);
+    this.$scope.changeNode = node => this.changeNode(node);
   }
 
   /**
@@ -46,7 +49,7 @@ class StatusController {
     try {
       const data = await Promise.all([
         this.apiReq.request('GET', '/agents/summary', {}),
-        this.apiReq.request('GET', '/manager/status', {}),
+        this.apiReq.request('GET', '/cluster/status', {}),
         this.apiReq.request('GET', '/manager/info', {}),
         this.apiReq.request('GET', '/rules', { offset: 0, limit: 1 }),
         this.apiReq.request('GET', '/decoders', { offset: 0, limit: 1 })
@@ -55,7 +58,7 @@ class StatusController {
       const parsedData = data.map(item => item.data.data);
       const [
         stats,
-        daemons,
+        clusterStatus,
         managerInfo,
         totalRules,
         totalDecoders
@@ -71,8 +74,41 @@ class StatusController {
 
       this.$scope.agentsCoverity = total ? (active / total) * 100 : 0;
 
-      this.$scope.daemons = daemons;
-      this.$scope.managerInfo = managerInfo;
+      if (
+        clusterStatus &&
+        clusterStatus.enabled === 'yes' &&
+        clusterStatus.running === 'yes'
+      ) {
+        const nodes = await this.apiReq.request('GET', '/cluster/nodes', {});
+        this.$scope.nodes = nodes.data.data.items.reverse();
+        const masterNode = nodes.data.data.items.filter(
+          item => item.type === 'master'
+        )[0];
+        const daemons = await this.apiReq.request(
+          'GET',
+          `/cluster/${masterNode.name}/status`,
+          {}
+        );
+        this.$scope.daemons = daemons.data.data;
+        this.$scope.selectedNode = masterNode.name;
+        const nodeInfo = await this.apiReq.request(
+          'GET',
+          `/cluster/${masterNode.name}/info`,
+          {}
+        );
+        this.$scope.managerInfo = nodeInfo.data.data;
+      } else if (
+        clusterStatus &&
+        clusterStatus.enabled === 'yes' &&
+        clusterStatus.running === 'no'
+      ) {
+        this.$scope.clusterError = `Cluster is enabled but it's not running, please check your cluster health.`;
+      } else {
+        const daemons = await this.apiReq.request('GET', '/manager/status', {});
+        this.$scope.daemons = daemons.data.data;
+        this.$scope.managerInfo = managerInfo;
+      }
+
       this.$scope.totalRules = totalRules.totalItems;
       this.$scope.totalDecoders = totalDecoders.totalItems;
 
@@ -94,8 +130,38 @@ class StatusController {
 
       return;
     } catch (error) {
+      this.$scope.load = false;
       return this.errorHandler.handle(error, 'Manager');
     }
+  }
+
+  async changeNode(node) {
+    try {
+      this.$scope.clusterError = false;
+      this.$scope.load = true;
+      const daemons = await this.apiReq.request(
+        'GET',
+        `/cluster/${node}/status`,
+        {}
+      );
+      this.$scope.daemons = daemons.data.data;
+
+      const nodeInfo = await this.apiReq.request(
+        'GET',
+        `/cluster/${node}/info`,
+        {}
+      );
+      this.$scope.managerInfo = nodeInfo.data.data;
+
+      this.$scope.load = false;
+      if (!this.$scope.$$phase) this.$scope.$digest();
+    } catch (error) {
+      this.$scope.load = false;
+      this.$scope.clusterError = `Node ${node} is down`;
+    }
+
+    if (!this.$scope.$$phase) this.$scope.$digest();
+    return;
   }
 }
 

--- a/public/templates/management/status.html
+++ b/public/templates/management/status.html
@@ -6,14 +6,39 @@
     </div>
 
     <!-- Headline -->
-    <div ng-show="!load" layout="column" layout-padding>
+    <div ng-show="!load" layout="row" layout-padding>
         <span class="font-size-18"><i class="fa fa-fw fa-heartbeat" aria-hidden="true"></i> Status</span>
-        <span class="md-subheader">Check the status of all Wazuh manager daemons</span>
+    </div>
+    <div ng-show="!load" layout="row" layout-padding>
+        <div flex layout="column" layout-align="center" class="height-40 wz-margin-right-15">
+            <span class="md-subheader">Check the status of all Wazuh manager daemons <span ng-show="selectedNode">({{selectedNode}})</span></span>
+        </div>
+        <div ng-show="selectedNode" layout="column" layout-align="center" class="height-40 wz-select-input">
+            <select class="kuiSelect wz-border-none cursor-pointer max-height-35" id="categoryBox" ng-model="selectedNode"
+                ng-change="changeNode(selectedNode)" aria-label="Select node">
+                <option ng-repeat="node in nodes" value="{{node.name}}">{{node.name}}</option>
+            </select>
+        </div>
     </div>
     <!-- End headline -->
 
+    <div layout="row" class="wz-margin-top-10 wz-margin-right-8 wz-margin-left-8" ng-show="clusterError && !load">
+        <div flex class="euiCallOut euiCallOut--warning">
+            <div class="euiCallOutHeader">
+                <svg class="euiIcon euiIcon--medium euiCallOutHeader__icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg"
+                    xmlns:xlink="http://www.w3.org/1999/xlink" width="16" height="16" viewBox="0 0 16 16">
+                    <defs>
+                        <path id="help-a" d="M13.6 12.186l-1.357-1.358c-.025-.025-.058-.034-.084-.056.53-.794.84-1.746.84-2.773a4.977 4.977 0 0 0-.84-2.772c.026-.02.059-.03.084-.056L13.6 3.813a6.96 6.96 0 0 1 0 8.373zM8 15A6.956 6.956 0 0 1 3.814 13.6l1.358-1.358c.025-.025.034-.057.055-.084C6.02 12.688 6.974 13 8 13a4.978 4.978 0 0 0 2.773-.84c.02.026.03.058.056.083l1.357 1.358A6.956 6.956 0 0 1 8 15zm-5.601-2.813a6.963 6.963 0 0 1 0-8.373l1.359 1.358c.024.025.057.035.084.056A4.97 4.97 0 0 0 3 8c0 1.027.31 1.98.842 2.773-.027.022-.06.031-.084.056l-1.36 1.358zm5.6-.187A4 4 0 1 1 8 4a4 4 0 0 1 0 8zM8 1c1.573 0 3.019.525 4.187 1.4l-1.357 1.358c-.025.025-.035.057-.056.084A4.979 4.979 0 0 0 8 3a4.979 4.979 0 0 0-2.773.842c-.021-.027-.03-.059-.055-.084L3.814 2.4A6.957 6.957 0 0 1 8 1zm0-1a8.001 8.001 0 1 0 .003 16.002A8.001 8.001 0 0 0 8 0z"></path>
+                    </defs>
+                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#help-a" fill-rule="evenodd"></use>
+                </svg>
+                <span class="euiCallOutHeader__title">{{clusterError}}</span>
+            </div>
+        </div>
+    </div>
+
     <!-- Daemons status section -->
-    <div layout="row" layout-align="start stretch" ng-if="!load">
+    <div layout="row" layout-align="start stretch" ng-show="!load && !clusterError">
         <md-card flex class="wz-md-card" ng-repeat="(k,v) in daemons">
             <md-card-content>
                 <center>
@@ -26,7 +51,7 @@
     <!-- End daemons status section -->
 
     <!-- Agents status section -->
-    <div layout="row" layout-align="start center" ng-if="!load">
+    <div layout="row" layout-align="start center" ng-show="!load && !clusterError">
         <md-card flex class="wz-metric-color wz-md-card">
             <md-card-content layout="row" class="wz-padding-metric">
                 <div flex class="wz-text-truncatable">Total agents:
@@ -48,11 +73,12 @@
     </div>
     <!-- End agents status section -->
 
-    <div layout="row" layout-align="start stretch" layout-wrap ng-if="!load">
+    <div layout="row" layout-align="start stretch" layout-wrap ng-if="!load && !clusterError">
         <!-- Manager information section -->
         <md-card flex class="wz-md-card">
             <md-card-content>
-                <i class="fa fa-fw fa-server" aria-hidden="true"></i> <span class="wz-headline-title">Manager information</span>
+                <i class="fa fa-fw fa-server" aria-hidden="true"></i> <span ng-if="selectedNode" class="wz-headline-title">{{selectedNode}}
+                    information</span> <span ng-if="!selectedNode" class="wz-headline-title">Manager information</span>
                 <md-divider class="wz-margin-top-10"></md-divider>
                 <div layout="row" class="wz-padding-top-10">
                     <span flex="25">Version</span>
@@ -60,7 +86,8 @@
                 </div>
                 <div layout="row" class="wz-padding-top-10">
                     <span flex="25">Compilation date</span>
-                    <span class="wz-text-right color-grey">{{managerInfo.compilation_date ? managerInfo.compilation_date : '-'}}</span>
+                    <span class="wz-text-right color-grey">{{managerInfo.compilation_date ?
+                        managerInfo.compilation_date : '-'}}</span>
                 </div>
                 <div layout="row" class="wz-padding-top-10">
                     <span flex="25">Installation path</span>
@@ -76,7 +103,8 @@
                 </div>
                 <div layout="row" class="wz-padding-top-10">
                     <span flex="25">OpenSSL Support</span>
-                    <span class="wz-text-right color-grey">{{managerInfo.openssl_support ? managerInfo.openssl_support : '-'}}</span>
+                    <span class="wz-text-right color-grey">{{managerInfo.openssl_support ? managerInfo.openssl_support
+                        : '-'}}</span>
                 </div>
                 <div layout="row" class="wz-padding-top-10">
                     <span flex="25">Total rules</span>
@@ -125,7 +153,8 @@
                 </div>
                 <div layout="row" class="wz-padding-top-10">
                     <span flex="25">Operating system</span>
-                    <span class="wz-text-right color-grey">{{agentInfo.os.name ? agentInfo.os.name + agentInfo.os.version : agentInfo.os.uname ? agentInfo.os.uname : '-'}}</span>
+                    <span class="wz-text-right color-grey">{{agentInfo.os.name ? agentInfo.os.name +
+                        agentInfo.os.version : agentInfo.os.uname ? agentInfo.os.uname : '-'}}</span>
                 </div>
             </md-card-content>
         </md-card>


### PR DESCRIPTION
Hello team, this PR adds a node selector for our _Management > Status_ view. Since Wazuh is now able to be a cluster, it makes sense to have a node selector for checking every node daemons and other useful information. 

This feature is also related to #970 

Regards