### PR TITLE
Ignore wazuh-registry.json in package creation

### DIFF
--- a/.kibana-plugin-helpers.json
+++ b/.kibana-plugin-helpers.json
@@ -5,8 +5,9 @@
       "tsconfig.json",
       "wazuh.yml",
       "index.js",
-        "init.js",
+      "init.js",
       "server/**/*",
+      "!server/wazuh-registry.json",
       "public/**/*",
       "util/**/*"
     ]


### PR DESCRIPTION
Now it is not necessary to delete the `wazuh-registry.json` file before running the `yarn build` command