### PR TITLE
Restored query from search bar in visualizations

### DIFF
--- a/public/kibana-integrations/kibana-discover.js
+++ b/public/kibana-integrations/kibana-discover.js
@@ -480,7 +480,6 @@ function discoverController(
                   queryFilter.getFilters()
                 );
                 $rootScope.$broadcast('updateVis');
-                $rootScope.$broadcast('fetch');
                 if ($location.search().tab != 'configuration') {
                   loadedVisualizations.removeAll();
                   $rootScope.rendered = false;
@@ -648,7 +647,12 @@ function discoverController(
   $scope.updateQueryAndFetch = function({ query, dateRange }) {
     // Wazuh filters are not ready yet
     if (!filtersAreReady()) return;
+    
+    // Update query from search bar
+    discoverPendingUpdates.removeAll();
+    discoverPendingUpdates.addItem($state.query, queryFilter.getFilters());
     $rootScope.$broadcast('updateVis');
+    
     timefilter.setTime(dateRange);
     if (query) $state.query = query;
     $scope.fetch();


### PR DESCRIPTION
Hi team,

This PR fixes #1686. The reason is that for 7.3.0 we missed storing the query in our factory named `discoverPendingUpdates` which we are using for passing data to the search sources of our visualizations.

That's said, the fix is adding the next block in the function `updateQueryAndFetch`:

```js
discoverPendingUpdates.removeAll();
discoverPendingUpdates.addItem($state.query, queryFilter.getFilters());
```

__Note:__ this fix must be backported to https://github.com/wazuh/wazuh-kibana-app/tree/v3.9.4-7.3.0 and https://github.com/wazuh/wazuh-kibana-app/tree/v3.9.5-7.3.0.

Regards