### PR TITLE
Fix new AppState service

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -71,7 +71,7 @@ const app = uiModules.get('app/wazuh', ['ngCookies', 'ngMaterial', 'chart.js']);
 
 app.config([
   '$compileProvider',
-  function($compileProvider) {
+  function ($compileProvider) {
     $compileProvider.aHrefSanitizationWhitelist(
       /^\s*(https?|ftp|mailto|data|blob):/
     );
@@ -80,14 +80,14 @@ app.config([
 
 app.config([
   '$httpProvider',
-  function($httpProvider) {
+  function ($httpProvider) {
     $httpProvider.useApplyAsync(true);
   }
 ]);
 
-app.run(function($rootScope, $route, $location, $window) {
+app.run(function ($rootScope, $route, $location) {
   chrome
-    .setRootTemplate('<react-component name="WzMenuWrapper" props="" /><div ng-view class="mainView"></div>')
+  .setRootTemplate('<react-component name="WzMenuWrapper" props="" /><div ng-view class="mainView"></div>')
     .setRootController(() => require('./app'));
   changeWazuhNavLogo();
   AppState.setNavigation({ status: false });
@@ -123,92 +123,6 @@ app.run(function($rootScope, $route, $location, $window) {
           $location.search('configSubTab', null);
           $location.search('editingFile', null);
           $route.reload();
-          //discover sections
-        } else if (
-          navigation.discoverSections.includes(navigation.currLocation)
-        ) {
-          if (navigation.currLocation === navigation.discoverSections[1]) {
-            $window.history.pushState(
-              {
-                page: chrome.addBasePath(
-                  'wazuh#' + navigation.discoverPrevious + '/'
-                )
-              },
-              '',
-              chrome.addBasePath('wazuh#' + navigation.discoverPrevious + '/')
-            );
-          } else if (
-            navigation.currLocation === navigation.discoverSections[2]
-          ) {
-            if (
-              $location.search().tab &&
-              $location.search().tab !== 'welcome'
-            ) {
-              $window.history.pushState(
-                {
-                  page: chrome.addBasePath(
-                    'wazuh#' + navigation.discoverPrevious
-                  )
-                },
-                '',
-                chrome.addBasePath('wazuh#' + navigation.discoverPrevious)
-              );
-              $window.history.pushState(
-                {
-                  page: chrome.addBasePath(
-                    'wazuh#' +
-                      navigation.discoverPrevious +
-                      '?agent=' +
-                      $location.search().agent
-                  )
-                },
-                '',
-                chrome.addBasePath(
-                  'wazuh#' +
-                    navigation.discoverPrevious +
-                    '?agent=' +
-                    $location.search().agent
-                )
-              );
-            } else {
-              $window.history.pushState(
-                {
-                  page: chrome.addBasePath(
-                    'wazuh#' + navigation.discoverPrevious
-                  )
-                },
-                '',
-                chrome.addBasePath('wazuh#' + navigation.discoverPrevious)
-              );
-            }
-          } else if (
-            navigation.currLocation === navigation.discoverSections[0] ||
-            navigation.currLocation === navigation.discoverSections[3]
-          ) {
-            $window.history.pushState(
-              {
-                page: chrome.addBasePath('wazuh#' + navigation.discoverPrevious)
-              },
-              '',
-              chrome.addBasePath('wazuh#' + navigation.discoverPrevious)
-            );
-          }
-          $window.history.pushState(
-            { page: chrome.addBasePath('wazuh#' + $location.$$url) },
-            '',
-            chrome.addBasePath('wazuh#' + $location.$$url)
-          );
-        } else if ($location.search().tabView === 'cluster-monitoring') {
-          $window.history.pushState(
-            { page: chrome.addBasePath('wazuh#/manager/') },
-            '',
-            chrome.addBasePath('wazuh#/manager/')
-          );
-          $window.history.pushState(
-            { page: 'wazuh#' + $location.$$url },
-            '',
-            chrome.addBasePath('wazuh#' + $location.$$url)
-          );
         }
       }
     }

--- a/public/controllers/misc/blank-screen-controller.js
+++ b/public/controllers/misc/blank-screen-controller.js
@@ -22,6 +22,7 @@ export class BlankScreenController {
     this.$location = $location;
     this.errorHandler = errorHandler;
     this.wzMisc = wzMisc;
+    this.showErrorPage = false;
   }
 
   /**
@@ -35,9 +36,13 @@ export class BlankScreenController {
         parsed = this.errorHandler.handle(catchedError, '', false, true);
       } catch (error) {} // eslint-disable-line
       this.errorToShow = parsed || catchedError;
-      this.wzMisc.setBlankScr(false);
       this.$scope.$applyAsync();
+      this.wzMisc.setBlankScr(false);
+    }else{
+      this.goOverview();
+      return;
     }
+    this.showErrorPage = true;
   }
 
   /**

--- a/public/controllers/misc/health-check.js
+++ b/public/controllers/misc/health-check.js
@@ -13,6 +13,7 @@ import { SavedObjectsClientProvider } from 'ui/saved_objects';
 
 import chrome from 'ui/chrome';
 import { AppState } from '../../react-services/app-state';
+import { PatternHandler } from '../../react-services/pattern-handler'
 import { WazuhConfig } from '../../react-services/wazuh-config';
 import { GenericRequest } from '../../react-services/generic-request';
 
@@ -106,8 +107,13 @@ export class HealthCheck {
           `/elastic/index-patterns/${patternTitle}`
         );
         if (!patternData.data.status) {
-          this.errors.push('The selected index-pattern is not present.');
-          this.results[i].status = 'Error';
+          const patternList = await PatternHandler.getPatternList();
+          if(patternList.length){
+            return this.checkPatterns();
+          }else{
+            this.errors.push('The selected index-pattern is not present.');
+            this.results[i].status = 'Error';
+          }
         } else {
           this.processedChecks++;
           this.results[i].status = 'Ready';

--- a/public/react-services/app-state.js
+++ b/public/react-services/app-state.js
@@ -216,6 +216,14 @@ export class AppState {
 
 
     /**
+     * Remove '_currentPattern' value   
+     */
+    static removeCurrentPattern() {
+        return Cookies.remove('_currentPattern', { path : '/app' });
+    }
+
+
+    /**
      * Set a new value to the 'currentDevTools' cookie
      * @param {*} current 
      **/

--- a/public/react-services/app-state.js
+++ b/public/react-services/app-state.js
@@ -48,7 +48,7 @@ export class AppState {
             exp.setDate(exp.getDate() + 365);
             if (extensions) {
                 const encodedExtensions = encodeURI(JSON.stringify(current));
-                Cookies.set('extensions', encodedExtensions, { expires: exp, path: '/app'});
+                Cookies.set('extensions', encodedExtensions, { expires: exp, path: window.location.pathname});
             }
         }catch(err){
             console.log("Error set extensions");
@@ -82,7 +82,7 @@ export class AppState {
             const exp = new Date();
             exp.setDate(exp.getDate() + 365);
             if (cluster_info) {
-                Cookies.set('_clusterInfo', encodedClusterInfo, { expires: exp, path: '/app'  });
+                Cookies.set('_clusterInfo', encodedClusterInfo, { expires: exp, path: window.location.pathname  });
             }
         }catch(err){
             console.log("Error set cluster info");
@@ -100,7 +100,7 @@ export class AppState {
             const createdAt = encodeURI(date);
             const exp = new Date();
             exp.setDate(exp.getDate() + 365);
-            Cookies.set('_createdAt', createdAt, { expires: exp, path: '/app' });
+            Cookies.set('_createdAt', createdAt, { expires: exp, path: window.location.pathname });
         }catch(err){
             console.log("Error set createdAt date");
             console.log(err);
@@ -143,7 +143,7 @@ export class AppState {
     static removeCurrentAPI() {
         const updateApiMenu = updateCurrentApi(false);
         store.dispatch(updateApiMenu);
-        return Cookies.remove('API', { path : '/app' });
+        return Cookies.remove('API', { path : window.location.pathname });
     }
 
     /**
@@ -156,7 +156,7 @@ export class AppState {
             const exp = new Date();
             exp.setDate(exp.getDate() + 365);
             if (API) {
-                Cookies.set('API', encodedApi, { expires: exp, path: '/app' });
+                Cookies.set('API', encodedApi, { expires: exp, path: window.location.pathname });
                 try{
                     const updateApiMenu = updateCurrentApi(JSON.parse(API).name);
                     store.dispatch(updateApiMenu);
@@ -183,7 +183,7 @@ export class AppState {
      */
     static setPatternSelector(value) {
         const encodedPattern = encodeURI(value);
-        Cookies.set('patternSelector', encodedPattern, { path: '/app'});
+        Cookies.set('patternSelector', encodedPattern, { path: window.location.pathname});
     }
 
 
@@ -197,7 +197,7 @@ export class AppState {
         const exp = new Date();
         exp.setDate(exp.getDate() + 365);
         if (newPattern) {
-            Cookies.set('_currentPattern', encodedPattern, { expires: exp, path: '/app' });
+            Cookies.set('_currentPattern', encodedPattern, { expires: exp, path: window.location.pathname });
         }
     }
 
@@ -219,7 +219,7 @@ export class AppState {
      * Remove '_currentPattern' value   
      */
     static removeCurrentPattern() {
-        return Cookies.remove('_currentPattern', { path : '/app' });
+        return Cookies.remove('_currentPattern', { path : window.location.pathname });
     }
 
 
@@ -272,7 +272,7 @@ export class AppState {
         }
         if(navigate){
             const encodedURI = encodeURI(JSON.stringify(navigate));
-            Cookies.set('navigate', encodedURI, {path: '/app'});
+            Cookies.set('navigate', encodedURI, {path: window.location.pathname});
         }
     }
 
@@ -283,7 +283,7 @@ export class AppState {
     }
 
     static removeNavigation() {
-        return Cookies.remove('navigate', {path: '/app'});
+        return Cookies.remove('navigate', {path: window.location.pathname});
     }
 
     static setWzMenu() {

--- a/public/react-services/generic-request.js
+++ b/public/react-services/generic-request.js
@@ -86,9 +86,9 @@ export class GenericRequest {
       }
       return data;
     }catch(err){
-      return (((err || {}).response || {}).data || {}).message || false
-        ? Promise.reject(err.response.data.message)
-        : Promise.reject(err.response.message || err.response || err);
+        return ((err || {}).message) || false
+        ? Promise.reject(err.message)
+        : Promise.reject(err || 'Server did not respond');
     }
   }
 

--- a/public/react-services/pattern-handler.js
+++ b/public/react-services/pattern-handler.js
@@ -11,6 +11,7 @@
  */
 import { GenericRequest } from "./generic-request";
 import { AppState } from "./app-state";
+import chrome from 'ui/chrome';
 
 export class PatternHandler {
 
@@ -26,9 +27,14 @@ export class PatternHandler {
       );
 
       if (!patternList.data.data.length) {
-        //this.wzMisc.setBlankScr('Sorry but no valid index patterns were found');
-        if(!window.location.hash.includes('#/settings') && !window.location.hash.includes('#/blank-screen'))
-          window.location.href = "/app/wazuh#/settings/";
+        AppState.removeCurrentPattern();
+
+        const $injector = await chrome.dangerouslyGetActiveInjector();
+        this.wzMisc = $injector.get('wzMisc');
+        this.wzMisc.setBlankScr('Sorry but no valid index patterns were found');
+        if(!window.location.hash.includes('#/settings') && !window.location.hash.includes('#/blank-screen')){
+          window.location.href = "/app/wazuh#/blank-screen/";
+        }
         return;
       }
 

--- a/public/react-services/wz-request.js
+++ b/public/react-services/wz-request.js
@@ -38,10 +38,10 @@ export class WzRequest {
         throw new Error(data.error);
       }
       return Promise.resolve(data);
-    } catch (error) {
-      return (((error || {}).response || {}).data || {}).message || false
-        ? Promise.reject(error.response.data.message)
-        : Promise.reject(error.response.message || error.response || error);
+    } catch(err){
+      return ((err || {}).message) || false
+      ? Promise.reject(err.message)
+      : Promise.reject(err || 'Server did not respond');
     }
   }
 

--- a/public/templates/error-handler/blank-screen.html
+++ b/public/templates/error-handler/blank-screen.html
@@ -1,4 +1,5 @@
 <div flex="auto" layout="column" ng-controller="blankScreenController as ctrl" layout-align="center center">
+    <div ng-if="ctrl.showErrorPage">
     <div class="wz-text-center">
         <img class="loading-logo-fail" aria-hidden="true" wz-src="/plugins/wazuh/img/icon_fail.svg" />
     </div>
@@ -22,5 +23,6 @@
                 </md-button>
             </p>
         </div>
+    </div>
     </div>
 </div>


### PR DESCRIPTION
Hi team,

Some fixes are added in this PR:
- The new AppState service didn't support Kibana spaces and caused an infinite loop freezing the current browser tab, it has been fixed here: https://github.com/wazuh/wazuh-kibana-app/commit/fb147601ca86d5b5368777ef8c17fab7f0b33e41

- When there was an error in the Wazuh UI and the user refreshed the page, we were showing an error page with a `Something went wrong` message. We now check if the error is still happening, in that case, we show the error message (not a generic error message) or if the error has been fixed we redirect to the Overview page. A double-page refresh flick has also been fixed. Fixed here: https://github.com/wazuh/wazuh-kibana-app/commit/cb19c385ceeba19bc32b67245a280b54adbdf1b1

- When a user deletes the `wazuh-alerts*` index-pattern and creates a new index-pattern manually (either with the same name or with a different name). The app was showing an error and the only way to fix it was by deleting the cookies manually. The index-pattern cookie is now deleted automatically and a new index pattern (if exists) is selected so the user does not have to do the process manually. Fixed here:  https://github.com/wazuh/wazuh-kibana-app/commit/9ee792905b20ff70cf442b6efa628751a5554ab7

- When there was an error in either our generic request method or in our wz-request services, a generic error message (`Server did not respond`) was being shown with no extra details to the user. We now show the error in the request, for example, a timeout exceeded in a request. Fixed here: https://github.com/wazuh/wazuh-kibana-app/commit/768cd09766f9ce8c36a3b5949f2f4320bd6178c2