### PR TITLE
Adapt Labels configuration section with new format

### DIFF
--- a/public/templates/management/configuration/alerts/labels.html
+++ b/public/templates/management/configuration/alerts/labels.html
@@ -46,7 +46,7 @@
                                 ng-repeat="currentLabel in currentConfig[(agent && agent.id !== '000') ? 'agent-labels' : 'analysis-labels'].labels">
                                 <td>{{ currentLabel.key }}</td>
                                 <td>{{ currentLabel.value }}</td>
-                                <td>{{ currentLabel.hidden ? 'yes' : 'no' }}</td>
+                                <td>{{ currentLabel.hidden }}</td>
                             </tr>
                         </tbody>
                     </table>

--- a/public/templates/management/configuration/alerts/labels.html
+++ b/public/templates/management/configuration/alerts/labels.html
@@ -39,12 +39,14 @@
                         <thead class="wz-text-bold">
                             <th class="wz-text-left">Label key</th>
                             <th class="wz-text-left">Label value</th>
+                            <th class="wz-text-left">Hidden</th>
                         </thead>
                         <tbody class="wz-word-wrap">
                             <tr
-                                ng-repeat="(key, value) in currentConfig[(agent && agent.id !== '000') ? 'agent-labels' : 'analysis-labels'].labels">
-                                <td>{{ key }}</td>
-                                <td>{{ value }}</td>
+                                ng-repeat="currentLabel in currentConfig[(agent && agent.id !== '000') ? 'agent-labels' : 'analysis-labels'].labels">
+                                <td>{{ currentLabel.key }}</td>
+                                <td>{{ currentLabel.value }}</td>
+                                <td>{{ currentLabel.hidden ? 'yes' : 'no' }}</td>
                             </tr>
                         </tbody>
                     </table>


### PR DESCRIPTION
Hi team,

Due to this issue: https://github.com/wazuh/wazuh/issues/3429. Labels configuration format has been modified. The `Labels configuration section` is now being shown correctly with this new format. 
Solves #1816. 