### PR TITLE
Fixed covered points in visualizations

### DIFF
--- a/public/less/common.less
+++ b/public/less/common.less
@@ -991,3 +991,12 @@ wz-xml-file-editor {
 discover-app-w .container-fluid {
   background: #fff;
 }
+
+.visChart__container .chart > svg{
+  position: absolute;
+}
+
+.visChart__container svg g.points.line, 
+.visChart__container svg g.points.area {
+  display: contents;
+}


### PR DESCRIPTION
Hi team, 

This PR manages to show the top line of visualizations and not just half of the line as the screenshot below:

![image](https://user-images.githubusercontent.com/21195730/58033356-9cba3980-7b24-11e9-9115-b96cf9bcb915.png)

This PR solves #1379 

Regards