### PR TITLE
Reset timefilter auto-refresh feature when not in visualization tabs

### DIFF
--- a/public/controllers/agent/agents.js
+++ b/public/controllers/agent/agents.js
@@ -69,6 +69,7 @@ export class AgentsController {
   }
 
   $onInit() {
+    timefilter.setRefreshInterval({pause:true,value:0})
     this.$scope.TabDescription = TabDescription;
 
     this.$rootScope.reportStatus = false;
@@ -321,12 +322,7 @@ export class AgentsController {
   // Switch tab
   async switchTab(tab, force = false) {
     if (this.ignoredTabs.includes(tab)) {
-      const timeFilterRefreshStatus = timefilter.getRefreshInterval();
-      const toggle =
-        timeFilterRefreshStatus &&
-        timeFilterRefreshStatus.value &&
-        !timeFilterRefreshStatus.pause;
-      if (toggle) timefilter.toggleRefresh();
+      timefilter.setRefreshInterval({pause:true,value:0})
     }
 
     try {

--- a/public/controllers/management/monitoring.js
+++ b/public/controllers/management/monitoring.js
@@ -10,6 +10,7 @@
  * Find more information about this on the LICENSE file.
  */
 import { FilterHandler } from '../../utils/filter-handler';
+import { timefilter } from 'ui/timefilter';
 
 export function ClusterController(
   $scope,
@@ -27,6 +28,7 @@ export function ClusterController(
   appState,
   genericReq
 ) {
+  timefilter.setRefreshInterval({pause:true,value:0})
   $scope.search = term => {
     $scope.$broadcast('wazuhSearch', { term });
   };

--- a/public/controllers/overview/overview.js
+++ b/public/controllers/overview/overview.js
@@ -25,6 +25,7 @@ import {
 } from '../../utils/overview-metrics';
 
 import { queryConfig } from '../../services/query-config';
+import { timefilter } from 'ui/timefilter';
 
 export class OverviewController {
   constructor(
@@ -54,6 +55,7 @@ export class OverviewController {
   }
 
   $onInit() {
+    timefilter.setRefreshInterval({pause:true,value:0})
     this.wodlesConfiguration = false;
     this.TabDescription = TabDescription;
     this.$rootScope.reportStatus = false;
@@ -211,6 +213,10 @@ export class OverviewController {
   // Switch tab
   async switchTab(newTab, force = false) {
     try {
+      if(newTab === 'welcome') {
+        timefilter.setRefreshInterval({pause:true,value:0})
+      }
+
       if (newTab !== 'welcome') {
         await this.fetchWodles();
       }


### PR DESCRIPTION
Fix #964 

From now and onwards the auto-refresh feature is removed whenever the user goes to _Overview > Welcome_, _Agents > Welcome, Configuration, Inventory_ and whenever the user switches from a subset of tabs inside Overview or inside Agents. This is the cleanest way because we have a Discover instance under the hood manipulating the filters too.

Example:
- _Overview > Security events_ to _Overview > Integrity monitoring_ will preserve the auto-refresh feature if it was enabled.
- _Overview > Security events_ to _Overview > Vulnerability_ won't preserve the auto-refresh feature if it was enabled.
- The very first time the user enters Overview or Agents won't preserve the auto-refresh feature if it was enabled.
- If the user comes from other Kibana apps, the auto-refresh feature won't be preserved.

This is less intrusive and keeps clear some variables that could produce weird behaviors.

This line makes the trick:

```js
timefilter.setRefreshInterval({pause:true,value:0})
```

Regards