### PR TITLE
Fix missing healthcheck when loading dev-tools

### DIFF
--- a/public/controllers/dev-tools/dev-tools.js
+++ b/public/controllers/dev-tools/dev-tools.js
@@ -19,6 +19,7 @@ import chrome from 'ui/chrome';
 import { DynamicHeight } from '../../utils/dynamic-height';
 import { AppState } from '../../react-services/app-state';
 import { GenericRequest } from '../../react-services/generic-request';
+import store from '../../redux/store';
 
 export class DevToolsController {
   /**
@@ -56,6 +57,9 @@ export class DevToolsController {
    * When controller loads
    */
   $onInit() {
+    if(store.getState() && store.getState().appStateReducers && !store.getState().appStateReducers.showMenu){
+      AppState.setWzMenu();
+    }
     $(this.$document[0]).keydown(e => {
       if (!this.multipleKeyPressed.includes(e.which)) {
         this.multipleKeyPressed.push(e.which);

--- a/public/services/routes.js
+++ b/public/services/routes.js
@@ -186,7 +186,7 @@ routes
   })
   .when('/wazuh-dev', {
     template: devToolsTemplate,
-    resolve: { enableWzMenu, nestedResolve }
+    resolve: { enableWzMenu, nestedResolve, ip, savedSearch }
   })
   .when('/blank-screen', {
     template: blankScreenTemplate,


### PR DESCRIPTION
Hi team,

When we start the Wazuh UI for the first time and access the Dev Tools tab, the health check was not being launched and the WzMenu wasn't being shown.
This PR now allows the UI to launch the Health Check even if the first page accessed is DevTools. When opening the DevTools on a new page, the main menu was missing so now it's being checked if the menu is loaded or not, so we can force its load.