### PR TITLE
Add rule group win_authentication_failed to metrics

### DIFF
--- a/server/integration-files/visualizations/agents/agents-general.js
+++ b/server/integration-files/visualizations/agents/agents-general.js
@@ -104,10 +104,11 @@ export default [
                               "index": "wazuh-alerts",
                               "type": "phrases",
                               "key": "rule.groups",
-                              "value": "authentication_failed, authentication_failures",
+                              "value": "win_authentication_failed, authentication_failed, authentication_failures",
                               "params": [
+                                "win_authentication_failed",
                                 "authentication_failed",
-                                "win_authentication_failed"
+                                "authentication_failures"
                               ],
                               "negate": false,
                               "disabled": false,
@@ -118,12 +119,17 @@ export default [
                                 "should": [
                                   {
                                     "match_phrase": {
+                                      "rule.groups": "win_authentication_failed"
+                                    }
+                                  },
+                                  {
+                                    "match_phrase": {
                                       "rule.groups": "authentication_failed"
                                     }
                                   },
                                   {
                                     "match_phrase": {
-                                      "rule.groups": "win_authentication_failed"
+                                      "rule.groups": "authentication_failures"
                                     }
                                   }
                                 ],

--- a/server/integration-files/visualizations/overview/overview-general.js
+++ b/server/integration-files/visualizations/overview/overview-general.js
@@ -105,8 +105,9 @@ export default [
                               "index": "wazuh-alerts",
                               "type": "phrases",
                               "key": "rule.groups",
-                              "value": "authentication_failed, authentication_failures",
+                              "value": "win_authentication_failed, authentication_failed, authentication_failures",
                               "params": [
+                                "win_authentication_failed",
                                 "authentication_failed",
                                 "authentication_failures"
                               ],
@@ -117,6 +118,11 @@ export default [
                             "query": {
                               "bool": {
                                 "should": [
+                                  {
+                                    "match_phrase": {
+                                      "rule.groups": "win_authentication_failed"
+                                    }
+                                  },
                                   {
                                     "match_phrase": {
                                       "rule.groups": "authentication_failed"


### PR DESCRIPTION
Hi team,

This PR adds the rules group `win_authentication_failed` to the `Authentication failure` metric, both in Overview and Agents.

Regards.
