### PR TITLE
Fix discover background

### DIFF
--- a/public/less/common.less
+++ b/public/less/common.less
@@ -983,3 +983,7 @@ wz-xml-file-editor {
   background-color: #0079a5;
   white-space: nowrap;
 }
+
+discover-app-w .container-fluid {
+  background: #fff;
+}


### PR DESCRIPTION
Hi team,

This PR solves white background problems in the app discover sections like this:

![image](https://user-images.githubusercontent.com/21195730/57709170-e01b3080-766a-11e9-8639-755c76dd20ee.png)

Regards.