### PR TITLE
Fix visualizations rendering

### DIFF
--- a/public/controllers/agent/agents.js
+++ b/public/controllers/agent/agents.js
@@ -546,6 +546,7 @@ export class AgentsController {
    * @param {*} force
    */
   async switchTab(tab, force = false) {
+    this.tabVisualizations.setTab(tab);
     this.$rootScope.rendered = false;
     this.$rootScope.$applyAsync();
     this.falseAllExpand();
@@ -633,7 +634,6 @@ export class AgentsController {
       if (!this.ignoredTabs.includes(tab)) this.tabHistory.push(tab);
       if (this.tabHistory.length > 2)
         this.tabHistory = this.tabHistory.slice(-2);
-      this.tabVisualizations.setTab(tab);
 
       if (this.$scope.tab === tab && !force) {
         this.$scope.$applyAsync();

--- a/public/controllers/overview/overview.js
+++ b/public/controllers/overview/overview.js
@@ -260,6 +260,7 @@ export class OverviewController {
 
   // Switch tab
   async switchTab(newTab, force = false) {
+    this.tabVisualizations.setTab(newTab);
     this.$rootScope.rendered = false;
     this.$rootScope.$applyAsync();
     this.falseAllExpand();
@@ -302,8 +303,6 @@ export class OverviewController {
 
       if (this.tabHistory.length > 2)
         this.tabHistory = this.tabHistory.slice(-2);
-
-      this.tabVisualizations.setTab(newTab);
 
       if (this.tab === newTab && !force) return;
       

--- a/public/controllers/overview/overview.js
+++ b/public/controllers/overview/overview.js
@@ -260,7 +260,6 @@ export class OverviewController {
 
   // Switch tab
   async switchTab(newTab, force = false) {
-    this.loading = true;
     this.$rootScope.rendered = false;
     this.$rootScope.$applyAsync();
     this.falseAllExpand();
@@ -306,10 +305,8 @@ export class OverviewController {
 
       this.tabVisualizations.setTab(newTab);
 
-      if (this.tab === newTab && !force) {
-        this.loading = false;
-        return;
-      }
+      if (this.tab === newTab && !force) return;
+      
       const sameTab =
         ((this.tab === newTab && this.tabHistory.length < 2) ||
           (this.tabHistory.length === 2 &&
@@ -333,7 +330,6 @@ export class OverviewController {
     }
     this.setTabs();
     this.$scope.$applyAsync();
-    this.loading = false;
     return;
   }
 

--- a/public/kibana-integrations/kibana-visualization.js
+++ b/public/kibana-integrations/kibana-visualization.js
@@ -17,6 +17,7 @@ import dateMath from '@elastic/datemath';
 
 const app = uiModules.get('app/wazuh', []);
 let lockFields = false;
+
 app.directive('kbnVis', function() {
   return {
     restrict: 'E',
@@ -205,17 +206,25 @@ app.directive('kbnVis', function() {
         }
       });
 
-      $scope.$on('$destroy', () => {
-        updateVisWatcher();
+      const destroyAll = () => {
         try {
           visualization.destroy();
         } catch (error) {} // eslint-disable-line
         try {
           visHandler.destroy();
         } catch (error) {} // eslint-disable-line
+      }
+
+      $scope.$on('$destroy', () => {
+        updateVisWatcher();
+        destroyAll();
       });
 
       const renderComplete = () => {
+        if(!$scope.visID.toLowerCase().includes(tabVisualizations.getTab())){
+          destroyAll();
+          return;
+        }
         rendered = true;
         loadedVisualizations.addItem(true);
         const currentCompleted = Math.round(

--- a/public/templates/overview/overview-audit.html
+++ b/public/templates/overview/overview-audit.html
@@ -1,5 +1,5 @@
 <md-content flex layout="column" ng-if="octrl.tab === 'audit' && octrl.tabView === 'panels'"
-    ng-class="{'no-opacity': resultState !== 'ready' || !rendered || octrl.loading}" layout-align="space-around">
+    ng-class="{'no-opacity': resultState !== 'ready' || !rendered}" layout-align="space-around">
 
     <div layout="row" layout-align="center stretch" class="height-250">
         <md-card flex="25" class="wz-md-card" ng-class="{'fullscreen': octrl.expandArray[0]}">

--- a/public/templates/overview/overview-aws.html
+++ b/public/templates/overview/overview-aws.html
@@ -1,5 +1,5 @@
 <md-content flex layout="column" ng-if="octrl.tab === 'aws' && octrl.tabView === 'panels'"
-    ng-class="{'no-opacity': resultState !== 'ready' || !rendered || octrl.loading}" layout-align="start">
+    ng-class="{'no-opacity': resultState !== 'ready' || !rendered}" layout-align="start">
     <div layout="row" class="height-250">
         <md-card flex class="wz-md-card" ng-class="{'fullscreen': octrl.expandArray[0]}">
             <md-card-content class="wazuh-column">

--- a/public/templates/overview/overview-ciscat.html
+++ b/public/templates/overview/overview-ciscat.html
@@ -1,5 +1,5 @@
 <md-content flex layout="column" ng-if="octrl.tab === 'ciscat' && octrl.tabView === 'panels'"
-    ng-class="{'no-opacity': resultState !== 'ready' || !rendered || octrl.loading}" layout-align="start">
+    ng-class="{'no-opacity': resultState !== 'ready' || !rendered}" layout-align="start">
 
     <!-- Metric bar section -->
     <div layout="row" layout-align="start center">

--- a/public/templates/overview/overview-docker.html
+++ b/public/templates/overview/overview-docker.html
@@ -1,5 +1,5 @@
 <md-content flex layout="column" ng-if="octrl.tab === 'docker' && octrl.tabView === 'panels'"
-    ng-class="{'no-opacity': resultState !== 'ready' || !rendered || octrl.loading}">
+    ng-class="{'no-opacity': resultState !== 'ready' || !rendered}">
 
     <div layout="row" class="height-300">
 

--- a/public/templates/overview/overview-fim.html
+++ b/public/templates/overview/overview-fim.html
@@ -1,4 +1,4 @@
-<md-content flex layout="column" ng-if="octrl.tab === 'fim' && octrl.tabView === 'panels'" ng-class="{'no-opacity': resultState !== 'ready' || !rendered || octrl.loading}">
+<md-content flex layout="column" ng-if="octrl.tab === 'fim' && octrl.tabView === 'panels'" ng-class="{'no-opacity': resultState !== 'ready' || !rendered}">
 
     <div layout="row" class="height-400">
         <md-card flex class="wz-md-card" ng-class="{'fullscreen': octrl.expandArray[0]}">

--- a/public/templates/overview/overview-gdpr.html
+++ b/public/templates/overview/overview-gdpr.html
@@ -1,5 +1,5 @@
 <md-content flex layout="column" ng-if="octrl.tab === 'gdpr' && octrl.tabView === 'panels'"
-    ng-class="{'no-opacity': resultState !== 'ready' || !rendered || octrl.loading}" layout-align="start">
+    ng-class="{'no-opacity': resultState !== 'ready' || !rendered}" layout-align="start">
 
     <div ng-if="octrl.gdprReqs" class="wz-margin-10">
         <react-component name='RequirementCard' props="octrl.gdprReqs"/>

--- a/public/templates/overview/overview-general.html
+++ b/public/templates/overview/overview-general.html
@@ -1,5 +1,5 @@
 <md-content flex layout="column" ng-if="octrl.tab === 'general' && octrl.tabView === 'panels'" layout-align="start"
-    ng-class="{'no-opacity': resultState !== 'ready' || !rendered || octrl.loading}">
+    ng-class="{'no-opacity': resultState !== 'ready' || !rendered}">
 
     <div layout="row" layout-padding>
         <react-component flex name="AlertsStats" props="{

--- a/public/templates/overview/overview-hipaa.html
+++ b/public/templates/overview/overview-hipaa.html
@@ -1,5 +1,5 @@
 <md-content flex layout="column" ng-if="octrl.tab === 'hipaa' && octrl.tabView === 'panels'"
-    ng-class="{'no-opacity': resultState !== 'ready' || !rendered || octrl.loading}" layout-align="start">
+    ng-class="{'no-opacity': resultState !== 'ready' || !rendered}" layout-align="start">
 
     <div ng-if="octrl.hipaaReqs" class="wz-margin-10">
         <react-component name='RequirementCard' props="octrl.hipaaReqs" />

--- a/public/templates/overview/overview-nist.html
+++ b/public/templates/overview/overview-nist.html
@@ -1,4 +1,4 @@
-<md-content flex layout="column" ng-if="octrl.tab === 'nist' && octrl.tabView === 'panels'" ng-class="{'no-opacity': resultState !== 'ready' || !rendered || octrl.loading}"
+<md-content flex layout="column" ng-if="octrl.tab === 'nist' && octrl.tabView === 'panels'" ng-class="{'no-opacity': resultState !== 'ready' || !rendered}"
     layout-align="start">
 
     <div ng-if="octrl.nistReqs" class="wz-margin-10">

--- a/public/templates/overview/overview-oscap.html
+++ b/public/templates/overview/overview-oscap.html
@@ -1,4 +1,4 @@
-<md-content flex layout="column" ng-if="octrl.tab === 'oscap' && octrl.tabView === 'panels'" ng-class="{'no-opacity': resultState !== 'ready' || !rendered || octrl.loading}"
+<md-content flex layout="column" ng-if="octrl.tab === 'oscap' && octrl.tabView === 'panels'" ng-class="{'no-opacity': resultState !== 'ready' || !rendered}"
     layout-align="start">
 
     <div layout="row">

--- a/public/templates/overview/overview-osquery.html
+++ b/public/templates/overview/overview-osquery.html
@@ -1,4 +1,4 @@
-<md-content flex layout="column" ng-if="octrl.tab === 'osquery' && octrl.tabView === 'panels'" ng-class="{'no-opacity': resultState !== 'ready' || !rendered || octrl.loading}"
+<md-content flex layout="column" ng-if="octrl.tab === 'osquery' && octrl.tabView === 'panels'" ng-class="{'no-opacity': resultState !== 'ready' || !rendered}"
     layout-align="start">
     <div layout="row">
         <md-card flex class="wz-metric-color wz-md-card">

--- a/public/templates/overview/overview-pci.html
+++ b/public/templates/overview/overview-pci.html
@@ -1,5 +1,5 @@
 <md-content flex layout="column" ng-if="octrl.tab === 'pci' && octrl.tabView === 'panels'"
-    ng-class="{'no-opacity': resultState !== 'ready' || !rendered || octrl.loading}" layout-align="start">
+    ng-class="{'no-opacity': resultState !== 'ready' || !rendered}" layout-align="start">
 
     <div ng-if="octrl.pciReqs" class="wz-margin-10">
         <react-component name='RequirementCard' props="octrl.pciReqs"/>

--- a/public/templates/overview/overview-pm.html
+++ b/public/templates/overview/overview-pm.html
@@ -1,4 +1,4 @@
-<md-content flex layout="column" ng-if="octrl.tab === 'pm' && octrl.tabView === 'panels'" ng-class="{'no-opacity': resultState !== 'ready' || !rendered || octrl.loading}"
+<md-content flex layout="column" ng-if="octrl.tab === 'pm' && octrl.tabView === 'panels'" ng-class="{'no-opacity': resultState !== 'ready' || !rendered}"
     layout-align="start">
 
     <div layout="row" layout-align="center stretch" class="height-290">

--- a/public/templates/overview/overview-virustotal.html
+++ b/public/templates/overview/overview-virustotal.html
@@ -1,5 +1,5 @@
 <md-content flex layout="column" ng-if="octrl.tab === 'virustotal' && octrl.tabView === 'panels'"
-    ng-class="{'no-opacity': resultState !== 'ready' || !rendered || octrl.loading}" layout-align="start">
+    ng-class="{'no-opacity': resultState !== 'ready' || !rendered}" layout-align="start">
 
     <div layout="row">
         <md-card flex class="wz-metric-color wz-md-card">

--- a/public/templates/overview/overview-vuls.html
+++ b/public/templates/overview/overview-vuls.html
@@ -1,4 +1,4 @@
-<md-content flex layout="column" ng-if="octrl.tab === 'vuls' && octrl.tabView === 'panels'" ng-class="{'no-opacity': resultState !== 'ready' || !rendered || octrl.loading}"
+<md-content flex layout="column" ng-if="octrl.tab === 'vuls' && octrl.tabView === 'panels'" ng-class="{'no-opacity': resultState !== 'ready' || !rendered}"
     layout-align="start">
 
     <div layout="row" layout-padding>

--- a/public/templates/overview/overview.head
+++ b/public/templates/overview/overview.head
@@ -57,7 +57,7 @@
 
     <!-- Loading status section -->
     <div layout="column" layout-align="center center"
-        ng-if="(octrl.tab !== 'welcome' && octrl.tabView === 'panels' && !rendered) || octrl.loading">
+        ng-if="octrl.tab !== 'welcome' && octrl.tabView === 'panels' && !rendered">
         <div class="percentage"><i class="fa fa-fw fa-spin fa-spinner" aria-hidden="true"></i></div>
         <div class="percentage">{{loadingStatus}}</div>
     </div>
@@ -73,7 +73,7 @@
 
     <!-- No results section -->
     <div layout="row" class="wz-margin-top-10 wz-margin-right-8 wz-margin-left-8" ng-if="octrl.tab !== 'welcome'"
-        ng-show="resultState === 'none' && octrl.tabView === 'panels' && !octrl.loading">
+        ng-show="resultState === 'none' && octrl.tabView === 'panels'">
         <react-component flex name="EuiCallOut" props="{color:'warning',iconType:'help', title:'There are no results for selected time range. Try another
             one.'}" />
     </div>


### PR DESCRIPTION
This PR completes https://github.com/wazuh/wazuh-kibana-app/pull/1748/ and is part of _Flick between dashboards, once the user is for example in "Overview > Security events" and then the user clicks on "Overview > FIM" a flick is happening, showing empty cards briefly._ from https://github.com/wazuh/wazuh-kibana-app/issues/1726