### PR TITLE
Add validator true to -- within in commentary

### DIFF
--- a/public/directives/wz-xml-file-editor/wz-xml-file-editor.js
+++ b/public/directives/wz-xml-file-editor/wz-xml-file-editor.js
@@ -89,6 +89,7 @@ app.directive('wzXmlFileEditor', function() {
           let xml = replaceIllegalXML(text);
           xml = xml.replace(/..xml.+\?>/, '');
           xml = xml.replace(/\\</gm, '');
+          xml = xml.replace(/<!--[\s\S\n]*?-->/gm, '');
           const xmlDoc = parser.parseFromString(
             `<file>${xml}</file>`,
             'text/xml'


### PR DESCRIPTION
Hi team!

In this PR we have adapted the Wazuh app for the XML validator error for -- within in comment.

This PR solves #1979 

Regards!