### PR TITLE
Add the app as a "native" plugin for Kibana spaces

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,13 +40,16 @@ export default kibana =>
     init(server, options) {
       // Kibana spaces locker
       const xpackMainPlugin = server.plugins.xpack_main;
-      xpackMainPlugin.registerFeature({
-        id: 'wazuh',
-        name: 'Wazuh',
-        app: ['wazuh','kibana','elasticsearch'],
-        navLinkId: 'wazuh',
-        privileges: {}
-      });
+      
+      if (xpackMainPlugin) {
+        xpackMainPlugin.registerFeature({
+          id: 'wazuh',
+          name: 'Wazuh',
+          app: ['wazuh', 'kibana', 'elasticsearch'],
+          navLinkId: 'wazuh',
+          privileges: {}
+        });
+      }
 
       return initApp(server, options);
     }

--- a/index.js
+++ b/index.js
@@ -38,6 +38,16 @@ export default kibana =>
       }
     },
     init(server, options) {
+      // Kibana spaces locker
+      const xpackMainPlugin = server.plugins.xpack_main;
+      xpackMainPlugin.registerFeature({
+        id: 'wazuh',
+        name: 'Wazuh',
+        app: ['wazuh','kibana','elasticsearch'],
+        navLinkId: 'wazuh',
+        privileges: {}
+      });
+
       return initApp(server, options);
     }
   });


### PR DESCRIPTION
Hi team,

This PR implements #1601. Now the Wazuh app is listed as a plugin in the features selector of any Kibana space, allowing the user tho hide/show this plugin for a certain space.

It was tested with the next configurations:
- Kibana 7.3.0 security enabled
- Kibana 7.3.0 security disabled
- Kibana 7.3.0 OSS (it ignores this logic since OSS has no spaces feature)

See ticket #1601 for details.

Regards,
Jesús