### PR TITLE
Change devtools method for new API

### DIFF
--- a/public/controllers/dev-tools/dev-tools.js
+++ b/public/controllers/dev-tools/dev-tools.js
@@ -368,7 +368,7 @@ export class DevToolsController {
     const currentState = AppState.getCurrentDevTools();
     if (!currentState) {
       const demoStr =
-        'GET /agents?status=Active\n\n#Example comment\nGET /manager/info\n\nGET /syscollector/000/packages?search=ssh\n' +
+        'GET /agents?status=active\n\n#Example comment\nGET /manager/info\n\nGET /syscollector/000/packages?search=ssh\n' +
         JSON.stringify({ limit: 5 }, null, 2);
 
       AppState.setCurrentDevTools(demoStr);
@@ -577,28 +577,29 @@ export class DevToolsController {
             : `/${requestCopy}`
           : '/';
 
-        let JSONraw = {};
+        let body = {};
         try {
-          JSONraw = JSON.parse(paramsInline || desiredGroup.requestTextJson);
+          body = JSON.parse(paramsInline || desiredGroup.requestTextJson);
         } catch (error) {
-          JSONraw = {};
+          body = {};
         }
 
         if (typeof extra.pretty !== 'undefined') delete extra.pretty;
-        if (typeof JSONraw.pretty !== 'undefined') delete JSONraw.pretty;
+        if (typeof body.pretty !== 'undefined') delete body.pretty;
 
+        let params = {};
         // Assign inline parameters
-        for (const key in extra) JSONraw[key] = extra[key];
+        for (const key in extra) params[key] = extra[key];
         const path = req.includes('?') ? req.split('?')[0] : req;
 
-        if (typeof JSONraw === 'object') JSONraw.devTools = true;
         if (!firstTime) {
-          const output = await this.apiReq.request(method, path, JSONraw);
+          const output = await this.apiReq.request(method, path, {
+            params: params,
+            body: body,
+            devTools: true,
+          });
           this.apiOutputBox.setValue(
-            JSON.stringify((output || {}).data || {}, null, 2).replace(
-              /\\\\/g,
-              '\\'
-            )
+            JSON.stringify((output || {}).data || {}, null, 2).replace(/\\\\/g, '\\')
           );
         }
       }


### PR DESCRIPTION
Hi team,

This PR adapts the whole Devtools section with all the API endpoints adapted to the new API 4.0, except for the autocomplete