### PR TITLE
Fix step in manual

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,13 +98,13 @@ Restart Kibana
 - Systemd:
 
 ```
-systemctl restart kibana
+systemctl start kibana
 ```
 
 - SysV Init:
 
 ```
-service kibana restart
+service kibana start
 ```
 
 ## Older packages


### PR DESCRIPTION
Because we stop Kibana in first step, final step should be `start` instead of `restart`.