### PR TITLE
Requests from react

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wazuh",
-  "version": "3.11.0",
+  "version": "3.1.0",
   "revision": "0560",
   "code": "0560-0",
   "kibana": {
@@ -38,6 +38,8 @@
     "angular-chart.js": "1.1.1",
     "angular-cookies": "1.6.5",
     "angular-material": "1.1.18",
+    "axios": "^0.19.0",
+    "babel-polyfill": "^6.13.0",
     "dom-to-image": "^2.6.0",
     "install": "^0.10.1",
     "js2xmlparser": "^3.0.0",
@@ -49,8 +51,7 @@
     "querystring-browser": "1.0.4",
     "simple-tail": "^1.1.0",
     "timsort": "^0.3.0",
-    "winston": "3.0.0",
-    "babel-polyfill": "^6.13.0"
+    "winston": "3.0.0"
   },
   "devDependencies": {
     "@elastic/plugin-helpers": "^7.1.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wazuh",
-  "version": "3.1.0",
+  "version": "3.11.0",
   "revision": "0560",
   "code": "0560-0",
   "kibana": {

--- a/public/react-services/wz-request.js
+++ b/public/react-services/wz-request.js
@@ -38,9 +38,9 @@ export class WzRequest {
       }
       return Promise.resolve(data);
     } catch (error) {
-      return ((error || {}).data || {}).message || false
-        ? Promise.reject(error.data.message)
-        : Promise.reject(error.message || error);
+      return (((error || {}).response || {}).data || {}).message || false
+        ? Promise.reject(error.response.data.message)
+        : Promise.reject(error.response.message || error.response || error);
     }
   }
 

--- a/public/react-services/wz-request.js
+++ b/public/react-services/wz-request.js
@@ -13,33 +13,29 @@ import axios from 'axios';
 import chrome from 'ui/chrome';
 
 export class WzRequest {
-  /**
-   * Perform an API request
-   * @param {String} method Eg. GET, PUT, POST, DELETE
-   * @param {String} path API route
-   * @param {Object} body Request body
+    /**
+   * Permorn a generic request
+   * @param {String} method 
+   * @param {String} path 
+   * @param {Object} payload 
    */
-  static async request(method, path, body) {
+  static async genericReq(method, path, payload = null) {
     try {
-      if (!method || !path || !body) {
+      if (!method || !path) {
         throw new Error('Missing parameters');
       }
-      const url = chrome.addBasePath('/api/request');
-      const id = this.getCookie('API').id;
-      const requestData = { method, path, body, id };
+      const url = chrome.addBasePath(path);
       const options = {
-        method: 'POST',
+        method: method,
         headers: { 'Content-Type': 'application/json', 'kbn-xsrf': 'kibana' },
-        data: requestData,
         url: url,
+        data: payload,
         timeout: 20000
       };
-      
       const data = await axios(options);
       if (data.error) {
         throw new Error(data.error);
       }
-      
       return Promise.resolve(data);
     } catch (error) {
       return ((error || {}).data || {}).message || false
@@ -49,7 +45,50 @@ export class WzRequest {
   }
 
   /**
-   * Gets the current API in order to get the credentials from it
+   * Perform a request to the Wazuh API
+   * @param {String} method Eg. GET, PUT, POST, DELETE
+   * @param {String} path API route
+   * @param {Object} body Request body
+   */
+  static async apiReq(method, path, body) {
+    try {
+      if (!method || !path || !body) {
+        throw new Error('Missing parameters');
+      }
+      const id = this.getCookie('API').id;
+      const requestData = { method, path, body, id };
+      const data = await this.genericReq('POST', '/api/request', requestData);
+      return Promise.resolve(data);
+    } catch (error) {
+      return ((error || {}).data || {}).message || false
+        ? Promise.reject(error.data.message)
+        : Promise.reject(error.message || error);
+    }
+  }
+
+  /**
+   * Perform a request to generate a CSV
+   * @param {String} path 
+   * @param {Object} filters 
+   */
+  static async csvReq(path, filters){
+    try {
+      if (!path || !filters) {
+        throw new Error('Missing parameters');
+      }
+      const id = this.getCookie('API').id;
+      const requestData = { path, id, filters };
+      const data = await this.genericReq('POST', '/api/csv', requestData);
+      return Promise.resolve(data);
+    } catch (error) {
+      return ((error || {}).data || {}).message || false
+        ? Promise.reject(error.data.message)
+        : Promise.reject(error.message || error);
+    }
+  }
+
+  /**
+   * Gets the value from a cookie
    * @param {String} cookieName
    */
   static getCookie(cookieName) {
@@ -61,7 +100,7 @@ export class WzRequest {
         const decode = decodeURIComponent(cookie);
         try {
           return JSON.parse(JSON.parse(decode));
-        } catch(error) {
+        } catch (error) {
           return decode;
         }
       } else {

--- a/public/react-services/wz-request.js
+++ b/public/react-services/wz-request.js
@@ -1,0 +1,74 @@
+/*
+ * Wazuh app - API request service
+ * Copyright (C) 2015-2019 Wazuh, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Find more information about this on the LICENSE file.
+ */
+import axios from 'axios';
+import chrome from 'ui/chrome';
+
+export class WzRequest {
+  /**
+   * Perform an API request
+   * @param {String} method Eg. GET, PUT, POST, DELETE
+   * @param {String} path API route
+   * @param {Object} body Request body
+   */
+  static async request(method, path, body) {
+    try {
+      if (!method || !path || !body) {
+        throw new Error('Missing parameters');
+      }
+      const url = chrome.addBasePath('/api/request');
+      const id = this.getCookie('API').id;
+      const requestData = { method, path, body, id };
+      const options = {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'kbn-xsrf': 'kibana' },
+        data: requestData,
+        url: url,
+        timeout: 20000
+      };
+      
+      const data = await axios(options);
+      if (data.error) {
+        throw new Error(data.error);
+      }
+      
+      return Promise.resolve(data);
+    } catch (error) {
+      return ((error || {}).data || {}).message || false
+        ? Promise.reject(error.data.message)
+        : Promise.reject(error.message || error);
+    }
+  }
+
+  /**
+   * Gets the current API in order to get the credentials from it
+   * @param {String} cookieName
+   */
+  static getCookie(cookieName) {
+    try {
+      const value = "; " + document.cookie;
+      const parts = value.split("; " + cookieName + "=");
+      const cookie = parts.length === 2 ? parts.pop().split(';').shift() : false;
+      if (cookie && decodeURIComponent(cookie)) {
+        const decode = decodeURIComponent(cookie);
+        try {
+          return JSON.parse(JSON.parse(decode));
+        } catch(error) {
+          return decode;
+        }
+      } else {
+        throw `Cannot get ${cookieName}`;
+      }
+    } catch (error) {
+      throw new Error(error);
+    }
+  }
+}


### PR DESCRIPTION
Hi team,

This PR creates a new service called WzRequest to use it directly in the react component instead use ApiRequest through the props.

Now from any react component can make the following requests:

- Generic requests
- Requests to the Wazuh API
- Request to generate a CSV

Solves  https://github.com/wazuh/wazuh-kibana-app/issues/1844

Regards,