### PR TITLE
Fixes the error produced when changing agent in FIM

### DIFF
--- a/public/components/agents/fim/inventory.tsx
+++ b/public/components/agents/fim/inventory.tsx
@@ -52,6 +52,7 @@ export class Inventory extends Component {
     syscheck: []
     customBadges: ICustomBadges[]
   }
+
   props: any;
 
   constructor(props) {
@@ -70,6 +71,20 @@ export class Inventory extends Component {
 
   async componentDidMount() {
     this._isMount = true;
+    await this.loadAgent();
+  }
+
+  componentDidUpdate(prevProps) {
+    if (JSON.stringify(this.props.agent) !== JSON.stringify(prevProps.agent)){
+      this.setState({isLoading: true}, this.loadAgent)
+    }
+  }
+
+  componentWillUnmount() {
+    this._isMount = false;
+  }
+
+  async loadAgent() {
     const agentPlatform  = ((this.props.agent || {}).os || {}).platform;
     const {totalItemsFile, syscheck} = await this.getItemNumber('file');
     const totalItemsRegistry = agentPlatform === 'windows' ? await this.getItemNumber('registry') : 0;
@@ -86,10 +101,6 @@ export class Inventory extends Component {
   //     this.setState({ filters });
   //   }
   // }
-
-  componentWillUnmount() {
-    this._isMount = false;
-  }
 
   tabs() {
     let auxTabs = [


### PR DESCRIPTION
Hi team!

When you change the agent in inventory FIM the component is not reloaded with the data of the new agent.
![fim_table_onchange_agent](https://user-images.githubusercontent.com/3064506/84916800-d14d4b80-b0be-11ea-8223-067102b558b3.gif)

This PR mounts the component again when a new agent is selected
![fim_table_onchange_agent_good](https://user-images.githubusercontent.com/3064506/84916935-fcd03600-b0be-11ea-9a3c-421ebc18d22c.gif)

Regards.