### PR TITLE
Remove previous version format on currentPattern Cookie

### DIFF
--- a/public/react-services/app-state.js
+++ b/public/react-services/app-state.js
@@ -205,6 +205,12 @@ export class AppState {
      * Get '_currentPattern' value   
      */
     static getCurrentPattern() {
+        const currentPattern = Cookies.get('_currentPattern') ? decodeURI(Cookies.get('_currentPattern')) : "";
+         // check if the current Cookie has the format of 3.11 and previous versions, in that case we remove the extra " " characters
+        if(currentPattern[0] === '"' && currentPattern[currentPattern.length-1] === '"'){
+            const newPattern = currentPattern.substring(1, currentPattern.length-1);
+            this.setCurrentPattern(newPattern);
+        }
         return Cookies.get('_currentPattern') ? decodeURI(Cookies.get('_currentPattern')) : "";
     }
 

--- a/public/react-services/app-state.js
+++ b/public/react-services/app-state.js
@@ -207,7 +207,7 @@ export class AppState {
     static getCurrentPattern() {
         const currentPattern = Cookies.get('_currentPattern') ? decodeURI(Cookies.get('_currentPattern')) : "";
          // check if the current Cookie has the format of 3.11 and previous versions, in that case we remove the extra " " characters
-        if(currentPattern[0] === '"' && currentPattern[currentPattern.length-1] === '"'){
+        if(currentPattern && currentPattern[0] === '"' && currentPattern[currentPattern.length-1] === '"'){
             const newPattern = currentPattern.substring(1, currentPattern.length-1);
             this.setCurrentPattern(newPattern);
         }


### PR DESCRIPTION
Hi team,

The format of the CurrentPattern Cookie in previous versions (3.11-) was:
`"index-pattern"`
As the AppState service has been migrated, this format has been changed and this old format causes an error when upgrading, forcing the user to refresh the page in order to make it work. To avoid this, the AppState now detects if the format of the cookie is correct and replace its value with a correct value removing the extra `" "` characters.