### PR TITLE
Fix typo tags filter bar

### DIFF
--- a/public/directives/wz-tag-filter/wz-tag-filter.js
+++ b/public/directives/wz-tag-filter/wz-tag-filter.js
@@ -48,7 +48,7 @@ app.directive('wzTagFilter', function() {
           );
           input.blur();
           const term = $scope.newTag.split(':');
-          const obj = { name: term[0].trim(), value: term[1].trim() };
+          const obj = { name: term[0].trim(), value: term[1] ? term[1].trim() : '' };
           const isFilter = obj.value;
           if (
             (isFilter &&


### PR DESCRIPTION
Hi team,

This PR fix a typo in the new tags bar filter when the key typed doesn't exist.

Regards!