### PR TITLE
Refactor select columns bar

### DIFF
--- a/public/directives/wz-table/wz-table.html
+++ b/public/directives/wz-table/wz-table.html
@@ -3,16 +3,15 @@
         <div></div>
     </div>
 </div>
-<div layout="row" ng-show="!error && !wazuh_table_loading && items.length">
+<div layout="row" ng-show="!error && !wazuh_table_loading && items.length" class="columns-bar" ng-class="{'columns-bar-active': showColumns}">
+    <div ng-if="showColumns" class="euiCheckbox wz-margin-right-8" ng-repeat="key in originalkeys" ng-click="updateColumns(key)">
+        <input class="euiCheckbox__input" type="checkbox" aria-label="Select all rows" ng-checked="exists(key)">
+        <div class="euiCheckbox__square"></div>
+        <span class="euiCheckbox__label">{{ keyEquivalence[key.key.value || key.key] }}</span>
+    </div>
     <span flex></span>
-    <span class="wz-text-link" ng-click="showColumns = !showColumns" tooltip="Columns"><i class="fa fa-fw fa-gear"></i></span>
-</div>
-<div layout="row" layout-wrap ng-show="!error && !wazuh_table_loading && items.length" ng-if="showColumns">
-    <span flex></span>
-    <md-checkbox ng-repeat="key in originalkeys" ng-click="updateColumns(key)" ng-checked="exists(key)">
-        {{ keyEquivalence[key.key.value ||
-        key.key] }}
-    </md-checkbox>
+    <span class="wz-text-link" style="line-height: 24px;" ng-click="showColumns = !showColumns" tooltip="Columns"><i
+            class="fa fa-fw fa-gear"></i></span>
 </div>
 
 <div layout="row" ng-show="!error && !wazuh_table_loading && items.length">

--- a/public/less/layout.less
+++ b/public/less/layout.less
@@ -391,3 +391,19 @@ display: -webkit-box;
     background-color: #0079a5 !important;
     border-color: #0079a5 !important;
 }
+
+.columns-bar {
+    margin-top: -17px;
+    margin-left: -16px;
+    margin-right: -16px;
+    padding-right: 16px;
+    padding-left: 16px;
+    min-height: 42px;
+    padding-top: 8px;
+}
+
+.columns-bar-active {
+    padding-top: 7px !important;
+    border-top: 1px solid #dfeff8 !important;
+    background-color: #ecf6fb;
+}

--- a/public/templates/management/ruleset/decoders/decoders-list.html
+++ b/public/templates/management/ruleset/decoders/decoders-list.html
@@ -58,7 +58,8 @@
             </div>
             <div layout="row" ng-if="dctrl.newFile" class="wz-padding-bottom-14">
                 <span ng-click='dctrl.closeEditingFile()' class='btn btn-info'>Cancel</span>
-                <button ng-disabled='dctrl.xmlHasErrors || dctrl.newFileName ===  ""' ng-click='dctrl.doSaveConfig(true,dctrl.newFileName)' class='btn wz-button pull-right wz-margin-left-8'>
+                <button ng-disabled='dctrl.xmlHasErrors || dctrl.newFileName ===  ""' ng-click='dctrl.doSaveConfig(true,dctrl.newFileName)'
+                    class='btn wz-button pull-right wz-margin-left-8'>
                     <span ng-show='!dctrl.xmlHasErrors'><i aria-hidden='true' class='fa fa-fw fa-save'></i>Save
                         file</span>
                     <span ng-show='dctrl.xmlHasErrors' class='btn-danger'><i aria-hidden='true' class='fa fa-fw fa-exclamation-triangle'></i>


### PR DESCRIPTION
Fix _`wz-table` column selector and gear icon must appear in a new row (like `wz-card-actions` new file bar)_, _Change checkboxes design to adapt it to Kibana's design_ from #1249 