### PR TITLE
Mail configuration on the configuration on demand

### DIFF
--- a/public/templates/management/configuration/global-configuration/global.html
+++ b/public/templates/management/configuration/global-configuration/global.html
@@ -89,7 +89,7 @@
                     <wz-config-item label="Sender address for email alerts"
                         value="currentConfig['mail-global'].global.email_from">
                     </wz-config-item>
-                    <wz-config-item label="Recipient address for email alerts "
+                    <wz-config-item is-array="true" label="Recipient address for email alerts "
                         value="currentConfig['mail-global'].global.email_to">
                     </wz-config-item>
                     <wz-config-item label="Reply-to address for email alerts"

--- a/public/templates/management/configuration/global-configuration/global.html
+++ b/public/templates/management/configuration/global-configuration/global.html
@@ -87,25 +87,25 @@
                         value="currentConfig['analysis-global'].global.email_notification">
                     </wz-config-item>
                     <wz-config-item label="Sender address for email alerts"
-                        value="currentConfig['analysis-global'].global.email_from">
+                        value="currentConfig['mail-global'].global.email_from">
                     </wz-config-item>
                     <wz-config-item label="Recipient address for email alerts "
-                        value="currentConfig['analysis-global'].global.email_to">
+                        value="currentConfig['mail-global'].global.email_to">
                     </wz-config-item>
                     <wz-config-item label="Reply-to address for email alerts"
-                        value="currentConfig['analysis-global'].global.email_reply_to">
+                        value="currentConfig['mail-global'].global.email_reply_to">
                     </wz-config-item>
                     <wz-config-item label="Address for SMTP mail server"
-                        value="currentConfig['analysis-global'].global.smtp_server">
+                        value="currentConfig['mail-global'].global.smtp_server">
                     </wz-config-item>
                     <wz-config-item label="Maximum number of email alerts sent per hour"
-                        value="currentConfig['analysis-global'].global.email_maxperhour">
+                        value="currentConfig['mail-global'].global.email_maxperhour">
                     </wz-config-item>
                     <wz-config-item label="File to read data from"
-                        value="currentConfig['analysis-global'].global.email_log_source">
+                        value="currentConfig['mail-global'].global.email_log_source">
                     </wz-config-item>
                     <wz-config-item label="Name used for email alerts headers"
-                        value="currentConfig['analysis-global'].global.email_idsname">
+                        value="currentConfig['mail-global'].global.email_idsname">
                     </wz-config-item>
 
                 </div>

--- a/public/templates/management/configuration/welcome.html
+++ b/public/templates/management/configuration/welcome.html
@@ -31,7 +31,7 @@
                         </thead>
                         <tbody>
                             <tr class="cursor-pointer"
-                                ng-click="switchConfigTab('global-configuration', [{component:'analysis',configuration:'global'},{component:'request',configuration:'remote'},{component:'com',configuration:'logging'}])">
+                                ng-click="switchConfigTab('global-configuration', [{component:'analysis',configuration:'global'},{component:'mail',configuration:'global'},{component:'request',configuration:'remote'},{component:'com',configuration:'logging'}])">
                                 <td>Global configuration</td>
                                 <td>Global and remote settings</td>
                             </tr>


### PR DESCRIPTION
Hi team,

This PR show up in our config on-demand global section the mail configuration (if `alerts sent by email`
 is enabled). We have appended the output of `/manager/config/mail/global` to the output of the current call. 

This PR solves #1401 

Regards.