### PR TITLE
Add pinned filters after refresh

### DIFF
--- a/public/kibana-integrations/kibana-discover.js
+++ b/public/kibana-integrations/kibana-discover.js
@@ -1155,7 +1155,7 @@ function discoverController(
       }
 
       queryFilter
-        .addFilters(wzCurrentFilters)
+        .addFilters([...wzCurrentFilters, ...globalState.filters || []])
         .then(() => {})
         .catch(error => console.log(error.message || error)); // eslint-disable-line
     }


### PR DESCRIPTION
Hi team,

This PR apply again the pinned filters before a refresh of the page so that they are not lost when returning to load the implicit filters.

Regards.