### PR TITLE
[Backport-3.9.5-7.3.0] Restored query from search bar in visualizations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,13 @@
 
 All notable changes to the Wazuh app project will be documented in this file.
 
-## Wazuh v3.9.5 - Kibana v6.8.2 / Kibana v7.2.1 / Kibana v7.3.0 - Revision 531
+## Wazuh v3.9.5 - Kibana v6.8.2 / Kibana v7.2.1 / Kibana v7.3.0 - Revision 533
 
 ### Added
 
 - Support for Wazuh v3.9.5
 
-## Wazuh v3.9.4 - Kibana v6.8.1 / Kibana v6.8.2 / Kibana v7.2.0 / Kibana v7.2.1 / Kibana v7.3.0 - Revision 528
+## Wazuh v3.9.4 - Kibana v6.8.1 / Kibana v6.8.2 / Kibana v7.1.1 / Kibana v7.2.0 / Kibana v7.2.1 / Kibana v7.3.0 - Revision 532
 
 ### Added
 
@@ -46,6 +46,8 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Missing scrollbar on Firefox file viewer.  [df4e8f9](https://github.com/wazuh/wazuh-kibana-app/commit/df4e8f9305b35e9ee1473bed5f5d452dd3420567) 
 - Agent search filter by name, lost when refreshing. [71b5274](https://github.com/wazuh/wazuh-kibana-app/commit/71b5274ccc332d8961a158587152f7badab28a95) 
 - Alerts of level 12 cannot be displayed in the Summary table. [ec0e888](https://github.com/wazuh/wazuh-kibana-app/commit/ec0e8885d9f1306523afbc87de01a31f24e36309) 
+- Restored query from search bar in visualizations. [439128f](https://github.com/wazuh/wazuh-kibana-app/commit/439128f0a1f65b649a9dcb81ab5804ca20f65763) 
+- Fix Kibana filters loop in Firefox. [82f0f32](https://github.com/wazuh/wazuh-kibana-app/commit/82f0f32946d844ce96a28f0185f903e8e05c5589) 
 
 ## Wazuh v3.9.3 - Kibana v6.8.1 / v7.1.1 / v7.2.0 - Revision 523
 

--- a/config.yml
+++ b/config.yml
@@ -112,4 +112,4 @@
 # Set the logging level for the Wazuh App log files.
 # Default value: info
 # Allowed values: info, debug
-logs.level: debug
+#logs.level: info

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "wazuh",
   "version": "3.9.5",
-  "revision": "0531",
-  "code": "0531-0",
+  "revision": "0533",
+  "code": "0533-0",
   "kibana": {
     "version": "7.3.0"
   },

--- a/public/kibana-integrations/kibana-discover.js
+++ b/public/kibana-integrations/kibana-discover.js
@@ -480,7 +480,6 @@ function discoverController(
                   queryFilter.getFilters()
                 );
                 $rootScope.$broadcast('updateVis');
-                $rootScope.$broadcast('fetch');
                 if ($location.search().tab != 'configuration') {
                   loadedVisualizations.removeAll();
                   $rootScope.rendered = false;
@@ -648,7 +647,12 @@ function discoverController(
   $scope.updateQueryAndFetch = function({ query, dateRange }) {
     // Wazuh filters are not ready yet
     if (!filtersAreReady()) return;
+    
+    // Update query from search bar
+    discoverPendingUpdates.removeAll();
+    discoverPendingUpdates.addItem($state.query, queryFilter.getFilters());
     $rootScope.$broadcast('updateVis');
+    
     timefilter.setTime(dateRange);
     if (query) $state.query = query;
     $scope.fetch();


### PR DESCRIPTION
Hi team,

This PR fixes #1686. The reason is that for 7.3.0 we missed storing the query in our factory named `discoverPendingUpdates` which we are using for passing data to the search sources of our visualizations.

That's said, the fix is adding the next block in the function `updateQueryAndFetch`:

```js
discoverPendingUpdates.removeAll();
discoverPendingUpdates.addItem($state.query, queryFilter.getFilters());
```

Regards