### PR TITLE
3.13-7.6 Fix Management problems

### DIFF
--- a/public/components/wz-menu/wz-menu-management.js
+++ b/public/components/wz-menu/wz-menu-management.js
@@ -95,7 +95,7 @@ class WzMenuManagement extends Component {
         items: [
           this.createItem(this.managementSections.status),
           this.createItem(this.managementSections.cluster),
-          this.createItem(this.managementSections.statistics),
+          // this.createItem(this.managementSections.statistics),
           this.createItem(this.managementSections.logs),
           this.createItem(this.managementSections.reporting)
         ]

--- a/public/controllers/management/components/management/configuration/edit-configuration/edit-configuration.js
+++ b/public/controllers/management/components/management/configuration/edit-configuration/edit-configuration.js
@@ -387,7 +387,7 @@ const WzEditorConfiguration = compose(
                 value={editorValue}
                 onChange={value => onChange(value)}
                 minusHeight={
-                  wazuhNotReadyYet || infoChangesAfterRestart ? 260 : 200
+                  wazuhNotReadyYet || infoChangesAfterRestart ? 270 : 215
                 }
               />
               )}

--- a/public/controllers/management/components/management/configuration/util-components/code-editor.js
+++ b/public/controllers/management/components/management/configuration/util-components/code-editor.js
@@ -31,7 +31,8 @@ class WzCodeEditor extends Component {
       onChange,
       isReadOnly,
       height,
-      minusHeight
+      minusHeight,
+      setOptions
     } = this.props;
     return (
       <Fragment>
@@ -53,11 +54,9 @@ class WzCodeEditor extends Component {
             highlightActiveLine={false}
             onChange={onChange}
             isReadOnly={isReadOnly}
-            setOptions={{
-              fontSize: '14px',
-              // enableBasicAutocompletion: true,
+            setOptions={setOptions || {
+              fontSize: '16px',
               enableSnippets: true
-              // enableLiveAutocompletion: true,
             }}
             aria-label="Code Editor"
           />

--- a/public/controllers/management/components/upload-files.js
+++ b/public/controllers/management/components/upload-files.js
@@ -191,7 +191,7 @@ export class UploadFiles extends Component {
             <EuiListGroupItem
               id={index}
               key={index}
-              label={`${this.state.files[index].name} (${this.state.files[index].size} Bytes)`}
+              label={`${this.state.files[index].name} (${this.formatBytes(this.state.files[index].size)})`}
               isActive
             />
           ))}
@@ -199,6 +199,11 @@ export class UploadFiles extends Component {
       </Fragment>
     );
   }
+
+  /**
+   * Format Bytes size to largest unit
+   */
+  formatBytes(a, b = 2) { if (0 === a) return "0 Bytes"; const c = 0 > b ? 0 : b, d = Math.floor(Math.log(a) / Math.log(1024)); return parseFloat((a / Math.pow(1024, d)).toFixed(c)) + " " + ["Bytes", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"][d] }
 
   /**
    * Renders the errors when trying to upload files

--- a/public/controllers/management/components/upload-files.js
+++ b/public/controllers/management/components/upload-files.js
@@ -38,7 +38,7 @@ export class UploadFiles extends Component {
       uploadErrors: false,
       errorPopover: false
     };
-    this.maxSize = 5120000; // 5Mb
+    this.maxSize = 10485760; // 10Mb
   }
 
   onChange = files => {
@@ -320,7 +320,7 @@ export class UploadFiles extends Component {
           {this.checkOverSize() > 0 && (
             <Fragment>
               {this.renderWarning(
-                `The max size per file allowed is ${this.maxSize / 1024} Kb`
+                `The max size per file allowed is ${this.maxSize / (1024*1024)} MB`
               )}
             </Fragment>
           )}

--- a/public/directives/wz-multiple-selector/wz-multiple-selector.js
+++ b/public/directives/wz-multiple-selector/wz-multiple-selector.js
@@ -74,8 +74,8 @@ app.directive('wzMultipleSelector', function() {
         if (pos >= max) {
           target.parentElement.parentElement.parentElement.className ===
           'wzMultipleSelectorLeft'
-            ? $scope.doReload('left')
-            : $scope.doReload('right');
+            ? $scope.doReload('left', $scope.availableFilter, false)
+            : $scope.doReload('right', $scope.selectedFilter, false);
         }
       };
     },

--- a/public/templates/management/groups/groups.html
+++ b/public/templates/management/groups/groups.html
@@ -46,7 +46,7 @@
                                 <div class="euiFlexItem"></div>
                                 <div class="euiFlexItem euiFlexItem--flexGrowZero">
                                     <button ng-hide='moreThan500' ng-click='gp.saveAddAgents()'
-                                        class="euiButton euiButton--primary euiButton--fill" type="button"><span
+                                        class="euiButton euiButton--primary euiButton--fill" type="button" ng-disabled='gp.moreThan500'><span
                                             class="euiButton__content">
                                             <span class="euiButton__text">Apply changes</span></span></button>
                                     <span class='error-msg' ng-show='gp.moreThan500'><i
@@ -66,7 +66,7 @@
                                         selected-items="gp.selectedAgents.data" title-available-items="Available agents"
                                         title-selected-items="Current agents in the group"
                                         total-selected-items="gp.totalSelectedAgents"
-                                        reload-scroll='gp.reload(element, searchTerm, 499, start)'
+                                        reload-scroll='gp.reload(element, searchTerm, start)'
                                         limit="gp.checkLimit()">
                                     </wz-multiple-selector>
                                     <div class="euiSpacer euiSpacer--l"></div>


### PR DESCRIPTION
Hi team this, pr resolves (atm):

- Removed **Statistics** of Wazuh menu.
- Added `reload` method to **GroupsController** what was missing, maybe it was removed some commits before (in v3.12 release isn't). Code taken of `v3.10-7.5`. This fixes the filter in **Manage agents** of **Management/Groups** section.
- Upload file size in **UploadFiles** component increased from `5MB` to `10MB`.
- **Font size** in **Management/Configuration** (editors and viewers) incresed from `14px` to `16px`.
- **Height adjustment** in Management/Configuration editor
- **Improved the displayed size** of the **file to be uploaded to largest unit** in UploadFiles React component
