### PR TITLE
Admin mode for the Wazuh API requests

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -94,3 +94,6 @@
 # Configure wazuh-monitoring-3.x-* indices shards and replicas.
 #wazuh.monitoring.shards: 5
 #wazuh.monitoring.replicas: 1
+#
+# ------------------------------- App privileges --------------------------------
+#admin: false

--- a/config.yml
+++ b/config.yml
@@ -96,4 +96,4 @@
 #wazuh.monitoring.replicas: 1
 #
 # ------------------------------- App privileges --------------------------------
-#admin: false
+#admin: true

--- a/public/controllers/agent/agents.js
+++ b/public/controllers/agent/agents.js
@@ -67,6 +67,8 @@ class AgentsController {
     this.$scope.integrations = {};
     this.$scope.selectedItem = 0;
     this.targetLocation = null;
+
+    this.ignoredTabs = ['configuration', 'welcome', 'syscollector'];
   }
 
   $onInit() {
@@ -94,11 +96,7 @@ class AgentsController {
     }
 
     this.tabHistory = [];
-    if (
-      this.$scope.tab !== 'configuration' &&
-      this.$scope.tab !== 'welcome' &&
-      this.$scope.tab !== 'syscollector'
-    )
+    if (!this.ignoredTabs.includes(this.$scope.tab))
       this.tabHistory.push(this.$scope.tab);
 
     // Tab names
@@ -251,7 +249,7 @@ class AgentsController {
             typeof this.targetLocation === 'object' &&
             this.targetLocation.subTab === 'discover' &&
             subtab === 'discover')) &&
-        !['configuration', 'welcome', 'syscollector'].includes(this.$scope.tab)
+        !this.ignoredTabs.includes(this.$scope.tab)
       ) {
         const condition =
           !this.changeAgent && (localChange || preserveDiscover);
@@ -308,12 +306,7 @@ class AgentsController {
       } else {
         this.configurationHandler.reset(this.$scope);
       }
-      if (
-        tab !== 'configuration' &&
-        tab !== 'welcome' &&
-        tab !== 'syscollector'
-      )
-        this.tabHistory.push(tab);
+      if (!this.ignoredTabs.includes(tab)) this.tabHistory.push(tab);
       if (this.tabHistory.length > 2)
         this.tabHistory = this.tabHistory.slice(-2);
       this.tabVisualizations.setTab(tab);

--- a/public/services/resolves/get-config.js
+++ b/public/services/resolves/get-config.js
@@ -38,7 +38,7 @@ export async function getWzConfig($q, genericReq, errorHandler, wazuhConfig) {
     'wazuh.monitoring.frequency': 3600,
     'wazuh.monitoring.shards': 5,
     'wazuh.monitoring.replicas': 1,
-    'admin': false
+    'admin': true
   };
 
   try {

--- a/public/services/resolves/get-config.js
+++ b/public/services/resolves/get-config.js
@@ -37,7 +37,8 @@ export async function getWzConfig($q, genericReq, errorHandler, wazuhConfig) {
     'wazuh.monitoring.enabled': true,
     'wazuh.monitoring.frequency': 3600,
     'wazuh.monitoring.shards': 5,
-    'wazuh.monitoring.replicas': 1
+    'wazuh.monitoring.replicas': 1,
+    'admin': false
   };
 
   try {

--- a/server/controllers/wazuh-api.js
+++ b/server/controllers/wazuh-api.js
@@ -659,7 +659,8 @@ export class WazuhApiCtrl {
 
   requestApi(req, reply) {
     const configuration = getConfiguration();
-    const adminMode = configuration && configuration.admin;
+    const adminMode = !(configuration && typeof configuration.admin !== 'undefined' && !configuration.admin);
+
     if (!req.payload.method) {
       return ErrorResponse('Missing param: method', 3015, 400, reply);
     } else if (!req.payload.path) {

--- a/server/controllers/wazuh-api.js
+++ b/server/controllers/wazuh-api.js
@@ -658,6 +658,8 @@ export class WazuhApiCtrl {
   }
 
   requestApi(req, reply) {
+    const configuration = getConfiguration();
+    const adminMode = configuration && configuration.admin;
     if (!req.payload.method) {
       return ErrorResponse('Missing param: method', 3015, 400, reply);
     } else if (!req.payload.path) {
@@ -668,11 +670,7 @@ export class WazuhApiCtrl {
         req.payload.body &&
         req.payload.body.devTools
       ) {
-        const configuration = getConfiguration();
-        if (
-          !configuration ||
-          (configuration && !configuration['devtools.allowall'])
-        ) {
+        if (!adminMode) {
           return ErrorResponse('Allowed method: [GET]', 3029, 400, reply);
         }
       }
@@ -681,7 +679,8 @@ export class WazuhApiCtrl {
         const keyRegex = new RegExp(/.*agents\/\d*\/key.*/);
         if (
           typeof req.payload.path === 'string' &&
-          keyRegex.test(req.payload.path)
+          keyRegex.test(req.payload.path) &&
+          !adminMode
         ) {
           return ErrorResponse(
             'Forbidden route /agents/<id>/key',


### PR DESCRIPTION
Closes https://github.com/wazuh/wazuh-kibana-app/issues/1003

Hi team, this PR adds the ability to make admin requests to the Wazuh API from the Wazuh App. This means you can make POST, DELETE and PUT requests.

By default it's enabled:

```yml
#admin: true
```

To disable it, edit the `config.yml` file and set `admin: false`.

Regards