### PR TITLE
API calls improved

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "wazuh",
     "version": "3.7.0",
     "revision": "0413",
-    "code":"0413-1",
+    "code":"0413-2",
     "kibana": {
         "version": "6.4.2"
     },

--- a/public/controllers/agent/agents.js
+++ b/public/controllers/agent/agents.js
@@ -283,28 +283,39 @@ class AgentsController {
   // Switch tab
   async switchTab(tab, force = false) {
     try {
-      if(tab === 'pci') {
+      if (tab === 'pci') {
         const pciTabs = await this.commonData.getPCI();
         this.$scope.pciTabs = pciTabs;
         this.$scope.selectedPciIndex = 0;
       }
-      if(tab === 'gdpr') {
+      if (tab === 'gdpr') {
         const gdprTabs = await this.commonData.getPCI();
         this.$scope.gdprTabs = gdprTabs;
         this.$scope.selectedGdprIndex = 0;
       }
-      if(tab === 'syscollector') await this.loadSyscollector(this.$scope.agent.id);
+      if (tab === 'syscollector')
+        await this.loadSyscollector(this.$scope.agent.id);
       if (tab === 'configuration') {
-        const isSync = await this.apiReq.request('GET', `/agents/${this.$scope.agent.id}/group/is_sync`, {})
+        const isSync = await this.apiReq.request(
+          'GET',
+          `/agents/${this.$scope.agent.id}/group/is_sync`,
+          {}
+        );
         // Configuration synced
-        this.$scope.isSynchronized = isSync && isSync.data && isSync.data.data && isSync.data.data.synced;
+        this.$scope.isSynchronized =
+          isSync && isSync.data && isSync.data.data && isSync.data.data.synced;
         this.$scope.switchConfigurationTab('welcome');
       } else {
         this.configurationHandler.reset(this.$scope);
       }
-      if (tab !== 'configuration' && tab !== 'welcome' && tab !== 'syscollector')
+      if (
+        tab !== 'configuration' &&
+        tab !== 'welcome' &&
+        tab !== 'syscollector'
+      )
         this.tabHistory.push(tab);
-      if (this.tabHistory.length > 2) this.tabHistory = this.tabHistory.slice(-2);
+      if (this.tabHistory.length > 2)
+        this.tabHistory = this.tabHistory.slice(-2);
       this.tabVisualizations.setTab(tab);
       if (this.$scope.tab === tab && !force) return;
       const onlyAgent = this.$scope.tab === tab && force;
@@ -333,8 +344,8 @@ class AgentsController {
 
       this.shareAgent.deleteTargetLocation();
       this.targetLocation = null;
-    } catch(error) {
-      return Promise.reject(error)
+    } catch (error) {
+      return Promise.reject(error);
     }
     if (!this.$scope.$$phase) this.$scope.$digest();
   }
@@ -451,12 +462,8 @@ class AgentsController {
       const result = data.map(
         item => (item && item.data && item.data.data ? item.data.data : false)
       );
-      
-      const [
-        agentInfo,
-        syscheckLastScan,
-        rootcheckLastScan
-      ] = result;
+
+      const [agentInfo, syscheckLastScan, rootcheckLastScan] = result;
 
       // Agent
       this.$scope.agent = agentInfo;

--- a/public/controllers/agent/agents.js
+++ b/public/controllers/agent/agents.js
@@ -149,17 +149,6 @@ class AgentsController {
       this.visFactoryService.clearAll();
     });
 
-    // PCI and GDPR requirements
-    Promise.all([this.commonData.getPCI(), this.commonData.getGDPR()])
-      .then(data => {
-        const [pciTabs, gdprTabs] = data;
-        this.$scope.pciTabs = pciTabs;
-        this.$scope.selectedPciIndex = 0;
-        this.$scope.gdprTabs = gdprTabs;
-        this.$scope.selectedGdprIndex = 0;
-      })
-      .catch(error => this.errorHandler.handle(error, 'Agents'));
-
     this.$scope.isArray = Array.isArray;
 
     this.$scope.goGroup = () => {
@@ -294,6 +283,16 @@ class AgentsController {
   // Switch tab
   async switchTab(tab, force = false) {
     try {
+      if(tab === 'pci') {
+        const pciTabs = await this.commonData.getPCI();
+        this.$scope.pciTabs = pciTabs;
+        this.$scope.selectedPciIndex = 0;
+      }
+      if(tab === 'gdpr') {
+        const gdprTabs = await this.commonData.getPCI();
+        this.$scope.gdprTabs = gdprTabs;
+        this.$scope.selectedGdprIndex = 0;
+      }
       if(tab === 'syscollector') await this.loadSyscollector(this.$scope.agent.id);
       if (tab === 'configuration') {
         const isSync = await this.apiReq.request('GET', `/agents/${this.$scope.agent.id}/group/is_sync`, {})

--- a/public/controllers/management/status.js
+++ b/public/controllers/management/status.js
@@ -50,9 +50,7 @@ class StatusController {
       const data = await Promise.all([
         this.apiReq.request('GET', '/agents/summary', {}),
         this.apiReq.request('GET', '/cluster/status', {}),
-        this.apiReq.request('GET', '/manager/info', {}),
-        this.apiReq.request('GET', '/rules', { offset: 0, limit: 1 }),
-        this.apiReq.request('GET', '/decoders', { offset: 0, limit: 1 })
+        this.apiReq.request('GET', '/manager/info', {})
       ]);
 
       const parsedData = data.map(
@@ -61,9 +59,7 @@ class StatusController {
       const [
         stats,
         clusterStatus,
-        managerInfo,
-        totalRules,
-        totalDecoders
+        managerInfo
       ] = parsedData;
 
       // Once Wazuh core fixes agent 000 issues, this should be adjusted
@@ -110,9 +106,6 @@ class StatusController {
         this.$scope.daemons = daemons.data.data;
         this.$scope.managerInfo = managerInfo;
       }
-
-      this.$scope.totalRules = totalRules.totalItems;
-      this.$scope.totalDecoders = totalDecoders.totalItems;
 
       const lastAgentRaw = await this.apiReq.request('GET', '/agents', {
         limit: 1,

--- a/public/controllers/management/status.js
+++ b/public/controllers/management/status.js
@@ -56,11 +56,7 @@ class StatusController {
       const parsedData = data.map(
         item => (item && item.data && item.data.data ? item.data.data : false)
       );
-      const [
-        stats,
-        clusterStatus,
-        managerInfo
-      ] = parsedData;
+      const [stats, clusterStatus, managerInfo] = parsedData;
 
       // Once Wazuh core fixes agent 000 issues, this should be adjusted
       const active = stats.Active - 1;

--- a/public/directives/wz-menu/wz-menu.js
+++ b/public/directives/wz-menu/wz-menu.js
@@ -69,8 +69,7 @@ class WzMenu {
           filtered = list.filter(item =>
             item.id.includes(appState.getCurrentPattern())
           );
-          if (!filtered.length)
-            appState.setCurrentPattern(list[0].id);
+          if (!filtered.length) appState.setCurrentPattern(list[0].id);
         }
 
         const data = filtered
@@ -78,7 +77,6 @@ class WzMenu {
           : await indexPatterns.get(appState.getCurrentPattern());
         $scope.theresPattern = true;
         $scope.currentPattern = data.title;
-        
 
         // Getting the list of index patterns
         if (list) {

--- a/public/directives/wz-menu/wz-menu.js
+++ b/public/directives/wz-menu/wz-menu.js
@@ -50,6 +50,7 @@ class WzMenu {
 
     const load = async () => {
       try {
+        const list = await patternHandler.getPatternList();
         // Get the configuration to check if pattern selector is enabled
         const config = wazuhConfig.getConfig();
         appState.setPatternSelector(config['ip.selector']);
@@ -62,31 +63,14 @@ class WzMenu {
         let filtered = false;
         // If there is no current pattern, fetch it
         if (!appState.getCurrentPattern()) {
-          const currentPattern = await genericReq.request('GET', '/elastic/index-patterns');
-          if (!currentPattern.data.data.length) {
-            wzMisc.setBlankScr('Sorry but no valid index patterns were found');
-            $location.search('tab', null);
-            $location.path('/blank-screen');
-            return;
-          }
-          appState.setCurrentPattern(currentPattern.data.data[0].id);
+          appState.setCurrentPattern(list[0].id);
         } else {
-          // If there is current pattern, check if there is some pattern
-          const patternList = await genericReq.request('GET', '/elastic/index-patterns');
-
-          if (!patternList.data.data.length) {
-            wzMisc.setBlankScr('Sorry but no valid index patterns were found');
-            $location.search('tab', null);
-            $location.path('/blank-screen');
-            return;
-          }
-
           // Check if the current pattern cookie is valid
-          filtered = patternList.data.data.filter(item =>
+          filtered = list.filter(item =>
             item.id.includes(appState.getCurrentPattern())
           );
           if (!filtered.length)
-            appState.setCurrentPattern(patternList.data.data[0].id);
+            appState.setCurrentPattern(list[0].id);
         }
 
         const data = filtered
@@ -94,7 +78,7 @@ class WzMenu {
           : await indexPatterns.get(appState.getCurrentPattern());
         $scope.theresPattern = true;
         $scope.currentPattern = data.title;
-        const list = await patternHandler.getPatternList();
+        
 
         // Getting the list of index patterns
         if (list) {

--- a/public/templates/management/status.html
+++ b/public/templates/management/status.html
@@ -106,14 +106,6 @@
                     <span class="wz-text-right color-grey">{{managerInfo.openssl_support ? managerInfo.openssl_support
                         : '-'}}</span>
                 </div>
-                <div layout="row" class="wz-padding-top-10">
-                    <span flex="25">Total rules</span>
-                    <span class="wz-text-right color-grey">{{totalRules ? totalRules : '-'}}</span>
-                </div>
-                <div layout="row" class="wz-padding-top-10">
-                    <span flex="25">Total decoders</span>
-                    <span class="wz-text-right color-grey">{{totalDecoders ? totalDecoders : '-'}}</span>
-                </div>
             </md-card-content>
         </md-card>
         <!-- End manager information section -->

--- a/server/lib/elastic-wrapper.js
+++ b/server/lib/elastic-wrapper.js
@@ -588,7 +588,7 @@ export class ElasticWrapper {
       const id = typeof req === 'object' && req.payload ? req.payload.id : req;
       if (!id || !doc) throw new Error('No valid parameters given');
 
-      const data = await this.elasticRequest.callWithRequest(req, 'update', {
+      const data = await this.elasticRequest.callWithInternalUser('update', {
         index: '.wazuh',
         type: 'wazuh-configuration',
         id: id,


### PR DESCRIPTION
Brief summary:

- Removed `this.commonData.getPCI()`, `this.commonData.getGDPR()` from `$onInit` method. Now they are used only in the proper tab.
- Loading _syscollector_ data only once we are in the _Agent > Inventory_ tab because are heavy calls and they are useless in a welcome screen.
- Using `is_sync` only when we are on the configuration tab.
- Method `this.$scope.switchTab` is now `async`.
- Removed _Total rules_ and _Total decoders_ metrics from _Management > Status_ due to perfomance reasons.
- Replaced the Elasticsearch wrapper method at https://github.com/wazuh/wazuh-kibana-app/blob/c7cbbbed8cc2876bf8c4fbbf29fedbfe5be36a7a/server/lib/elastic-wrapper.js#L591 in order to work properly when using X-Pack security features. This __must be fixed__ as soon as possible because it's now working but it doesn't take care about the X-Pack role being applied.