### PR TITLE
Fix total hits on custom discover

### DIFF
--- a/public/components/common/modules/discover/discover.tsx
+++ b/public/components/common/modules/discover/discover.tsx
@@ -541,7 +541,7 @@ export class Discover extends Component {
     const pagination = {
       pageIndex: this.state.pageIndex,
       pageSize: this.state.pageSize,
-      totalItemCount: this.state.total,
+      totalItemCount: this.state.total > 10000 ? 10000 : this.state.total,
       pageSizeOptions: [10, 25, 50],
     };
     const noResultsText = `No results match for this search criteria`

--- a/server/controllers/wazuh-elastic.js
+++ b/server/controllers/wazuh-elastic.js
@@ -759,6 +759,7 @@ export class WazuhElasticCtrl {
       }
       payload.sort.push(sort);
       payload.size = size;
+      payload.track_total_hits = true;
       payload.from = req.payload.offset || 0;
       const spaces = this._server.plugins.spaces;
       const namespace = spaces && spaces.getSpaceId(req);


### PR DESCRIPTION
Hi team,
This PR fixes the total count shown in our custom discover, it was limited to 10.000, now it shows the real total count of alerts
![image](https://user-images.githubusercontent.com/35685689/84916624-964b1800-b0be-11ea-9abd-778574182463.png)
