### PR TITLE
Testing 3.8.0 - fixes

### DIFF
--- a/public/controllers/dev-tools/dev-tools.js
+++ b/public/controllers/dev-tools/dev-tools.js
@@ -519,7 +519,7 @@ export class DevToolsController {
         if (typeof JSONraw === 'object') JSONraw.devTools = true;
         const output = await this.apiReq.request(method, path, JSONraw);
 
-        this.apiOutputBox.setValue(JSON.stringify(output.data, null, 2));
+        this.apiOutputBox.setValue(JSON.stringify((output || {}).data, null, 2));
       } else {
         this.apiOutputBox.setValue('Welcome!');
       }

--- a/public/templates/agents/agents-syscollector.html
+++ b/public/templates/agents/agents-syscollector.html
@@ -105,7 +105,7 @@
 
     <div layout="row" class="layout-padding wz-padding-bottom-0" ng-if="agent && agent.status === 'Active' && hasSize(syscollector)">
         <md-card flex class="wz-md-card">
-            <md-card-content class="wz-text-center" ng-if="syscollector.netiface && !syscollector.netiface.items.length">
+            <md-card-content class="wz-text-center" ng-if="!syscollector.netiface || !syscollector.netiface.items || !syscollector.netiface.items.length">
                 <i class="fa fa-fw fa-info-circle" aria-hidden="true"></i> <span class="wz-headline-title">No interfaces scan available</span>
              </md-card-content>
             <md-card-content ng-if="syscollector.netiface && syscollector.netiface.items.length">
@@ -145,7 +145,9 @@
                 <span class="wz-headline-title"><i class="fa fa-fw fa-exchange"></i> Network ports</span>
                 <span class="color-grey pull-right">Last scan: {{syscollector.ports.items[0].scan.time}}</span>
                 <md-divider class="wz-margin-top-10"></md-divider>
-                <wz-table flex path="'/syscollector/' + agent.id + '/ports'" row-sizes="[4]" keys="[{value:'local.ip',nosortable:true}, {value:'local.port',nosortable:true},{value:'remote.ip',nosortable:true},{value:'remote.port',nosortable:true},'state','protocol']">
+                <wz-table flex ng-if="agent && agent.os && agent.os.platform === 'windows'" path="'/syscollector/' + agent.id + '/ports'" row-sizes="[4]" keys="[{value:'process',nosortable:true},{value:'local.ip',nosortable:true}, {value:'local.port',nosortable:true},'state','protocol']">
+                </wz-table>
+                <wz-table flex ng-if="agent && agent.os && agent.os.platform !== 'windows'" path="'/syscollector/' + agent.id + '/ports'" row-sizes="[4]" keys="[{value:'local.ip',nosortable:true}, {value:'local.port',nosortable:true},'state','protocol']">
                 </wz-table>
             </md-card-content>
         </md-card>
@@ -153,7 +155,7 @@
 
     <div layout="row" class="layout-padding wz-padding-bottom-0" ng-if="agent && agent.status === 'Active' && hasSize(syscollector)">
         <md-card flex class="wz-md-card">
-            <md-card-content class="wz-text-center" ng-if="syscollector.netaddr && !syscollector.netaddr.items.length">
+            <md-card-content class="wz-text-center" ng-if="!syscollector.netaddr || !syscollector.netaddr.items || !syscollector.netaddr.items.length">
                 <i class="fa fa-fw fa-info-circle" aria-hidden="true"></i> <span class="wz-headline-title">No network addresses scan available</span>
              </md-card-content>
             <md-card-content class="wz-margin-bottom-40-inv" ng-if="syscollector.netaddr && syscollector.netaddr.items.length">

--- a/server/controllers/wazuh-api.js
+++ b/server/controllers/wazuh-api.js
@@ -520,10 +520,10 @@ export class WazuhApiCtrl {
    * @returns {Object} API response or ErrorResponse
    */
   async makeRequest(method, path, data, id, reply) {
+    const devTools = !!(data || {}).devTools;
     try {
       const api = await this.wzWrapper.getWazuhConfigurationById(id);
 
-      const devTools = !!(data || {}).devTools;
       if (devTools) {
         delete data.devTools;
       }
@@ -576,12 +576,14 @@ export class WazuhApiCtrl {
         ? { message: response.body.message, code: response.body.error }
         : new Error('Unexpected error fetching data from the Wazuh API');
     } catch (error) {
-      return ErrorResponse(
-        error.message || error,
-        `Wazuh API error: ${error.code}` || 3013,
-        500,
-        reply
-      );
+      return devTools
+        ? reply({ error: '3013', message: error.message || error })
+        : ErrorResponse(
+            error.message || error,
+            `Wazuh API error: ${error.code}` || 3013,
+            500,
+            reply
+          );
     }
   }
 

--- a/util/csv-key-equivalence.js
+++ b/util/csv-key-equivalence.js
@@ -78,5 +78,6 @@ export const KeyEquivalenece = {
   mtime: 'Last modified',
   priority: 'Priority',
   cmd: 'CMD',
-  nlwp: 'NLWP'
+  nlwp: 'NLWP',
+  process: 'Process'
 };


### PR DESCRIPTION
- Added `Process` column for Windows agent on syscollector ports table
- Removed `remote.port` and `remote.ip` from syscollector ports table
- Split `netaddr` and `netiface` calls into separated try/catch blocks
- Forwarding all errors as they are when using Dev tools