### PR TITLE
Manage not applicable checks in SCA policies

### DIFF
--- a/public/directives/wz-table/wz-table.html
+++ b/public/directives/wz-table/wz-table.html
@@ -192,11 +192,11 @@
                     <div ng-class="customColumns ? 'wz-text-truncatable-container' : ''">
                         <span class="wz-text-truncatable">
                             <span ng-show="(key.value || key ) === 'result'" class="no-wrap">
-                                <p class="round status little" ng-class="(item.result === 'passed') ? 'teal' : 'red'">
+                                <p class="round status little" ng-class="item.result ? (item.result === 'passed' ? 'teal' : 'red') : 'gray'">
                                 </p>&nbsp;&nbsp;
                             </span>
                             {{
-                            parseValue(key,item)
+                                key.value === 'result' && !item.result ? item.status : parseValue(key,item)
                             }}
                         </span>
                         <md-tooltip ng-show="item.showTooltip[$index]" md-direction="bottom" class="wz-tooltip">
@@ -213,6 +213,15 @@
                         <md-card flex="" class="wz-md-card wz-padding-top-0 wz-padding-bottom-0 wz-no-margin _md flex">
                             <md-card-content>
                                 <div>
+                                    <div class="euiFlexItem euiFlexItem--flexGrowZero" ng-if="item.reason">
+                                            <div class="euiStat euiStat--leftAligned">
+                                                   <p class="euiTitle euiTitle--small euiStat__title ng-binding" style="font-size: 1.15rem;">Check not applicable due to:</p>
+                                                <div class="euiText euiText--small euiStat__description wz-text-gray">
+                                                    <p>{{item.reason}}</p>
+                                                  </div>
+                                            </div>
+                                             <div layout="column" class="wz-margin-bottom-10"></div>
+                                        </div>
                                     <div class="euiFlexItem euiFlexItem--flexGrowZero" ng-if="item.rationale">
                                         <div class="euiStat euiStat--leftAligned">
                                             <p class="euiTitle euiTitle--small euiStat__title ng-binding" style="font-size: 1.15rem;">Rationale</p>

--- a/public/less/common.less
+++ b/public/less/common.less
@@ -187,6 +187,10 @@
   margin-top: 8px;
 }
 
+.status.round.little.gray {
+  background-color: #5c6773;
+}
+
 /* Custom Manager/Ruleset styles */
 
 .manager-ruleset-decoders-top-24 {

--- a/public/templates/agents/agents-pm.html
+++ b/public/templates/agents/agents-pm.html
@@ -2,8 +2,9 @@
     layout-align="start">
     <div layout="row" layout-padding class="wz-padding-top-0">
         <span flex></span>
-        <md-button ng-click="launchRootcheckScan()" class="wz-button pull-right"><i class="fa fa-fw fa-play"></i> Run
-            scan</md-button>
+            <md-button ng-click="launchRootcheckScan()" class="discoverSectionSwitchBtn pull-right"><i
+                class="fa fa-fw fa-play"></i>
+            Run scan</md-button>
     </div>
     <div layout="row" class="height-240">
         <md-card flex="50" class="wz-md-card" ng-class="{'fullscreen': expandArray[0]}">

--- a/public/templates/agents/agents-sca.html
+++ b/public/templates/agents/agents-sca.html
@@ -113,7 +113,7 @@
                     </td>
                     <td class="euiTableRowCell">
                         <div class="euiTableCellContent euiTableCellContent--overflowingContent no-wrap">
-                            <span>{{policy.invalid || '-'}}</span>
+                            <span>{{policy.invalid}}</span>
                         </div>
                     </td>
                     <td class="euiTableRowCell">
@@ -135,6 +135,7 @@
                     </span>
                     <span class="wz-margin-left-16">Pass: <span class="wz-text-bold">{{lookingSca.pass}}</span></span>
                     <span class="wz-margin-left-16">Fail: <span class="wz-text-bold">{{lookingSca.fail}}</span></span>
+                    <span class="wz-margin-left-16">Not applicable: <span class="wz-text-bold">{{lookingSca.invalid}}</span></span>
                     <span class="wz-margin-left-16">Score: <span class="wz-text-bold">{{lookingSca.score}}%</span></span>
                     <span flex></span>
                     <span class="wz-text-gray">{{lookingSca.end_scan}}</span>

--- a/public/templates/agents/agents-sca.html
+++ b/public/templates/agents/agents-sca.html
@@ -45,8 +45,8 @@
         <div class="layout-column md-padding" ng-repeat="policy in policies">
             <span class="wz-headline-title">{{policy.name}}</span>
             <md-divider class="wz-margin-top-10"></md-divider>
-            <canvas id="bar" class="wz-margin-top-10 chart chart-doughnut" chart-data="[policy.pass, policy.fail]"
-                chart-labels="['pass','fail']" chart-colors="['#00a69b', '#ff645c']"
+            <canvas id="bar" class="wz-margin-top-10 chart chart-doughnut" chart-data="[policy.pass, policy.fail, policy.total_checks - policy.pass - policy.fail]"
+                chart-labels="['pass','fail', 'not applicable']" chart-colors="['#00a69b', '#ff645c', '#5c6773']"
                 chart-options="{cutoutPercentage: 75, legend: {display: true,position: 'right',},responsive: false, maintainAspectRatio: false}" />
         </div>
     </div>

--- a/public/templates/agents/agents-sca.html
+++ b/public/templates/agents/agents-sca.html
@@ -45,7 +45,7 @@
         <div class="layout-column md-padding" ng-repeat="policy in policies">
             <span class="wz-headline-title">{{policy.name}}</span>
             <md-divider class="wz-margin-top-10"></md-divider>
-            <canvas id="bar" class="wz-margin-top-10 chart chart-doughnut" chart-data="[policy.pass, policy.fail, policy.total_checks - policy.pass - policy.fail]"
+            <canvas id="bar" class="wz-margin-top-10 chart chart-doughnut" chart-data="[policy.pass, policy.fail, policy.invalid]"
                 chart-labels="['pass','fail', 'not applicable']" chart-colors="['#00a69b', '#ff645c', '#5c6773']"
                 chart-options="{cutoutPercentage: 75, legend: {display: true,position: 'right',},responsive: false, maintainAspectRatio: false}" />
         </div>
@@ -66,10 +66,13 @@
                         <div class="euiTableCellContent"><span class="euiTableCellContent__text">Last scan</span></div>
                     </th>
                     <th class="euiTableHeaderCell padding-left-0">
+                         <div class="euiTableCellContent"><span class="euiTableCellContent__text">Pass</span></div>
+                    </th>
+                    <th class="euiTableHeaderCell padding-left-0">
                         <div class="euiTableCellContent"><span class="euiTableCellContent__text">Fail</span></div>
                     </th>
                     <th class="euiTableHeaderCell padding-left-0">
-                        <div class="euiTableCellContent"><span class="euiTableCellContent__text">Pass</span></div>
+                        <div class="euiTableCellContent"><span class="euiTableCellContent__text">Not applicable</span></div>
                     </th>
                     <th class="euiTableHeaderCell padding-left-0">
                         <div class="euiTableCellContent"><span class="euiTableCellContent__text">Score</span></div>
@@ -100,12 +103,17 @@
                     </td>
                     <td class="euiTableRowCell">
                         <div class="euiTableCellContent euiTableCellContent--overflowingContent no-wrap">
+                            <span>{{policy.pass}}</span>
+                        </div>
+                    </td>
+                    <td class="euiTableRowCell">
+                        <div class="euiTableCellContent euiTableCellContent--overflowingContent no-wrap">
                             <span>{{policy.fail}}</span>
                         </div>
                     </td>
                     <td class="euiTableRowCell">
                         <div class="euiTableCellContent euiTableCellContent--overflowingContent no-wrap">
-                            <span>{{policy.pass}}</span>
+                            <span>{{policy.invalid || '-'}}</span>
                         </div>
                     </td>
                     <td class="euiTableRowCell">

--- a/server/integration-files/known-fields.js
+++ b/server/integration-files/known-fields.js
@@ -5846,6 +5846,24 @@ export const knownFields = [
     readFromDocValues: true
   },
   {
+    name: 'data.sca.check.status',
+    type: 'string',
+    count: 0,
+    scripted: false,
+    searchable: true,
+    aggregatable: true,
+    readFromDocValues: true
+  },
+  {
+    name: 'data.sca.check.reason',
+    type: 'string',
+    count: 0,
+    scripted: false,
+    searchable: true,
+    aggregatable: true,
+    readFromDocValues: true
+  },
+  {
     name: 'data.sca.description',
     type: 'string',
     count: 0,

--- a/server/integration-files/known-fields.js
+++ b/server/integration-files/known-fields.js
@@ -5909,6 +5909,15 @@ export const knownFields = [
     readFromDocValues: true
   },
   {
+    name: 'data.sca.invalid',
+    type: 'number',
+    count: 0,
+    scripted: false,
+    searchable: true,
+    aggregatable: true,
+    readFromDocValues: true
+  },
+  {
     name: 'data.sca.policy',
     type: 'string',
     count: 0,


### PR DESCRIPTION
Hi team,

This PR implements the management of all these policies checks that are not applicable. In this case, the result field is changed in favor of status and reason. Now we are showing these new fields properly in the checks tables and SCA charts.

This PR solves #1407 

Regards