### PR TITLE
Fix most active and last registered agents

### DIFF
--- a/public/controllers/agent/agents-preview.js
+++ b/public/controllers/agent/agents-preview.js
@@ -34,7 +34,8 @@ export class AgentsPreviewController {
     shareAgent,
     wzTableFilter,
     commonData,
-    wazuhConfig
+    wazuhConfig,
+    $window
   ) {
     this.$scope = $scope;
     this.genericReq = genericReq;
@@ -47,6 +48,7 @@ export class AgentsPreviewController {
     this.commonData = commonData;
     this.wazuhConfig = wazuhConfig;
     this.errorInit = false;
+    this.$window = $window;
   }
 
   /**
@@ -230,5 +232,12 @@ export class AgentsPreviewController {
 
   reloadList() {
     this.$scope.$broadcast('wazuhSearch', { term: '' });
+  }
+
+  openRegistrationDocs() {
+    this.$window.open(
+      'https://documentation.wazuh.com/current/user-manual/registering/index.html',
+      '_blank'
+    );
   }
 }

--- a/public/templates/agents-prev/agents-prev.html
+++ b/public/templates/agents-prev/agents-prev.html
@@ -4,12 +4,7 @@
         <md-card flex="50" class="wz-md-card" flex>
             <md-card-content class="wz-text-center">
                 <span class="wz-headline-title">
-                    <svg class="euiIcon euiIcon--medium" focusable="false" xmlns="http://www.w3.org/2000/svg" width="16"
-                        height="16" viewBox="0 0 16 16">
-                        <path fill-rule="evenodd"
-                            d="M8.378 1.496l6.695 10.984A1 1 0 0 1 14.22 14H1.667a1 1 0 0 1-.883-1.47L6.642 1.545a1 1 0 0 1 1.736-.05zm-.853.52L1.667 13h12.552L7.525 2.016zM7.14 10.06L6.9 5.18h1.3l-.25 4.878h-.81zm.394 1.901a.61.61 0 0 1-.448-.186.606.606 0 0 1-.186-.444c0-.174.062-.323.186-.446a.614.614 0 0 1 .448-.184c.169 0 .315.06.44.182.124.122.186.27.186.448a.6.6 0 0 1-.189.446.607.607 0 0 1-.437.184z">
-                        </path>
-                    </svg> Error fetching agents
+                    <react-component name="EuiIcon" props="{type: 'help'}" /> Error fetching agents
                 </span>
                 <md-divider class="wz-margin-top-10"></md-divider>
                 <div layout="row" class="wz-margin-top-10 layout-align-center-center">
@@ -19,12 +14,7 @@
                 </div>
                 <div layout="row" class="wz-margin-top-10 layout-align-center-center">
                     <button class="kuiButton kuiButton--secondary height-35" ng-click="ctrl.load()">
-                        <svg class="euiIcon euiIcon--medium" focusable="false" xmlns="http://www.w3.org/2000/svg"
-                            width="16" height="16" viewBox="0 0 16 16">
-                            <path
-                                d="M11.228 2.942a.5.5 0 1 1-.538.842A5 5 0 1 0 13 8a.5.5 0 1 1 1 0 6 6 0 1 1-2.772-5.058zM14 1.5v3A1.5 1.5 0 0 1 12.5 6h-3a.5.5 0 0 1 0-1h3a.5.5 0 0 0 .5-.5v-3a.5.5 0 1 1 1 0z">
-                            </path>
-                        </svg> Refresh
+                        <react-component name="EuiIcon" props="{type: 'refresh'}" /> Refresh
                     </button>
                 </div>
             </md-card-content>
@@ -40,11 +30,21 @@
                 <react-component name="EuiIcon" props="{type:'node'}" /> Status
             </span>
             <md-divider class="wz-margin-top-10"></md-divider>
-            <canvas id="bar" class="wz-margin-top-16 chart chart-doughnut"
+            <canvas id="bar" ng-if="ctrl.lastAgent && ctrl.lastAgent.id" class="wz-margin-top-16 chart chart-doughnut"
                 chart-data="[ctrl.agentsCountActive,ctrl.agentsCountDisconnected,ctrl.agentsCountNeverConnected]"
                 chart-labels="['Active','Disconnected', 'Never connected']"
                 chart-colors="['#00a69b', '#ff645c', '#eff0f1']"
                 chart-options="{cutoutPercentage: 75, legend: {display: true,position: 'right',},responsive: false, maintainAspectRatio: false}" />
+            <div layout="row" class="wz-margin-top-16 layout-align-center-center"
+                ng-if="!ctrl.lastAgent || !ctrl.lastAgent.id">
+                There are no agents yet.
+            </div>
+            <div layout="row" class="wz-margin-top-16 layout-align-center-center"
+                ng-if="!ctrl.lastAgent || !ctrl.lastAgent.id">
+                <button class="kuiButton kuiButton--success" ng-click="ctrl.openRegistrationDocs()">
+                    <react-component name="EuiIcon" props="{type: 'help'}" /> How to
+                </button>
+            </div>
         </div>
         <div flex class="layout-column md-padding">
             <span class="wz-headline-title">
@@ -59,7 +59,7 @@
                         <div class="euiText euiText--small euiStat__description">
                             <p>Active</p>
                         </div>
-                        <p class="euiTitle euiTitle--large euiStat__title">{{ctrl.agentsCountActive}}</p>
+                        <p class="euiTitle euiTitle--small euiStat__title">{{ctrl.agentsCountActive}}</p>
                     </div>
                 </div>
                 <div class="euiFlexItem euiFlexItem--flexGrowZero">
@@ -68,7 +68,7 @@
                         <div class="euiText euiText--small euiStat__description">
                             <p>Disconnected</p>
                         </div>
-                        <p class="euiTitle euiTitle--large euiStat__title">{{ctrl.agentsCountDisconnected}}</p>
+                        <p class="euiTitle euiTitle--small euiStat__title">{{ctrl.agentsCountDisconnected}}</p>
                     </div>
                 </div>
                 <div class="euiFlexItem euiFlexItem--flexGrowZero">
@@ -77,7 +77,7 @@
                         <div class="euiText euiText--small euiStat__description">
                             <p>Never connected</p>
                         </div>
-                        <p class="euiTitle euiTitle--large euiStat__title">{{ctrl.agentsCountNeverConnected}}</p>
+                        <p class="euiTitle euiTitle--small euiStat__title">{{ctrl.agentsCountNeverConnected}}</p>
                     </div>
                 </div>
                 <div class="euiFlexItem euiFlexItem--flexGrowZero">
@@ -86,7 +86,7 @@
                         <div class="euiText euiText--small euiStat__description">
                             <p>Agents coverage</p>
                         </div>
-                        <p class="euiTitle euiTitle--large euiStat__title">{{(ctrl.agentsCoverity | number:2)}}%</p>
+                        <p class="euiTitle euiTitle--small euiStat__title">{{(ctrl.agentsCoverity | number:2)}}%</p>
                     </div>
                 </div>
             </div>
@@ -97,11 +97,13 @@
                         <div class="euiText euiText--small euiStat__description">
                             <p>Last registered agent</p>
                         </div>
-                        <p ng-if="ctrl.lastAgent.id !== '000'" ng-click="ctrl.showAgent(ctrl.lastAgent)"
-                            class="euiTitle euiTitle--large euiStat__title wz-text-link cursor-pointer">
+                        <p ng-if="ctrl.lastAgent && ctrl.lastAgent.id && ctrl.lastAgent.id !== '000'"
+                            ng-click="ctrl.showAgent(ctrl.lastAgent)"
+                            class="euiTitle euiTitle--small euiStat__title wz-text-link cursor-pointer">
                             {{ctrl.lastAgent.name}}</p>
-                        <p ng-if="ctrl.lastAgent.id === '000'" class="euiTitle euiTitle--large euiStat__title">
-                            {{ctrl.lastAgent.name}} (manager)</p>
+                        <p ng-if="!ctrl.lastAgent || !ctrl.lastAgent.id"
+                            class="euiTitle euiTitle--small euiStat__title">
+                            -</p>
                     </div>
                 </div>
                 <div class="euiFlexItem euiFlexItem--flexGrowZero">
@@ -110,11 +112,13 @@
                         <div class="euiText euiText--small euiStat__description">
                             <p>Most active agent</p>
                         </div>
-                        <p ng-if="ctrl.mostActiveAgent.id !== '000'" ng-click="ctrl.showAgent(ctrl.mostActiveAgent)"
-                            class="euiTitle euiTitle--large euiStat__title wz-text-link cursor-pointer">
+                        <p ng-if="ctrl.lastAgent && ctrl.lastAgent.id && ctrl.mostActiveAgent.id !== '000'"
+                            ng-click="ctrl.showAgent(ctrl.mostActiveAgent)"
+                            class="euiTitle euiTitle--small euiStat__title wz-text-link cursor-pointer">
                             {{ctrl.mostActiveAgent.name}}</p>
-                        <p ng-if="ctrl.mostActiveAgent.id === '000'" class="euiTitle euiTitle--large euiStat__title">
-                            {{ctrl.mostActiveAgent.name}}</p>
+                        <p ng-if="!ctrl.lastAgent || !ctrl.lastAgent.id"
+                            class="euiTitle euiTitle--small euiStat__title">
+                            -</p>
                     </div>
                 </div>
             </div>

--- a/server/controllers/wazuh-api.js
+++ b/server/controllers/wazuh-api.js
@@ -1055,7 +1055,7 @@ export class WazuhApiCtrl {
         needle(
           'get',
           `${config.url}:${config.port}/agents`,
-          { limit: 1, sort: '-dateAdd' },
+          { limit: 1, sort: '-dateAdd', q: 'id!=000' },
           headers
         )
       ]);

--- a/server/controllers/wazuh-elastic.js
+++ b/server/controllers/wazuh-elastic.js
@@ -206,6 +206,11 @@ export class WazuhElasticCtrl {
         query: {
           bool: {
             must: [],
+            must_not: {
+              term: {
+                'agent.id': '000'
+              }
+            },
             filter: { range: { '@timestamp': {} } }
           }
         },

--- a/server/initialize.js
+++ b/server/initialize.js
@@ -236,7 +236,7 @@ export function Initialize(server) {
         );
 
         // Save Setup Info
-        await saveConfiguration(defaultIndexPattern);
+        await saveConfiguration();
       }
 
       await wzWrapper.updateWazuhVersionIndexLastRestart(


### PR DESCRIPTION
Hi team, this PR makes some changes in our agents preview section.

Summary:

- Exclude agent "000" from the Elasticsearch query we are using for getting the most active agent.
  - Do not show it if we have no last registered agent (you can have data in Elasticsearch even if you have no agents)
- Exclude agent "000" from the Wazuh API query we are using for getting the last registered agent.
- Replace the status chart with a meaningful message + docs button for registering agents.
- Reduce font size for the stats being shown in agents preview.

Regards