### PR TITLE
Fix ruleset-overview count

### DIFF
--- a/public/controllers/management/components/management/ruleset/ruleset-overview.js
+++ b/public/controllers/management/components/management/ruleset/ruleset-overview.js
@@ -25,13 +25,17 @@ import store from '../../../../../redux/store';
 import { WzRulesetTotalItems } from './ruleset-total-items';
 
 class WzRulesetOverview extends Component {
+  sectionNames = {
+    rules: 'Rules',
+    decoders: 'Decoders',
+    lists: 'CDB lists'
+  };
+
   constructor(props) {
     super(props);
-    this.sectionNames = {
-      rules: 'Rules',
-      decoders: 'Decoders',
-      lists: 'CDB lists'
-    };
+    this.state = {
+      totalItems: 0
+    }
   }
 
   componentDidMount() {
@@ -63,6 +67,7 @@ class WzRulesetOverview extends Component {
 
   render() {
     const { section } = this.props.state;
+    const { totalItems } = this.state;
 
     return (
       <EuiPage style={{ background: 'transparent' }}>
@@ -70,7 +75,7 @@ class WzRulesetOverview extends Component {
           <EuiFlexGroup>
             <EuiFlexItem grow={false}>
               <EuiTitle>
-                <h2>{this.sectionNames[section]} <WzRulesetTotalItems section={section}/></h2>
+                <h2>{this.sectionNames[section]} <WzRulesetTotalItems section={section} totalItems={totalItems} /></h2>
               </EuiTitle>
             </EuiFlexItem>
             <EuiFlexItem></EuiFlexItem>
@@ -86,7 +91,7 @@ class WzRulesetOverview extends Component {
           <WzRulesetSearchBar />
           <EuiFlexGroup>
             <EuiFlexItem>
-              <WzRulesetTable request={`${section}`} />
+              <WzRulesetTable request={section} updateTotalItems={(totalItems) => this.setState({totalItems})} />
             </EuiFlexItem>
           </EuiFlexGroup>
         </EuiPanel>

--- a/public/controllers/management/components/management/ruleset/ruleset-table.js
+++ b/public/controllers/management/components/management/ruleset/ruleset-table.js
@@ -127,6 +127,7 @@ class WzRulesetTable extends Component {
 
     const { items = [], totalItems = 0 } =
       ((rawItems || {}).data || {}).data || {};
+    this.props.updateTotalItems(totalItems);
     this.setState({
       items,
       totalItems,

--- a/public/controllers/management/components/management/ruleset/ruleset-total-items.tsx
+++ b/public/controllers/management/components/management/ruleset/ruleset-total-items.tsx
@@ -11,6 +11,7 @@ const sectionToAPIRequest = {
 
 export const WzRulesetTotalItems = withLoading(
   async (props) => { /* Load function meanwhile while Loading component is rendered */
+    if (props.totalItems) return { totalItems: props.totalItems };
     try {
       const apiRequest = sectionToAPIRequest[props.section];
       if(apiRequest){
@@ -22,7 +23,7 @@ export const WzRulesetTotalItems = withLoading(
       return { totalItems: undefined, error }
     }
   },
-  (props, prevProps) => props.section !== prevProps.section, /* Reload if section changed */
+  (props, prevProps) => (props.section !== prevProps.section || prevProps.totalItems < props.totalItems), /* Reload if section changed */
   () => <EuiLoadingSpinner /> /* Loading component */
 )(
   (props) => props.totalItems ? <span>({props.totalItems})</span> : null /* React component after run the Load function. Render (totalItems) */


### PR DESCRIPTION
Hey, team!

This PR adds an arrangement to the list of CBD:

When a new list is imported, the item count of the main title is not updated. This solution obtains the total number of items in the table and sends them to the counting component if the number is greater than the last value, it will be updated.

Regards.