### PR TITLE
Fix infinite loop when an index pattern alias is removed

### DIFF
--- a/public/react-services/pattern-handler.js
+++ b/public/react-services/pattern-handler.js
@@ -40,7 +40,7 @@ export class PatternHandler {
 
       if (AppState.getCurrentPattern()) {
         let filtered = patternList.data.data.filter(item =>
-          item.id.includes(AppState.getCurrentPattern())
+          item.id === AppState.getCurrentPattern()
         );
         if (!filtered.length)
           AppState.setCurrentPattern(patternList.data.data[0].id);


### PR DESCRIPTION
Hi team,
How to reproduce this error:
1. Use an index pattern alias, e.g. `wazuh-alerts`. The Wazuh UI will store that index pattern in the cookie.
2. Remove the index pattern alias and restart Kibana (Kibana will create a new index pattern `wazuh-alerts-3.x-`
3. The App will check if the stored index pattern in our cookies is **INCLUDED** in the new index pattern created, in this case `wazuh-alerts` is included in "**wazuh-alerts**-3.x-" so the app thinks it is a valid index pattern when it's not. 


This produces an infinite loop in our Wazuh UI, this has been fixed by just removing the `include` condition and now it checks if it is the exact same index pattern name. This was just happening when using index pattern aliases.
