### PR TITLE
 Restore "rule.id" as a clickable field in vis

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -36,6 +36,9 @@ import './components';
 // angular-charts.js
 import 'angular-chart.js';
 
+// Override FieldFormat from Kibana (rule.id, agent.id clickable feature)
+import './kibana-integrations/field_format';
+
 // Set up Wazuh app
 const app = uiModules.get('app/wazuh', ['ngCookies', 'ngMaterial', 'chart.js']);
 

--- a/public/kibana-integrations/field_format.js
+++ b/public/kibana-integrations/field_format.js
@@ -1,0 +1,47 @@
+/*
+ * Author: Elasticsearch B.V.
+ * Updated by Wazuh, Inc.
+ *
+ * Copyright (C) 2015-2019 Wazuh, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Find more information about this on the LICENSE file.
+ */
+
+import { FieldFormat } from 'plugins/kibana/../../../ui/field_formats/field_format.js';
+
+/**
+ * Extracts the value from a generated <span> in the Kibana field formatter.
+ * @param {*} str 
+ * @returns {string|boolean} If something fails, returns false.
+ */
+const getWazuhURL = str => {
+  try {
+    const isWazuh = str.includes('/app/wazuh');
+    const isSpan = str.includes('<span');
+    if (isWazuh && isSpan) {
+      const spanContent = str.split('>')[1].split('<')[0];
+      return spanContent;
+    }
+  } catch (error) {}
+  return false;
+};
+
+/**
+ * The function we are overriding from Kibana. Enforcing to use simple links for Wazuh relative URLs.
+ */
+FieldFormat.prototype.convert = function(value, contentType) {
+  const result = this.getConverterFor(contentType)(value);
+  const wazuhURL = getWazuhURL(result);
+
+  if (value && contentType === 'html' && wazuhURL) {
+    const formattedURL = `<a href="${wazuhURL}" target="_blank" rel="noopener noreferrer">${value}</a>`;
+    return formattedURL;
+  }
+
+  return result;
+};

--- a/server/lib/elastic-wrapper.js
+++ b/server/lib/elastic-wrapper.js
@@ -320,7 +320,8 @@ export class ElasticWrapper {
               fields: currentFieldsString,
               fieldFormatMap: `{
                   "data.virustotal.permalink":{"id":"url"},
-                  "data.vulnerability.reference":{"id":"url"},"data.url":{"id":"url"}
+                  "data.vulnerability.reference":{"id":"url"},"data.url":{"id":"url"},
+                  "rule.id":{"id":"url","params":{"urlTemplate":"/app/wazuh#/manager/?tab=ruleset&currentRule&ruleid={{value}}","labelTemplate":"{{value}}","openLinkInCurrentTab":true}}
                 }`,
               sourceFilters: '[{"value":"@timestamp"}]'
             }


### PR DESCRIPTION
This change restores the `rule.id` the action we miss with Elastic 7, the related issue is https://github.com/wazuh/wazuh-kibana-app/issues/1529 and the solution was overriding a method from Kibana, now it's working again.