### PR TITLE
Adjust columns for discover tables

### DIFF
--- a/public/components/common/modules/discover/discover.tsx
+++ b/public/components/common/modules/discover/discover.tsx
@@ -326,6 +326,7 @@ export class Discover extends Component {
         return  {
           field: 'timestamp',
           name: 'Time',
+          width: '160px',
           sortable: true,
           render: time => {
             const date = time.split('.')[0];
@@ -333,8 +334,26 @@ export class Discover extends Component {
           },
         }
       }
+      let width = false;
+      const arrayCompilance = ["rule.pci_dss", "rule.gdpr", "rule.nist_800_53", "rule.tsc", "rule.hipaa"];
 
-      return {
+      if(item === 'rule.level') {
+        width = '75px';
+      }
+      if(item === 'rule.id') {
+        width = '90px';
+      }
+      if(item === 'rule.description' && this.state.columns.indexOf('syscheck.event') === -1) {
+        width = '30%';
+      }
+      if(item === 'syscheck.event') {
+        width = '100px';
+      }
+      if(arrayCompilance.indexOf(item) !== -1) {
+        width = '150px';
+      }
+
+      let column = {
         field: item,
         name: (<span 
           onMouseEnter={() => { this.setState({hover: item}) }}
@@ -353,7 +372,11 @@ export class Discover extends Component {
         sortable: true
       }
 
+      if (width) {
+        column.width = width;
+      }
 
+      return column;
     })
     return columns;
   }

--- a/public/components/overview/mitre/components/techniques/components/flyout-technique/flyout-technique.tsx
+++ b/public/components/overview/mitre/components/techniques/components/flyout-technique/flyout-technique.tsx
@@ -341,7 +341,6 @@ export class FlyoutTechnique extends Component {
     return(
         <EuiFlyout
           onClose={() => onChangeFlyout(false)}
-          maxWidth="60%"
           size="l"
           className="flyout-no-overlap"
           aria-labelledby="flyoutSmallTitle"

--- a/public/less/common.less
+++ b/public/less/common.less
@@ -1138,6 +1138,26 @@ wz-xml-file-editor {
   }
 }
 
+.flyout-no-overlap {
+  width: auto;
+}
+
+@media only screen and (max-width: 1000px){
+  .flyout-no-overlap {
+    max-width: 90%;
+  }
+}
+@media only screen and (min-width: 1000px) and (max-width: 1400px){
+  .flyout-no-overlap {
+    max-width: 85%;
+  }
+}
+@media only screen and (min-width: 1400px){
+  .flyout-no-overlap {
+    max-width: 60%;
+  }
+}
+
 .requirements-cards.euiFlexGroup--gutterLarge {
   margin: -10px !important;
 }


### PR DESCRIPTION
Hi team!

In this PR, we adjusted the size of the columns for the Discover tables in FIM, MITRE and compliance. With these settings, we give more prominence to the descriptions, and adjust the other fields that are fixed.