### PR TITLE
"New file" editor doesn't allow saving twice #1896

### DIFF
--- a/public/controllers/management/files.js
+++ b/public/controllers/management/files.js
@@ -57,6 +57,12 @@ export class FilesController {
       this.$scope.$applyAsync();
     });
 
+    this.$scope.$on('showSaveAndOverwrite', () => {
+      this.$scope.newFile = true;
+      this.$scope.editorReadOnly = false;
+      this.$scope.$applyAsync();
+    });
+
     this.$scope.$on('viewFileOnly', (ev, params) => {
       this.$scope.editorReadOnly = true;
       this.editFile(params, true);

--- a/public/directives/wz-xml-file-editor/wz-xml-file-editor.js
+++ b/public/directives/wz-xml-file-editor/wz-xml-file-editor.js
@@ -263,6 +263,17 @@ app.directive('wzXmlFileEditor', function() {
                 ? showRestartMessage(msg, params.showRestartManager)
                 : errorHandler.handle(warnMsg, '', true)
               : errorHandler.info(msg);
+            if(params.isNewFile) {
+              $scope.$emit('editFile', {
+                file: {
+                  file: params.rule.file,
+                  path: 'etc/rules',
+                  status: 'enabled',
+                  type: 'rule',
+                },
+                path: 'etc/rules',
+              });
+            }
           } else if (params.decoder) {
             close = false;
             await rulesetHandler.sendDecoderConfiguration(
@@ -281,6 +292,17 @@ app.directive('wzXmlFileEditor', function() {
                 ? showRestartMessage(msg, params.showRestartManager)
                 : errorHandler.handle(warnMsg, '', true)
               : errorHandler.info(msg);
+            if(params.isNewFile) {
+              $scope.$emit('editFile', {
+                file: {
+                  file: params.decoder.file,
+                  path: '/decoders/files',
+                  status: 'enabled',
+                  type: 'decoder',
+                },
+                path: '/decoders/files',
+              });
+            }
           } else if (params.node) {
             close = false;
             await configHandler.saveNodeConfiguration(params.node, xml);


### PR DESCRIPTION
Hi team,

In this PR we have adapted the Wazuh Kibana app so that when we create a file for **rules** or **decoders**, it automatically takes us to edit it, thus eliminating the problem of overwriting files

This PR solves #1896 

Regards!