### PR TITLE
Show readable API error response messages

### DIFF
--- a/server/controllers/wazuh-api.js
+++ b/server/controllers/wazuh-api.js
@@ -22,6 +22,7 @@ import { Parser } from 'json2csv';
 import { getConfiguration } from '../lib/get-configuration';
 import { log } from '../logger';
 import { KeyEquivalenece } from '../../util/csv-key-equivalence';
+import { ApiErrorEquivalenece } from '../../util/api-errors-equivalence';
 import { cleanKeys } from '../../util/remove-key';
 import { apiRequestList } from '../../util/api-request-list';
 import * as ApiHelper from '../lib/api-helper';
@@ -191,7 +192,7 @@ export class WazuhApiCtrl {
                   req.idChanged = api._id;
                   return this.checkStoredAPI(req, reply);
                 }
-              } catch (error) {} // eslint-disable-line
+              } catch (error) { } // eslint-disable-line
             }
           } catch (error) {
             log('POST /api/check-stored-api', error.message || error);
@@ -572,18 +573,23 @@ export class WazuhApiCtrl {
       }
 
       throw ((response || {}).body || {}).error &&
-      ((response || {}).body || {}).message
+        ((response || {}).body || {}).message
         ? { message: response.body.message, code: response.body.error }
         : new Error('Unexpected error fetching data from the Wazuh API');
     } catch (error) {
-      return devTools
-        ? reply({ error: '3013', message: error.message || error })
-        : ErrorResponse(
-            error.message || error,
-            `Wazuh API error: ${error.code}` || 3013,
-            500,
-            reply
-          );
+      if (devTools) {
+        return reply({ error: '3013', message: error.message || error });
+      } else {
+        if ((error || {}).code && ApiErrorEquivalenece[error.code]) {
+          error.message = ApiErrorEquivalenece[error.code];
+        }
+        return ErrorResponse(
+          error.message || error,
+          `Wazuh API error: ${error.code}` || 3013,
+          500,
+          reply
+        );
+      }
     }
   }
 
@@ -626,7 +632,7 @@ export class WazuhApiCtrl {
       }
 
       throw ((response || {}).body || {}).error &&
-      ((response || {}).body || {}).message
+        ((response || {}).body || {}).message
         ? { message: response.body.message, code: response.body.error }
         : new Error('Unexpected error fetching data from the Wazuh API');
     } catch (error) {
@@ -775,18 +781,18 @@ export class WazuhApiCtrl {
       if ((((output || {}).body || {}).data || {}).totalItems) {
         const fields = req.payload.path.includes('/agents')
           ? [
-              'id',
-              'status',
-              'name',
-              'ip',
-              'group',
-              'manager',
-              'node_name',
-              'dateAdd',
-              'version',
-              'lastKeepAlive',
-              'os'
-            ]
+            'id',
+            'status',
+            'name',
+            'ip',
+            'group',
+            'manager',
+            'node_name',
+            'dateAdd',
+            'version',
+            'lastKeepAlive',
+            'os'
+          ]
           : Object.keys(output.body.data.items[0]);
 
         const json2csvParser = new Parser({ fields });

--- a/server/controllers/wazuh-api.js
+++ b/server/controllers/wazuh-api.js
@@ -22,7 +22,7 @@ import { Parser } from 'json2csv';
 import { getConfiguration } from '../lib/get-configuration';
 import { log } from '../logger';
 import { KeyEquivalenece } from '../../util/csv-key-equivalence';
-import { ApiErrorEquivalenece } from '../../util/api-errors-equivalence';
+import { ApiErrorEquivalence } from '../../util/api-errors-equivalence';
 import { cleanKeys } from '../../util/remove-key';
 import { apiRequestList } from '../../util/api-request-list';
 import * as ApiHelper from '../lib/api-helper';
@@ -580,8 +580,8 @@ export class WazuhApiCtrl {
       if (devTools) {
         return reply({ error: '3013', message: error.message || error });
       } else {
-        if ((error || {}).code && ApiErrorEquivalenece[error.code]) {
-          error.message = ApiErrorEquivalenece[error.code];
+        if ((error || {}).code && ApiErrorEquivalence[error.code]) {
+          error.message = ApiErrorEquivalence[error.code];
         }
         return ErrorResponse(
           error.message || error,

--- a/util/api-errors-equivalence.js
+++ b/util/api-errors-equivalence.js
@@ -10,7 +10,7 @@
  * Find more information about this on the LICENSE file.
  */
 
-export const ApiErrorEquivalenece = {
+export const ApiErrorEquivalence = {
   1113: 'Invalid configuration syntax',
   1114: 'Invalid element in configuration'
 };

--- a/util/api-errors-equivalence.js
+++ b/util/api-errors-equivalence.js
@@ -1,0 +1,16 @@
+/*
+ * Wazuh app - Wazuh error messages equivalence
+ * Copyright (C) 2015-2019 Wazuh, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Find more information about this on the LICENSE file.
+ */
+
+export const ApiErrorEquivalenece = {
+  1113: 'Invalid configuration syntax',
+  1114: 'Invalid element in configuration'
+};


### PR DESCRIPTION
Hi team,

This PR adds an equivalence list to avoid showing errors that are too long and do not provide useful information to the user.

This PR solves #1155 

Regards.