### PR TITLE
[6.8] Fix pinned filters in syscollector

### DIFF
--- a/public/kibana-integrations/kibana-discover.js
+++ b/public/kibana-integrations/kibana-discover.js
@@ -1049,7 +1049,10 @@ function discoverController(
     'changeTabView',
     (evt, parameters) => {
       if(parameters.syscollector){
-        queryFilter.removeAll();
+        const currentFilters = queryFilter.getFilters();
+        currentFilters
+          .filter(item => ((item || {}).$state || {}).store !== 'globalState')
+          .forEach(item => queryFilter.removeFilter(item));
       }
       $rootScope.resultState = 'loading';
       evt.stopPropagation();


### PR DESCRIPTION
Hi team, 

Due to a problem of no recovery after returning from Syscollector, we decided to remove all filters to recharge them and force data recovery again. With this PR and fix, we are not going to erase the pinned filters so as not to lose them.

Regards.