### PR TITLE
Customized empty results message in tables directive

### DIFF
--- a/public/directives/wz-table/wz-table-directive.js
+++ b/public/directives/wz-table/wz-table-directive.js
@@ -68,10 +68,9 @@ app.directive('wzTable', function () {
 
       const configuration = wazuhConfig.getConfig();
       $scope.adminMode = !!(configuration || {}).admin;
-      $scope.customEmptyResults =
-        $scope.emptyResults && typeof $scope.emptyResults === 'string'
-          ? $scope.emptyResults
-          : 'Empty results for this table.'
+
+      $scope.customEmptyResults = $scope.emptyResults || 'Empty results for this table.';
+
       /**
        * Resizing. Calculate number of table rows depending on the screen height
        */
@@ -133,7 +132,7 @@ app.directive('wzTable', function () {
        */
       const search = async (term, removeFilters) => {
         if (term && typeof term === 'string') {
-          $scope.customEmptyResults = 'No results match your search criteria.'
+          $scope.emptyResults = false;
         }
         searchData(
           term,

--- a/public/directives/wz-table/wz-table-directive.js
+++ b/public/directives/wz-table/wz-table-directive.js
@@ -26,7 +26,7 @@ import { checkGap } from './lib/check-gap';
 
 const app = uiModules.get('app/wazuh', []);
 
-app.directive('wzTable', function() {
+app.directive('wzTable', function () {
   return {
     restrict: 'E',
     scope: {
@@ -35,7 +35,8 @@ app.directive('wzTable', function() {
       allowClick: '=allowClick',
       implicitFilter: '=implicitFilter',
       rowSizes: '=rowSizes',
-      extraLimit: '=extraLimit'
+      extraLimit: '=extraLimit',
+      emptyResults: '=emptyResults'
     },
     controller(
       $scope,
@@ -67,6 +68,10 @@ app.directive('wzTable', function() {
 
       const configuration = wazuhConfig.getConfig();
       $scope.adminMode = !!(configuration || {}).admin;
+      $scope.customEmptyResults =
+        $scope.emptyResults && typeof $scope.emptyResults === 'string'
+          ? $scope.emptyResults
+          : 'Empty results for this table.'
       /**
        * Resizing. Calculate number of table rows depending on the screen height
        */
@@ -126,7 +131,10 @@ app.directive('wzTable', function() {
       /**
        * This search in table data with a given term
        */
-      const search = async (term, removeFilters) =>
+      const search = async (term, removeFilters) => {
+        if (term && typeof term === 'string') {
+          $scope.customEmptyResults = 'No results match your search criteria.'
+        }
         searchData(
           term,
           removeFilters,
@@ -136,7 +144,7 @@ app.directive('wzTable', function() {
           wzTableFilter,
           errorHandler
         );
-
+      }
       /**
        * This filter table with a given filter
        * @param {Object} filter
@@ -221,7 +229,7 @@ app.directive('wzTable', function() {
       $scope.prevPage = () => pagination.prevPage($scope);
       $scope.nextPage = async currentPage =>
         pagination.nextPage(currentPage, $scope, errorHandler, fetch);
-      $scope.setPage = function() {
+      $scope.setPage = function () {
         $scope.currentPage = this.n;
         $scope.nextPage(this.n);
       };

--- a/public/directives/wz-table/wz-table.html
+++ b/public/directives/wz-table/wz-table.html
@@ -106,7 +106,7 @@
                 </defs>
                 <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#help-a" fill-rule="evenodd"></use>
             </svg>
-            <span class="euiCallOutHeader__title">No results match your search criteria</span>
+            <span class="euiCallOutHeader__title">{{customEmptyResults}}</span>
         </div>
     </div>
 </div>

--- a/public/templates/management/groups/groups.html
+++ b/public/templates/management/groups/groups.html
@@ -141,7 +141,7 @@
                     <!-- Group agents table -->
                     <div layout="row" ng-if="lookingGroup && groupsSelectedTab==='agents' && currentGroup" class="md-padding">
                         <wz-table flex path="'/agents/groups/' + currentGroup.name" keys="['id','name','ip','status','os.name','os.version','version']"
-                            allow-click="true" row-sizes="[14,12,10]" />
+                            allow-click="true" row-sizes="[14,12,10]" empty-results="'No agents were added to this group.'"/>
                     </div>
                     <!-- End Group agents table -->
 


### PR DESCRIPTION
Hi team,

This PR adds the ability to set a custom message for tables that have empty results.
Now, the wz-table-directive receives a new parameter for the custom message:

`=emptyResults`

And it can be used like this example:

`<wazuh-table empty-results="'No agents were added to this group'">`

This PR solves #1154 

Regards.