### PR TITLE
Merge dynamic known fields, added new cron task

### DIFF
--- a/init.js
+++ b/init.js
@@ -18,10 +18,13 @@ import { Monitoring } from './server/monitoring';
 import { WazuhApiRoutes } from './server/routes/wazuh-api';
 import { WazuhReportingRoutes } from './server/routes/wazuh-reporting';
 import { WazuhUtilsRoutes } from './server/routes/wazuh-utils';
+import { IndexPatternCronJob } from './server/index-pattern-cron-job';
 import { log } from './server/logger';
 
 export function initApp(server) {
   const monitoringInstance = new Monitoring(server);
+  const indexPatternCronJobInstance = new IndexPatternCronJob(server);
+
   log('[initApp]', `Waiting for awaitMigration()`, 'info');
   server.kibanaMigrator
     .awaitMigration()
@@ -35,6 +38,7 @@ export function initApp(server) {
       WazuhElasticRouter(server);
       WazuhApiElasticRoutes(server);
       monitoringInstance.run();
+      indexPatternCronJobInstance.run();
       WazuhApiRoutes(server);
       WazuhReportingRoutes(server);
       WazuhUtilsRoutes(server);

--- a/public/services/routes.js
+++ b/public/services/routes.js
@@ -81,21 +81,20 @@ function nestedResolve(
 ) {
   assignPreviousLocation($rootScope, $location);
   const location = $location.path();
-  return getWzConfig($q, genericReq, errorHandler, wazuhConfig)
-    .then(() =>
-      settingsWizard(
-        $location,
-        $q,
-        $window,
-        testAPI,
-        appState,
-        genericReq,
-        errorHandler,
-        wzMisc,
-        wazuhConfig,
-        location && location.includes('/health-check')
-      )
-    );
+  return getWzConfig($q, genericReq, errorHandler, wazuhConfig).then(() =>
+    settingsWizard(
+      $location,
+      $q,
+      $window,
+      testAPI,
+      appState,
+      genericReq,
+      errorHandler,
+      wzMisc,
+      wazuhConfig,
+      location && location.includes('/health-check')
+    )
+  );
 }
 
 function savedSearch(
@@ -170,15 +169,15 @@ routes
     resolve: { wzConfig }
   })
   .when('/visualize/create?', {
-    redirectTo: function () { },
+    redirectTo: function() {},
     resolve: { wzConfig, wzKibana }
   })
   .when('/context/:pattern?/:type?/:id?', {
-    redirectTo: function () { },
+    redirectTo: function() {},
     resolve: { wzKibana }
   })
   .when('/doc/:pattern?/:index?/:type?/:id?', {
-    redirectTo: function () { },
+    redirectTo: function() {},
     resolve: { wzKibana }
   })
   .when('/wazuh-dev', {

--- a/public/services/routes.js
+++ b/public/services/routes.js
@@ -95,12 +95,7 @@ function nestedResolve(
         wazuhConfig,
         location && location.includes('/health-check')
       )
-    )
-    .then(async () => {
-      try {
-        await this.genericReq.request('GET', '/elastic/known-fields/all', {});
-      } catch (error) {} //eslint-disable-line
-    });
+    );
 }
 
 function savedSearch(
@@ -175,15 +170,15 @@ routes
     resolve: { wzConfig }
   })
   .when('/visualize/create?', {
-    redirectTo: function() {},
+    redirectTo: function () { },
     resolve: { wzConfig, wzKibana }
   })
   .when('/context/:pattern?/:type?/:id?', {
-    redirectTo: function() {},
+    redirectTo: function () { },
     resolve: { wzKibana }
   })
   .when('/doc/:pattern?/:index?/:type?/:id?', {
-    redirectTo: function() {},
+    redirectTo: function () { },
     resolve: { wzKibana }
   })
   .when('/wazuh-dev', {

--- a/server/controllers/wazuh-elastic.js
+++ b/server/controllers/wazuh-elastic.js
@@ -117,20 +117,20 @@ export class WazuhElasticCtrl {
 
       return isIncluded && Array.isArray(isIncluded) && isIncluded.length
         ? {
-          statusCode: 200,
-          status: true,
-          data: `Template found for ${req.params.pattern}`
-        }
+            statusCode: 200,
+            status: true,
+            data: `Template found for ${req.params.pattern}`
+          }
         : {
-          statusCode: 200,
-          status: false,
-          data: `No template found for ${req.params.pattern}`
-        };
+            statusCode: 200,
+            status: false,
+            data: `No template found for ${req.params.pattern}`
+          };
     } catch (error) {
       log('GET /elastic/template/{pattern}', error.message || error);
       return ErrorResponse(
         `Could not retrieve templates from Elasticsearch due to ${error.message ||
-        error}`,
+          error}`,
         4002,
         500,
         reply
@@ -155,16 +155,16 @@ export class WazuhElasticCtrl {
       return filtered.length >= 1
         ? { statusCode: 200, status: true, data: 'Index pattern found' }
         : {
-          statusCode: 500,
-          status: false,
-          error: 10020,
-          message: 'Index pattern not found'
-        };
+            statusCode: 500,
+            status: false,
+            error: 10020,
+            message: 'Index pattern not found'
+          };
     } catch (error) {
       log('GET /elastic/index-patterns/{pattern}', error.message || error);
       return ErrorResponse(
         `Something went wrong retrieving index-patterns from Elasticsearch due to ${error.message ||
-        error}`,
+          error}`,
         4003,
         500,
         reply
@@ -221,9 +221,9 @@ export class WazuhElasticCtrl {
         typeof data.aggregations['2'].buckets[0] === 'undefined'
         ? { statusCode: 200, data: '' }
         : {
-          statusCode: 200,
-          data: data.aggregations['2'].buckets[0].key
-        };
+            statusCode: 200,
+            data: data.aggregations['2'].buckets[0].key
+          };
     } catch (error) {
       return ErrorResponse(error.message || error, 4004, 500, reply);
     }
@@ -246,7 +246,7 @@ export class WazuhElasticCtrl {
       log('GET /elastic/setup', error.message || error);
       return ErrorResponse(
         `Could not get data from elasticsearch due to ${error.message ||
-        error}`,
+          error}`,
         4005,
         500,
         reply
@@ -396,15 +396,15 @@ export class WazuhElasticCtrl {
 
           defaultStr.includes('wazuh-monitoring')
             ? (aux_source.kibanaSavedObjectMeta.searchSourceJSON = defaultStr.replace(
-              'wazuh-monitoring',
-              monitoringPattern[monitoringPattern.length - 1] === '*'
-                ? monitoringPattern
-                : monitoringPattern + '*'
-            ))
+                'wazuh-monitoring',
+                monitoringPattern[monitoringPattern.length - 1] === '*'
+                  ? monitoringPattern
+                  : monitoringPattern + '*'
+              ))
             : (aux_source.kibanaSavedObjectMeta.searchSourceJSON = defaultStr.replace(
-              'wazuh-alerts',
-              id
-            ));
+                'wazuh-alerts',
+                id
+              ));
         }
 
         // Replace index-pattern for selector visualizations
@@ -473,7 +473,7 @@ export class WazuhElasticCtrl {
             for (const node of nodes) {
               query += `.es(index=${pattern_name},q="cluster.name: ${name} AND cluster.node: ${
                 node.name
-                }").label("${node.name}"),`;
+              }").label("${node.name}"),`;
             }
             query = query.substring(0, query.length - 1);
           } else if (title === 'Wazuh App Cluster Overview Manager') {
@@ -591,10 +591,16 @@ export class WazuhElasticCtrl {
       if (!req.params.pattern) throw new Error('Missing parameters');
       const output =
         ((req || {}).params || {}).pattern === 'all'
-          ? await checkKnownFields(this.wzWrapper, false, this._server, false, true)
+          ? await checkKnownFields(
+              this.wzWrapper,
+              false,
+              this._server,
+              false,
+              true
+            )
           : await this.wzWrapper.updateIndexPatternKnownFields(
-            req.params.pattern
-          );
+              req.params.pattern
+            );
 
       return { acknowledge: true, output: output };
     } catch (error) {

--- a/server/controllers/wazuh-elastic.js
+++ b/server/controllers/wazuh-elastic.js
@@ -591,13 +591,7 @@ export class WazuhElasticCtrl {
       if (!req.params.pattern) throw new Error('Missing parameters');
       const output =
         ((req || {}).params || {}).pattern === 'all'
-          ? await checkKnownFields(
-              this.wzWrapper,
-              false,
-              this._server,
-              false,
-              true
-            )
+          ? await checkKnownFields(this.wzWrapper, false, false, false, true)
           : await this.wzWrapper.updateIndexPatternKnownFields(
               req.params.pattern
             );

--- a/server/controllers/wazuh-elastic.js
+++ b/server/controllers/wazuh-elastic.js
@@ -27,6 +27,7 @@ export class WazuhElasticCtrl {
    * @param {*} server
    */
   constructor(server) {
+    this._server = server;
     this.wzWrapper = new ElasticWrapper(server);
   }
 
@@ -116,20 +117,20 @@ export class WazuhElasticCtrl {
 
       return isIncluded && Array.isArray(isIncluded) && isIncluded.length
         ? {
-            statusCode: 200,
-            status: true,
-            data: `Template found for ${req.params.pattern}`
-          }
+          statusCode: 200,
+          status: true,
+          data: `Template found for ${req.params.pattern}`
+        }
         : {
-            statusCode: 200,
-            status: false,
-            data: `No template found for ${req.params.pattern}`
-          };
+          statusCode: 200,
+          status: false,
+          data: `No template found for ${req.params.pattern}`
+        };
     } catch (error) {
       log('GET /elastic/template/{pattern}', error.message || error);
       return ErrorResponse(
         `Could not retrieve templates from Elasticsearch due to ${error.message ||
-          error}`,
+        error}`,
         4002,
         500,
         reply
@@ -154,16 +155,16 @@ export class WazuhElasticCtrl {
       return filtered.length >= 1
         ? { statusCode: 200, status: true, data: 'Index pattern found' }
         : {
-            statusCode: 500,
-            status: false,
-            error: 10020,
-            message: 'Index pattern not found'
-          };
+          statusCode: 500,
+          status: false,
+          error: 10020,
+          message: 'Index pattern not found'
+        };
     } catch (error) {
       log('GET /elastic/index-patterns/{pattern}', error.message || error);
       return ErrorResponse(
         `Something went wrong retrieving index-patterns from Elasticsearch due to ${error.message ||
-          error}`,
+        error}`,
         4003,
         500,
         reply
@@ -220,9 +221,9 @@ export class WazuhElasticCtrl {
         typeof data.aggregations['2'].buckets[0] === 'undefined'
         ? { statusCode: 200, data: '' }
         : {
-            statusCode: 200,
-            data: data.aggregations['2'].buckets[0].key
-          };
+          statusCode: 200,
+          data: data.aggregations['2'].buckets[0].key
+        };
     } catch (error) {
       return ErrorResponse(error.message || error, 4004, 500, reply);
     }
@@ -245,7 +246,7 @@ export class WazuhElasticCtrl {
       log('GET /elastic/setup', error.message || error);
       return ErrorResponse(
         `Could not get data from elasticsearch due to ${error.message ||
-          error}`,
+        error}`,
         4005,
         500,
         reply
@@ -395,15 +396,15 @@ export class WazuhElasticCtrl {
 
           defaultStr.includes('wazuh-monitoring')
             ? (aux_source.kibanaSavedObjectMeta.searchSourceJSON = defaultStr.replace(
-                'wazuh-monitoring',
-                monitoringPattern[monitoringPattern.length - 1] === '*'
-                  ? monitoringPattern
-                  : monitoringPattern + '*'
-              ))
+              'wazuh-monitoring',
+              monitoringPattern[monitoringPattern.length - 1] === '*'
+                ? monitoringPattern
+                : monitoringPattern + '*'
+            ))
             : (aux_source.kibanaSavedObjectMeta.searchSourceJSON = defaultStr.replace(
-                'wazuh-alerts',
-                id
-              ));
+              'wazuh-alerts',
+              id
+            ));
         }
 
         // Replace index-pattern for selector visualizations
@@ -472,7 +473,7 @@ export class WazuhElasticCtrl {
             for (const node of nodes) {
               query += `.es(index=${pattern_name},q="cluster.name: ${name} AND cluster.node: ${
                 node.name
-              }").label("${node.name}"),`;
+                }").label("${node.name}"),`;
             }
             query = query.substring(0, query.length - 1);
           } else if (title === 'Wazuh App Cluster Overview Manager') {
@@ -588,13 +589,12 @@ export class WazuhElasticCtrl {
   async refreshIndex(req, reply) {
     try {
       if (!req.params.pattern) throw new Error('Missing parameters');
-
       const output =
         ((req || {}).params || {}).pattern === 'all'
-          ? await checkKnownFields(this.wzWrapper, false, false, false, true)
+          ? await checkKnownFields(this.wzWrapper, false, this._server, false, true)
           : await this.wzWrapper.updateIndexPatternKnownFields(
-              req.params.pattern
-            );
+            req.params.pattern
+          );
 
       return { acknowledge: true, output: output };
     } catch (error) {

--- a/server/index-pattern-cron-job.js
+++ b/server/index-pattern-cron-job.js
@@ -21,7 +21,7 @@ export class IndexPatternCronJob {
   constructor(server) {
     this.server = server;
     this.wzWrapper = new ElasticWrapper(server);
-    this.CRON_FREQ = '0 * * * * *'; // Every minute
+    this.CRON_FREQ = '0 */2 * * * *'; // Every minute
   }
 
   /**

--- a/server/index-pattern-cron-job.js
+++ b/server/index-pattern-cron-job.js
@@ -15,37 +15,49 @@ import { ElasticWrapper } from './lib/elastic-wrapper';
 import { log } from './logger';
 
 export class IndexPatternCronJob {
-    /**
-     * @param {Object} server Hapi.js server object provided by Kibana
-     */
-    constructor(server) {
-        this.server = server;
-        this.wzWrapper = new ElasticWrapper(server);
-        this.CRON_FREQ = '0 * * * * *'; // Every minute
-    }
+  /**
+   * @param {Object} server Hapi.js server object provided by Kibana
+   */
+  constructor(server) {
+    this.server = server;
+    this.wzWrapper = new ElasticWrapper(server);
+    this.CRON_FREQ = '0 * * * * *'; // Every minute
+  }
 
-    /**
-     * Check all known fields for all Wazuh valid index patterns, every "this.CRON_FREQ".
-     * This function is wrapped into a double try/catch block because we 
-     * don't want to kill the Node.js process or to stop the app execution.
-     * This is not a reason to stop, a log is just enough to advice the user.
-     */
-    async run() {
-        try {
-            // Launch the Cron job
-            cron.schedule(this.CRON_FREQ, async () => {
-                try {
-                    // Call the proper method to refresh the known fields
-                    await checkKnownFields(this.wzWrapper, false, this.server, false, true);
-                } catch (error) {
-                    // Await execution failed
-                    log('[IndexPatternCronJob][checkKnownFields]', error.message || error);
-                }
-            }, true);
-        } catch (error) {
-            // Cron job creation failed
-            log('[IndexPatternCronJob][create-job]', error.message || error);
-        }
+  /**
+   * Check all known fields for all Wazuh valid index patterns, every "this.CRON_FREQ".
+   * This function is wrapped into a double try/catch block because we
+   * don't want to kill the Node.js process or to stop the app execution.
+   * This is not a reason to stop, a log is just enough to advice the user.
+   */
+  async run() {
+    try {
+      // Launch the Cron job
+      cron.schedule(
+        this.CRON_FREQ,
+        async () => {
+          try {
+            // Call the proper method to refresh the known fields
+            await checkKnownFields(
+              this.wzWrapper,
+              false,
+              this.server,
+              false,
+              true
+            );
+          } catch (error) {
+            // Await execution failed
+            log(
+              '[IndexPatternCronJob][checkKnownFields]',
+              error.message || error
+            );
+          }
+        },
+        true
+      );
+    } catch (error) {
+      // Cron job creation failed
+      log('[IndexPatternCronJob][create-job]', error.message || error);
     }
-
+  }
 }

--- a/server/index-pattern-cron-job.js
+++ b/server/index-pattern-cron-job.js
@@ -1,0 +1,51 @@
+/*
+ * Wazuh app - Module for refreshing all known fields every 1 minute
+ * Copyright (C) 2015-2019 Wazuh, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Find more information about this on the LICENSE file.
+ */
+import { checkKnownFields } from './lib/refresh-known-fields';
+import cron from 'node-cron';
+import { ElasticWrapper } from './lib/elastic-wrapper';
+import { log } from './logger';
+
+export class IndexPatternCronJob {
+    /**
+     * @param {Object} server Hapi.js server object provided by Kibana
+     */
+    constructor(server) {
+        this.server = server;
+        this.wzWrapper = new ElasticWrapper(server);
+        this.CRON_FREQ = '0 * * * * *'; // Every minute
+    }
+
+    /**
+     * Check all known fields for all Wazuh valid index patterns, every "this.CRON_FREQ".
+     * This function is wrapped into a double try/catch block because we 
+     * don't want to kill the Node.js process or to stop the app execution.
+     * This is not a reason to stop, a log is just enough to advice the user.
+     */
+    async run() {
+        try {
+            // Launch the Cron job
+            cron.schedule(this.CRON_FREQ, async () => {
+                try {
+                    // Call the proper method to refresh the known fields
+                    await checkKnownFields(this.wzWrapper, false, this.server, false, true);
+                } catch (error) {
+                    // Await execution failed
+                    log('[IndexPatternCronJob][checkKnownFields]', error.message || error);
+                }
+            }, true);
+        } catch (error) {
+            // Cron job creation failed
+            log('[IndexPatternCronJob][create-job]', error.message || error);
+        }
+    }
+
+}

--- a/server/index-pattern-cron-job.js
+++ b/server/index-pattern-cron-job.js
@@ -55,6 +55,10 @@ export class IndexPatternCronJob {
         },
         true
       );
+      log(
+        '[IndexPatternCronJob][create-job]',
+        'Index pattern cron job started'
+      );
     } catch (error) {
       // Cron job creation failed
       log('[IndexPatternCronJob][create-job]', error.message || error);

--- a/server/lib/elastic-wrapper.js
+++ b/server/lib/elastic-wrapper.js
@@ -234,9 +234,10 @@ export class ElasticWrapper {
 
   /**
    * Updates index-pattern known fields
-   * @param {*} patternId 'index-pattern:' + id
+   * @param {*} id 'index-pattern:' + id
+   * @param {*} detectedFields Array of fields that we may be missing (commonly due to dynamic fields, eg: aws)
    */
-  async updateIndexPatternKnownFields(id) {
+  async updateIndexPatternKnownFields(id, detectedFields = []) {
     try {
       if (!id)
         return Promise.reject(
@@ -256,9 +257,9 @@ export class ElasticWrapper {
             item =>
               item.name &&
               item.name !==
-                'data.aws.service.action.networkConnectionAction.remoteIpDetails.geoLocation.lat' &&
+              'data.aws.service.action.networkConnectionAction.remoteIpDetails.geoLocation.lat' &&
               item.name !==
-                'data.aws.service.action.networkConnectionAction.remoteIpDetails.geoLocation.lon'
+              'data.aws.service.action.networkConnectionAction.remoteIpDetails.geoLocation.lon'
           );
 
           for (const field of knownFields) {
@@ -279,6 +280,22 @@ export class ElasticWrapper {
       } else {
         // It's a new index pattern, just add our known fields
         currentFields = knownFields;
+      }
+
+      // Iterate over dynamic fields
+      for (const field of detectedFields) {
+        // It has this field?
+        const index = currentFields
+          .map(item => item.name)
+          .indexOf(field.name);
+
+        if (index >= 0 && currentFields[index]) {
+          // If field already exists, update its type
+          currentFields[index].type = field.type;
+        } else {
+          // If field doesn't exist, add it
+          currentFields.push(field);
+        }
       }
 
       // This array always must has items
@@ -581,17 +598,17 @@ export class ElasticWrapper {
 
       const data = req
         ? await this.elasticRequest.callWithRequest(req, 'update', {
-            index: '.wazuh',
-            type: 'wazuh-configuration',
-            id: id,
-            body: doc
-          })
+          index: '.wazuh',
+          type: 'wazuh-configuration',
+          id: id,
+          body: doc
+        })
         : await this.elasticRequest.callWithInternalUser('update', {
-            index: '.wazuh',
-            type: 'wazuh-configuration',
-            id: id,
-            body: doc
-          });
+          index: '.wazuh',
+          type: 'wazuh-configuration',
+          id: id,
+          body: doc
+        });
 
       return data;
     } catch (error) {
@@ -666,7 +683,7 @@ export class ElasticWrapper {
       return (
         this.usingSearchGuard ||
         ((((data || {}).defaults || {}).xpack || {}).security || {}).enabled ==
-          'true'
+        'true'
       );
     } catch (error) {
       return Promise.reject(error);

--- a/server/lib/elastic-wrapper.js
+++ b/server/lib/elastic-wrapper.js
@@ -257,9 +257,9 @@ export class ElasticWrapper {
             item =>
               item.name &&
               item.name !==
-              'data.aws.service.action.networkConnectionAction.remoteIpDetails.geoLocation.lat' &&
+                'data.aws.service.action.networkConnectionAction.remoteIpDetails.geoLocation.lat' &&
               item.name !==
-              'data.aws.service.action.networkConnectionAction.remoteIpDetails.geoLocation.lon'
+                'data.aws.service.action.networkConnectionAction.remoteIpDetails.geoLocation.lon'
           );
 
           for (const field of knownFields) {
@@ -285,9 +285,7 @@ export class ElasticWrapper {
       // Iterate over dynamic fields
       for (const field of detectedFields) {
         // It has this field?
-        const index = currentFields
-          .map(item => item.name)
-          .indexOf(field.name);
+        const index = currentFields.map(item => item.name).indexOf(field.name);
 
         if (index >= 0 && currentFields[index]) {
           // If field already exists, update its type
@@ -598,17 +596,17 @@ export class ElasticWrapper {
 
       const data = req
         ? await this.elasticRequest.callWithRequest(req, 'update', {
-          index: '.wazuh',
-          type: 'wazuh-configuration',
-          id: id,
-          body: doc
-        })
+            index: '.wazuh',
+            type: 'wazuh-configuration',
+            id: id,
+            body: doc
+          })
         : await this.elasticRequest.callWithInternalUser('update', {
-          index: '.wazuh',
-          type: 'wazuh-configuration',
-          id: id,
-          body: doc
-        });
+            index: '.wazuh',
+            type: 'wazuh-configuration',
+            id: id,
+            body: doc
+          });
 
       return data;
     } catch (error) {
@@ -683,7 +681,7 @@ export class ElasticWrapper {
       return (
         this.usingSearchGuard ||
         ((((data || {}).defaults || {}).xpack || {}).security || {}).enabled ==
-        'true'
+          'true'
       );
     } catch (error) {
       return Promise.reject(error);

--- a/server/lib/refresh-known-fields.js
+++ b/server/lib/refresh-known-fields.js
@@ -56,14 +56,15 @@ export async function checkKnownFields(
 
             // Merge fields logic
             const pattern = index._id.split('index-pattern:')[1];
-            const meta_fields = ["_source", "_id", "_type", "_index", "_score"];
+            const meta_fields = ['_source', '_id', '_type', '_index', '_score'];
             const standardRequest = {
-              url: `/api/index_patterns/_fields_for_wildcard?${querystring.stringify({ pattern, meta_fields })}`,
+              url: `/api/index_patterns/_fields_for_wildcard?${querystring.stringify(
+                { pattern, meta_fields }
+              )}`,
               method: 'GET'
             };
             standardResponse = await server.inject(standardRequest);
             // End merge fields logic
-
           } catch (error) {
             continue;
           }
@@ -73,7 +74,8 @@ export async function checkKnownFields(
             list.push({
               id: index._id.split('index-pattern:')[1],
               title: index._source['index-pattern'].title,
-              detectedFields: ((standardResponse || {}).result || {}).fields || []
+              detectedFields:
+                ((standardResponse || {}).result || {}).fields || []
             });
           }
         }
@@ -172,7 +174,10 @@ export async function checkKnownFields(
           [blueWazuh, 'initialize', 'info'],
           `Refreshing known fields for "index-pattern:${item.title}"`
         );
-      await wzWrapper.updateIndexPatternKnownFields('index-pattern:' + item.id, item.detectedFields);
+      await wzWrapper.updateIndexPatternKnownFields(
+        'index-pattern:' + item.id,
+        item.detectedFields
+      );
     }
 
     !quiet &&

--- a/server/lib/refresh-known-fields.js
+++ b/server/lib/refresh-known-fields.js
@@ -11,7 +11,6 @@
  */
 import colors from 'ansicolors';
 const blueWazuh = colors.blue('wazuh');
-import querystring from 'querystring';
 
 /**
  * Refresh known fields for all valid index patterns.
@@ -50,21 +49,9 @@ export async function checkKnownFields(
 
       if (indexPatternList.hits.hits.length > 0) {
         for (const index of indexPatternList.hits.hits) {
-          let valid, parsed, standardResponse;
+          let valid, parsed;
           try {
             parsed = JSON.parse(index._source['index-pattern'].fields);
-
-            // Merge fields logic
-            const pattern = index._id.split('index-pattern:')[1];
-            const meta_fields = ['_source', '_id', '_type', '_index', '_score'];
-            const standardRequest = {
-              url: `/api/index_patterns/_fields_for_wildcard?${querystring.stringify(
-                { pattern, meta_fields }
-              )}`,
-              method: 'GET'
-            };
-            standardResponse = await server.inject(standardRequest);
-            // End merge fields logic
           } catch (error) {
             continue;
           }
@@ -73,9 +60,7 @@ export async function checkKnownFields(
           if (valid.length === 4) {
             list.push({
               id: index._id.split('index-pattern:')[1],
-              title: index._source['index-pattern'].title,
-              detectedFields:
-                ((standardResponse || {}).result || {}).fields || []
+              title: index._source['index-pattern'].title
             });
           }
         }
@@ -174,10 +159,7 @@ export async function checkKnownFields(
           [blueWazuh, 'initialize', 'info'],
           `Refreshing known fields for "index-pattern:${item.title}"`
         );
-      await wzWrapper.updateIndexPatternKnownFields(
-        'index-pattern:' + item.id,
-        item.detectedFields
-      );
+      await wzWrapper.updateIndexPatternKnownFields('index-pattern:' + item.id);
     }
 
     !quiet &&


### PR DESCRIPTION
Changes:

- The way we refresh an index pattern has been changed. Now we are fetching all the dynamic fields that we may be missing and it merges those fields with our known fields.
- Added a new `cron` task in our server side, it refreshes all valid index patterns every 2 minutes.
- Removed refreshing action per every parent state change.
- Keep the refreshing action for all the index patterns if `kbn-vis` fails due to missing fields*.
- Keep the refreshing action for all the index patterns if the app health check is fired*.
- Keep the refreshing action for the selected pattern only when using the index pattern selector*.
- Wrapped into a double try/catch block, so the server won't be crashed under any error that this feature may throw.

_* Now, the refreshing action is using the merging feature described above_