### PR TITLE
Backports for Wazuh 3.12.0 [7.6.1]

### DIFF
--- a/.kibana-plugin-helpers.json
+++ b/.kibana-plugin-helpers.json
@@ -3,7 +3,6 @@
       "package.json",
       "LICENSE",
       "tsconfig.json",
-      "wazuh.yml",
       "index.js",
         "init.js",
       "server/**/*",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ All notable changes to the Wazuh app project will be documented in this file.
 ### Added
 
 - Support for Wazuh v3.12.0
+- Added a new setting to hide manager alerts from dashboards. [#2102](https://github.com/wazuh/wazuh-kibana-app/pull/2102)
+- Added suport for PCI 11.2.1 and 11.2.3 rules. [#2062](https://github.com/wazuh/wazuh-kibana-app/pull/2062)
+
+### Changed
+
+- Restructuring of the optimize/wazuh directory. Now the Wazuh configuration file (wazuh.yml) is placed on /usr/share/kibana/optimize/wazuh/config. [#2116](https://github.com/wazuh/wazuh-kibana-app/pull/2116)
+- Improve performance of Dasboards reports generation. [1802344](https://github.com/wazuh/wazuh-kibana-app/commit/18023447c6279d385df84d7f4a5663ed2167fdb5)
+
+### Fixed
+
+- Dicover time range selector is now displayed on Cluster section. [08901df](https://github.com/wazuh/wazuh-kibana-app/commit/08901dfcbe509f17e4fab26877c8b7dae8a66bff)
+- Added the win_auth_failure rule group to Authentication failure metrics. [#2099](https://github.com/wazuh/wazuh-kibana-app/pull/2099)
+- Negative values in Syscheck attributes now have their correct value in reports. [7c3e84e](https://github.com/wazuh/wazuh-kibana-app/commit/7c3e84ec8f00760b4f650cfc00a885d868123f99)
 
 
 ## Wazuh v3.11.4 - Kibana v7.6.1 - Revision 858

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 
 - Support for Wazuh v3.12.0
 - Added a new setting to hide manager alerts from dashboards. [#2102](https://github.com/wazuh/wazuh-kibana-app/pull/2102)
+- Added a new setting to enable/disable the known fields health check [#2037](https://github.com/wazuh/wazuh-kibana-app/pull/2037)
 - Added suport for PCI 11.2.1 and 11.2.3 rules. [#2062](https://github.com/wazuh/wazuh-kibana-app/pull/2062)
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to the Wazuh app project will be documented in this file.
 
 
+## Wazuh v3.12.0 - Kibana v6.8.7, v7.4.2, v7.6.1 - Revision 870
+
+### Added
+
+- Support for Wazuh v3.12.0
+
+
 ## Wazuh v3.11.4 - Kibana v7.6.1 - Revision 858
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 
 ### Fixed
 
-- Dicover time range selector is now displayed on Cluster section. [08901df](https://github.com/wazuh/wazuh-kibana-app/commit/08901dfcbe509f17e4fab26877c8b7dae8a66bff)
+- Discover time range selector is now displayed on the Cluster section. [08901df](https://github.com/wazuh/wazuh-kibana-app/commit/08901dfcbe509f17e4fab26877c8b7dae8a66bff)
 - Added the win_auth_failure rule group to Authentication failure metrics. [#2099](https://github.com/wazuh/wazuh-kibana-app/pull/2099)
 - Negative values in Syscheck attributes now have their correct value in reports. [7c3e84e](https://github.com/wazuh/wazuh-kibana-app/commit/7c3e84ec8f00760b4f650cfc00a885d868123f99)
 

--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ Visualize and analyze Wazuh alerts stored in Elasticsearch using our Kibana app 
 
 ## Requisites
 
-- Wazuh HIDS 3.11.4
-- Wazuh RESTful API 3.11.4
+- Wazuh HIDS 3.12.0
+- Wazuh RESTful API 3.12.0
 - Kibana 7.6.1
 - Elasticsearch 7.6.1
 
@@ -40,8 +40,8 @@ Visualize and analyze Wazuh alerts stored in Elasticsearch using our Kibana app 
 Install the app
 
 ```
-cd /usr/share/kibana/
-sudo -u kibana bin/kibana-plugin install https://packages.wazuh.com/wazuhapp/wazuhapp-3.11.4_7.6.1.zip
+cd /usr/share/kibana
+sudo -u kibana bin/kibana-plugin install https://packages.wazuh.com/wazuhapp/wazuhapp-3.12.0_7.6.1.zip
 ```
 
 Restart Kibana
@@ -60,7 +60,7 @@ service kibana restart
 
 ## Upgrade
 
-Note: For updates from Wazuh 3.11.x to 3.11.y (regardless of the version of the Elastic Stack) it is recommended to make a backup of the Wazuh app configuration file in order not to lose the modified parameters or the configured APIs.
+Note: In Wazuh 3.12.0 (regardless of the Elastic Stack version) the location of the wazuh.yml has been moved from `/usr/share/kibana/plugins/wazuh/wazuh.yml` to `/usr/share/kibana/optimize/wazuh/config/wazuh.yml`.
 
 Stop Kibana
 
@@ -76,17 +76,18 @@ systemctl stop kibana
 service kibana stop
 ```
 
-Make a backup of the configuration file.
+Copy the wazuh.yml to its new location. (Only needed for upgrades from 3.11.x to 3.12.y)
 
 ```
-cp /usr/share/kibana/plugins/wazuh/wazuh.yml /tmp/wazuh-backup.yml
+mkdir -p /usr/share/kibana/optimize/wazuh/config
+cp /usr/share/kibana/plugins/wazuh/wazuh.yml /usr/share/kibana/optimize/wazuh/config/wazuh.yml
 ```
 
 Remove the app using kibana-plugin tool
 
 ```
 cd /usr/share/kibana/
-bin/kibana-plugin remove wazuh
+sudo -u kibana bin/kibana-plugin remove wazuh
 ```
 
 Remove generated bundles
@@ -106,20 +107,14 @@ Install the app
 
 ```
 cd /usr/share/kibana/
-sudo -u kibana bin/kibana-plugin install https://packages.wazuh.com/wazuhapp/wazuhapp-3.11.4_7.6.1.zip
-```
-
-Restore the configuration file backup.
-
-```
-sudo cp /tmp/wazuh-backup.yml /usr/share/kibana/plugins/wazuh/wazuh.yml
+sudo -u kibana bin/kibana-plugin install https://packages.wazuh.com/wazuhapp/wazuhapp-3.12.0_7.6.1.zip
 ```
 
 Update configuration file permissions.
 
 ```
-sudo chown kibana:kibana /usr/share/kibana/plugins/wazuh/wazuh.yml
-sudo chmod 600 /usr/share/kibana/plugins/wazuh/wazuh.yml
+sudo chown kibana:kibana /usr/share/kibana/optimize/wazuh/config/wazuh.yml
+sudo chmod 600 /usr/share/kibana/optimize/wazuh/config/wazuh.yml
 ```
 
 Restart Kibana
@@ -134,118 +129,123 @@ systemctl restart kibana
  
 ``` 
 service kibana restart 
-``` 
+```
+
  
-## Older packages 
+## Wazuh - Kibana compatibility matrix
  
-| Kibana version | Wazuh app version | Package                                                         |
-| :------------: | :---------------: | :-------------------------------------------------------------- |
-|      6.0.0     |       3.0.0       | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.0.0_6.0.0.zip>  |
-|      6.0.1     |       3.0.0       | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.0.0_6.0.1.zip>  |
-|      6.1.0     |       3.0.0       | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.0.0_6.1.0.zip>  |
-|      6.1.0     |       3.1.0       | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.1.0_6.1.0.zip>  |
-|      6.1.1     |       3.1.0       | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.1.0_6.1.1.zip>  |
-|      6.1.2     |       3.1.0       | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.1.0_6.1.2.zip>  |
-|      6.1.3     |       3.1.0       | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.1.0_6.1.3.zip>  |
-|      6.1.0     |       3.2.0       | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.2.0_6.1.0.zip>  |
-|      6.1.1     |       3.2.0       | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.2.0_6.1.1.zip>  |
-|      6.1.2     |       3.2.0       | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.2.0_6.1.2.zip>  |
-|      6.1.3     |       3.2.0       | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.2.0_6.1.3.zip>  |
-|      6.2.0     |       3.2.0       | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.2.0_6.2.0.zip>  |
-|      6.2.1     |       3.2.0       | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.2.0_6.2.1.zip>  |
-|      6.2.2     |       3.2.0       | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.2.0_6.2.2.zip>  |
-|      6.2.2     |       3.2.1       | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.2.1_6.2.2.zip>  |
-|      6.2.3     |       3.2.1       | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.2.1_6.2.3.zip>  |
-|      6.2.4     |       3.2.1       | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.2.1_6.2.4.zip>  |
-|      6.2.4     |       3.2.2       | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.2.2_6.2.4.zip>  |
-|      6.2.4     |       3.2.3       | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.2.3_6.2.4.zip>  |
-|      6.2.4     |       3.2.4       | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.2.4_6.2.4.zip>  |
-|      6.2.4     |       3.3.0       | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.3.0_6.2.4.zip>  |
-|      6.2.4     |       3.3.1       | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.3.1_6.2.4.zip>  |
-|      6.3.0     |       3.3.0       | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.3.0_6.3.0.zip>  |
-|      6.3.0     |       3.3.1       | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.3.1_6.3.0.zip>  |
-|      6.3.1     |       3.3.1       | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.3.1_6.3.1.zip>  |
-|      6.3.1     |       3.4.0       | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.4.0_6.3.1.zip>  |
-|      6.3.2     |       3.4.0       | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.4.0_6.3.2.zip>  |
-|      6.3.2     |       3.5.0       | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.5.0_6.3.2.zip>  |
-|      6.4.0     |       3.5.0       | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.5.0_6.4.0.zip>  |
-|      6.3.2     |       3.6.0       | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.6.0_6.3.2.zip>  |
-|      6.4.0     |       3.6.0       | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.6.0_6.4.0.zip>  |
-|      6.3.2     |       3.6.1       | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.6.1_6.3.2.zip>  |
-|      6.4.0     |       3.6.1       | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.6.1_6.4.0.zip>  |
-|      6.4.1     |       3.6.1       | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.6.1_6.4.1.zip>  |
-|      6.4.2     |       3.6.1       | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.6.1_6.4.2.zip>  |
-|      6.4.3     |       3.6.1       | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.6.1_6.4.3.zip>  |
-|      6.4.2     |       3.7.0       | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.7.0_6.4.2.zip>  |
-|      6.4.3     |       3.7.0       | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.7.0_6.4.3.zip>  |
-|      6.5.0     |       3.7.0       | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.7.0_6.5.0.zip>  |
-|      6.5.1     |       3.7.0       | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.7.0_6.5.1.zip>  |
-|      6.5.1     |       3.7.1       | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.7.1_6.5.1.zip>  |
-|      6.5.2     |       3.7.1       | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.7.1_6.5.2.zip>  |
-|      6.5.3     |       3.7.1       | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.7.1_6.5.3.zip>  |
-|      6.5.3     |       3.7.2       | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.7.2_6.5.3.zip>  |
-|      6.5.4     |       3.7.2       | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.7.2_6.5.4.zip>  |
-|      6.5.4     |       3.8.0       | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.8.0_6.5.4.zip>  |
-|      6.5.4     |       3.8.1       | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.8.1_6.5.4.zip>  |
-|      6.5.4     |       3.8.2       | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.8.2_6.5.4.zip>  |
-|      6.6.0     |       3.8.2       | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.8.2_6.6.0.zip>  |
-|      6.6.1     |       3.8.2       | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.8.2_6.6.1.zip>  |
-|      6.6.2     |       3.8.2       | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.8.2_6.6.2.zip>  |
-|      6.7.0     |       3.8.2       | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.8.2_6.7.0.zip>  |
-|      6.7.1     |       3.8.2       | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.8.2_6.7.1.zip>  |
-|      6.7.1     |       3.9.0       | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.9.0_6.7.1.zip>  |
-|      6.7.2     |       3.9.0       | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.9.0_6.7.2.zip>  |
-|      6.8.0     |       3.9.1       | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.9.1_6.8.0.zip>  |
-|      7.1.0     |       3.9.1       | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.9.1_7.1.0.zip>  |
-|      7.1.1     |       3.9.1       | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.9.1_7.1.1.zip>  |
-|      7.1.1     |       3.9.2       | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.9.2_7.1.1.zip>  |
-|      6.8.1     |       3.9.3       | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.9.3_6.8.1.zip>  |
-|      7.0.1     |       3.9.3       | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.9.3_7.0.1.zip>  |
-|      7.1.1     |       3.9.3       | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.9.3_7.1.1.zip>  |
-|      7.2.0     |       3.9.3       | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.9.3_7.2.0.zip>  |
-|      6.8.1     |       3.9.4       | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.9.4_6.8.1.zip>  |
-|      6.8.2     |       3.9.4       | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.9.4_6.8.2.zip>  |
-|      7.2.0     |       3.9.4       | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.9.4_7.2.0.zip>  |
-|      7.2.1     |       3.9.4       | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.9.4_7.2.1.zip>  |
-|      7.3.0     |       3.9.4       | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.9.4_7.3.0.zip>  |
-|      6.8.2     |       3.9.5       | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.9.5_6.8.2.zip>  |
-|      7.2.1     |       3.9.5       | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.9.5_7.2.1.zip>  |
-|      7.3.0     |       3.9.5       | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.9.5_7.3.0.zip>  |
-|      6.8.2     |       3.10.0      | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.10.0_6.8.2.zip> |
-|      7.3.1     |       3.10.0      | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.10.0_7.3.1.zip> |
-|      7.3.2     |       3.10.0      | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.10.0_7.3.2.zip> |
-|      6.8.2     |       3.10.1      | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.10.1_6.8.2.zip> |
-|      7.3.1     |       3.10.1      | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.10.1_7.3.1.zip> |
-|      7.3.2     |       3.10.1      | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.10.1_7.3.2.zip> |
-|      6.8.3     |       3.10.2      | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.10.2_6.8.3.zip> |
-|      6.8.4     |       3.10.2      | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.10.2_6.8.4.zip> |
-|      6.8.5     |       3.10.2      | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.10.2_6.8.5.zip> |
-|      6.8.6     |       3.10.2      | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.10.2_6.8.6.zip> |
-|      7.3.2     |       3.10.2      | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.10.2_7.3.2.zip> |
-|      7.4.0     |       3.10.2      | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.10.2_7.4.0.zip> |
-|      7.4.1     |       3.10.2      | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.10.2_7.4.1.zip> |
-|      7.4.2     |       3.10.2      | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.10.2_7.4.2.zip> |
-|      7.5.0     |       3.10.2      | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.10.2_7.5.0.zip> |
-|      7.5.1     |       3.10.2      | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.10.2_7.5.1.zip> |
-|      6.8.6     |       3.11.0      | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.11.0_6.8.6.zip> |
-|      7.3.2     |       3.11.0      | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.11.0_7.3.2.zip> |
-|      7.5.1     |       3.11.0      | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.11.0_7.5.1.zip> |
-|      6.8.6     |       3.11.1      | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.11.1_6.8.6.zip> |
-|      7.3.2     |       3.11.1      | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.11.1_7.3.2.zip> |
-|      7.5.1     |       3.11.1      | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.11.1_7.5.1.zip> |
-|      6.8.6     |       3.11.2      | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.11.2_6.8.6.zip> |
-|      7.3.2     |       3.11.2      | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.11.2_7.3.2.zip> |
-|      7.5.1     |       3.11.2      | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.11.2_7.5.1.zip> |
-|      7.5.2     |       3.11.2      | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.11.2_7.5.2.zip> |
-|      6.8.6     |       3.11.3      | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.11.3_6.8.6.zip> |
-|      7.3.2     |       3.11.3      | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.11.3_7.3.2.zip> |
-|      7.4.2     |       3.11.3      | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.11.3_7.4.2.zip> |
-|      7.5.2     |       3.11.3      | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.11.3_7.5.2.zip> |
-|      7.6.0     |       3.11.3      | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.11.3_7.6.0.zip> |
-|      6.8.6     |       3.11.4      | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.11.4_6.8.6.zip> |
-|      7.4.2     |       3.11.4      | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.11.4_7.4.2.zip> |
-|      7.6.0     |       3.11.4      | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.11.4_7.6.0.zip> |
-|      7.6.1     |       3.11.4      | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.11.4_7.6.1.zip> |
+| Wazuh app version | Kibana version | Package                                                         |
+| :---------------: | :------------: | :-------------------------------------------------------------- |
+|       3.12.0      |      7.6.1     | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.12.0_7.6.1.zip> |
+|       3.12.0      |      7.4.2     | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.12.0_7.4.2.zip> |
+|       3.12.0      |      6.8.7     | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.12.0_6.8.7.zip> |
+|       3.11.4      |      7.6.1     | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.11.4_7.6.1.zip> |
+|       3.11.4      |      7.6.0     | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.11.4_7.6.0.zip> |
+|       3.11.4      |      7.4.2     | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.11.4_7.4.2.zip> |
+|       3.11.4      |      6.8.7     | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.11.4_6.8.7.zip> |
+|       3.11.4      |      6.8.6     | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.11.4_6.8.6.zip> |
+|       3.11.3      |      7.6.0     | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.11.3_7.6.0.zip> |
+|       3.11.3      |      7.5.2     | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.11.3_7.5.2.zip> |
+|       3.11.3      |      7.4.2     | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.11.3_7.4.2.zip> |
+|       3.11.3      |      7.3.2     | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.11.3_7.3.2.zip> |
+|       3.11.3      |      6.8.6     | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.11.3_6.8.6.zip> |
+|       3.11.2      |      7.5.2     | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.11.2_7.5.2.zip> |
+|       3.11.2      |      7.5.1     | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.11.2_7.5.1.zip> |
+|       3.11.2      |      7.3.2     | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.11.2_7.3.2.zip> |
+|       3.11.2      |      6.8.6     | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.11.2_6.8.6.zip> |
+|       3.11.1      |      7.5.1     | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.11.1_7.5.1.zip> |
+|       3.11.1      |      7.3.2     | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.11.1_7.3.2.zip> |
+|       3.11.1      |      6.8.6     | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.11.1_6.8.6.zip> |
+|       3.11.0      |      7.5.1     | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.11.0_7.5.1.zip> |
+|       3.11.0      |      7.3.2     | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.11.0_7.3.2.zip> |
+|       3.11.0      |      6.8.6     | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.11.0_6.8.6.zip> |
+|       3.10.2      |      7.5.1     | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.10.2_7.5.1.zip> |
+|       3.10.2      |      7.5.0     | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.10.2_7.5.0.zip> |
+|       3.10.2      |      7.4.2     | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.10.2_7.4.2.zip> |
+|       3.10.2      |      7.4.1     | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.10.2_7.4.1.zip> |
+|       3.10.2      |      7.4.0     | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.10.2_7.4.0.zip> |
+|       3.10.2      |      7.3.2     | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.10.2_7.3.2.zip> |
+|       3.10.2      |      6.8.6     | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.10.2_6.8.6.zip> |
+|       3.10.2      |      6.8.5     | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.10.2_6.8.5.zip> |
+|       3.10.2      |      6.8.4     | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.10.2_6.8.4.zip> |
+|       3.10.2      |      6.8.3     | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.10.2_6.8.3.zip> |
+|       3.10.1      |      7.3.2     | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.10.1_7.3.2.zip> |
+|       3.10.1      |      7.3.1     | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.10.1_7.3.1.zip> |
+|       3.10.1      |      6.8.2     | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.10.1_6.8.2.zip> |
+|       3.10.0      |      7.3.2     | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.10.0_7.3.2.zip> |
+|       3.10.0      |      7.3.1     | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.10.0_7.3.1.zip> |
+|       3.10.0      |      6.8.2     | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.10.0_6.8.2.zip> |
+|       3.9.5       |      7.3.0     | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.9.5_7.3.0.zip>  |
+|       3.9.5       |      7.2.1     | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.9.5_7.2.1.zip>  |
+|       3.9.5       |      6.8.2     | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.9.5_6.8.2.zip>  |
+|       3.9.4       |      7.3.0     | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.9.4_7.3.0.zip>  |
+|       3.9.4       |      7.2.1     | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.9.4_7.2.1.zip>  |
+|       3.9.4       |      7.2.0     | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.9.4_7.2.0.zip>  |
+|       3.9.4       |      6.8.2     | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.9.4_6.8.2.zip>  |
+|       3.9.4       |      6.8.1     | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.9.4_6.8.1.zip>  |
+|       3.9.3       |      7.2.0     | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.9.3_7.2.0.zip>  |
+|       3.9.3       |      7.1.1     | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.9.3_7.1.1.zip>  |
+|       3.9.3       |      7.0.1     | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.9.3_7.0.1.zip>  |
+|       3.9.3       |      6.8.1     | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.9.3_6.8.1.zip>  |
+|       3.9.2       |      7.1.1     | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.9.2_7.1.1.zip>  |
+|       3.9.1       |      7.1.1     | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.9.1_7.1.1.zip>  |
+|       3.9.1       |      7.1.0     | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.9.1_7.1.0.zip>  |
+|       3.9.1       |      6.8.0     | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.9.1_6.8.0.zip>  |
+|       3.9.0       |      6.7.2     | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.9.0_6.7.2.zip>  |
+|       3.9.0       |      6.7.1     | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.9.0_6.7.1.zip>  |
+|       3.8.2       |      6.7.1     | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.8.2_6.7.1.zip>  |
+|       3.8.2       |      6.7.0     | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.8.2_6.7.0.zip>  |
+|       3.8.2       |      6.6.2     | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.8.2_6.6.2.zip>  |
+|       3.8.2       |      6.6.1     | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.8.2_6.6.1.zip>  |
+|       3.8.2       |      6.6.0     | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.8.2_6.6.0.zip>  |
+|       3.8.2       |      6.5.4     | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.8.2_6.5.4.zip>  |
+|       3.8.1       |      6.5.4     | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.8.1_6.5.4.zip>  |
+|       3.8.0       |      6.5.4     | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.8.0_6.5.4.zip>  |
+|       3.7.2       |      6.5.4     | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.7.2_6.5.4.zip>  |
+|       3.7.2       |      6.5.3     | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.7.2_6.5.3.zip>  |
+|       3.7.1       |      6.5.3     | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.7.1_6.5.3.zip>  |
+|       3.7.1       |      6.5.2     | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.7.1_6.5.2.zip>  |
+|       3.7.1       |      6.5.1     | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.7.1_6.5.1.zip>  |
+|       3.7.0       |      6.5.1     | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.7.0_6.5.1.zip>  |
+|       3.7.0       |      6.5.0     | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.7.0_6.5.0.zip>  |
+|       3.7.0       |      6.4.3     | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.7.0_6.4.3.zip>  |
+|       3.7.0       |      6.4.2     | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.7.0_6.4.2.zip>  |
+|       3.6.1       |      6.4.3     | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.6.1_6.4.3.zip>  |
+|       3.6.1       |      6.4.2     | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.6.1_6.4.2.zip>  |
+|       3.6.1       |      6.4.1     | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.6.1_6.4.1.zip>  |
+|       3.6.1       |      6.4.0     | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.6.1_6.4.0.zip>  |
+|       3.6.1       |      6.3.2     | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.6.1_6.3.2.zip>  |
+|       3.6.0       |      6.4.0     | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.6.0_6.4.0.zip>  |
+|       3.6.0       |      6.3.2     | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.6.0_6.3.2.zip>  |
+|       3.5.0       |      6.4.0     | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.5.0_6.4.0.zip>  |
+|       3.5.0       |      6.3.2     | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.5.0_6.3.2.zip>  |
+|       3.4.0       |      6.3.2     | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.4.0_6.3.2.zip>  |
+|       3.4.0       |      6.3.1     | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.4.0_6.3.1.zip>  |
+|       3.3.1       |      6.3.1     | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.3.1_6.3.1.zip>  |
+|       3.3.1       |      6.3.0     | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.3.1_6.3.0.zip>  |
+|       3.3.0       |      6.3.0     | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.3.0_6.3.0.zip>  |
+|       3.3.1       |      6.2.4     | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.3.1_6.2.4.zip>  |
+|       3.3.0       |      6.2.4     | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.3.0_6.2.4.zip>  |
+|       3.2.4       |      6.2.4     | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.2.4_6.2.4.zip>  |
+|       3.2.3       |      6.2.4     | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.2.3_6.2.4.zip>  |
+|       3.2.2       |      6.2.4     | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.2.2_6.2.4.zip>  |
+|       3.2.1       |      6.2.4     | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.2.1_6.2.4.zip>  |
+|       3.2.1       |      6.2.3     | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.2.1_6.2.3.zip>  |
+|       3.2.1       |      6.2.2     | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.2.1_6.2.2.zip>  |
+|       3.2.0       |      6.2.2     | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.2.0_6.2.2.zip>  |
+|       3.2.0       |      6.2.1     | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.2.0_6.2.1.zip>  |
+|       3.2.0       |      6.2.0     | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.2.0_6.2.0.zip>  |
+|       3.2.0       |      6.1.3     | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.2.0_6.1.3.zip>  |
+|       3.2.0       |      6.1.2     | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.2.0_6.1.2.zip>  |
+|       3.2.0       |      6.1.1     | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.2.0_6.1.1.zip>  |
+|       3.2.0       |      6.1.0     | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.2.0_6.1.0.zip>  |
+|       3.1.0       |      6.1.3     | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.1.0_6.1.3.zip>  |
+|       3.1.0       |      6.1.2     | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.1.0_6.1.2.zip>  |
+|       3.1.0       |      6.1.1     | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.1.0_6.1.1.zip>  |
+|       3.1.0       |      6.1.0     | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.1.0_6.1.0.zip>  |
+|       3.0.0       |      6.1.0     | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.0.0_6.1.0.zip>  |
+|       3.0.0       |      6.0.1     | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.0.0_6.0.1.zip>  |
+|       3.0.0       |      6.0.0     | <https://packages.wazuh.com/wazuhapp/wazuhapp-3.0.0_6.0.0.zip>  |
 
 
 ## Contribute

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wazuh",
-  "version": "3.11.4",
+  "version": "3.12.0",
   "revision": "0870",
   "code": "0870-0",
   "kibana": {

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "wazuh",
   "version": "3.11.4",
-  "revision": "0858",
-  "code": "0858-0",
+  "revision": "0870",
+  "code": "0870-0",
   "kibana": {
     "version": "7.6.1"
   },
@@ -42,10 +42,11 @@
   "dependencies": {
     "angular-animate": "1.7.8",
     "angular-chart.js": "1.1.1",
+    "d3": "^5.12.0",
     "angular-cookies": "1.6.5",
     "angular-material": "1.1.18",
+    "axios": "^0.19.0",
     "babel-polyfill": "^6.13.0",
-    "dom-to-image": "^2.6.0",
     "install": "^0.10.1",
     "js2xmlparser": "^3.0.0",
     "json2csv": "^4.1.2",
@@ -54,6 +55,9 @@
     "pdfmake": "^0.1.37",
     "pug-loader": "^2.4.0",
     "querystring-browser": "1.0.4",
+    "react-redux": "^7.1.1",
+    "react-codemirror": "^1.0.0",
+    "redux": "^4.0.4",
     "simple-tail": "^1.1.0",
     "timsort": "^0.3.0",
     "winston": "3.0.0"

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "d3": "^5.12.0",
     "angular-cookies": "1.6.5",
     "angular-material": "1.1.18",
-    "axios": "^0.19.0",
     "babel-polyfill": "^6.13.0",
     "install": "^0.10.1",
     "js2xmlparser": "^3.0.0",
@@ -55,9 +54,6 @@
     "pdfmake": "^0.1.37",
     "pug-loader": "^2.4.0",
     "querystring-browser": "1.0.4",
-    "react-redux": "^7.1.1",
-    "react-codemirror": "^1.0.0",
-    "redux": "^4.0.4",
     "simple-tail": "^1.1.0",
     "timsort": "^0.3.0",
     "winston": "3.0.0"

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
   "dependencies": {
     "angular-animate": "1.7.8",
     "angular-chart.js": "1.1.1",
-    "d3": "^5.12.0",
     "angular-cookies": "1.6.5",
     "angular-material": "1.1.18",
     "babel-polyfill": "^6.13.0",

--- a/public/app.js
+++ b/public/app.js
@@ -29,7 +29,8 @@ import 'angular-sanitize';
 
 // Require CSS
 import './less/loader';
-import chrome from 'ui/chrome';
+// Require lib to dashboards PDFs
+require ('./utils/dom-to-image.js');
 
 // EUI React components wrapper
 import './components';
@@ -58,6 +59,7 @@ import 'angular-material/angular-material';
 import 'angular-cookies/angular-cookies';
 
 import 'ui/autoload/all';
+import chrome from 'ui/chrome';
 
 // Set up Wazuh app
 import './setup';

--- a/public/controllers/misc/health-check.js
+++ b/public/controllers/misc/health-check.js
@@ -224,6 +224,7 @@ export class HealthCheck {
       this.checks.template = configuration['checks.template'];
       this.checks.api = configuration['checks.api'];
       this.checks.setup = configuration['checks.setup'];
+      this.checks.fields = configuration['checks.fields'];
 
       this.results.push(
         {
@@ -249,7 +250,7 @@ export class HealthCheck {
         {
           id: 4,
           description: 'Check index pattern known fields',
-          status: 'Checking...'
+          status: this.checks.fields ? 'Checking...' : 'disabled'
         }
       );
 
@@ -261,12 +262,14 @@ export class HealthCheck {
 
       this.checksDone = true;
 
-      try {
-        await this.genericReq.request('GET', '/elastic/known-fields/all', {});
-        this.results[this.results.length - 1].status = 'Ready';
-      } catch (error) {
-        this.results[this.results.length - 1].status = 'Error';
-        this.handleError(error);
+      if(this.checks.fields){
+        try {
+          await this.genericReq.request('GET', '/elastic/known-fields/all', {});
+          this.results[this.results.length - 1].status = 'Ready';
+        } catch (error) {
+          this.results[this.results.length - 1].status = 'Error';
+          this.handleError(error);
+        }
       }
 
       if (!this.errors || !this.errors.length) {

--- a/public/controllers/settings/components/add-api.js
+++ b/public/controllers/settings/components/add-api.js
@@ -137,7 +137,7 @@ export class AddApi extends Component {
     const editConfigChildren = (
       <div>
         <EuiText>
-          Modify <EuiCode>kibana/plugins/wazuh/wazuh.yml</EuiCode> to set the
+          Modify <EuiCode>/usr/share/kibana/optimize/wazuh/config/wazuh.yml</EuiCode> to set the
           connection information.
         </EuiText>
         <EuiSpacer />

--- a/public/controllers/settings/components/api-is-down.js
+++ b/public/controllers/settings/components/api-is-down.js
@@ -223,7 +223,7 @@ hosts:
           <div>
             <EuiText>
               Review the settings in the{' '}
-              <EuiCode>kibana/plugins/wazuh/wazuh.yml</EuiCode> file.
+              <EuiCode>/usr/share/kibana/optimize/wazuh/config/wazuh.yml</EuiCode> file.
             </EuiText>
             <EuiSpacer />
             <EuiCodeBlock language="yaml">{apiExample}</EuiCodeBlock>

--- a/public/controllers/settings/components/api-is-down.js
+++ b/public/controllers/settings/components/api-is-down.js
@@ -107,7 +107,7 @@ export class ApiIsDown extends Component {
     const apiExample = `# Example Wazuh API configuration
 hosts:
     - production:
-        url: http://172.16.1.2
+        url: https://172.16.1.2
         port: 55000
         user: foo
         password: bar

--- a/public/factories/vis2png.js
+++ b/public/factories/vis2png.js
@@ -10,7 +10,7 @@
  * Find more information about this on the LICENSE file.
  */
 
-import domtoimage from 'dom-to-image';
+import domtoimage from '../utils/dom-to-image';
 
 export class Vis2PNG {
   /**
@@ -38,13 +38,14 @@ export class Vis2PNG {
           const tmpNode = this.htmlObject[currentValue];
           try {
             const tmpResult = await domtoimage.toPng(tmpNode[0]);
+            if (tmpResult === 'data:,') return;
             this.rawArray.push({
               element: tmpResult,
               width: tmpNode.width(),
               height: tmpNode.height(),
               id: currentValue
             });
-          } catch (error) {} // eslint-disable-line
+          } catch (error) { } // eslint-disable-line
           currentCompleted++;
           this.$rootScope.reportStatus = `Generating report...${Math.round(
             (currentCompleted / len) * 100

--- a/public/kibana-integrations/kibana-discover.js
+++ b/public/kibana-integrations/kibana-discover.js
@@ -72,7 +72,6 @@ import { FilterStateManager } from 'plugins/data';
 import { buildServices } from 'plugins/kibana/discover/build_services';
 import { npStart } from 'ui/new_platform';
 import { pluginInstance } from 'plugins/kibana/discover/index';
-import { WazuhConfig } from '../factories/wazuh-config';
 
 const fetchStatuses = {
   UNINITIALIZED: 'uninitialized',
@@ -116,7 +115,8 @@ function discoverController(
   $rootScope,
   $location,
   loadedVisualizations,
-  discoverPendingUpdates
+  discoverPendingUpdates,
+  wazuhConfig
 ) {
   //WAZUH
   (async () => {
@@ -130,7 +130,6 @@ function discoverController(
     timefilter,
     toastNotifications,
   } = getServices();
-  const wazuhConfig = new WazuhConfig();
   //////
   const responseHandler = vislibSeriesResponseHandlerProvider().handler;
   const filterStateManager = new FilterStateManager(globalState, getAppState, filterManager);

--- a/public/less/common.less
+++ b/public/less/common.less
@@ -1082,8 +1082,8 @@ md-toolbar.md-default-theme:not(.md-menu-toolbar), md-toolbar:not(.md-menu-toolb
   text-align: right;
 }
 
-.monitoring-discover form{
-  display: none;
+.monitoring-discover{
+  margin-bottom: 25px;
 }
 
 .euiBadge, .euiBadge__childButton{

--- a/public/services/resolves/get-config.js
+++ b/public/services/resolves/get-config.js
@@ -18,6 +18,7 @@ export async function getWzConfig($q, genericReq, wazuhConfig) {
     'checks.template': true,
     'checks.api': true,
     'checks.setup': true,
+    'checks.fields': true,
     'extensions.pci': true,
     'extensions.gdpr': true,
     'extensions.hipaa': true,

--- a/public/services/resolves/get-config.js
+++ b/public/services/resolves/get-config.js
@@ -42,6 +42,7 @@ export async function getWzConfig($q, genericReq, wazuhConfig) {
     'wazuh.monitoring.creation': 'd',
     'wazuh.monitoring.pattern': 'wazuh-monitoring-3.x-*',
     admin: true,
+    'hideManagerAlerts': false,
     'logs.level': 'info'
   };
 

--- a/public/services/routes.js
+++ b/public/services/routes.js
@@ -127,10 +127,12 @@ function wzConfig($q, genericReq, wazuhConfig, $rootScope, $location) {
 
 function wzKibana($location, $window, $rootScope) {
   assignPreviousLocation($rootScope, $location);
-  // Sets ?_a=(columns:!(_source),filters:!())
-  $location.search('_a', '(columns:!(_source),filters:!())');
-  // Removes ?_g
-  $location.search('_g', null);
+  if ($location.$$path !== "/visualize/create") {
+    // Sets ?_a=(columns:!(_source),filters:!())
+    $location.search('_a', '(columns:!(_source),filters:!())');
+    // Removes ?_g
+    $location.search('_g', null);
+  }
   return goToKibana($location, $window);
 }
 
@@ -172,20 +174,20 @@ routes
     resolve: { enableWzMenu, nestedResolve, ip, savedSearch }
   })
   .when('/visualize/create?', {
-    redirectTo: function() {},
+    redirectTo: function () { },
     resolve: { wzConfig, wzKibana }
   })
   .when('/discover/context/:pattern?/:type?/:id?', {
-    redirectTo: function() {},
+    redirectTo: function () { },
     resolve: { wzKibana }
   })
   .when('/discover/doc/:pattern?/:index?/:type?/:id?', {
-    redirectTo: function() {},
+    redirectTo: function () { },
     resolve: { wzKibana }
   })
   .when('/wazuh-dev', {
     template: devToolsTemplate,
-    resolve: { enableWzMenu, nestedResolve }
+    resolve: { enableWzMenu, nestedResolve, ip, savedSearch }
   })
   .when('/blank-screen', {
     template: blankScreenTemplate,
@@ -200,3 +202,4 @@ routes
   .otherwise({
     redirectTo: '/overview'
   });
+  

--- a/public/templates/discover/discover.html
+++ b/public/templates/discover/discover.html
@@ -5,7 +5,10 @@
     <wz-top-nav
       app-name="'discover'"
       config="topNavMenu"
-      show-search-bar="tabView !== 'cluster-monitoring'"
+      show-search-bar="tabView"
+      show-filter-bar="tabView !== 'cluster-monitoring'"
+      show-query-input="tabView !== 'cluster-monitoring'"
+      show-save-query="tabView !== 'cluster-monitoring'"
       show-date-picker="enableTimeRangeSelector"
       show-save-query="showSaveQuery"
       query="state.query"

--- a/public/templates/management/monitoring/configuration.html
+++ b/public/templates/management/monitoring/configuration.html
@@ -2,8 +2,7 @@
 <div layout="row" layout-align="start stretch" class="wz-timelions wz-margin-top-0" ng-show="showConfig">
 
     <!-- Overview visualization card -->
-    <md-card class="wz-md-card"
-        ng-class="{'no-opacity-overview-monitoring': resultState === 'none' || !rendered,'flex-30': resultState === 'ready' && rendered}">
+    <md-card class="wz-md-card" style="height: 400px; width: 400px">
         <md-card-content class="wazuh-column">
             <span class="wz-headline-title">Top 5 nodes</span>
             <md-divider class="wz-margin-top-10"></md-divider>

--- a/public/templates/management/monitoring/monitoring.html
+++ b/public/templates/management/monitoring/monitoring.html
@@ -1,46 +1,24 @@
-<div layout="column" ng-controller="clusterController" ng-if="mctrl.tab === 'monitoring'">
-    <div flex layout="column" ng-show="!isClusterEnabled || !isClusterRunning">
+<div style="padding:16px" ng-controller="clusterController" ng-if="mctrl.tab === 'monitoring'">
 
-        <!-- Cluster disabled breadcrumbs -->
-        <div layout="row" layout-align="start center">
-            <div layout="row" layout-padding>
-                <div>
-                    <span class="wz-text-link cursor-pointer" ng-click="mctrl.switchTab('welcome')">Management</span>
-                    <span> / </span>
-                    <span>{{ mctrl.tabNames[tab] }}</span>
+    <!-- Cluster disabled or not running -->
+    <div ng-show="!isClusterEnabled || !isClusterRunning"
+        class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--responsive">
+        <div ng-if="!isClusterEnabled" class="euiFlexItem euiTextAlign euiTextAlign--center">
+            <div class="euiPanel euiPanel--paddingMedium">
+                <i class="fa fa-fw fa-info-circle" aria-hidden="true"></i> <span class="wz-headline-title">Cluster
+                    disabled</span>
+                <div class="euiSpacer euiSpacer--m"></div>
+                <div layout="column" class="wz-padding-top-10">
+                    <p>The cluster is disabled. Visit the documentation on <a target="_blank"
+                            href="https://documentation.wazuh.com/current/user-manual/configuring-cluster/index.html">this
+                            link</a> to learn about how to enable it.
+                    </p>
                 </div>
             </div>
         </div>
-        <!-- End cluster disabled breadcrumbs -->
-
-        <!-- Status and reports navigation bar -->
-        <div ng-show="mctrl.tab !== 'welcome'" class="md-padding-h">
-            <react-component name="Tabs" props="mctrl.managementTabsProps" />
-        </div>
-        <!-- End status and reports navigation bar -->
-
-        <!-- Cluster disabled section -->
-        <div flex layout="row" layout-align="start start" ng-if="!isClusterEnabled">
-            <md-card flex class="wz-md-card" flex>
-                <md-card-content class="wz-text-center">
-                    <i class="fa fa-fw fa-info-circle" aria-hidden="true"></i> <span class="wz-headline-title">Cluster
-                        disabled</span>
-                    <md-divider class="wz-margin-top-10"></md-divider>
-                    <div layout="column" class="wz-padding-top-10">
-                        <p>The cluster is disabled. Visit the documentation on <a target="_blank"
-                                href="https://documentation.wazuh.com/current/user-manual/configuring-cluster/index.html">this
-                                link</a> to learn about how to enable it.
-                        </p>
-                    </div>
-                </md-card-content>
-            </md-card>
-        </div>
-        <!-- End cluster disabled section -->
-
-        <!-- Cluster not running section -->
-        <div flex layout="row" layout-align="start start" ng-if="!isClusterRunning">
-            <md-card flex class="wz-md-card" flex>
-                <md-card-content class="wz-text-center">
+        <div ng-if="!isClusterRunning">
+            <div class="euiFlexItem euiTextAlign euiTextAlign--center">
+                <div class="euiPanel euiPanel--paddingMedium">
                     <i class="fa fa-fw fa-info-circle" aria-hidden="true"></i> <span class="wz-headline-title">Cluster
                         not running</span>
                     <md-divider class="wz-margin-top-10"></md-divider>
@@ -49,14 +27,13 @@
                             The cluster is enabled but it's not running.
                         </p>
                     </div>
-                </md-card-content>
-            </md-card>
+                </div>
+            </div>
         </div>
-        <!-- End cluster not running section -->
     </div>
 
-    <div flex="auto" layout="column" ng-show="isClusterEnabled && isClusterRunning">
-
+    <!-- Cluster enabled -->
+    <div ng-show="isClusterEnabled && isClusterRunning" class="monitoring-discover">
         <div class="md-padding md-padding-top-16" ng-show="loading">
             <react-component name="EuiProgress" props="{size: 'xs', color: 'primary'}" />
         </div>
@@ -104,20 +81,29 @@
         <!-- End navigation section -->
 
         <!-- Status and reports navigation bar -->
-        <div ng-if="!loading"  ng-show="mctrl.tab !== 'welcome'" class="md-padding-h">
+        <div ng-if="!loading" ng-show="mctrl.tab !== 'welcome'" class="md-padding-h">
             <react-component name="Tabs" props="mctrl.managementTabsProps" />
         </div>
         <!-- End status and reports navigation bar -->
 
         <!-- Discover search bar section -->
-        <kbn-dis ng-show="!loading && (!showNodes || currentNode)" class="wz-margin-top-10 monitoring-discover"></kbn-dis>
+        <kbn-dis class="monitoring-discover" ng-show="!loading && (!showNodes || currentNode)"></kbn-dis>
         <!-- End Discover search bar section -->
 
         <!-- Loading status section -->
-        <div layout="column" layout-align="center center" class="wz-margin-bottom-40"
-            ng-show="!loading && !rendered && resultState === 'ready' && (!showNodes || (showNodes && currentNode))">
-            <div class="percentage"><i class="fa fa-fw fa-spin fa-spinner" aria-hidden="true"></i></div>
-            <div class="percentage">{{loadingStatus}}</div>
+        <div
+            class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--justifyContentSpaceAround euiFlexGroup--directionRow euiFlexGroup--responsive">
+            <div class="euiFlexItem euiFlexItem--flexGrowZero euiTextAlign euiTextAlign--center"
+                ng-show="!loading && !rendered && resultState === 'ready' && (!showNodes || (showNodes && currentNode))">
+                <span class="euiLoadingChart euiLoadingChart--large">
+                    <span class="euiLoadingChart__bar"></span>
+                    <span class="euiLoadingChart__bar"></span>
+                    <span class="euiLoadingChart__bar"></span>
+                    <span class="euiLoadingChart__bar"></span>
+                </span>
+                <div class="euiSpacer euiSpacer--m"></div>
+                <div class="percentage">{{loadingStatus}}</div>
+            </div>
         </div>
         <!-- End loading status section -->
     </div>

--- a/public/templates/management/monitoring/monitoring.html
+++ b/public/templates/management/monitoring/monitoring.html
@@ -1,4 +1,4 @@
-<div style="padding:16px" ng-controller="clusterController" ng-if="mctrl.tab === 'monitoring'">
+<div ng-controller="clusterController" ng-if="mctrl.tab === 'monitoring'">
 
     <!-- Cluster disabled or not running -->
     <div ng-show="!isClusterEnabled || !isClusterRunning"

--- a/public/templates/management/monitoring/monitoring.pug
+++ b/public/templates/management/monitoring/monitoring.pug
@@ -1,4 +1,4 @@
-include ./monitoring.head
+include ./monitoring.html
 include ./main.html
 include ./main-timelions.html
 include ./configuration.html

--- a/public/templates/management/monitoring/nodes-list.html
+++ b/public/templates/management/monitoring/nodes-list.html
@@ -1,6 +1,6 @@
 <div layout="column" ng-if="showNodes && !currentNode" class="wz-margin-top-10">
     <!-- Back button -->
-    <div layout="row" class="md-padding-h">
+    <div layout="row" class="md-padding">
         <md-button class="md-icon-button md-icon-button-back wz-padding-right-16 btn btn-info" aria-label="Back"
             tooltip="Go back" tooltip-placement="bottom" ng-click="goBack()"><i class="fa fa-fw fa-arrow-left"
                 aria-hidden="true"></i></md-button>

--- a/public/templates/settings/settings-configuration.html
+++ b/public/templates/settings/settings-configuration.html
@@ -6,7 +6,7 @@
             configuration settings
         </span>
         <span class="md-subheader">Configuration file located at <span
-                class="wz-text-monospace">/usr/share/kibana/plugins/wazuh/wazuh.yml</span></span>
+                class="wz-text-monospace">/usr/share/kibana/optimize/wazuh/config/wazuh.yml</span></span>
     </div>
     <!-- End headline -->
     <div layout="row" layout-align="start center" ng-if="!ctrl.load">

--- a/public/templates/settings/settings-logs.html
+++ b/public/templates/settings/settings-logs.html
@@ -5,7 +5,7 @@
             <react-component name="EuiIcon" props="{type:'visTable'}" /> Wazuh Kibana plugin log
             messages</span>
         <span class="md-subheader">Log file located at <span
-                class="wz-text-monospace">/usr/share/kibana/optimize/wazuh-logs/wazuhapp.log</span></span>
+                class="wz-text-monospace">/usr/share/kibana/optimize/wazuh/logs/wazuhapp.log</span></span>
     </div>
 
     <div ng-if="ctrl.loadingLogs" class="md-padding wz-margin-top-16">

--- a/public/utils/config-equivalences.js
+++ b/public/utils/config-equivalences.js
@@ -7,6 +7,8 @@ export const configEquivalences = {
   'checks.api': 'Enable or disable the API health check when opening the app.',
   'checks.setup':
     'Enable or disable the setup health check when opening the app.',
+  'checks.fields':
+    'Enable or disable the known fields health check when opening the app.',
   'extensions.pci': 'Enable or disable the PCI DSS tab on Overview and Agents.',
   'extensions.gdpr': 'Enable or disable the GDPR tab on Overview and Agents.',
   'extensions.audit': 'Enable or disable the Audit tab on Overview and Agents.',

--- a/public/utils/config-equivalences.js
+++ b/public/utils/config-equivalences.js
@@ -46,6 +46,8 @@ export const configEquivalences = {
     'Default index pattern to use on the app for Wazuh monitoring.',
   admin:
     'Enable or disable administrator requests to the Wazuh API when using the app.',
+  hideManagerAlerts:
+    'Hide the alerts of the manager in all dashboards and discover',
   'logs.level':
     'Set the app logging level, allowed values are info and debug. Default is info.'
 };

--- a/public/utils/dom-to-image.js
+++ b/public/utils/dom-to-image.js
@@ -1,0 +1,770 @@
+(function (global) {
+    'use strict';
+
+    var util = newUtil();
+    var inliner = newInliner();
+    var fontFaces = newFontFaces();
+    var images = newImages();
+
+    // Default impl options
+    var defaultOptions = {
+        // Default is to fail on error, no placeholder
+        imagePlaceholder: undefined,
+        // Default cache bust is false, it will use the cache
+        cacheBust: false
+    };
+
+    var domtoimage = {
+        toSvg: toSvg,
+        toPng: toPng,
+        toJpeg: toJpeg,
+        toBlob: toBlob,
+        toPixelData: toPixelData,
+        impl: {
+            fontFaces: fontFaces,
+            images: images,
+            util: util,
+            inliner: inliner,
+            options: {}
+        }
+    };
+
+    if (typeof module !== 'undefined')
+        module.exports = domtoimage;
+    else
+        global.domtoimage = domtoimage;
+
+
+    /**
+     * @param {Node} node - The DOM Node object to render
+     * @param {Object} options - Rendering options
+     * @param {Function} options.filter - Should return true if passed node should be included in the output
+     *          (excluding node means excluding it's children as well). Not called on the root node.
+     * @param {String} options.bgcolor - color for the background, any valid CSS color value.
+     * @param {Number} options.width - width to be applied to node before rendering.
+     * @param {Number} options.height - height to be applied to node before rendering.
+     * @param {Object} options.style - an object whose properties to be copied to node's style before rendering.
+     * @param {Number} options.quality - a Number between 0 and 1 indicating image quality (applicable to JPEG only),
+                defaults to 1.0.
+     * @param {String} options.imagePlaceholder - dataURL to use as a placeholder for failed images, default behaviour is to fail fast on images we can't fetch
+     * @param {Boolean} options.cacheBust - set to true to cache bust by appending the time to the request url
+     * @return {Promise} - A promise that is fulfilled with a SVG image data URL
+     * */
+    function toSvg(node, options) {
+        options = options || {};
+        copyOptions(options);
+        return Promise.resolve(node)
+            .then(function (node) {
+                return cloneNode(node, options.filter, true);
+            })
+            // WAZUH NOT DOWNLOAD FONTS
+            //.then(embedFonts)
+            .then(inlineImages)
+            .then(applyOptions)
+            .then(function (clone) {
+                return makeSvgDataUri(clone,
+                    options.width || util.width(node),
+                    options.height || util.height(node)
+                );
+            });
+
+        function applyOptions(clone) {
+            if (options.bgcolor) clone.style.backgroundColor = options.bgcolor;
+
+            if (options.width) clone.style.width = options.width + 'px';
+            if (options.height) clone.style.height = options.height + 'px';
+
+            if (options.style)
+                Object.keys(options.style).forEach(function (property) {
+                    clone.style[property] = options.style[property];
+                });
+
+            return clone;
+        }
+    }
+
+    /**
+     * @param {Node} node - The DOM Node object to render
+     * @param {Object} options - Rendering options, @see {@link toSvg}
+     * @return {Promise} - A promise that is fulfilled with a Uint8Array containing RGBA pixel data.
+     * */
+    function toPixelData(node, options) {
+        return draw(node, options || {})
+            .then(function (canvas) {
+                return canvas.getContext('2d').getImageData(
+                    0,
+                    0,
+                    util.width(node),
+                    util.height(node)
+                ).data;
+            });
+    }
+
+    /**
+     * @param {Node} node - The DOM Node object to render
+     * @param {Object} options - Rendering options, @see {@link toSvg}
+     * @return {Promise} - A promise that is fulfilled with a PNG image data URL
+     * */
+    function toPng(node, options) {
+        return draw(node, options || {})
+            .then(function (canvas) {
+                return canvas.toDataURL();
+            });
+    }
+
+    /**
+     * @param {Node} node - The DOM Node object to render
+     * @param {Object} options - Rendering options, @see {@link toSvg}
+     * @return {Promise} - A promise that is fulfilled with a JPEG image data URL
+     * */
+    function toJpeg(node, options) {
+        options = options || {};
+        return draw(node, options)
+            .then(function (canvas) {
+                return canvas.toDataURL('image/jpeg', options.quality || 1.0);
+            });
+    }
+
+    /**
+     * @param {Node} node - The DOM Node object to render
+     * @param {Object} options - Rendering options, @see {@link toSvg}
+     * @return {Promise} - A promise that is fulfilled with a PNG image blob
+     * */
+    function toBlob(node, options) {
+        return draw(node, options || {})
+            .then(util.canvasToBlob);
+    }
+
+    function copyOptions(options) {
+        // Copy options to impl options for use in impl
+        if (typeof (options.imagePlaceholder) === 'undefined') {
+            domtoimage.impl.options.imagePlaceholder = defaultOptions.imagePlaceholder;
+        } else {
+            domtoimage.impl.options.imagePlaceholder = options.imagePlaceholder;
+        }
+
+        if (typeof (options.cacheBust) === 'undefined') {
+            domtoimage.impl.options.cacheBust = defaultOptions.cacheBust;
+        } else {
+            domtoimage.impl.options.cacheBust = options.cacheBust;
+        }
+    }
+
+    function draw(domNode, options) {
+        return toSvg(domNode, options)
+            .then(util.makeImage)
+            .then(util.delay(100))
+            .then(function (image) {
+                var canvas = newCanvas(domNode);
+                canvas.getContext('2d').drawImage(image, 0, 0);
+                return canvas;
+            });
+
+        function newCanvas(domNode) {
+            var canvas = document.createElement('canvas');
+            canvas.width = options.width || util.width(domNode);
+            canvas.height = options.height || util.height(domNode);
+
+            if (options.bgcolor) {
+                var ctx = canvas.getContext('2d');
+                ctx.fillStyle = options.bgcolor;
+                ctx.fillRect(0, 0, canvas.width, canvas.height);
+            }
+
+            return canvas;
+        }
+    }
+
+    function cloneNode(node, filter, root) {
+        if (!root && filter && !filter(node)) return Promise.resolve();
+
+        return Promise.resolve(node)
+            .then(makeNodeCopy)
+            .then(function (clone) {
+                return cloneChildren(node, clone, filter);
+            })
+            .then(function (clone) {
+                return processClone(node, clone);
+            });
+
+        function makeNodeCopy(node) {
+            if (node instanceof HTMLCanvasElement) return util.makeImage(node.toDataURL());
+            return node.cloneNode(false);
+        }
+
+        function cloneChildren(original, clone, filter) {
+            var children = original.childNodes;
+            if (children.length === 0) return Promise.resolve(clone);
+
+            return cloneChildrenInOrder(clone, util.asArray(children), filter)
+                .then(function () {
+                    return clone;
+                });
+
+            function cloneChildrenInOrder(parent, children, filter) {
+                var done = Promise.resolve();
+                children.forEach(function (child) {
+                    done = done
+                        .then(function () {
+                            return cloneNode(child, filter);
+                        })
+                        .then(function (childClone) {
+                            if (childClone) parent.appendChild(childClone);
+                        });
+                });
+                return done;
+            }
+        }
+
+        function processClone(original, clone) {
+            if (!(clone instanceof Element)) return clone;
+
+            return Promise.resolve()
+                .then(cloneStyle)
+                .then(clonePseudoElements)
+                .then(copyUserInput)
+                .then(fixSvg)
+                .then(function () {
+                    return clone;
+                });
+
+            function cloneStyle() {
+                copyStyle(window.getComputedStyle(original), clone.style);
+
+                function copyStyle(source, target) {
+                    if (source.cssText) target.cssText = source.cssText;
+                    else copyProperties(source, target);
+
+                    function copyProperties(source, target) {
+                        util.asArray(source).forEach(function (name) {
+                            target.setProperty(
+                                name,
+                                source.getPropertyValue(name),
+                                source.getPropertyPriority(name)
+                            );
+                        });
+                    }
+                }
+            }
+
+            function clonePseudoElements() {
+                [':before', ':after'].forEach(function (element) {
+                    clonePseudoElement(element);
+                });
+
+                function clonePseudoElement(element) {
+                    var style = window.getComputedStyle(original, element);
+                    var content = style.getPropertyValue('content');
+
+                    if (content === '' || content === 'none') return;
+
+                    var className = util.uid();
+                    clone.className = clone.className + ' ' + className;
+                    var styleElement = document.createElement('style');
+                    styleElement.appendChild(formatPseudoElementStyle(className, element, style));
+                    clone.appendChild(styleElement);
+
+                    function formatPseudoElementStyle(className, element, style) {
+                        var selector = '.' + className + ':' + element;
+                        var cssText = style.cssText ? formatCssText(style) : formatCssProperties(style);
+                        return document.createTextNode(selector + '{' + cssText + '}');
+
+                        function formatCssText(style) {
+                            var content = style.getPropertyValue('content');
+                            return style.cssText + ' content: ' + content + ';';
+                        }
+
+                        function formatCssProperties(style) {
+
+                            return util.asArray(style)
+                                .map(formatProperty)
+                                .join('; ') + ';';
+
+                            function formatProperty(name) {
+                                return name + ': ' +
+                                    style.getPropertyValue(name) +
+                                    (style.getPropertyPriority(name) ? ' !important' : '');
+                            }
+                        }
+                    }
+                }
+            }
+
+            function copyUserInput() {
+                if (original instanceof HTMLTextAreaElement) clone.innerHTML = original.value;
+                if (original instanceof HTMLInputElement) clone.setAttribute("value", original.value);
+            }
+
+            function fixSvg() {
+                if (!(clone instanceof SVGElement)) return;
+                clone.setAttribute('xmlns', 'http://www.w3.org/2000/svg');
+
+                if (!(clone instanceof SVGRectElement)) return;
+                ['width', 'height'].forEach(function (attribute) {
+                    var value = clone.getAttribute(attribute);
+                    if (!value) return;
+
+                    clone.style.setProperty(attribute, value);
+                });
+            }
+        }
+    }
+
+    function embedFonts(node) {
+        return fontFaces.resolveAll()
+            .then(function (cssText) {
+                var styleNode = document.createElement('style');
+                node.appendChild(styleNode);
+                styleNode.appendChild(document.createTextNode(cssText));
+                return node;
+            });
+    }
+
+    function inlineImages(node) {
+        return images.inlineAll(node)
+            .then(function () {
+                return node;
+            });
+    }
+
+    function makeSvgDataUri(node, width, height) {
+        return Promise.resolve(node)
+            .then(function (node) {
+                node.setAttribute('xmlns', 'http://www.w3.org/1999/xhtml');
+                return new XMLSerializer().serializeToString(node);
+            })
+            .then(util.escapeXhtml)
+            .then(function (xhtml) {
+                return '<foreignObject x="0" y="0" width="100%" height="100%">' + xhtml + '</foreignObject>';
+            })
+            .then(function (foreignObject) {
+                return '<svg xmlns="http://www.w3.org/2000/svg" width="' + width + '" height="' + height + '">' +
+                    foreignObject + '</svg>';
+            })
+            .then(function (svg) {
+                return 'data:image/svg+xml;charset=utf-8,' + svg;
+            });
+    }
+
+    function newUtil() {
+        return {
+            escape: escape,
+            parseExtension: parseExtension,
+            mimeType: mimeType,
+            dataAsUrl: dataAsUrl,
+            isDataUrl: isDataUrl,
+            canvasToBlob: canvasToBlob,
+            resolveUrl: resolveUrl,
+            getAndEncode: getAndEncode,
+            uid: uid(),
+            delay: delay,
+            asArray: asArray,
+            escapeXhtml: escapeXhtml,
+            makeImage: makeImage,
+            width: width,
+            height: height
+        };
+
+        function mimes() {
+            /*
+             * Only WOFF and EOT mime types for fonts are 'real'
+             * see http://www.iana.org/assignments/media-types/media-types.xhtml
+             */
+            var WOFF = 'application/font-woff';
+            var JPEG = 'image/jpeg';
+
+            return {
+                'woff': WOFF,
+                'woff2': WOFF,
+                'ttf': 'application/font-truetype',
+                'eot': 'application/vnd.ms-fontobject',
+                'png': 'image/png',
+                'jpg': JPEG,
+                'jpeg': JPEG,
+                'gif': 'image/gif',
+                'tiff': 'image/tiff',
+                'svg': 'image/svg+xml'
+            };
+        }
+
+        function parseExtension(url) {
+            var match = /\.([^\.\/]*?)$/g.exec(url);
+            if (match) return match[1];
+            else return '';
+        }
+
+        function mimeType(url) {
+            var extension = parseExtension(url).toLowerCase();
+            return mimes()[extension] || '';
+        }
+
+        function isDataUrl(url) {
+            return url.search(/^(data:)/) !== -1;
+        }
+
+        function toBlob(canvas) {
+            return new Promise(function (resolve) {
+                var binaryString = window.atob(canvas.toDataURL().split(',')[1]);
+                var length = binaryString.length;
+                var binaryArray = new Uint8Array(length);
+
+                for (var i = 0; i < length; i++)
+                    binaryArray[i] = binaryString.charCodeAt(i);
+
+                resolve(new Blob([binaryArray], {
+                    type: 'image/png'
+                }));
+            });
+        }
+
+        function canvasToBlob(canvas) {
+            if (canvas.toBlob)
+                return new Promise(function (resolve) {
+                    canvas.toBlob(resolve);
+                });
+
+            return toBlob(canvas);
+        }
+
+        function resolveUrl(url, baseUrl) {
+            var doc = document.implementation.createHTMLDocument();
+            var base = doc.createElement('base');
+            doc.head.appendChild(base);
+            var a = doc.createElement('a');
+            doc.body.appendChild(a);
+            base.href = baseUrl;
+            a.href = url;
+            return a.href;
+        }
+
+        function uid() {
+            var index = 0;
+
+            return function () {
+                return 'u' + fourRandomChars() + index++;
+
+                function fourRandomChars() {
+                    /* see http://stackoverflow.com/a/6248722/2519373 */
+                    return ('0000' + (Math.random() * Math.pow(36, 4) << 0).toString(36)).slice(-4);
+                }
+            };
+        }
+
+        function makeImage(uri) {
+            return new Promise(function (resolve, reject) {
+                var image = new Image();
+                image.onload = function () {
+                    resolve(image);
+                };
+                image.onerror = reject;
+                image.src = uri;
+            });
+        }
+
+        function getAndEncode(url) {
+            var TIMEOUT = 30000;
+            if (domtoimage.impl.options.cacheBust) {
+                // Cache bypass so we dont have CORS issues with cached images
+                // Source: https://developer.mozilla.org/en/docs/Web/API/XMLHttpRequest/Using_XMLHttpRequest#Bypassing_the_cache
+                url += ((/\?/).test(url) ? "&" : "?") + (new Date()).getTime();
+            }
+
+            return new Promise(function (resolve) {
+                var request = new XMLHttpRequest();
+
+                request.onreadystatechange = done;
+                request.ontimeout = timeout;
+                request.responseType = 'blob';
+                request.timeout = TIMEOUT;
+                request.open('GET', url, true);
+                request.send();
+
+                var placeholder;
+                if (domtoimage.impl.options.imagePlaceholder) {
+                    var split = domtoimage.impl.options.imagePlaceholder.split(/,/);
+                    if (split && split[1]) {
+                        placeholder = split[1];
+                    }
+                }
+
+                function done() {
+                    if (request.readyState !== 4) return;
+
+                    if (request.status !== 200) {
+                        if (placeholder) {
+                            resolve(placeholder);
+                        } else {
+                            fail('cannot fetch resource: ' + url + ', status: ' + request.status);
+                        }
+
+                        return;
+                    }
+
+                    var encoder = new FileReader();
+                    encoder.onloadend = function () {
+                        var content = encoder.result.split(/,/)[1];
+                        resolve(content);
+                    };
+                    encoder.readAsDataURL(request.response);
+                }
+
+                function timeout() {
+                    if (placeholder) {
+                        resolve(placeholder);
+                    } else {
+                        fail('timeout of ' + TIMEOUT + 'ms occured while fetching resource: ' + url);
+                    }
+                }
+
+                function fail(message) {
+                    console.error(message);
+                    resolve('');
+                }
+            });
+        }
+
+        function dataAsUrl(content, type) {
+            return 'data:' + type + ';base64,' + content;
+        }
+
+        function escape(string) {
+            return string.replace(/([.*+?^${}()|\[\]\/\\])/g, '\\$1');
+        }
+
+        function delay(ms) {
+            return function (arg) {
+                return new Promise(function (resolve) {
+                    setTimeout(function () {
+                        resolve(arg);
+                    }, ms);
+                });
+            };
+        }
+
+        function asArray(arrayLike) {
+            var array = [];
+            var length = arrayLike.length;
+            for (var i = 0; i < length; i++) array.push(arrayLike[i]);
+            return array;
+        }
+
+        function escapeXhtml(string) {
+            return string.replace(/#/g, '%23').replace(/\n/g, '%0A');
+        }
+
+        function width(node) {
+            var leftBorder = px(node, 'border-left-width');
+            var rightBorder = px(node, 'border-right-width');
+            return node.scrollWidth + leftBorder + rightBorder;
+        }
+
+        function height(node) {
+            var topBorder = px(node, 'border-top-width');
+            var bottomBorder = px(node, 'border-bottom-width');
+            return node.scrollHeight + topBorder + bottomBorder;
+        }
+
+        function px(node, styleProperty) {
+            var value = window.getComputedStyle(node).getPropertyValue(styleProperty);
+            return parseFloat(value.replace('px', ''));
+        }
+    }
+
+    function newInliner() {
+        var URL_REGEX = /url\(['"]?([^'"]+?)['"]?\)/g;
+
+        return {
+            inlineAll: inlineAll,
+            shouldProcess: shouldProcess,
+            impl: {
+                readUrls: readUrls,
+                inline: inline
+            }
+        };
+
+        function shouldProcess(string) {
+            return string.search(URL_REGEX) !== -1;
+        }
+
+        function readUrls(string) {
+            var result = [];
+            var match;
+            while ((match = URL_REGEX.exec(string)) !== null) {
+                result.push(match[1]);
+            }
+            return result.filter(function (url) {
+                return !util.isDataUrl(url);
+            });
+        }
+
+        function inline(string, url, baseUrl, get) {
+            return Promise.resolve(url)
+                .then(function (url) {
+                    return baseUrl ? util.resolveUrl(url, baseUrl) : url;
+                })
+                .then(get || util.getAndEncode)
+                .then(function (data) {
+                    return util.dataAsUrl(data, util.mimeType(url));
+                })
+                .then(function (dataUrl) {
+                    return string.replace(urlAsRegex(url), '$1' + dataUrl + '$3');
+                });
+
+            function urlAsRegex(url) {
+                return new RegExp('(url\\([\'"]?)(' + util.escape(url) + ')([\'"]?\\))', 'g');
+            }
+        }
+
+        function inlineAll(string, baseUrl, get) {
+            if (nothingToInline()) return Promise.resolve(string);
+
+            return Promise.resolve(string)
+                .then(readUrls)
+                .then(function (urls) {
+                    var done = Promise.resolve(string);
+                    urls.forEach(function (url) {
+                        done = done.then(function (string) {
+                            return inline(string, url, baseUrl, get);
+                        });
+                    });
+                    return done;
+                });
+
+            function nothingToInline() {
+                return !shouldProcess(string);
+            }
+        }
+    }
+
+    function newFontFaces() {
+        return {
+            resolveAll: resolveAll,
+            impl: {
+                readAll: readAll
+            }
+        };
+
+        function resolveAll() {
+            return readAll(document)
+                .then(function (webFonts) {
+                    return Promise.all(
+                        webFonts.map(function (webFont) {
+                            return webFont.resolve();
+                        })
+                    );
+                })
+                .then(function (cssStrings) {
+                    return cssStrings.join('\n');
+                });
+        }
+
+        function readAll() {
+            return Promise.resolve(util.asArray(document.styleSheets))
+                .then(getCssRules)
+                .then(selectWebFontRules)
+                .then(function (rules) {
+                    return rules.map(newWebFont);
+                });
+
+            function selectWebFontRules(cssRules) {
+                return cssRules
+                    .filter(function (rule) {
+                        return rule.type === CSSRule.FONT_FACE_RULE;
+                    })
+                    .filter(function (rule) {
+                        return inliner.shouldProcess(rule.style.getPropertyValue('src'));
+                    });
+            }
+
+            function getCssRules(styleSheets) {
+                var cssRules = [];
+                styleSheets.forEach(function (sheet) {
+                    try {
+                        util.asArray(sheet.cssRules || []).forEach(cssRules.push.bind(cssRules));
+                    } catch (e) {
+                        console.log('Error while reading CSS rules from ' + sheet.href, e.toString());
+                    }
+                });
+                return cssRules;
+            }
+
+            function newWebFont(webFontRule) {
+                return {
+                    resolve: function resolve() {
+                        var baseUrl = (webFontRule.parentStyleSheet || {}).href;
+                        return inliner.inlineAll(webFontRule.cssText, baseUrl);
+                    },
+                    src: function () {
+                        return webFontRule.style.getPropertyValue('src');
+                    }
+                };
+            }
+        }
+    }
+
+    function newImages() {
+        return {
+            inlineAll: inlineAll,
+            impl: {
+                newImage: newImage
+            }
+        };
+
+        function newImage(element) {
+            return {
+                inline: inline
+            };
+
+            function inline(get) {
+                if (util.isDataUrl(element.src)) return Promise.resolve();
+
+                return Promise.resolve(element.src)
+                    .then(get || util.getAndEncode)
+                    .then(function (data) {
+                        return util.dataAsUrl(data, util.mimeType(element.src));
+                    })
+                    .then(function (dataUrl) {
+                        return new Promise(function (resolve, reject) {
+                            element.onload = resolve;
+                            element.onerror = reject;
+                            element.src = dataUrl;
+                        });
+                    });
+            }
+        }
+
+        function inlineAll(node) {
+            if (!(node instanceof Element)) return Promise.resolve(node);
+
+            return inlineBackground(node)
+                .then(function () {
+                    if (node instanceof HTMLImageElement)
+                        return newImage(node).inline();
+                    else
+                        return Promise.all(
+                            util.asArray(node.childNodes).map(function (child) {
+                                return inlineAll(child);
+                            })
+                        );
+                });
+
+            function inlineBackground(node) {
+                var background = node.style.getPropertyValue('background');
+
+                if (!background) return Promise.resolve(node);
+
+                return inliner.inlineAll(background)
+                    .then(function (inlined) {
+                        node.style.setProperty(
+                            'background',
+                            inlined,
+                            node.style.getPropertyPriority('background')
+                        );
+                    })
+                    .then(function () {
+                        return node;
+                    });
+            }
+        }
+    }
+})(this);

--- a/server/controllers/wazuh-reporting.js
+++ b/server/controllers/wazuh-reporting.js
@@ -40,7 +40,8 @@ import {
 
 import { log } from '../logger';
 
-const REPORTING_PATH = '../../../../optimize/wazuh-reporting';
+const BASE_OPTIMIZE_PATH = '../../../../optimize';
+const REPORTING_PATH = `${BASE_OPTIMIZE_PATH}/wazuh/downloads/reports`;
 
 export class WazuhReportingCtrl {
   /**
@@ -1811,6 +1812,12 @@ export class WazuhReportingCtrl {
       // Init
       this.printer = new PdfPrinter(this.fonts);
       this.dd.content = [];
+      if (!fs.existsSync(path.join(__dirname, `${BASE_OPTIMIZE_PATH}/wazuh`))) {
+        fs.mkdirSync(path.join(__dirname, `${BASE_OPTIMIZE_PATH}/wazuh`));
+      }
+      if (!fs.existsSync(path.join(__dirname, `${BASE_OPTIMIZE_PATH}/wazuh/downloads`))) {
+        fs.mkdirSync(path.join(__dirname, `${BASE_OPTIMIZE_PATH}/wazuh/downloads`));
+      }
       if (!fs.existsSync(path.join(__dirname, REPORTING_PATH))) {
         fs.mkdirSync(path.join(__dirname, REPORTING_PATH));
       }

--- a/server/controllers/wazuh-reporting.js
+++ b/server/controllers/wazuh-reporting.js
@@ -2663,6 +2663,13 @@ export class WazuhReportingCtrl {
   async getReports(req, reply) {
     try {
       log('reporting:report', `Fetching created reports`, 'info');
+
+      if (!fs.existsSync(path.join(__dirname, `${BASE_OPTIMIZE_PATH}/wazuh`))) {
+        fs.mkdirSync(path.join(__dirname, `${BASE_OPTIMIZE_PATH}/wazuh`));
+      }
+      if (!fs.existsSync(path.join(__dirname, `${BASE_OPTIMIZE_PATH}/wazuh/downloads`))) {
+        fs.mkdirSync(path.join(__dirname, `${BASE_OPTIMIZE_PATH}/wazuh/downloads`));
+      }
       if (!fs.existsSync(path.join(__dirname, REPORTING_PATH))) {
         fs.mkdirSync(path.join(__dirname, REPORTING_PATH));
       }

--- a/server/controllers/wazuh-reporting.js
+++ b/server/controllers/wazuh-reporting.js
@@ -2038,7 +2038,7 @@ export class WazuhReportingCtrl {
                         columns.forEach(y => {
                           if (y !== '') {
                             y = y !== "check_whodata" ? y : 'whodata';
-                            row.push(x[y] ? 'yes' : 'no');
+                            row.push(x[y] ? x[y] : 'no');
                           }
                         });
                         row.push(x.recursion_level);

--- a/server/controllers/wazuh-reporting.js
+++ b/server/controllers/wazuh-reporting.js
@@ -140,7 +140,7 @@ export class WazuhReportingCtrl {
         return {
           columns: [
             {
-              text: 'Copyright © 2019 Wazuh, Inc.',
+              text: 'Copyright © 2020 Wazuh, Inc.',
               color: '#1EA5C8',
               margin: [40, 40, 0, 0]
             },

--- a/server/controllers/wazuh-utils.js
+++ b/server/controllers/wazuh-utils.js
@@ -72,8 +72,8 @@ export class WazuhUtilsCtrl {
   async getAppLogs(req, reply) {
     try {
       const lastLogs = await simpleTail(
-        path.join(__dirname, '../../../../optimize/wazuh-logs/wazuhapp.log'),
-        20
+        path.join(__dirname, '../../../../optimize/wazuh/logs/wazuhapp.log'),
+        50
       );
       return lastLogs && Array.isArray(lastLogs)
         ? {

--- a/server/integration-files/pci-requirements.js
+++ b/server/integration-files/pci-requirements.js
@@ -79,5 +79,9 @@ export const pciRequirementsFile = {
   '11.4':
     'Use intrusion detection and/or intrusion prevention techniques to detect and/or prevent intrusions into the network.Monitor all traffic at the perimeter of the cardholder data environment as well as at critical points in the cardholder data environment, and alert personnel to suspected compromises. Keep all intrusion detection and prevention engines, baselines, and signatures up to date.',
   '11.5':
-    'Deploy a change detection mechanism (for example, file integrity monitoring tools) to alert personnel to unauthorized modification of critical system files, configuration files, or content files; and configure the software to perform critical file comparisons at least weekly.'
+    'Deploy a change detection mechanism (for example, file integrity monitoring tools) to alert personnel to unauthorized modification of critical system files, configuration files, or content files; and configure the software to perform critical file comparisons at least weekly.',
+  '11.2.1':
+    'Perform quarterly internal vulnerability scans. Address vulnerabilities and perform rescans to verify all “high risk” vulnerabilities are resolved in accordance with the entity’s vulnerability ranking. Scans must be performed by qualified personnel.',
+  '11.2.3':
+    'Perform internal and external scans, and rescans as needed, after any significant change. Scans must be performed by qualified personnel.',
 };

--- a/server/integration-files/visualizations/agents/agents-general.js
+++ b/server/integration-files/visualizations/agents/agents-general.js
@@ -104,10 +104,11 @@ export default [
                               "index": "wazuh-alerts",
                               "type": "phrases",
                               "key": "rule.groups",
-                              "value": "authentication_failed, authentication_failures",
+                              "value": "win_authentication_failed, authentication_failed, authentication_failures",
                               "params": [
+                                "win_authentication_failed",
                                 "authentication_failed",
-                                "win_authentication_failed"
+                                "authentication_failures"
                               ],
                               "negate": false,
                               "disabled": false,
@@ -118,12 +119,17 @@ export default [
                                 "should": [
                                   {
                                     "match_phrase": {
+                                      "rule.groups": "win_authentication_failed"
+                                    }
+                                  },
+                                  {
+                                    "match_phrase": {
                                       "rule.groups": "authentication_failed"
                                     }
                                   },
                                   {
                                     "match_phrase": {
-                                      "rule.groups": "win_authentication_failed"
+                                      "rule.groups": "authentication_failures"
                                     }
                                   }
                                 ],

--- a/server/integration-files/visualizations/overview/overview-general.js
+++ b/server/integration-files/visualizations/overview/overview-general.js
@@ -105,8 +105,9 @@ export default [
                               "index": "wazuh-alerts",
                               "type": "phrases",
                               "key": "rule.groups",
-                              "value": "authentication_failed, authentication_failures",
+                              "value": "win_authentication_failed, authentication_failed, authentication_failures",
                               "params": [
+                                "win_authentication_failed",
                                 "authentication_failed",
                                 "authentication_failures"
                               ],
@@ -117,6 +118,11 @@ export default [
                             "query": {
                               "bool": {
                                 "should": [
+                                  {
+                                    "match_phrase": {
+                                      "rule.groups": "win_authentication_failed"
+                                    }
+                                  },
                                   {
                                     "match_phrase": {
                                       "rule.groups": "authentication_failed"

--- a/server/lib/get-configuration.js
+++ b/server/lib/get-configuration.js
@@ -14,12 +14,12 @@ import yml from 'js-yaml';
 import path from 'path';
 let cachedConfiguration = null;
 let lastAssign = new Date().getTime();
-export function getConfiguration() {
+export function getConfiguration(isUpdating = false) {
   try {
     const now = new Date().getTime();
     const dateDiffer = now - lastAssign;
-    if (!cachedConfiguration || dateDiffer >= 10000) {
-      const customPath = path.join(__dirname, '../../wazuh.yml');
+    if (!cachedConfiguration || dateDiffer >= 10000 || isUpdating) {
+      const customPath = path.join(__dirname, '../../../../optimize/wazuh/config/wazuh.yml');
       const raw = fs.readFileSync(customPath, { encoding: 'utf-8' });
       const file = yml.load(raw);
       cachedConfiguration = { ...file };

--- a/server/lib/initial-wazuh-config.js
+++ b/server/lib/initial-wazuh-config.js
@@ -142,7 +142,7 @@
 
 hosts:
   - default:
-     url: http://localhost
+     url: https://localhost
      port: 55000
      user: foo
      password: bar

--- a/server/lib/initial-wazuh-config.js
+++ b/server/lib/initial-wazuh-config.js
@@ -1,4 +1,16 @@
----
+/*
+ * Wazuh app - Initial basic configuration file
+ * Copyright (C) 2015-2020 Wazuh, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Find more information about this on the LICENSE file.
+ */
+
+ export const initialWazuhConfig = `---
 #
 # Wazuh app - App configuration file
 # Copyright (C) 2015-2020 Wazuh, Inc.
@@ -130,3 +142,5 @@ hosts:
      port: 55000
      user: foo
      password: bar
+
+`

--- a/server/lib/initial-wazuh-config.js
+++ b/server/lib/initial-wazuh-config.js
@@ -43,6 +43,7 @@
 #checks.template: true
 #checks.api     : true
 #checks.setup   : true
+#checks.fields   : true
 #
 # --------------------------------- Extensions ---------------------------------
 #

--- a/server/lib/initial-wazuh-config.js
+++ b/server/lib/initial-wazuh-config.js
@@ -120,6 +120,10 @@
 # ------------------------------- App privileges --------------------------------
 #admin: true
 #
+# ---------------------------- Hide manager alerts ------------------------------
+# Hide the alerts of the manager in all dashboards and discover
+#hideManagerAlerts: false
+#
 # ------------------------------- App logging level -----------------------------
 # Set the logging level for the Wazuh App log files.
 # Default value: info

--- a/server/lib/manage-hosts.js
+++ b/server/lib/manage-hosts.js
@@ -14,12 +14,16 @@ import yml from 'js-yaml';
 import path from 'path';
 import { log } from '../logger';
 import { UpdateRegistry } from './update-registry';
+import { initialWazuhConfig } from './initial-wazuh-config'
+
+const BASE_LOGS_PATH = '../../../../optimize/wazuh';
 
 export class ManageHosts {
   constructor() {
     this.busy = false;
-    this.file = path.join(__dirname, '../../wazuh.yml');
+    this.file = path.join(__dirname, `${BASE_LOGS_PATH}/config/wazuh.yml`);
     this.updateRegistry = new UpdateRegistry();
+    this.initialConfig = initialWazuhConfig;
   }
 
   /**
@@ -64,6 +68,15 @@ export class ManageHosts {
     try {
       this.checkBusy();
       this.busy = true;
+      if (!fs.existsSync(path.join(__dirname, BASE_LOGS_PATH))) {
+        fs.mkdirSync(path.join(__dirname, BASE_LOGS_PATH));
+      }
+      if (!fs.existsSync(path.join(__dirname, `${BASE_LOGS_PATH}/config`))) {
+        fs.mkdirSync(path.join(__dirname, `${BASE_LOGS_PATH}/config`));
+      }
+      if (!fs.existsSync(path.join(__dirname, '../../../../optimize/wazuh/config/wazuh.yml'))) {
+        await fs.writeFileSync(this.file, this.initialConfig, 'utf8');
+      }
       const raw = fs.readFileSync(this.file, { encoding: 'utf-8' });
       this.busy = false;
       const content = yml.load(raw);

--- a/server/lib/update-configuration.js
+++ b/server/lib/update-configuration.js
@@ -13,7 +13,7 @@ import fs from 'fs';
 import path from 'path';
 import { log } from '../logger';
 import { getConfiguration } from './get-configuration';
-
+​
 const needRestartFields = [
   'pattern',
   'wazuh.shards',
@@ -24,14 +24,15 @@ const needRestartFields = [
   'wazuh.monitoring.replicas',
   'wazuh.monitoring.creation',
   'wazuh.monitoring.pattern',
-  'logs.level'
+  'logs.level',
+  'hideManagerAlerts'
 ];
 export class UpdateConfigurationFile {
   constructor() {
     this.busy = false;
     this.file = path.join(__dirname, '../../../../optimize/wazuh/config/wazuh.yml');
   }
-
+​
   /**
    * Add or replace specific setting from wazuh.yml
    * @param {String} key The setting name.
@@ -53,7 +54,7 @@ export class UpdateConfigurationFile {
       throw error;
     }
   }
-
+​
   /**
    * Updates wazuh.yml file. If it fails, it throws the error to the next function.
    * @param {Object} input
@@ -67,7 +68,7 @@ export class UpdateConfigurationFile {
       const configuration = getConfiguration(true) || {};
       const adminUndefined = !Object.keys(configuration).includes('admin');
       const adminIsTrue = configuration.admin;
-
+​
       if (!adminUndefined && !adminIsTrue) {
         throw new Error('You are not authorized to update the configuration');
       }

--- a/server/lib/update-configuration.js
+++ b/server/lib/update-configuration.js
@@ -29,7 +29,7 @@ const needRestartFields = [
 export class UpdateConfigurationFile {
   constructor() {
     this.busy = false;
-    this.file = path.join(__dirname, '../../wazuh.yml');
+    this.file = path.join(__dirname, '../../../../optimize/wazuh/config/wazuh.yml');
   }
 
   /**
@@ -64,7 +64,7 @@ export class UpdateConfigurationFile {
         throw new Error('Another process is updating the configuration file');
       }
       this.busy = true;
-      const configuration = getConfiguration() || {};
+      const configuration = getConfiguration(true) || {};
       const adminUndefined = !Object.keys(configuration).includes('admin');
       const adminIsTrue = configuration.admin;
 

--- a/server/logger.js
+++ b/server/logger.js
@@ -17,6 +17,9 @@ import { getConfiguration } from './lib/get-configuration';
 let allowed = false;
 let wazuhlogger = undefined;
 let wazuhPlainLogger = undefined;
+const logsBasePath = '../../../optimize/wazuh/logs'
+const plainLogFilePath = `${logsBasePath}/wazuhapp-plain.log`
+const rawLogFilePath = `${logsBasePath}/wazuhapp.log`
 
 /**
  * Here we create the loggers
@@ -37,7 +40,7 @@ const initLogger = () => {
       new winston.transports.File({
         filename: path.join(
           __dirname,
-          '../../../optimize/wazuh-logs/wazuhapp.log'
+          rawLogFilePath
         )
       })
     ]
@@ -54,7 +57,7 @@ const initLogger = () => {
       new winston.transports.File({
         filename: path.join(
           __dirname,
-          '../../../optimize/wazuh-logs/wazuhapp-plain.log'
+          plainLogFilePath
         )
       })
     ]
@@ -65,12 +68,16 @@ const initLogger = () => {
 };
 
 /**
- * Checks if wazuh-logs exists. If it doesn't exist, it will be created.
+ * Checks if wazuh/logs exists. If it doesn't exist, it will be created.
  */
 const initDirectory = async () => {
   try {
-    if (!fs.existsSync(path.join(__dirname, '../../../optimize/wazuh-logs'))) {
-      fs.mkdirSync(path.join(__dirname, '../../../optimize/wazuh-logs'));
+
+    if (!fs.existsSync(path.join(__dirname, '../../../optimize/wazuh'))) {
+      fs.mkdirSync(path.join(__dirname, '../../../optimize/wazuh'));
+    }
+    if (!fs.existsSync(path.join(__dirname, logsBasePath))) {
+      fs.mkdirSync(path.join(__dirname, logsBasePath));
     }
     if (
       typeof wazuhlogger === 'undefined' ||
@@ -109,18 +116,18 @@ const checkFiles = () => {
   if (allowed) {
     if (
       getFilesizeInMegaBytes(
-        path.join(__dirname, '../../../optimize/wazuh-logs/wazuhapp.log')
+        path.join(__dirname, rawLogFilePath)
       ) >= 100
     ) {
       fs.renameSync(
-        path.join(__dirname, '../../../optimize/wazuh-logs/wazuhapp.log'),
+        path.join(__dirname, rawLogFilePath),
         path.join(
           __dirname,
-          `../../../optimize/wazuh-logs/wazuhapp.${new Date().getTime()}.log`
+          `${logsBasePath}/wazuhapp.${new Date().getTime()}.log`
         )
       );
       fs.writeFileSync(
-        path.join(__dirname, '../../../optimize/wazuh-logs/wazuhapp.log'),
+        path.join(__dirname, rawLogFilePath),
         JSON.stringify({
           date: new Date(),
           level: 'info',
@@ -131,14 +138,14 @@ const checkFiles = () => {
     }
     if (
       getFilesizeInMegaBytes(
-        path.join(__dirname, '../../../optimize/wazuh-logs/wazuhapp-plain.log')
+        path.join(__dirname, plainLogFilePath)
       ) >= 100
     ) {
       fs.renameSync(
-        path.join(__dirname, '../../../optimize/wazuh-logs/wazuhapp-plain.log'),
+        path.join(__dirname, plainLogFilePath),
         path.join(
           __dirname,
-          `../../../optimize/wazuh-logs/wazuhapp-plain.${new Date().getTime()}.log`
+          `${plainLogFilePath}.${new Date().getTime()}.log`
         )
       );
     }


### PR DESCRIPTION
Hi team,

This PR prepares de 3.11.4-7.6.1 branch for the new release of Wazuh 3.12.0, adding some changes:

### Added

- Support for Wazuh v3.12.0
- Added a new setting to hide manager alerts from dashboards. [#2102](https://github.com/wazuh/wazuh-kibana-app/pull/2102)
- Added suport for PCI 11.2.1 and 11.2.3 rules. [#2062](https://github.com/wazuh/wazuh-kibana-app/pull/2062)

### Changed

- Restructuring of the optimize/wazuh directory. Now the Wazuh configuration file (wazuh.yml) is placed on /usr/share/kibana/optimize/wazuh/config. [#2116](https://github.com/wazuh/wazuh-kibana-app/pull/2116)
- Improve performance of Dasboards reports generation. [1802344](https://github.com/wazuh/wazuh-kibana-app/commit/18023447c6279d385df84d7f4a5663ed2167fdb5)

### Fixed

- Discover time range selector is now displayed on the Cluster section. [08901df](https://github.com/wazuh/wazuh-kibana-app/commit/08901dfcbe509f17e4fab26877c8b7dae8a66bff)
- Added the win_auth_failure rule group to Authentication failure metrics. [#2099](https://github.com/wazuh/wazuh-kibana-app/pull/2099)
- Negative values in Syscheck attributes now have their correct value in reports. [7c3e84e](https://github.com/wazuh/wazuh-kibana-app/commit/7c3e84ec8f00760b4f650cfc00a885d868123f99)

Regards, 