### PR TITLE
Compliance inventory. Add search on requirements description

### DIFF
--- a/public/components/overview/compliance-table/components/subrequirements/subrequirements.tsx
+++ b/public/components/overview/compliance-table/components/subrequirements/subrequirements.tsx
@@ -79,7 +79,6 @@ export class ComplianceSubrequirements extends Component {
   }
 
   getRequirementKey() {
-    //TODO all other requirements
     if (this.props.section === 'pci') {
       return 'rule.pci_dss';
     }
@@ -131,7 +130,7 @@ export class ComplianceSubrequirements extends Component {
       const currentTechniques = complianceObject[key];
       if (this.props.selectedRequirements[key]) {
         currentTechniques.forEach((technique, idx) => {
-          if (!showTechniques[technique] && (technique.toLowerCase().includes(this.state.searchValue.toLowerCase()))) {
+          if (!showTechniques[technique] && ((technique.toLowerCase().includes(this.state.searchValue.toLowerCase())) || this.props.descriptions[technique].toLowerCase().includes(this.state.searchValue.toLowerCase() ) )) {
             const quantity = (requirementsCount.find(item => item.key === technique) || {}).doc_count || 0;
             if (!this.state.hideAlerts || (this.state.hideAlerts && quantity > 0)) {
               showTechniques[technique] = true;


### PR DESCRIPTION
Hi team,

As requested, the searchbar of the compliance component now also searches on the requirements description, not just on its name.
![Peek 2020-06-18 08-37](https://user-images.githubusercontent.com/35685689/84986861-89223d80-b13f-11ea-889e-7add2b63c5e9.gif)
