### PR TITLE
UI improvements for group management and rules

### DIFF
--- a/public/controllers/management/rules.js
+++ b/public/controllers/management/rules.js
@@ -193,6 +193,9 @@ export function RulesController(
   //listeners
   $scope.$on('wazuhShowRule', (event, parameters) => {
     $scope.currentRule = parameters.rule;
+    if(!(Object.keys((($scope.currentRule || {}).details || {})) || []).length) {
+      $scope.currentRule.details = false;
+    }
     $scope.viewingDetail = true;
     if (!$scope.$$phase) $scope.$digest();
   });
@@ -218,6 +221,9 @@ export function RulesController(
       .request('get', `/rules/${incomingRule}`, {})
       .then(data => {
         $scope.currentRule = data.data.data.items[0];
+        if(!(Object.keys((($scope.currentRule || {}).details || {})) || []).length) {
+          $scope.currentRule.details = false;
+        }
         $scope.viewingDetail = true;
         if (!$scope.$$phase) $scope.$digest();
       })

--- a/public/directives/wz-xml-file-editor/wz-xml-file-editor.html
+++ b/public/directives/wz-xml-file-editor/wz-xml-file-editor.html
@@ -1,6 +1,6 @@
 <div class='wzXmlEditor'>
     <div class='wzXmlEditorHeader'>
-        <span>Edit <b>{{fileName}}</b> of <b>{{targetName}}</b> group</span>
+        <span>Edit <b>configuration</b> of <b>{{targetName}}</b> group</span>
     </div>
     <div class='wzXmlEditorBody'>
         <div ng-show='!loadingFile'>

--- a/public/directives/wz-xml-file-editor/wz-xml-file-editor.less
+++ b/public/directives/wz-xml-file-editor/wz-xml-file-editor.less
@@ -37,3 +37,8 @@
     height: calc(~'100vh - 475px');
     min-height: 300px;
 }
+
+.groupContentViewer {
+    height: calc(~'100vh - 550px');
+    min-height: 300px;
+}

--- a/public/less/common.less
+++ b/public/less/common.less
@@ -610,7 +610,7 @@ md-sidenav {
 
 .wz-circle-back-button{
     border: 1px solid #d9d9d9!important;
-    margin: 8px 15px 0px 0px!important;
+    margin: 0px 15px 0px 0px!important;
 }
 
 .wz-circle-back-button:hover{
@@ -627,4 +627,8 @@ md-sidenav {
 
 .cursor-wait {
     cursor: wait !important;
+}
+
+.wz-padding-bottom-14 {
+    padding-bottom: 14px;
 }

--- a/public/less/layout.less
+++ b/public/less/layout.less
@@ -131,6 +131,10 @@
     padding-left: 0px;
 }
 
+.wz-padding-left-8 {
+    padding-left: 8px
+}
+
 .wz-padding-left-16 {
     padding-left: 16px
 }

--- a/public/templates/management/groups/groups.html
+++ b/public/templates/management/groups/groups.html
@@ -17,8 +17,6 @@
         <div flex layout="column" layout-align="start stretch" ng-show="!load" ng-init="groupsSelectedTab='agents'">
             <!-- MD5 Sums and Details cards -->
             <div layout="row" class="md-padding-h" ng-if="lookingGroup">
-                <md-button class="md-icon-button wz-circle-back-button" ng-if="lookingGroup" aria-label="Back" tooltip="Go back"
-                    tooltip-placement="bottom" ng-click="goBackGroups()"><i class="fa fa-fw fa-arrow-left" aria-hidden="true"></i></md-button>
                 <!-- Group MD5 sums section -->
                 <md-card flex class="no-margin-left wz-md-card">
                     <md-card-content>
@@ -64,10 +62,12 @@
             <!-- End MD5 Sums and Details cards -->
 
             <!-- Group actions -->
-            <div layout="row" class="md-padding" ng-if="lookingGroup && currentGroup && groupsSelectedTab==='agents' && !addingAgents && !editingFile">
+            <div layout="row" class="md-padding" ng-if="lookingGroup && currentGroup && !addingAgents && !editingFile">
+                <md-button class="md-icon-button wz-circle-back-button" ng-if="lookingGroup" aria-label="Back" tooltip="Go back"
+                    tooltip-placement="bottom" ng-click="goBackGroups()"><i class="fa fa-fw fa-arrow-left" aria-hidden="true"></i></md-button>
                 <button ng-click='editGroupAgentConfig(currentGroup)' class='btn btn-primary'><i aria-hidden='true'
                         class='fa fa-fw fa-file-code-o'></i>
-                    Edit agent.conf
+                    Edit configuration
                 </button>
                 <button ng-disabled="currentGroup.name === 'default'" ng-click='addMultipleAgents(true)' class='btn btn-primary wz-margin-left-8'><i
                         aria-hidden='true' class='fa fa-fw fa-pencil'></i>
@@ -175,7 +175,7 @@
                                 <span flex class="wz-text-right cursor-pointer color-grey" ng-click="goBackFiles()">close</span>
                             </div>
                             <div flex layout="column">
-                                <pre flex class="wz-pre json-beautifier jsonbeauty2 wz-overflow-y-auto"><code wz-dynamic="file"></code></pre>
+                                <pre flex class="groupContentViewer wzXmlEditor wz-overflow-y-auto"><code wz-dynamic="file"></code></pre>
                             </div>
                         </div>
                     </div>

--- a/public/templates/management/ruleset/rules/rules-detail.html
+++ b/public/templates/management/ruleset/rules/rules-detail.html
@@ -12,7 +12,7 @@
     <!-- End back button, title and status indicator -->
 
     <!-- Rule information ribbon -->
-    <div layout="row" class="wz-padding-left-16">
+    <div layout="row" class="wz-padding-left-8">
         <md-card flex class="wz-metric-color wz-md-card">
             <md-card-content layout="row" class="wz-padding-metric">
                 <div flex="15" ng-if="currentRule.id" class="wz-text-truncatable">ID: <span class="wz-text-bold">{{currentRule.id}}</span></div>
@@ -34,10 +34,10 @@
     <!-- Rest of rule information -->
     <div layout="column" layout-align="start">
 
-        <div layout="row" class="wz-padding-left-16" layout-align="start stretch">
+        <div layout="row" class="wz-padding-left-8" layout-align="start stretch">
 
             <!-- Groups section -->
-            <md-card ng-if="currentRule.groups.length > 0" flex class="wz-md-card">
+            <md-card ng-if="currentRule.groups.length > 0" flex="50" class="wz-md-card">
                 <md-card-content>
                     <span class="wz-headline-title"><i class="fa fa-fw fa-tasks" aria-hidden="true"></i> Groups</span>
                     <md-divider class="wz-margin-top-10"></md-divider>
@@ -52,7 +52,7 @@
             <!-- End groups section -->
 
             <!-- Details section -->
-            <md-card flex class="wz-md-card">
+            <md-card flex class="wz-md-card" ng-if="currentRule.details">
                 <md-card-content>
                     <span class="wz-headline-title"><i class="fa fa-fw fa-info" aria-hidden="true"></i> Details</span>
                     <md-divider class="wz-margin-top-10"></md-divider>


### PR DESCRIPTION
- Checking the `rule.details` keys length. Showing details only if it has content to show.
- Replaced "agent.conf" by "configuration" when using XML editor
- Minor CSS changes
- Modified JSON viewer for group content. 
- Added edit button for group content.
- Corrected padding for rules detail view. 
