### PR TITLE
Show tooltip only in truncated texts

### DIFF
--- a/public/directives/wz-table/wz-table-directive.js
+++ b/public/directives/wz-table/wz-table-directive.js
@@ -381,6 +381,21 @@ app.directive('wzTable', function () {
           $scope.$emit('openGroupFromList', { group });
         }
       };
+
+      $scope.showTooltip = (id1, id2, item) => {
+        var $element = $('#td-' + id1 + '-' + id2 + ' div');
+        var $c = $element
+          .clone()
+          .css({ display: 'inline', width: 'auto', visibility: 'hidden' })
+          .appendTo('body');
+        if ($c.width() > $element.width()) {
+          if (!item.showTooltip) {
+            item.showTooltip = [];
+          }
+          item.showTooltip[id2] = true;
+        }
+        $c.remove();
+      };
     },
     template
   };

--- a/public/directives/wz-table/wz-table.html
+++ b/public/directives/wz-table/wz-table.html
@@ -31,13 +31,16 @@
         <tbody>
             <tr ng-class="allowClick ? 'cursor-pointer' : ''" class="wz-word-wrap" ng-repeat="item in pagedItems[currentPage] | filter:{item:'!'}"
                 ng-click="clickAction(item)">
-                <td ng-repeat="key in keys">
-                    <div class="wz-text-truncatable" tooltip="{{ parseValue(key,item) }}" tooltip-placement="bottom">
+                <td ng-repeat="key in keys" id="td-{{$parent.$index}}-{{$index}}" ng-mouseover="showTooltip($parent.$index, $index, item)">
+                    <div class="wz-text-truncatable">
                         <span>
                             {{
                             parseValue(key,item)
                             }}
                         </span>
+                        <md-tooltip ng-show="item.showTooltip[$index]" md-direction="bottom" class="wz-tooltip">
+                            {{ parseValue(key,item) }}
+                        </md-tooltip>
                     </div>
                 </td>
                 <td ng-if="path === '/agents'" ng-click="$event.stopPropagation()" class="cursor-default action-btn-td">


### PR DESCRIPTION
Hi team,

This PR adds new tooltip behavior in order to show it only in truncated texts (in `wz-table`).

Regards.