### PR TITLE
Fix app installation date not being updated properly

### DIFF
--- a/server/controllers/wazuh-api.js
+++ b/server/controllers/wazuh-api.js
@@ -1318,7 +1318,7 @@ export class WazuhApiCtrl {
    * @param {Object} reply
    * @returns {Object} timestamp field or ErrorResponse
    */
-  async getTimeStamp(req, reply) {
+  getTimeStamp(req, reply) {
     try {
       const source = JSON.parse(fs.readFileSync(this.wazuhVersion, 'utf8'));
       if (source.installationDate && source.lastRestart) {


### PR DESCRIPTION
- If the registry file doesn't exist yet, create the registry file. The installation date is just fine.
- For those cases where the registry file already exists, we need to check if it's an app with a different revision, then it means it's a new installation. Now the installation date is being updated properly.

Also, some code was fixed, it was not too clear.

![image](https://user-images.githubusercontent.com/8860227/63164230-12507b80-c028-11e9-8858-047d2578d395.png)
