### PR TITLE
No longer using "ansicolors" as a dependency

### DIFF
--- a/server/initialize.js
+++ b/server/initialize.js
@@ -9,7 +9,6 @@
  *
  * Find more information about this on the LICENSE file.
  */
-import colors from 'ansicolors';
 import { log } from './logger';
 import { ElasticWrapper } from './lib/elastic-wrapper';
 import packageJSON from '../package.json';
@@ -21,8 +20,7 @@ import { checkKnownFields } from './lib/refresh-known-fields';
 import { totalmem } from 'os';
 
 export function Initialize(server) {
-  const blueWazuh = colors.blue('wazuh');
-
+  const blueWazuh = '\u001b[34mwazuh\u001b[39m';
   // Elastic JS Client
   const wzWrapper = new ElasticWrapper(server);
   log('initialize', `Kibana index: ${wzWrapper.WZ_KIBANA_INDEX}`, 'info');

--- a/server/lib/refresh-known-fields.js
+++ b/server/lib/refresh-known-fields.js
@@ -9,8 +9,7 @@
  *
  * Find more information about this on the LICENSE file.
  */
-import colors from 'ansicolors';
-const blueWazuh = colors.blue('wazuh');
+const blueWazuh = '\u001b[34mwazuh\u001b[39m';
 
 /**
  * Refresh known fields for all valid index patterns.

--- a/server/monitoring.js
+++ b/server/monitoring.js
@@ -12,7 +12,6 @@
 import cron from 'node-cron';
 import needle from 'needle';
 import { getPath } from '../util/get-path';
-import colors from 'ansicolors';
 import { log } from './logger';
 import { ElasticWrapper } from './lib/elastic-wrapper';
 import { monitoringTemplate } from './integration-files/monitoring-template';
@@ -22,7 +21,7 @@ import { indexDate } from './lib/index-date';
 import { BuildBody } from './lib/replicas-shards-helper';
 import * as ApiHelper from './lib/api-helper';
 
-const blueWazuh = colors.blue('wazuh');
+const blueWazuh = '\u001b[34mwazuh\u001b[39m';
 
 export class Monitoring {
   /**


### PR DESCRIPTION
As we explain in #1464, this PR removes `ansicolors` as a dependency because in Kibana OSS that dependency is not imported so the app installation fails. 

The solution is to replace it with the result the library would generate, it's just `'\u001b[34mwazuh\u001b[39m'` so we don't need the library.

Regards