### PR TITLE
Remove format for URL Fields

### DIFF
--- a/server/lib/elastic-wrapper.js
+++ b/server/lib/elastic-wrapper.js
@@ -289,9 +289,9 @@ export class ElasticWrapper {
               timeFieldName: 'timestamp',
               fields: currentFieldsString,
               fieldFormatMap: `{
-                  "data.virustotal.permalink":{"id":"url"},
-                  "data.vulnerability.reference":{"id":"url"},
-                  "data.url":{"id":"url"}
+                  "data.virustotal.permalink":{"id":""},
+                  "data.vulnerability.reference":{"id":""},
+                  "data.url":{"id":""}
                 }`,
               sourceFilters: '[{"value":"@timestamp"}]'
             }


### PR DESCRIPTION
In the Discover view, fields known as URLs are displayed with
the html tag <a>

We set them back to blank (default value),
if you remove the property `fieldFormatMap` the format does not change.

In future versions if Kibana solves this problem we will revert the
change, otherwise we remove the `fieldFormatMap` property.