### PR TITLE
[3.12-7.4] Allow \< in our xml validator

### DIFF
--- a/public/directives/wz-xml-file-editor/wz-xml-file-editor.js
+++ b/public/directives/wz-xml-file-editor/wz-xml-file-editor.js
@@ -88,6 +88,7 @@ app.directive('wzXmlFileEditor', function() {
           const text = $scope.xmlCodeBox.getValue();
           let xml = replaceIllegalXML(text);
           xml = xml.replace(/..xml.+\?>/, '');
+          xml = xml.replace(/\\</, '\ <');
           xml = xml.replace(/\\</gm, '');
           xml = xml.replace(/<!--[\s\S\n]*?-->/gm, '');
           const xmlDoc = parser.parseFromString(


### PR DESCRIPTION
Hi team,
There was an error in our xml validator when a value was being ended in \, for example:
`<tag>C:\</tag>`
or
`<tag>/etc/test/</tag>`

This PR fixes it.