### PR TITLE
UI/UX fixes

### DIFF
--- a/public/directives/wz-table/wz-table-directive.js
+++ b/public/directives/wz-table/wz-table-directive.js
@@ -520,9 +520,9 @@ app.directive('wzTable', function() {
           const key = $scope.parseKey(k);
           const canFilterInRules =
             $scope.path === '/rules' &&
-            (key === 'level' || key === 'file' || (key === 'path' && !$scope.lens));
+            (key === 'level' || (key === 'path' && !$scope.lens));
           const canFilterInDecoders =
-            $scope.path === '/decoders' && ((key === 'path' && !$scope.lens) || key === 'file');
+            $scope.path === '/decoders' && key === 'path' && !$scope.lens;
           $scope.filterableColumns[key] = !!(
             canFilterInRules || canFilterInDecoders
           );

--- a/public/templates/settings/settings-configuration.html
+++ b/public/templates/settings/settings-configuration.html
@@ -45,15 +45,15 @@
                                         ng-model="ctrl.editingNewValue" min=0></input>
                                     <select
                                         ng-if="ctrl.editingKey === key && ctrl.configurationTypes[key] === 'boolean'"
-                                        ng-disabled="ctrl.loadingChange" class="wz-input-text wz-width-100"
+                                        ng-disabled="ctrl.loadingChange" class="wz-menu-select wz-input-text wz-width-100"
                                         ng-model="ctrl.editingNewValue"
                                         ng-options="o as o for o in [true, false]"></select>
                                     <select ng-if="ctrl.editingKey === key && key === 'wazuh.monitoring.creation'"
-                                        ng-disabled="ctrl.loadingChange" class="wz-input-text wz-width-100"
+                                        ng-disabled="ctrl.loadingChange" class="wz-menu-select wz-input-text wz-width-100"
                                         ng-model="ctrl.editingNewValue"
                                         ng-options="key as value for (key , value) in  {'h': 'hourly', 'd': 'daily', 'w': 'weekly', 'm': 'monthly'}"></select>
                                     <select ng-if="ctrl.editingKey === key && key === 'logs.level'"
-                                        ng-disabled="ctrl.loadingChange" class="wz-input-text wz-width-100"
+                                        ng-disabled="ctrl.loadingChange" class="wz-menu-select wz-input-text wz-width-100"
                                         ng-model="ctrl.editingNewValue"
                                         ng-options="key as value for (key , value) in  {'info': 'info', 'debug': 'debug'}"></select>
                                     <textarea


### PR DESCRIPTION
Hi team,

This PR solves:

- Hide lens in the file column (Management > Rules/Decoders)
- (Firefox only) The arrow of the input select has an old-style

From this issue https://github.com/wazuh/wazuh-kibana-app/issues/1726