### PR TITLE
Add WindowsUpdate table to report

### DIFF
--- a/server/controllers/wazuh-reporting.js
+++ b/server/controllers/wazuh-reporting.js
@@ -2552,6 +2552,31 @@ export class WazuhReportingCtrl {
           } catch (error) {
             log('reporting:report', error.message || error, 'debug');
           }
+
+          try {
+            log(
+              'reporting:report',
+              `Fetching hotfixes for agent ${agentId}`,
+              'debug'
+            );
+            const hotfixes = await this.apiRequest.makeGenericRequest(
+              'GET',
+              `/syscollector/${agentId}/hotfixes`,
+              {},
+              apiId
+            );
+            if (hotfixes && hotfixes.data && hotfixes.data.items) {
+              tables.push({
+                title: 'Windows updates',
+                columns: ['Update code'],
+                rows: hotfixes.data.items.map(x => {
+                  return [x['hotfix']];
+                })
+              });
+            }
+          } catch (error) {
+            log('reporting:report', error.message || error, 'debug');
+          }
         }
 
         if (!isAgentConfig && !isGroupConfig) {


### PR DESCRIPTION
Hi team,

This PR closes #2024. The `Windows updates` table wasn't being shown in the generated report of Inventory Data, it has now been added to it.