### PR TITLE
Add help message for missing configuration in groups

### DIFF
--- a/public/controllers/overview/components/requirement-card.js
+++ b/public/controllers/overview/components/requirement-card.js
@@ -132,7 +132,10 @@ export class RequirementCard extends Component {
     const cards = this.state.slider[this.state.position];
     return (
       <div>
-        <EuiFlexGroup gutterSize="l">
+        <EuiFlexGroup 
+          gutterSize="l"
+          className="requirements-cards"  
+        >
           {this.state.sliderLength > 1 && this.state.position > 0 && (
             <EuiButtonIcon
               className="wz-margin-left-10"

--- a/public/less/common.less
+++ b/public/less/common.less
@@ -1149,3 +1149,7 @@ md-toolbar.md-default-theme:not(.md-menu-toolbar), md-toolbar:not(.md-menu-toolb
       left: 0!important;
   }
 }
+
+.requirements-cards.euiFlexGroup--gutterLarge {
+  margin: -10px !important;
+}

--- a/server/controllers/wazuh-reporting.js
+++ b/server/controllers/wazuh-reporting.js
@@ -467,10 +467,17 @@ export class WazuhReportingCtrl {
           });
         } else if (section === 'groupConfig') {
           this.dd.content.push({
-            text: `Agents in group`,
+            text: 'Agents in group',
             style: { fontSize: 14, color: '#000' },
             margin: [0, 20, 0, 0]
           });
+          if (section === 'groupConfig' && !Object.keys(isAgents).length) {
+            this.dd.content.push({
+              text: 'There are still no agents in this group.',
+              style: { fontSize: 12, color: '#000' },
+              margin: [0, 10, 0, 0]
+            });
+          }
         }
         this.dd.content.push('\n');
       }
@@ -1689,7 +1696,7 @@ export class WazuhReportingCtrl {
             } catch (err) {} //eslint-disable-line
             if (Object.keys(configuration.data.items[0].config).length) {
               this.dd.content.push({
-                text: `Configurations`,
+                text: 'Configurations',
                 style: { fontSize: 14, color: '#000' },
                 margin: [0, 10, 0, 15]
               });
@@ -1822,6 +1829,12 @@ export class WazuhReportingCtrl {
                 }
                 tables = [];
               }
+            }else{
+              this.dd.content.push({
+                text: 'A configuration for this group has not yet been set up.',
+                style: { fontSize: 12, color: '#000' },
+                margin: [0, 10, 0, 15]
+              });              
             }
           }
           if (enabledComponents['1']) {


### PR DESCRIPTION
Hi team,

This PR solves the following points related with this issue https://github.com/wazuh/wazuh-kibana-app/issues/1726

- Should be reviewed. If a group has no custom configurations yet, the configuration report with no agents is a bit poor.


In addition:

- Fix the bottom scroll bar in the sections that contain the requirement cards component.

Regards,