### PR TITLE
Safer checking for item key

### DIFF
--- a/public/kibana-integrations/kibana-discover.js
+++ b/public/kibana-integrations/kibana-discover.js
@@ -275,8 +275,13 @@ function discoverController(
 
     // Compose final filters array not including filters that also exist as non removable filter
     const finalFilters = filters.filter(item => {
-      const key =
-        item.meta.key || (Object.keys(item.query.match) || [undefined])[0];
+      let key;
+      if (typeof item.exists !== 'undefined') {
+        key = item.exists.field;
+      } else {
+        key =
+          item.meta.key || (Object.keys(item.query.match) || [undefined])[0];
+      }
       const isIncluded = nonRemovableFilters.includes(key);
       const isNonRemovable = isRemovable(item);
       const shouldBeAdded = (isIncluded && isNonRemovable) || !isIncluded;
@@ -285,7 +290,7 @@ function discoverController(
       }
       return shouldBeAdded;
     });
-    ///////////////////////////////  END-WAZUH   ////////////////////////////////
+    ///////////////////////////////  END-WAZUH   ////////////////////////////////  
     // The filters will automatically be set when the queryFilter emits an update event (see below)
     queryFilter.setFilters(finalFilters);
     // Update our internal copy for the pinned filters


### PR DESCRIPTION
This PR fixes "Adding a filter of type exists is failing if it's added by hand. E.g: rule.id exists. Not the query bar but the filters."

The reason was we were not safely checking an object property, generating a silent exception ending in not adding the filter.