### PR TITLE
Fix wrong filters history

### DIFF
--- a/public/controllers/agent/agents.js
+++ b/public/controllers/agent/agents.js
@@ -378,7 +378,7 @@ export class AgentsController {
       if (!this.$scope.showSyscheckFiles) {
         this.$scope.$emit('changeTabView', {
           tabView: this.$scope.tabView,
-          sameSection: true
+          tab: this.$scope.tab
         });
       }
       this.$scope.$applyAsync();
@@ -390,7 +390,7 @@ export class AgentsController {
       if (!this.$scope.showScaScan) {
         this.$scope.$emit('changeTabView', {
           tabView: this.$scope.tabView,
-          sameSection: true
+          tab: this.$scope.tab
         });
       }
       this.$scope.$applyAsync();
@@ -526,7 +526,8 @@ export class AgentsController {
         this.changeAgent = false;
       } else {
         this.$scope.$emit('changeTabView', {
-          tabView: this.$scope.tabView
+          tabView: this.$scope.tabView,
+          tab: this.$scope.tab
         });
       }
 

--- a/public/controllers/overview/overview.js
+++ b/public/controllers/overview/overview.js
@@ -236,7 +236,8 @@ export class OverviewController {
         );
       } else {
         this.$scope.$emit('changeTabView', {
-          tabView: this.tabView
+          tabView: this.tabView,
+          tab: this.tab
         });
       }
 

--- a/public/services/vis-factory-handler.js
+++ b/public/services/vis-factory-handler.js
@@ -79,7 +79,7 @@ export class VisFactoryService {
       );
       this.rawVisualizations.assignItems(data.data.raw);
       this.commonData.assignFilters(filterHandler, tab, localChange);
-      this.$rootScope.$emit('changeTabView', { tabView: subtab });
+      this.$rootScope.$emit('changeTabView', { tabView: subtab, tab });
       this.$rootScope.$broadcast('updateVis');
       return;
     } catch (error) {
@@ -106,7 +106,7 @@ export class VisFactoryService {
           : false;
       data && this.rawVisualizations.assignItems(data.data.raw);
       this.commonData.assignFilters(filterHandler, tab, localChange, id);
-      this.$rootScope.$emit('changeTabView', { tabView: subtab });
+      this.$rootScope.$emit('changeTabView', { tabView: subtab, tab });
       this.$rootScope.$broadcast('updateVis');
       return;
     } catch (error) {


### PR DESCRIPTION
This PR fixes _Bug introduced yesterday (8/28/2019). Go to "Overview > Security events", now go to "Overview > FIM", then go back to "Overview > Security events", the FIM filter is still being applied but it's not visible._ from https://github.com/wazuh/wazuh-kibana-app/issues/1726.

The reason was that filters from a tab were being applied to the next tab. Then if you go back to the first tab, the filters from the second tab were being applied to the first tab and so on...