### PR TITLE
Hide export PDF agents configuration if its not active

### DIFF
--- a/public/templates/management/configuration/welcome.html
+++ b/public/templates/management/configuration/welcome.html
@@ -13,12 +13,13 @@
     <div flex layout="row">
         <div flex layout="column">
             <md-card flex class="wz-md-card _md flex">
-                <md-card-actions layout="row" class="wz-card-actions wz-card-actions-top layout-align-end-center">
+                <md-card-actions layout="row" class="wz-card-actions wz-card-actions-top layout-align-end-center"
+                    ng-hide="agent && agent.id !== '000' && agent.status !== 'Active'">
                     <a ng-if="mctrl.adminMode || adminMode" ng-show="!agent || agent.id === '000'" ng-click="mctrl.setConfigTab('editconfiguration', true)">
                         <react-component name="EuiIcon" props="{type:'pencil', color:'primary'}" /> Edit configuration
                     </a>
-                    <button class="btn btn-primary btn-as-i" ng-show="agent && agent.id !== '000'" ng-click="exportConfiguration(agent)"
-                        ng-disabled="reportBusy && reportStatus">
+                    <button class="btn btn-primary btn-as-i" ng-show="agent && agent.id !== '000' && agent.status === 'Active'"
+                        ng-click="exportConfiguration(agent)" ng-disabled="reportBusy && reportStatus">
                         <react-component ng-show="!reportBusy || !reportStatus" name="EuiIcon" props="{type:'importAction', color:'primary'}" />
                         <react-component ng-show="reportBusy && reportStatus" name="EuiLoadingSpinner" props="{size:'m'}" />
                         PDF


### PR DESCRIPTION
Hi team,

This PR disables the button to export PDF of the configuration of an agent if it is not active, because if not when ordering the components it gives an error.

This PR solves #1519

Regards