### PR TITLE
Make custom discovery more responsive

### DIFF
--- a/public/less/common.less
+++ b/public/less/common.less
@@ -1447,9 +1447,61 @@ div.euiPopover__panel.euiPopover__panel-isOpen.euiPopover__panel--bottom.wz-menu
   padding: 0 3px;
 }
 
+  /* Change custom discover size */
+.wz-discover > .globalQueryBar > 
+.kbnQueryBar--withDatePicker > 
+.euiFlexItem.euiFlexItem--flexGrowZero >
+.euiFlexGroup > 
+.euiFlexItem.kbnQueryBar__datePickerWrapper {
+  max-width: 300px;
+}
+
 @media (max-width: 1300px) {
   .wz-select-agent-modal {
     max-width: 80vw;
+  }
+
+  /* Change custom discover size */
+  .wz-discover > .globalQueryBar > 
+  .euiFlexGroup.kbnQueryBar.kbnQueryBar--withDatePicker {
+    flex-wrap: wrap;
+    margin-left: 0;
+    margin-right: 0;
+  }
+
+  .wz-discover > .globalQueryBar > 
+  .euiFlexGroup.kbnQueryBar.kbnQueryBar--withDatePicker > 
+  .euiFlexItem {
+    width: 100% !important;
+    -ms-flex-preferred-size: 100% !important;
+    flex-basis: 100% !important;
+    margin-left: 0 !important;
+    margin-right: 0 !important;
+    margin-bottom: 16px !important;
+  }
+
+  .wz-discover > .globalQueryBar > 
+  .kbnQueryBar--withDatePicker > :first-child {
+    order: 1;
+    margin-top: -8px;
+  }
+
+  .wz-discover > .globalQueryBar > 
+  .kbnQueryBar--withDatePicker > 
+  .euiFlexItem.euiFlexItem--flexGrowZero >
+  .euiFlexGroup > 
+  .euiFlexItem.kbnQueryBar__datePickerWrapper >
+  .euiFlexGroup {
+    width: 100%;
+  }
+
+  .wz-discover > .globalQueryBar > 
+  .kbnQueryBar--withDatePicker > 
+  .euiFlexItem.euiFlexItem--flexGrowZero >
+  .euiFlexGroup > 
+  .euiFlexItem.kbnQueryBar__datePickerWrapper {
+    flex-grow: 1!important;
+    max-width: none;
   }
 }
 


### PR DESCRIPTION
Hi team!

This PR edits the style of the custom discovery component to make your search bar more responsive to window resizing.

![custom_discover_responsive](https://user-images.githubusercontent.com/3064506/84910801-a01d4d00-b0b7-11ea-8915-afd6e01312a5.gif)

Regards.