### PR TITLE
Enable agents remove option in default group

### DIFF
--- a/public/directives/wz-table/wz-table.html
+++ b/public/directives/wz-table/wz-table.html
@@ -29,7 +29,7 @@
                 </span>
             </th>
             <th ng-if="(path === '/agents' || (path === '/agents/groups' && adminMode) || (isLookingGroup() && adminMode) 
-            || path === '/rules/files' || path === '/decoders/files' || path === '/lists/files') && !isLookingDefaultGroup"
+            || path === '/rules/files' || path === '/decoders/files' || path === '/lists/files')"
                 class="wz-text-left" ng-class="{'col-lg-2': path !== '/agents', 'col-lg-1': path === '/agents'}">Actions</th>
         </thead>
         <tbody>
@@ -72,7 +72,7 @@
                         </div>
                     </div>
                 </td>
-                <td ng-if="isLookingGroup() && adminMode && !isLookingDefaultGroup" ng-click="$event.stopPropagation()"
+                <td ng-if="isLookingGroup() && adminMode" ng-click="$event.stopPropagation()"
                     class="cursor-default action-btn-td">
                     <i ng-if="removingAgent !== item.id && adminMode" ng-click="showConfirmRemoveAgentFromGroup($event, item); $event.stopPropagation()"
                         class="fa fa-fw fa-trash cursor-pointer" tooltip="Remove this agent from the group"
@@ -117,7 +117,7 @@
         </tbody>
         <tfoot>
             <td colspan="{{ (path === '/agents' || (path === '/agents/groups' && adminMode) || (isLookingGroup() && adminMode) ||
-            path === '/rules/files' || path === '/decoders/files' || path === '/lists/files') && !isLookingDefaultGroup ? keys.length + 1 : keys.length}}">
+            path === '/rules/files' || path === '/decoders/files' || path === '/lists/files') ? keys.length + 1 : keys.length}}">
                 <span ng-show="!wazuh_table_loading" class="color-grey">{{ totalItems }} items ({{time | number: 2}}
                     seconds)</span>
                 <div ng-show="items.length >= itemsPerPage" class="pagination pull-right" style="margin:0 !important">


### PR DESCRIPTION
Hi team, 

This PR adds the possibility of removing a single agent from the default group.

Regards