### PR TITLE
Fix delete API calls

### DIFF
--- a/public/controllers/management/groups.js
+++ b/public/controllers/management/groups.js
@@ -527,8 +527,8 @@ export function GroupsController(
       if (itemsToSave.deletedIds.length) {
         const deleteResponse = await apiReq.request(
           'DELETE',
-          `/agents/group/${$scope.currentGroup.name}`,
-          { ids: itemsToSave.deletedIds }
+          `/agents/group/${$scope.currentGroup.name}/ids=${itemsToSave.deletedIds}`,
+          {}
         );
         if (deleteResponse.data.data.failed_ids) {
           failedIds.push(...deleteResponse.data.data.failed_ids);

--- a/public/controllers/misc/reporting.js
+++ b/public/controllers/misc/reporting.js
@@ -48,7 +48,7 @@ export class ReportingController {
    */
   async deleteReport(name) {
     try {
-      await this.genericReq.request('DELETE', '/reports/' + name, {});
+      await this.genericReq.request('DELETE', `/reports/${name}`, {});
       this.items = this.items.filter(item => item.name !== name);
       this.errorHandler.info('Success');
     } catch (error) {


### PR DESCRIPTION
Hi team,

This PR solves https://github.com/wazuh/wazuh-kibana-app/issues/1555.

All `PUT` and `DELETE` methods were checked and fixed if it needed in order to make it compatible with Wazuh API 3.10.

Regards,