### PR TITLE
Improve how visualizations are handled

### DIFF
--- a/public/controllers/agent/agents.js
+++ b/public/controllers/agent/agents.js
@@ -501,7 +501,7 @@ export class AgentsController {
   ) {
     try {
       if (this.$scope.tabView === subtab && !force) return;
-
+      this.tabVisualizations.clearDeadVis();
       this.visFactoryService.clear(onlyAgent);
       this.$location.search('tabView', subtab);
       const localChange =

--- a/public/controllers/agent/agents.js
+++ b/public/controllers/agent/agents.js
@@ -454,7 +454,10 @@ export class AgentsController {
    */
   createMetrics(metricsObject) {
     for (let key in metricsObject) {
-      this.$scope[key] = () => generateMetric(metricsObject[key]);
+      this.$scope[key] = () => {
+        const metric = generateMetric(metricsObject[key]);
+        return !!metric ? metric : '-';
+      };
     }
   }
 

--- a/public/controllers/overview/overview.js
+++ b/public/controllers/overview/overview.js
@@ -148,7 +148,10 @@ export class OverviewController {
    */
   createMetrics(metricsObject) {
     for (const key in metricsObject) {
-      this[key] = () => generateMetric(metricsObject[key]);
+      this[key] = () => {
+        const metric = generateMetric(metricsObject[key]);
+        return !!metric ? metric : '-';
+      };
     }
   }
 
@@ -305,7 +308,7 @@ export class OverviewController {
         this.tabHistory = this.tabHistory.slice(-2);
 
       if (this.tab === newTab && !force) return;
-      
+
       const sameTab =
         ((this.tab === newTab && this.tabHistory.length < 2) ||
           (this.tabHistory.length === 2 &&

--- a/public/controllers/overview/overview.js
+++ b/public/controllers/overview/overview.js
@@ -223,7 +223,7 @@ export class OverviewController {
   ) {
     try {
       if (this.tabView === subtab && !force) return;
-
+      this.tabVisualizations.clearDeadVis();
       this.visFactoryService.clear();
       this.$location.search('tabView', subtab);
       const localChange =

--- a/public/factories/tab-visualizations.js
+++ b/public/factories/tab-visualizations.js
@@ -56,6 +56,8 @@ export class TabVisualizations {
 
     this.tabVisualizations = {};
     this.currentTab = '';
+
+    this.deadVisualizations = 0;
   }
 
   /**
@@ -63,6 +65,7 @@ export class TabVisualizations {
    * @param {Object} tab
    */
   setTab(tab) {
+    this.deadVisualizations = 0;
     this.currentTab = tab;
   }
 
@@ -99,5 +102,13 @@ export class TabVisualizations {
    */
   removeAll() {
     this.tabVisualizations = {};
+  }
+
+  addDeadVis() {
+    this.deadVisualizations += 1;
+  }
+
+  getDeadVis() {
+    return this.deadVisualizations;
   }
 }

--- a/public/factories/tab-visualizations.js
+++ b/public/factories/tab-visualizations.js
@@ -111,4 +111,8 @@ export class TabVisualizations {
   getDeadVis() {
     return this.deadVisualizations;
   }
+
+  clearDeadVis() {
+    this.deadVisualizations = 0;
+  }
 }

--- a/public/templates/overview/overview-ciscat.html
+++ b/public/templates/overview/overview-ciscat.html
@@ -23,13 +23,13 @@
         <md-card flex class="wz-metric-color wz-md-card">
             <md-card-content layout="row" class="wz-padding-metric">
                 <div class="wz-text-truncatable" flex>Last errors: <span class="wz-text-bold"
-                        ng-bind="ciscatScanError()"></span></div>
+                        ng-bind="octrl.ciscatScanError()"></span></div>
                 <div class="wz-text-truncatable" flex>Last fails: <span class="wz-text-bold"
-                        ng-bind="ciscatScanFail()"></span></div>
+                        ng-bind="octrl.ciscatScanFail()"></span></div>
                 <div class="wz-text-truncatable" flex>Last unknown: <span class="wz-text-bold"
-                        ng-bind="ciscatScanUnknown()"></span></div>
+                        ng-bind="octrl.ciscatScanUnknown()"></span></div>
                 <div class="wz-text-truncatable">Last scan benchmark: <span class="wz-text-bold"
-                        ng-bind="ciscatScanBenchmark()"></span></div>
+                        ng-bind="octrl.ciscatScanBenchmark()"></span></div>
             </md-card-content>
         </md-card>
     </div>


### PR DESCRIPTION
There is a certain use case, that was not working properly due to our latest change related to the known fields file (it was removed). If a visualization uses a field that doesn't exist in all the Elasticsearch indices, we try to find it 1 time, if we are on the same situation after trying to fetch it, then it means it doesn't exist. 

When the field doesn't exist, the visualization is marked as dead.