### PR TITLE
3.12 - Fix agent deployment command variables

### DIFF
--- a/public/controllers/agent/components/register-agent.js
+++ b/public/controllers/agent/components/register-agent.js
@@ -145,36 +145,36 @@ export class RegisterAgent extends Component {
       zIndex: '100'
     };
     const customTexts = {
-      rpmText: `sudo WAZUH_MANAGER_IP='${this.state.serverAddress}'${
+      rpmText: `sudo WAZUH_MANAGER='${this.state.serverAddress}'${
         this.state.needsPassword
-          ? ` WAZUH_PASSWORD='${this.state.wazuhPassword}' `
+          ? ` WAZUH_REGISTRATION_PASSWORD='${this.state.wazuhPassword}' `
           : ' '
       }yum install https://packages.wazuh.com/3.x/yum/wazuh-agent-${
         this.state.wazuhVersion
       }-1.x86_64.rpm`,
       debText: `curl -so wazuh-agent.deb https://packages.wazuh.com/3.x/apt/pool/main/w/wazuh-agent/wazuh-agent_${
         this.state.wazuhVersion
-      }-1_amd64.deb && sudo WAZUH_MANAGER_IP='${this.state.serverAddress}'${
+      }-1_amd64.deb && sudo WAZUH_MANAGER='${this.state.serverAddress}'${
         this.state.needsPassword
-          ? ` WAZUH_PASSWORD='${this.state.wazuhPassword}' `
+          ? ` WAZUH_REGISTRATION_PASSWORD='${this.state.wazuhPassword}' `
           : ' '
-      } dpkg -i ./wazuh-agent.deb`,
+      }dpkg -i ./wazuh-agent.deb`,
       macosText: `curl -so wazuh-agent.pkg https://packages.wazuh.com/3.x/osx/wazuh-agent-${
         this.state.wazuhVersion
-      }-1.pkg && sudo launchctl setenv WAZUH_MANAGER_IP '${
+      }-1.pkg && sudo launchctl setenv WAZUH_MANAGER '${
         this.state.serverAddress
       }'${
         this.state.needsPassword
-          ? ` WAZUH_PASSWORD '${this.state.wazuhPassword}'`
+          ? ` WAZUH_REGISTRATION_PASSWORD '${this.state.wazuhPassword}' `
           : ' '
-      } && sudo installer -pkg ./wazuh-agent.pkg -target /`,
+      }&& sudo installer -pkg ./wazuh-agent.pkg -target /`,
       winText: `Invoke-WebRequest -Uri https://packages.wazuh.com/3.x/windows/wazuh-agent-${
         this.state.wazuhVersion
-      }-1.msi -OutFile wazuh-agent.msi; ./wazuh-agent.msi /q ADDRESS='${
+      }-1.msi -OutFile wazuh-agent.msi; ./wazuh-agent.msi /q WAZUH_MANAGER='${
         this.state.serverAddress
-      }' AUTHD_SERVER='${this.state.serverAddress}'${
+      }' WAZUH_REGISTRATION_SERVER='${this.state.serverAddress}'${
         this.state.needsPassword
-          ? ` PASSWORD='${this.state.wazuhPassword}' `
+          ? ` WAZUH_REGISTRATION_PASSWORD='${this.state.wazuhPassword}' `
           : ' '
       }`
     };


### PR DESCRIPTION
Hi team, this PR resolves:
- fix agent deployment command variables in 3.12
- fix double spaces