### PR TITLE
Fix Wazuh version in upgrade guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Install the app
 - With sudo:
 
 ```
-sudo -u kibana /usr/share/kibana/bin/kibana-plugin install https://packages.wazuh.com/wazuhapp/wazuhapp-3.11.1_7.5.2.zip
+sudo -u kibana /usr/share/kibana/bin/kibana-plugin install https://packages.wazuh.com/wazuhapp/wazuhapp-3.11.2_7.5.2.zip
 ```
 
 - Without sudo:


### PR DESCRIPTION
The upgrade guide is using a previous version of Wazuh 3.11.1-7.5.2 when the latest version is 3.11.2-7.5.2.