### PR TITLE
Restored removing column feature in Discover

### DIFF
--- a/public/kibana-integrations/kibana-discover.js
+++ b/public/kibana-integrations/kibana-discover.js
@@ -801,7 +801,8 @@ function discoverController(
 
   $scope.removeColumn = function removeColumn(columnName) {
     // Commented due to https://github.com/elastic/kibana/issues/22426
-    //$scope.indexPattern.popularizeField(field, 1);    columnActions.removeColumn($scope.state.columns, columnName);
+    //$scope.indexPattern.popularizeField(field, 1);    
+    columnActions.removeColumn($scope.state.columns, columnName);
   };
 
   $scope.moveColumn = function moveColumn(columnName, newIndex) {


### PR DESCRIPTION
This PR just uncomment a line that was commented with no reason in our last Kibana adaptation. It fixes #1702.

```js
//columnActions.removeColumn($scope.state.columns, columnName);
```
to:

```js
columnActions.removeColumn($scope.state.columns, columnName);
```