### PR TITLE
Fix hidden overflow in the fim configuration

### DIFF
--- a/public/templates/management/configuration/integrity-monitoring/integrity-monitoring.head
+++ b/public/templates/management/configuration/integrity-monitoring/integrity-monitoring.head
@@ -35,7 +35,7 @@
     </div>
 
     <!-- This section contains the main content and the right sidenav -->
-    <div flex="auto" layout="row" ng-if="!load" class="d-height">
+    <div flex="auto" layout="row" ng-if="!load" >
 
         <!-- No configuration section -->
         <wz-no-config


### PR DESCRIPTION
@Joanes04 Report me a visualization bug in the File integrity monitoring configuration

This commit solved this removed the `d-height` class