### PR TITLE
Add requested fixes

### DIFF
--- a/public/components/agents/fim/states/fileDetail.tsx
+++ b/public/components/agents/fim/states/fileDetail.tsx
@@ -177,14 +177,16 @@ export class FileDetails extends Component {
                   ? <EuiToolTip position="top" anchorClassName="detail-tooltip" content={value} delay="long">
                       <span className={className}>{value}</span>
                     </EuiToolTip> 
-                  : <EuiLink
-                      className={className}
-                      onClick={() => {
-                        this.props.onFilterSelect(`${item.field}=${value}`);
-                        this.props.closeFlyout();
-                      }} >
-                      {value}
-                    </EuiLink>
+                  : <EuiToolTip position="top" anchorClassName="detail-tooltip" content={`Filter by ${item.field} is ${value} in states`} >
+                        <EuiLink
+                          className={className}
+                          onClick={() => {
+                            this.props.onFilterSelect(`${item.field}=${value}`);
+                            this.props.closeFlyout();
+                          }} >
+                          {value}
+                        </EuiLink>
+                    </EuiToolTip>
               }
               description={
                 <span>

--- a/public/components/agents/fim/states/fileDetail.tsx
+++ b/public/components/agents/fim/states/fileDetail.tsx
@@ -162,10 +162,11 @@ export class FileDetails extends Component {
   }
 
   getDetails() {
+    const { view } = this.props
     const columns = this.props.type === 'file' ? this.details() : this.registryDetails();
     const generalDetails = columns.map((item, idx) => {
       var value = this.props.currentFile[item.field] || '-';
-      var link = item.link || false;
+      var link = (item.link && view !== 'events') || false;
       if (!item.onlyLinux || (item.onlyLinux && this.props.agent.agentPlatform !== 'windows')){
         let className = item.checksum ? "detail-value detail-value-checksum" : "detail-value";
         className += item.field === 'perm' ? " detail-value-perm" : "";
@@ -173,7 +174,7 @@ export class FileDetails extends Component {
           <EuiFlexItem key={idx}>
             <EuiStat
               title={
-                  !link 
+                  !link
                   ? <EuiToolTip position="top" anchorClassName="detail-tooltip" content={value} delay="long">
                       <span className={className}>{value}</span>
                     </EuiToolTip> 

--- a/public/components/agents/fim/states/states.less
+++ b/public/components/agents/fim/states/states.less
@@ -26,7 +26,6 @@
 
 .detail-value{
     font-size: 14px;
-    padding-left: 36px;
     font-weight: 300;
     white-space: break-spaces;
 }
@@ -43,6 +42,7 @@
 }
 
 .detail-tooltip {
+    margin-left: 36px;
     float: left;
 }
 

--- a/public/components/common/modules/discover/discover.less
+++ b/public/components/common/modules/discover/discover.less
@@ -28,3 +28,7 @@ div.euiPanel.euiComboBoxOptionsList.euiComboBoxOptionsList {
 .module-discover-table-description-list .euiDescriptionList__description{
     width: 78%!important;
 }
+
+.wz-discover.hide-filter-controll .globalFilterGroup__branch {
+    display: none;
+}

--- a/public/components/common/modules/discover/discover.tsx
+++ b/public/components/common/modules/discover/discover.tsx
@@ -352,7 +352,7 @@ export class Discover extends Component {
   render() {
     if (this.state.isLoading)
       return (<div style={{ alignSelf: "center" }}><EuiLoadingSpinner size="xl" /> </div>)
-
+    const {total, searchBarFilters, itemIdToExpandedRowMap} = this.state;
 
     const getRowProps = item => {
       const { _id } = item;
@@ -381,18 +381,17 @@ export class Discover extends Component {
     };
     const noResultsText = `No results match for this ${this.props.type === 'file' ? 'file' : 'registry'} and search criteria`
     return (
-      <div>
-        {this.state.total && (
-          <div>
-            {this.getSearchBar()}
-            <EuiFlexGroup>
+      <div
+        className='wz-discover hide-filter-controll' >
+        {this.getSearchBar()}
+        {total 
+          ? <EuiFlexGroup>
               <EuiFlexItem>
                 {pageIndexItems.length && (
                   <EuiBasicTable
-                    className="module-discover-table"
                     items={pageIndexItems}
                     itemId="_id"
-                    itemIdToExpandedRowMap={this.state.itemIdToExpandedRowMap}
+                    itemIdToExpandedRowMap={itemIdToExpandedRowMap}
                     isExpandable={true}
                     columns={columns}
                     rowProps={getRowProps}
@@ -403,18 +402,13 @@ export class Discover extends Component {
                 )}
               </EuiFlexItem>
             </EuiFlexGroup>
-          </div>
-        ) || (
-            <div>
-              {this.getSearchBar()}
-              <EuiFlexGroup>
-                <EuiFlexItem>
-                  <EuiSpacer size="s" />
-                  <EuiCallOut title={noResultsText} color="warning" iconType="alert" />
-                </EuiFlexItem>
-              </EuiFlexGroup>
-            </div>
-          )}
+          : <EuiFlexGroup>
+              <EuiFlexItem>
+                <EuiSpacer size="s" />
+                <EuiCallOut title={noResultsText} color="warning" iconType="alert" />
+              </EuiFlexItem>
+            </EuiFlexGroup>
+        }
       </div>);
   }
 }

--- a/public/components/common/modules/discover/discover.tsx
+++ b/public/components/common/modules/discover/discover.tsx
@@ -39,7 +39,8 @@ import {
   TimeRange,
   Query,
   esFilters,
-  esQuery
+  esQuery,
+  IFieldType
 } from '../../../../../../../src/plugins/data/common';
 
 export class Discover extends Component {
@@ -106,15 +107,17 @@ export class Discover extends Component {
     this.onFiltersUpdated.bind(this);
   }
 
-  async componentDidMount() {
+  async componentDidMount () {
     this._isMount = true;
     try {
-      this.indexPattern = await this.KibanaServices.indexPatterns.get(AppState.getCurrentPattern());
+      await this.getIndexPattern(); 
       this.getAlerts();
     } catch (err) {
       console.log(err);
     }
   }
+
+ 
 
   componentWillUnmount() {
     this._isMount = false;
@@ -127,6 +130,25 @@ export class Discover extends Component {
     } catch (err) {
       console.log(err);
     }
+  }
+
+  async getIndexPattern () {
+    this.indexPattern = {...await this.KibanaServices.indexPatterns.get(AppState.getCurrentPattern())};
+    const fields:IFieldType[] = [];
+    Object.keys(this.indexPattern.fields).forEach(item => {
+      if (isNaN(item)) { fields.push(this.indexPattern.fields[item]) }
+      if (['syscheck.size_before', 'syscheck.uname_after', 'syscheck.mtime_after',
+        'syscheck.inode_before', 'syscheck.size_after', 'syscheck.gid_after',
+        'syscheck.md5_before', 'syscheck.sha256_before', 'syscheck.mtime_before',
+        'syscheck.path', 'syscheck.sha1_after', 'syscheck.changed_attributes',
+        'syscheck.gname_after', 'syscheck.uid_after', 'syscheck.perm_after',
+        'syscheck.event', 'syscheck.md5_after', 'syscheck.sha1_before',
+        'syscheck.sha256_after', 'syscheck.inode_after'
+      ].includes(this.indexPattern.fields[item].name)) {
+        fields.push(this.indexPattern.fields[item]);
+      }
+    })
+    this.indexPattern.fields = fields;
   }
 
   filtersAsArray(filters) {

--- a/public/components/common/modules/discover/discover.tsx
+++ b/public/components/common/modules/discover/discover.tsx
@@ -136,15 +136,9 @@ export class Discover extends Component {
     this.indexPattern = {...await this.KibanaServices.indexPatterns.get(AppState.getCurrentPattern())};
     const fields:IFieldType[] = [];
     Object.keys(this.indexPattern.fields).forEach(item => {
-      if (isNaN(item)) { fields.push(this.indexPattern.fields[item]) }
-      if (['syscheck.size_before', 'syscheck.uname_after', 'syscheck.mtime_after',
-        'syscheck.inode_before', 'syscheck.size_after', 'syscheck.gid_after',
-        'syscheck.md5_before', 'syscheck.sha256_before', 'syscheck.mtime_before',
-        'syscheck.path', 'syscheck.sha1_after', 'syscheck.changed_attributes',
-        'syscheck.gname_after', 'syscheck.uid_after', 'syscheck.perm_after',
-        'syscheck.event', 'syscheck.md5_after', 'syscheck.sha1_before',
-        'syscheck.sha256_after', 'syscheck.inode_after'
-      ].includes(this.indexPattern.fields[item].name)) {
+      if (isNaN(item)) { 
+        fields.push(this.indexPattern.fields[item]);
+      } else if (this.indexPattern.fields[item].name.includes('syscheck')) {
         fields.push(this.indexPattern.fields[item]);
       }
     })

--- a/public/components/common/modules/discover/row-details.tsx
+++ b/public/components/common/modules/discover/row-details.tsx
@@ -217,10 +217,11 @@ export class RowDetails extends Component {
    */
   renderDetails(details) {
     const detailsToRender: Array<JSX.Element> = [];
+    const capitalize = str => str[0].toUpperCase() + str.slice(1);
 
     Object.keys(details).forEach((key, inx) => {
       detailsToRender.push(
-        <li key={key}><b>{key}:</b>&nbsp;{details[key] === '' ? 'true' : details[key]}</li>
+        <li key={key} style={{marginTop: 10}}><b>{capitalize(key)}:</b>&nbsp;{details[key] === '' ? 'true' : details[key]}</li>
       );
     });
     return (

--- a/public/controllers/agent/components/agents-table.js
+++ b/public/controllers/agent/components/agents-table.js
@@ -145,7 +145,7 @@ export class AgentsTable extends Component {
     const { pageIndex, pageSize, search } = this.state;
 
     const filter = {
-      offset: pageIndex * pageSize,
+      offset: (pageIndex * pageSize) || 0,
       limit: pageSize,
       q: this.buildQFilter(),
       sort: this.buildSortFilter()


### PR DESCRIPTION
Hi team, as requested this PR adds some fixes to the latest fim section:
1. Discover -> Rules details box: 
![image](https://user-images.githubusercontent.com/35685689/80379267-25496a00-889e-11ea-959f-dcae533e4019.png)
- The margins have been fixed and the keys are correctly formatted.
2. Our custom discover should not show all the keys, only `syscheck` related keys are now being shown:
![image](https://user-images.githubusercontent.com/35685689/80379346-44e09280-889e-11ea-9dc1-c7255ef0ebaf.png)
3. Events detail section: 
![image](https://user-images.githubusercontent.com/35685689/80380328-b79e3d80-889f-11ea-87f8-b7ea80bb4b9c.png) 
The link is now working correctly only in States section.
4. sha1_after typo has been fixed.
![image](https://user-images.githubusercontent.com/35685689/80381349-1dd79000-88a1-11ea-8c2a-4d930b1de852.png)
5. Clicking on changed_attributes caused an error in the app, it has now been fixed:
![image](https://user-images.githubusercontent.com/35685689/80381468-43fd3000-88a1-11ea-9e9a-a8c6582247c4.png)

