### PR TITLE
Fix Zulu identifier in reports creation date

### DIFF
--- a/public/services/time-service.js
+++ b/public/services/time-service.js
@@ -17,7 +17,7 @@ export class TimeService {
    */
   offset(d) {
     try {
-      const date = new Date(d);
+      const date = new Date(d.replace('Z', ''));
       const offset = new Date().getTimezoneOffset();
       const offsetTime = new Date(date.getTime() - offset * 60000);
       return offsetTime.toLocaleString('en-ZA').replace(',', '');


### PR DESCRIPTION
Hi team

This PR removes Z character in creation dates of reports because when we add the browser timestamp with the new time service, we are adding offset 2 times because this dates sometimes contains this Zulu hour identifier in itself.

Regards