### PR TITLE
Job queue

### DIFF
--- a/init.js
+++ b/init.js
@@ -20,6 +20,7 @@ import { WazuhReportingRoutes } from './server/routes/wazuh-reporting';
 import { WazuhUtilsRoutes } from './server/routes/wazuh-utils';
 import { IndexPatternCronJob } from './server/index-pattern-cron-job';
 import { log } from './server/logger';
+import { Queue } from './server/jobs/queue';
 
 export function initApp(server) {
   const monitoringInstance = new Monitoring(server);
@@ -39,6 +40,7 @@ export function initApp(server) {
       WazuhApiElasticRoutes(server);
       monitoringInstance.run();
       indexPatternCronJobInstance.run();
+      Queue.launchCronJob();
       WazuhApiRoutes(server);
       WazuhReportingRoutes(server);
       WazuhUtilsRoutes(server);

--- a/public/controllers/management/edition.js
+++ b/public/controllers/management/edition.js
@@ -106,7 +106,7 @@ export class EditionController {
           '/cluster/status',
           {}
         );
-        let data;
+
         const clusterStatus =
           ((this.$scope.clusterStatus || {}).data || {}).data || {};
         if (
@@ -114,15 +114,11 @@ export class EditionController {
             clusterStatus.running === 'yes') ||
           (clusterStatus.enabled === 'no' && clusterStatus.running === 'yes')
         ) {
-          data = await this.configHandler.restartNode(selectedNode);
-          this.errorHandler.info(
-            `${data.data.data}. It will take up to 15 seconds.`
-          );
+          await this.configHandler.restartNode(selectedNode);
+          this.errorHandler.info('Success. It will take up to 15 seconds.');
         } else {
-          data = await this.configHandler.restartManager();
-          this.errorHandler.info(
-            `${data.data.data}. It may take a few seconds.`
-          );
+          await this.configHandler.restartManager();
+          this.errorHandler.info('Success. It may take a few seconds.');
         }
         this.$scope.$emit('removeRestarting', {});
         this.$scope.isRestarting = false;

--- a/public/controllers/management/management.js
+++ b/public/controllers/management/management.js
@@ -134,9 +134,9 @@ export class ManagementController {
   async restartManager() {
     try {
       this.isRestarting = true;
-      const data = await this.configHandler.restartManager();
+      await this.configHandler.restartManager();
       this.isRestarting = false;
-      this.errorHandler.info(`${data.data.data}. It may take a few seconds.`);
+      this.errorHandler.info('Success. It may take a few seconds.');
       this.$scope.$applyAsync();
     } catch (error) {
       this.isRestarting = false;
@@ -150,10 +150,8 @@ export class ManagementController {
   async restartCluster() {
     try {
       this.isRestarting = true;
-      const data = await this.configHandler.restartCluster();
-      this.errorHandler.info(
-        `${data.data.data}. It will take up to 15 seconds.`
-      );
+      await this.configHandler.restartCluster();
+      this.errorHandler.info('Success. It will take up to 15 seconds.');
       this.$scope.$applyAsync();
     } catch (error) {
       this.isRestarting = false;

--- a/public/directives/wz-list-manage/wz-list-manage.js
+++ b/public/directives/wz-list-manage/wz-list-manage.js
@@ -17,7 +17,7 @@ import { checkGap } from '../wz-table/lib/check-gap';
 
 const app = uiModules.get('app/wazuh', []);
 
-app.directive('wzListManage', function () {
+app.directive('wzListManage', function() {
   return {
     restrict: 'E',
     scope: {
@@ -50,7 +50,7 @@ app.directive('wzListManage', function () {
       $scope.prevPage = () => pagination.prevPage($scope);
       $scope.nextPage = async currentPage =>
         pagination.nextPage(currentPage, $scope, errorHandler, null);
-      $scope.setPage = function () {
+      $scope.setPage = function() {
         $scope.currentPage = this.n;
         $scope.nextPage(this.n);
       };

--- a/public/directives/wz-xml-file-editor/wz-xml-file-editor.js
+++ b/public/directives/wz-xml-file-editor/wz-xml-file-editor.js
@@ -316,7 +316,7 @@ app.directive('wzXmlFileEditor', function() {
         } catch (error) {
           $scope.savingParam();
           if ((error || '').includes('Wazuh API error: 1905')) {
-            $scope.configError = ["File name already exists"];
+            $scope.configError = ['File name already exists'];
             $scope.$emit('showSaveAndOverwrite', {});
           } else {
             errorHandler.handle(error, 'Error');

--- a/public/services/config-handler.js
+++ b/public/services/config-handler.js
@@ -53,7 +53,7 @@ export class ConfigHandler {
 
   async performClusterRestart() {
     try {
-      await this.apiReq.request('PUT', `/cluster/restart`, {});
+      await this.apiReq.request('PUT', `/cluster/restart`, { delay: 15000 });
       this.$rootScope.$emit('removeRestarting', {});
     } catch (error) {
       this.$rootScope.$emit('removeRestarting', {});
@@ -103,9 +103,7 @@ export class ConfigHandler {
         const str = data.details.join();
         throw new Error(str);
       }
-      setTimeout(() => {
-        this.performClusterRestart();
-      }, 15000);
+      this.performClusterRestart();
       return { data: { data: 'Restarting cluster' } };
     } catch (error) {
       return Promise.reject(error);

--- a/server/controllers/wazuh-api.js
+++ b/server/controllers/wazuh-api.js
@@ -203,7 +203,7 @@ export class WazuhApiCtrl {
                   req.idChanged = api._id;
                   return this.checkStoredAPI(req, reply);
                 }
-              } catch (error) { } // eslint-disable-line
+              } catch (error) {} // eslint-disable-line
             }
           } catch (error) {
             log('POST /api/check-stored-api', error.message || error);
@@ -624,7 +624,7 @@ export class WazuhApiCtrl {
       }
 
       throw ((response || {}).body || {}).error &&
-        ((response || {}).body || {}).message
+      ((response || {}).body || {}).message
         ? { message: response.body.message, code: response.body.error }
         : new Error('Unexpected error fetching data from the Wazuh API');
     } catch (error) {
@@ -683,7 +683,7 @@ export class WazuhApiCtrl {
       }
 
       throw ((response || {}).body || {}).error &&
-        ((response || {}).body || {}).message
+      ((response || {}).body || {}).message
         ? { message: response.body.message, code: response.body.error }
         : new Error('Unexpected error fetching data from the Wazuh API');
     } catch (error) {
@@ -832,18 +832,18 @@ export class WazuhApiCtrl {
       if ((((output || {}).body || {}).data || {}).totalItems) {
         const fields = req.payload.path.includes('/agents')
           ? [
-            'id',
-            'status',
-            'name',
-            'ip',
-            'group',
-            'manager',
-            'node_name',
-            'dateAdd',
-            'version',
-            'lastKeepAlive',
-            'os'
-          ]
+              'id',
+              'status',
+              'name',
+              'ip',
+              'group',
+              'manager',
+              'node_name',
+              'dateAdd',
+              'version',
+              'lastKeepAlive',
+              'os'
+            ]
           : Object.keys(output.body.data.items[0]);
 
         const json2csvParser = new Parser({ fields });

--- a/server/jobs/queue.js
+++ b/server/jobs/queue.js
@@ -17,50 +17,52 @@ let jobs = [];
 const CRON_FREQ = '0 * * * * *'; // Every 1 minute
 
 export class Queue {
-    static addJob(job) {
-        jobs.push(job);
-    }
+  static addJob(job) {
+    jobs.push(job);
+  }
 
-    static async run(job) {
+  static async run(job) {
+    try {
+      if (job.type === 'request') {
+        await needle(job.method, job.fullUrl, job.data, job.options);
+      }
+    } catch (error) {
+      return Promise.reject(error);
+    }
+  }
+
+  static async executePendingJobs() {
+    try {
+      if (!jobs || !jobs.length) return;
+      const now = new Date();
+      const pendingJobs = jobs.filter(item => item.startAt <= now);
+      if (!pendingJobs || !pendingJobs.length) return;
+      jobs = jobs.filter(item => item.startAt > now);
+
+      for (const job of pendingJobs) {
         try {
-            if (job.type === 'request') {
-                await needle(job.method, job.fullUrl, job.data, job.options);
-            }
+          await Queue.run(job);
         } catch (error) {
-            return Promise.reject(error);
+          continue;
         }
+      }
+    } catch (error) {
+      jobs = [];
+      return Promise.reject(error);
     }
+  }
 
-    static async executePendingJobs() {
+  static launchCronJob() {
+    cron.schedule(
+      CRON_FREQ,
+      async () => {
         try {
-            if (!jobs || !jobs.length) return;
-            const now = new Date();
-            const pendingJobs = jobs.filter(item => item.startAt <= now);
-            if (!pendingJobs || !pendingJobs.length) return;
-            jobs = jobs.filter(item => item.startAt > now);
-
-            for (const job of pendingJobs) {
-                try {
-                    await Queue.run(job);
-                } catch (error) { continue; }
-            }
+          await Queue.executePendingJobs();
         } catch (error) {
-            jobs = [];
-            return Promise.reject(error);
+          log('[queue]', error.message || error);
         }
-    }
-
-    static launchCronJob() {
-        cron.schedule(
-            CRON_FREQ,
-            async () => {
-                try {
-                    await Queue.executePendingJobs();
-                } catch (error) {
-                    log('[queue]', error.message || error);
-                }
-            },
-            true
-        );
-    }
+      },
+      true
+    );
+  }
 }

--- a/server/jobs/queue.js
+++ b/server/jobs/queue.js
@@ -1,0 +1,66 @@
+/*
+ * Wazuh app - Add delayed jobs to a queue.
+ * Copyright (C) 2015-2019 Wazuh, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Find more information about this on the LICENSE file.
+ */
+import needle from 'needle';
+import cron from 'node-cron';
+import { log } from '../logger';
+
+let jobs = [];
+const CRON_FREQ = '0 * * * * *'; // Every 1 minute
+
+export class Queue {
+    static addJob(job) {
+        jobs.push(job);
+    }
+
+    static async run(job) {
+        try {
+            if (job.type === 'request') {
+                await needle(job.method, job.fullUrl, job.data, job.options);
+            }
+        } catch (error) {
+            return Promise.reject(error);
+        }
+    }
+
+    static async executePendingJobs() {
+        try {
+            if (!jobs || !jobs.length) return;
+            const now = new Date();
+            const pendingJobs = jobs.filter(item => item.startAt <= now);
+            if (!pendingJobs || !pendingJobs.length) return;
+            jobs = jobs.filter(item => item.startAt > now);
+
+            for (const job of pendingJobs) {
+                try {
+                    await Queue.run(job);
+                } catch (error) { continue; }
+            }
+        } catch (error) {
+            jobs = [];
+            return Promise.reject(error);
+        }
+    }
+
+    static launchCronJob() {
+        cron.schedule(
+            CRON_FREQ,
+            async () => {
+                try {
+                    await Queue.executePendingJobs();
+                } catch (error) {
+                    log('[queue]', error.message || error);
+                }
+            },
+            true
+        );
+    }
+}

--- a/server/lib/elastic-wrapper.js
+++ b/server/lib/elastic-wrapper.js
@@ -263,7 +263,7 @@ export class ElasticWrapper {
         if (!Array.isArray(detectedFields)) {
           detectedFields = [];
         }
-      } catch (error) { } //eslint-disable-line
+      } catch (error) {} //eslint-disable-line
 
       let currentFields = [];
 
@@ -276,9 +276,9 @@ export class ElasticWrapper {
             item =>
               item.name &&
               item.name !==
-              'data.aws.service.action.networkConnectionAction.remoteIpDetails.geoLocation.lat' &&
+                'data.aws.service.action.networkConnectionAction.remoteIpDetails.geoLocation.lat' &&
               item.name !==
-              'data.aws.service.action.networkConnectionAction.remoteIpDetails.geoLocation.lon'
+                'data.aws.service.action.networkConnectionAction.remoteIpDetails.geoLocation.lon'
           );
 
           for (const field of knownFields) {
@@ -615,17 +615,17 @@ export class ElasticWrapper {
 
       const data = req
         ? await this.elasticRequest.callWithRequest(req, 'update', {
-          index: '.wazuh',
-          type: 'wazuh-configuration',
-          id: id,
-          body: doc
-        })
+            index: '.wazuh',
+            type: 'wazuh-configuration',
+            id: id,
+            body: doc
+          })
         : await this.elasticRequest.callWithInternalUser('update', {
-          index: '.wazuh',
-          type: 'wazuh-configuration',
-          id: id,
-          body: doc
-        });
+            index: '.wazuh',
+            type: 'wazuh-configuration',
+            id: id,
+            body: doc
+          });
 
       return data;
     } catch (error) {
@@ -700,7 +700,7 @@ export class ElasticWrapper {
       return (
         this.usingSearchGuard ||
         ((((data || {}).defaults || {}).xpack || {}).security || {}).enabled ==
-        'true'
+          'true'
       );
     } catch (error) {
       return Promise.reject(error);


### PR DESCRIPTION
Hi team, this PR adds a job queue so we can execute delayed tasks (such an API call).

This first iteration accepts Wazuh API request with a `delay` parameter in milliseconds. If `delay` is given, the API request is added to the queue and executed once its `startAt` property is equal or lower than the current server date.

Best regards,
Jesús