### PR TITLE
Fix time service for IE and Safari Dates

### DIFF
--- a/public/controllers/agent/agents.js
+++ b/public/controllers/agent/agents.js
@@ -920,7 +920,7 @@ export class AgentsController {
     try {
       return text + this.timeService.offset(time);
     } catch (error) {
-      return `${text}${time} (UTC)`;
+      return time !== '-' ? `${text}${time} (UTC)` : time;
     }
   }
 

--- a/public/controllers/misc/reporting.js
+++ b/public/controllers/misc/reporting.js
@@ -51,7 +51,7 @@ export class ReportingController {
     try {
       return this.timeService.offset(time);
     } catch (error) {
-      return `${time} (UTC)`;
+      return time !== '-' ? `${time} (UTC)` : time;
     }
   }
 

--- a/public/services/time-service.js
+++ b/public/services/time-service.js
@@ -19,7 +19,7 @@ export class TimeService {
     try {
       const [day, time] = d.indexOf('T') !== -1 ? d.split('T') : d.split(' ');
       const [year, month, monthDay] = d.indexOf('-') !== -1 ? day.split('-') : day.split('/');
-      const [hour, minute, seconds] = time.split(':')
+      const [hour, minute, seconds] = time.split(':');
       const date = new Date(year, parseInt(month) - 1, monthDay, hour, minute, seconds.split('.')[0]);
       const offset = new Date().getTimezoneOffset();
       const offsetTime = new Date(date.getTime() - offset * 60000);

--- a/public/services/time-service.js
+++ b/public/services/time-service.js
@@ -17,7 +17,10 @@ export class TimeService {
    */
   offset(d) {
     try {
-      const date = new Date(d.replace('Z', ''));
+      const [day, time] = d.indexOf('T') !== -1 ? d.split('T') : d.split(' ');
+      const [year, month, monthDay] = d.indexOf('-') !== -1 ? day.split('-') : day.split('/');
+      const [hour, minute, seconds] = time.split(':')
+      const date = new Date(year, parseInt(month) - 1, monthDay, hour, minute, seconds.split('.')[0]);
       const offset = new Date().getTimezoneOffset();
       const offsetTime = new Date(date.getTime() - offset * 60000);
       return offsetTime.toLocaleString('en-ZA').replace(',', '');


### PR DESCRIPTION
Hi team,

This PR solves the `Invalid date` problem in some browsers like Internet Explorer and Safari. The problem was that we were removing the Zulu time identifier 'Z' from the date it arrived (to add the timezone of the browser) and that towards it becoming a date format not supported by some browsers. Now we remove this identifier splitting and joining the original data to create a supported formatted one.

This PR solves #1469 

Regards.