### PR TITLE
Several fixes

### DIFF
--- a/public/services/resolves/get-ip.js
+++ b/public/services/resolves/get-ip.js
@@ -16,7 +16,6 @@ import { healthCheck } from './health-check';
 export function getIp(
   indexPatterns,
   $q,
-  $rootScope,
   $window,
   $location,
   Private,
@@ -84,7 +83,8 @@ export function getIp(
     }
   };
 
-  if (healthCheck($window, $rootScope)) {
+  const currentLocation = $location.path();
+  if (!currentLocation.includes('agents-preview') && healthCheck($window)) {
     deferred.reject();
     $location.path('/health-check');
   } else {

--- a/public/services/resolves/get-saved-search.js
+++ b/public/services/resolves/get-saved-search.js
@@ -14,12 +14,11 @@ import { recentlyAccessed } from 'ui/persisted_log';
 export function getSavedSearch(
   redirectWhenMissing,
   $location,
-  $window,
-  $rootScope,
+  $window,  
   savedSearches,
   $route
 ) {
-  if (healthCheck($window, $rootScope)) {
+  if (healthCheck($window)) {
     $location.path('/health-check');
     return Promise.reject();
   } else {

--- a/public/services/resolves/settings-wizard.js
+++ b/public/services/resolves/settings-wizard.js
@@ -14,7 +14,6 @@ import { healthCheck } from './health-check';
 import { totalRAM } from './check-ram';
 
 export function settingsWizard(
-  $rootScope,
   $location,
   $q,
   $window,
@@ -174,10 +173,11 @@ export function settingsWizard(
           $location.path('/settings');
         });
     };
-
+    const currentLocation = $location.path();
     if (
+      !currentLocation.includes('agents-preview') &&
       !disableErrors && 
-      healthCheck($window, $rootScope)
+      healthCheck($window)
     ) {
       $location.path('/health-check');
       deferred.reject();

--- a/public/services/routes.js
+++ b/public/services/routes.js
@@ -57,7 +57,6 @@ function ip(
   return getIp(
     indexPatterns,
     $q,
-    $rootScope,
     $window,
     $location,
     Private,
@@ -83,8 +82,7 @@ function nestedResolve(
   assignPreviousLocation($rootScope, $location);
   const location = $location.path();
   return getWzConfig($q, genericReq, errorHandler, wazuhConfig).then(() =>
-    settingsWizard(
-      $rootScope,
+    settingsWizard(      
       $location,
       $q,
       $window,
@@ -111,8 +109,7 @@ function savedSearch(
   return getSavedSearch(
     redirectWhenMissing,
     $location,
-    $window,
-    $rootScope,
+    $window,    
     savedSearches,
     $route
   );

--- a/public/templates/agents-prev/agents-prev.html
+++ b/public/templates/agents-prev/agents-prev.html
@@ -40,9 +40,9 @@
                 </div>
                 <div layout="row" class="wz-padding-top-10">
                     <p flex="35" class="manager-status-subtitle">Higher activity</p>
-                    <p ng-if="mostActiveAgent.id !== '000'" class="wz-text-right wz-text-link" tooltip="Click to open this agent" tooltip-placement="right"
+                    <p ng-show="mostActiveAgent.id !== '000'" class="wz-text-right wz-text-link" tooltip="Click to open this agent" tooltip-placement="right"
                         ng-click="showAgent(mostActiveAgent)">{{mostActiveAgent.name}}</p>
-                    <p ng-if="mostActiveAgent.id === '000'" class="wz-text-right" tooltip-placement="right">{{mostActiveAgent.name}} (manager)</p>
+                    <p ng-show="mostActiveAgent.id === '000'" class="wz-text-right" tooltip-placement="right">{{mostActiveAgent.name}}</p>
                 </div>
             </md-card-content>
         </md-card>


### PR DESCRIPTION
Closes https://github.com/wazuh/wazuh-kibana-app/issues/1006, https://github.com/wazuh/wazuh-kibana-app/issues/1007 and https://github.com/wazuh/wazuh-kibana-app/issues/1008

Brief summary:

- Removed `$rootScope` instance from some resolve functions
- Fix the navigability from the `agent.id` field in a visualization to the agent welcome view when opening in a new tab.
- Fix condition for showing agent-manager as _higher activity_ agent.
- Disable auto-refresh feature if the tab is _configuration_, _welcome_ or _syscollector_.