### PR TITLE
Fix KeyEquivalence import

### DIFF
--- a/public/directives/wz-table-eui/wz-table-directive.js
+++ b/public/directives/wz-table-eui/wz-table-directive.js
@@ -13,7 +13,7 @@
 import template from './wz-table.html';
 import { uiModules } from 'ui/modules';
 import { DataFactory } from '../../services/data-factory';
-import { KeyEquivalenece } from '../../../util/csv-key-equivalence';
+import { KeyEquivalence } from '../../../util/csv-key-equivalence';
 import * as listeners from './lib/listeners';
 import { searchData, filterData, queryData } from './lib/data';
 import { initTable } from './lib/init';
@@ -23,7 +23,7 @@ import { EuiHealth } from '@elastic/eui';
 import * as ProcessEquivalence from '../../../util/process-state-equivalence';
 const app = uiModules.get('app/wazuh', []);
 
-app.directive('wzTableEui', function() {
+app.directive('wzTableEui', function () {
   return {
     restrict: 'E',
     scope: {
@@ -43,7 +43,7 @@ app.directive('wzTableEui', function() {
 
       const parseColumns = columnsArray => {
         return columnsArray.map(item => ({
-          name: KeyEquivalenece[item.value || item] || item.value || item,
+          name: KeyEquivalence[item.value || item] || item.value || item,
           field: item.value || item,
           width: item.width || undefined,
           sortable: typeof item.sortable !== 'undefined' ? item.sortable : true,
@@ -51,8 +51,8 @@ app.directive('wzTableEui', function() {
             item.isHealth
               ? health(value, item.isHealth)
               : item.isProcessStatus
-              ? processStatus(value)
-              : defaultRender(value)
+                ? processStatus(value)
+                : defaultRender(value)
         }));
       };
 

--- a/server/controllers/wazuh-api.js
+++ b/server/controllers/wazuh-api.js
@@ -23,7 +23,7 @@ import { ErrorResponse } from './error-response';
 import { Parser } from 'json2csv';
 import { getConfiguration } from '../lib/get-configuration';
 import { log } from '../logger';
-import { KeyEquivalenece } from '../../util/csv-key-equivalence';
+import { KeyEquivalence } from '../../util/csv-key-equivalence';
 import { ApiErrorEquivalence } from '../../util/api-errors-equivalence';
 import { cleanKeys } from '../../util/remove-key';
 import { apiRequestList } from '../../util/api-request-list';
@@ -909,7 +909,7 @@ export class WazuhApiCtrl {
       if (method === 'DELETE') {
         fixedUrl = `${
           fullUrl.includes('?') ? fullUrl.split('?')[0] : fullUrl
-        }?${querystring.stringify(data)}`;
+          }?${querystring.stringify(data)}`;
       }
 
       log('wazuh-api:makeRequest', `${method} ${fixedUrl || fullUrl}`, 'debug');
@@ -1195,7 +1195,7 @@ export class WazuhApiCtrl {
 
         for (const field of fields) {
           if (csv.includes(field)) {
-            csv = csv.replace(field, KeyEquivalenece[field] || field);
+            csv = csv.replace(field, KeyEquivalence[field] || field);
           }
         }
 
@@ -1403,7 +1403,7 @@ export class WazuhApiCtrl {
       const syscollector = {
         hardware:
           typeof hardwareResponse === 'object' &&
-          Object.keys(hardwareResponse).length
+            Object.keys(hardwareResponse).length
             ? { ...hardwareResponse }
             : false,
         os:


### PR DESCRIPTION
Hi team,

This PR fixes a typo in the import of the `KeyEquivalence` module, which was being used in `wz-table` erroneously. 

`KeyEquivalenece ` -> `KeyEquivalence`

This PR solves #1535 

Regards.