### PR TITLE
Increased list filesize limit and fixed typo

### DIFF
--- a/public/controllers/management/components/upload-files.js
+++ b/public/controllers/management/components/upload-files.js
@@ -36,7 +36,7 @@ export class UploadFiles extends Component {
       uploadErrors: false,
       errorPopover: false
     };
-    this.maxSize = 307200; // 300Kb
+    this.maxSize = 5120000; // 5Mb
   }
 
   onChange = files => {
@@ -293,7 +293,7 @@ export class UploadFiles extends Component {
           {this.checkOverSize() > 0 && (
             <Fragment>
               {this.renderWarning(
-                `The max size per file allowd is ${this.maxSize / 1024} Kb`
+                `The max size per file allowed is ${this.maxSize / 1024} Kb`
               )}
             </Fragment>
           )}


### PR DESCRIPTION
As mentioned in #1947 the limit for uploading a list for the CDB-list capability is too low and the resulting error message contains a typo.

This PR addresses that by increasing the limit to 5MB and fixing the typo.