### PR TITLE
Minor fixes

### DIFF
--- a/public/controllers/management/groups.js
+++ b/public/controllers/management/groups.js
@@ -199,6 +199,7 @@ export function GroupsController(
   $scope.goBackFiles = () => {
     $scope.groupsSelectedTab = 'files';
     $scope.addingAgents = false;
+    $scope.editingFile = false;
     $scope.file = false;
     $scope.filename = false;
     $scope.fileViewer = false;

--- a/public/directives/wz-tag-filter/wz-tag-filter.js
+++ b/public/directives/wz-tag-filter/wz-tag-filter.js
@@ -343,6 +343,7 @@ app.directive('wzTagFilter', function() {
           }
         }
       });
+      $('#wz-search-filter-bar-input').attr('autocomplete', 'off');
       load();
     },
     template


### PR DESCRIPTION
Hi team,

This PR add a fix in tags filter bar to prevent the browser autocomplete from being placed on top of our autocomplete (#1130 ).

![image](https://user-images.githubusercontent.com/21195730/51031677-91b33380-159d-11e9-9496-745f28536018.png)

Also hides XML editor when clicking in agent's content section.

Regards.