### PR TITLE
Hide the kibana search bar in the FIM inventory

### DIFF
--- a/public/components/common/modules/dashboard.tsx
+++ b/public/components/common/modules/dashboard.tsx
@@ -15,23 +15,28 @@ import { getAngularModule } from 'plugins/kibana/discover/kibana_services';
 import { ModulesHelper } from './modules-helper'
 
 export class Dashboard extends Component {
+  _isMount = false;
   constructor(props) {
     super(props);
     this.modulesHelper = ModulesHelper;
   }
 
   async componentDidMount() {
+    this._isMount = true;
     document.body.scrollTop = 0; // For Safari
     document.documentElement.scrollTop = 0; // For Chrome, Firefox, IE and Opera
     const app = getAngularModule('app/wazuh');
     this.$rootScope = app.$injector.get('$rootScope');
     this.$rootScope.showModuleDashboard = this.props.section;
     await this.modulesHelper.getDiscoverScope();
-    this.$rootScope.moduleDiscoverReady = true;
-    this.$rootScope.$applyAsync();
+    if (this._isMount) {
+      this.$rootScope.moduleDiscoverReady = true;
+      this.$rootScope.$applyAsync();
+    }
   }
 
   componentWillUnmount() {
+    this._isMount = false;
     this.$rootScope.showModuleDashboard = false;
     this.$rootScope.moduleDiscoverReady = false;
     this.$rootScope.$applyAsync();


### PR DESCRIPTION
Hi team,

This PR fixes a bug where the Kibana search bar was not hidden when changing the view to inventory.

![image](https://user-images.githubusercontent.com/3064506/84743002-99a4ad80-afb1-11ea-8be9-f11ba646f366.png)

Regards,