### PR TITLE
Fix CDB list export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to the Wazuh app project will be documented in this file.
 
-## Wazuh v3.9.0 - Kibana v6.7.0 / v6.7.1 - Revision 438
+## Wazuh v3.9.0 - Kibana v6.7.0 / v6.7.1 - Revision 439
 
 ### Added
 

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "wazuh",
   "version": "3.9.0",
-  "revision": "0438",
-  "code": "0438-0",
+  "revision": "0439",
+  "code": "0439-0",
   "kibana": {
     "version": "6.7.1"
   },

--- a/public/directives/wz-list-manage/wz-list-manage.html
+++ b/public/directives/wz-list-manage/wz-list-manage.html
@@ -58,7 +58,7 @@
                             <td>
                                 <input ng-show="editingKey === item[0]" ng-disabled="loadingChange" type="text"
                                     class="wz-input-text" ng-model="currentList.editingNewValue"></input>
-                                <span ng-show="!editingKey || editingKey !== item[0]">{{item[1]}}</span>
+                                <span ng-show="!editingKey || editingKey !== item[0]">{{item[1] || '-'}}</span>
                             </td>
                             <td class="action-btn-td">
                                 <div ng-hide="!adminMode">

--- a/util/csv-key-equivalence.js
+++ b/util/csv-key-equivalence.js
@@ -99,5 +99,6 @@ export const KeyEquivalenece = {
   directory: 'Path(s)',
   rationale: 'Rationale',
   registry: 'Registry',
-  date: 'Date'
+  date: 'Date',
+  value: 'Value'
 };


### PR DESCRIPTION
The issue:

- The array for the key/values of a CDB list was inside of another array, so we were parsing a matrix instead of a 2D array, this only happens with CDB lists due to its nature.

The fix:

- Added an extra condition (boolean) to know if we are parsing a CDB list.
- Using the element zero from the array.
- Show `-` when has no value.