### PR TITLE
Fix autocomplete text color in dark mode

### DIFF
--- a/public/less/dark_theme/wz_theme_dark.css
+++ b/public/less/dark_theme/wz_theme_dark.css
@@ -271,7 +271,15 @@ md-divider.md-default-theme, md-divider {
 .CodeMirror-hints{
   background-color: #16171c !important;
   border-color: #000;
-  color: #dfe5ef;
+  color: #dfe5ef!important;
+}
+
+.CodeMirror-hint{
+  color: #dfe5ef!important;
+}
+
+.CodeMirror-hint:hover{
+  background-color: #25262E;
 }
 
 .wz-input-text {


### PR DESCRIPTION
Hi team, 

This PR fixes the autocomplete text color in the dark mode, which was black and hard to see.

![image](https://user-images.githubusercontent.com/21195730/63852523-bb886180-c998-11e9-83c4-915e1b0f66f0.png)

Regards