### PR TITLE
Fixes in Configuration

### DIFF
--- a/public/controllers/management/components/management/configuration/integrity-monitoring/integrity-monitoring-ignored.js
+++ b/public/controllers/management/components/management/configuration/integrity-monitoring/integrity-monitoring-ignored.js
@@ -23,8 +23,13 @@ const columnsPath = [{ field: 'path', name: 'Path' }];
 
 const columnsSregex = [{ field: 'sregex', name: 'Sregex' }];
 
-const columnsAgentWin = [
+const columnsEntryArch = [
   { field: 'entry', name: 'Entry' },
+  { field: 'arch', name: 'Arch' }
+];
+
+const columnsEntryArchSRegex = [
+  { field: 'entry', name: 'Entry Sregex' },
   { field: 'arch', name: 'Arch' }
 ];
 
@@ -40,16 +45,16 @@ class WzConfigurationMonitoringIgnored extends Component {
         currentConfig &&
         currentConfig['syscheck-syscheck'] &&
         currentConfig['syscheck-syscheck'].syscheck &&
-        currentConfig['syscheck-syscheck'].syscheck.ignore &&
-        !currentConfig['syscheck-syscheck'].syscheck.ignore.length ? (
+        !currentConfig['syscheck-syscheck'].syscheck.ignore &&
+        !currentConfig['syscheck-syscheck'].syscheck.ignore_sregex ? (
           <WzNoConfig error="not-present" help={helpLinks} />
         ) : null}
         {((agent || {}).os || {}).platform !== 'windows' &&
         currentConfig &&
         currentConfig['syscheck-syscheck'] &&
         currentConfig['syscheck-syscheck'].syscheck &&
-        currentConfig['syscheck-syscheck'].syscheck.ignore &&
-        currentConfig['syscheck-syscheck'].syscheck.ignore.length ? (
+        (currentConfig['syscheck-syscheck'].syscheck.ignore ||
+        currentConfig['syscheck-syscheck'].syscheck.ignore_sregex ) ? (
           <Fragment>
             <WzConfigurationSettingsTabSelector
               title="Ignored files and directories"
@@ -58,19 +63,25 @@ class WzConfigurationMonitoringIgnored extends Component {
               minusHeight={this.props.agent.id === '000' ? 320 : 415}
               helpLinks={helpLinks}
             >
-              <EuiBasicTable
-                items={currentConfig['syscheck-syscheck'].syscheck.ignore.map(
-                  item => ({ path: item })
-                )}
-                columns={columnsPath}
-              />
-              <EuiSpacer size="s" />
-              <EuiBasicTable
-                items={currentConfig[
-                  'syscheck-syscheck'
-                ].syscheck.ignore_sregex.map(item => ({ sregex: item }))}
-                columns={columnsSregex}
-              />
+              {currentConfig['syscheck-syscheck'].syscheck.ignore && (
+                <EuiBasicTable
+                  items={currentConfig['syscheck-syscheck'].syscheck.ignore.map(
+                    item => ({ path: item })
+                  )}
+                  columns={columnsPath}
+                />
+              )}
+              {currentConfig['syscheck-syscheck'].syscheck.ignore_sregex && (
+                <Fragment>
+                  {currentConfig['syscheck-syscheck'].syscheck.ignore && <EuiSpacer size="s" />}
+                  <EuiBasicTable
+                    items={currentConfig[
+                      'syscheck-syscheck'
+                    ].syscheck.ignore_sregex.map(item => ({ sregex: item }))}
+                    columns={columnsSregex}
+                  />
+                </Fragment>
+              )}
             </WzConfigurationSettingsTabSelector>
           </Fragment>
         ) : null}
@@ -78,16 +89,20 @@ class WzConfigurationMonitoringIgnored extends Component {
           currentConfig &&
           currentConfig['syscheck-syscheck'] &&
           currentConfig['syscheck-syscheck'].syscheck &&
-          !currentConfig['syscheck-syscheck'].syscheck.registry &&
-          !currentConfig['syscheck-syscheck'].syscheck.registry_ignore && (
+          !currentConfig['syscheck-syscheck'].syscheck.ignore &&
+          !currentConfig['syscheck-syscheck'].syscheck.ignore_sregex &&
+          !currentConfig['syscheck-syscheck'].syscheck.registry_ignore &&
+          !currentConfig['syscheck-syscheck'].syscheck.registry_ignore_sregex && (
             <WzNoConfig error="not-present" help={helpLinks} />
           )}
         {((agent || {}).os || {}).platform === 'windows' &&
           currentConfig &&
           currentConfig['syscheck-syscheck'] &&
           currentConfig['syscheck-syscheck'].syscheck &&
-          (currentConfig['syscheck-syscheck'].syscheck.registry ||
-            currentConfig['syscheck-syscheck'].syscheck.registry_ignore) && (
+          (currentConfig['syscheck-syscheck'].syscheck.ignore ||
+            currentConfig['syscheck-syscheck'].syscheck.ignore_sregex ||
+            currentConfig['syscheck-syscheck'].syscheck.registry_ignore ||
+            currentConfig['syscheck-syscheck'].syscheck.registry_ignore_sregex) && (
             <WzConfigurationSettingsTabSelector
               title="Ignored"
               description="A list of registry entries that will be ignored"
@@ -100,17 +115,44 @@ class WzConfigurationMonitoringIgnored extends Component {
                   items={
                     currentConfig['syscheck-syscheck'].syscheck.registry_ignore
                   }
-                  columns={columnsAgentWin}
+                  columns={columnsEntryArch}
                 />
               )}
               {currentConfig['syscheck-syscheck'].syscheck
                 .registry_ignore_sregex && (
-                <EuiBasicTable
-                  items={
-                    currentConfig['syscheck-syscheck'].syscheck.ignore_sregex
-                  }
-                  columns={columnsAgentWin}
-                />
+                  <Fragment>
+                    {(currentConfig['syscheck-syscheck'].syscheck.registry_ignore) && <EuiSpacer />}
+                    <EuiBasicTable
+                      items={
+                        currentConfig['syscheck-syscheck'].syscheck.registry_ignore_sregex
+                      }
+                      columns={columnsEntryArchSRegex}
+                    />
+                  </Fragment>
+              )}
+              {currentConfig['syscheck-syscheck'].syscheck
+                .ignore && (
+                  <Fragment>
+                    {(currentConfig['syscheck-syscheck'].syscheck.registry_ignore || currentConfig['syscheck-syscheck'].syscheck.registry_ignore_sregex ) && <EuiSpacer />}
+                    <EuiBasicTable
+                      items={
+                        currentConfig['syscheck-syscheck'].syscheck.ignore.map(item => ({ path: item }))
+                      }
+                      columns={columnsPath}
+                    />
+                  </Fragment>
+              )}
+              {currentConfig['syscheck-syscheck'].syscheck
+                .ignore_sregex && (
+                  <Fragment>
+                    {(currentConfig['syscheck-syscheck'].syscheck.registry_ignore || currentConfig['syscheck-syscheck'].syscheck.registry_ignore_sregex || currentConfig['syscheck-syscheck'].syscheck.ignore) && <EuiSpacer />}
+                    <EuiBasicTable
+                      items={
+                        currentConfig['syscheck-syscheck'].syscheck.ignore_sregex.map(item => ({ sregex: item }))
+                      }
+                      columns={columnsSregex}
+                    />
+                  </Fragment>
               )}
             </WzConfigurationSettingsTabSelector>
           )}

--- a/public/controllers/management/components/management/configuration/integrity-monitoring/integrity-monitoring-monitored.js
+++ b/public/controllers/management/components/management/configuration/integrity-monitoring/integrity-monitoring-monitored.js
@@ -13,9 +13,10 @@
 import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 
-import { EuiBasicTable } from '@elastic/eui';
+import { EuiBasicTable, EuiSpacer } from '@elastic/eui';
 
 import WzConfigurationSettingsTabSelector from '../util-components/configuration-settings-tab-selector';
+import WzConfigurationSettingsHeader from '../util-components/configuration-settings-header';
 import WzConfigurationListSelector from '../util-components/configuration-settings-list-selector';
 import WzNoConfig from '../util-components/no-config';
 import { settingsListBuilder } from '../utils/builders';
@@ -130,8 +131,10 @@ class WzConfigurationIntegrityMonitoringMonitored extends Component {
         {currentConfig &&
         currentConfig['syscheck-syscheck'] &&
         currentConfig['syscheck-syscheck'].syscheck &&
-        currentConfig['syscheck-syscheck'].syscheck.directories &&
-        !currentConfig['syscheck-syscheck'].syscheck.directories.length ? (
+        (currentConfig['syscheck-syscheck'].syscheck.directories &&
+        !currentConfig['syscheck-syscheck'].syscheck.directories.length &&
+        ((currentConfig['syscheck-syscheck'].syscheck.registry &&
+        !currentConfig['syscheck-syscheck'].syscheck.registry.length) || !currentConfig['syscheck-syscheck'].syscheck.registry)) ? (
           <WzNoConfig error="not-present" help={helpLinks} />
         ) : null}
         {currentConfig &&
@@ -156,28 +159,42 @@ class WzConfigurationIntegrityMonitoringMonitored extends Component {
           currentConfig &&
           currentConfig['syscheck-syscheck'] &&
           currentConfig['syscheck-syscheck'].syscheck &&
-          !currentConfig['syscheck-syscheck'].syscheck.registry &&
-          !currentConfig['syscheck-syscheck'].syscheck.registry_ignore && (
+          !currentConfig['syscheck-syscheck'].syscheck.registry && (
             <WzNoConfig error="not-present" help={helpLinks} />
           )}
         {((agent || {}).os || {}).platform === 'windows' &&
           currentConfig &&
           currentConfig['syscheck-syscheck'] &&
           currentConfig['syscheck-syscheck'].syscheck &&
-          (currentConfig['syscheck-syscheck'].syscheck.registry ||
-            currentConfig['syscheck-syscheck'].syscheck.registry_ignore) && (
-            <WzConfigurationSettingsTabSelector
-              title="Monitored"
-              description="A list of registry entries that will be monitored"
-              currentConfig={currentConfig}
-              minusHeight={this.props.agent.id === '000' ? 320 : 415}
-              helpLinks={helpLinks}
-            >
-              <EuiBasicTable
-                items={currentConfig['syscheck-syscheck'].syscheck.registry}
-                columns={columnsAgentWin}
-              />
-            </WzConfigurationSettingsTabSelector>
+          currentConfig['syscheck-syscheck'].syscheck.registry && (
+              <Fragment>
+                {currentConfig['syscheck-syscheck'].syscheck.directories && currentConfig['syscheck-syscheck'].syscheck.directories.length && (
+                  <Fragment>
+                    <EuiSpacer />
+                    <WzConfigurationSettingsHeader
+                      title="Monitored registry entries"
+                      description="A list of registry entries that will be monitored"
+                    />
+                    <EuiBasicTable
+                      items={currentConfig['syscheck-syscheck'].syscheck.registry}
+                      columns={columnsAgentWin}
+                    />
+                  </Fragment>
+                ) || (
+                  <WzConfigurationSettingsTabSelector
+                    title="Monitored registry entries"
+                    description="A list of registry entries that will be monitored"
+                    currentConfig={currentConfig}
+                    minusHeight={this.props.agent.id === '000' ? 320 : 415}
+                    helpLinks={helpLinks}
+                  >
+                    <EuiBasicTable
+                      items={currentConfig['syscheck-syscheck'].syscheck.registry}
+                      columns={columnsAgentWin}
+                    />
+                  </WzConfigurationSettingsTabSelector>
+                )}
+              </Fragment>
           )}
       </Fragment>
     );

--- a/public/controllers/management/components/management/configuration/integrity-monitoring/integrity-monitoring-monitored.js
+++ b/public/controllers/management/components/management/configuration/integrity-monitoring/integrity-monitoring-monitored.js
@@ -132,7 +132,7 @@ class WzConfigurationIntegrityMonitoringMonitored extends Component {
         currentConfig['syscheck-syscheck'] &&
         currentConfig['syscheck-syscheck'].syscheck &&
         (currentConfig['syscheck-syscheck'].syscheck.directories &&
-        !currentConfig['syscheck-syscheck'].syscheck.directories.length &&
+        !currentConfig['syscheck-syscheck'].syscheck.directories.length  &&
         ((currentConfig['syscheck-syscheck'].syscheck.registry &&
         !currentConfig['syscheck-syscheck'].syscheck.registry.length) || !currentConfig['syscheck-syscheck'].syscheck.registry)) ? (
           <WzNoConfig error="not-present" help={helpLinks} />
@@ -141,7 +141,7 @@ class WzConfigurationIntegrityMonitoringMonitored extends Component {
         currentConfig['syscheck-syscheck'] &&
         currentConfig['syscheck-syscheck'].syscheck &&
         currentConfig['syscheck-syscheck'].syscheck.directories &&
-        currentConfig['syscheck-syscheck'].syscheck.directories.length ? (
+        currentConfig['syscheck-syscheck'].syscheck.directories.length > 0 ? (
           <WzConfigurationSettingsTabSelector
             title="Monitored directories"
             description="These directories are included on the integrity scan"
@@ -153,6 +153,23 @@ class WzConfigurationIntegrityMonitoringMonitored extends Component {
               items={items}
               settings={mainSettings}
             />
+            {((agent || {}).os || {}).platform === 'windows' &&
+              currentConfig &&
+              currentConfig['syscheck-syscheck'] &&
+              currentConfig['syscheck-syscheck'].syscheck &&
+              currentConfig['syscheck-syscheck'].syscheck.registry && (
+                <Fragment>
+                  <EuiSpacer />
+                  <WzConfigurationSettingsHeader
+                    title="Monitored registry entries"
+                    description="A list of registry entries that will be monitored"
+                  />
+                  <EuiBasicTable
+                    items={currentConfig['syscheck-syscheck'].syscheck.registry}
+                    columns={columnsAgentWin}
+                  />
+                </Fragment>
+            )}
           </WzConfigurationSettingsTabSelector>
         ) : null}
         {((agent || {}).os || {}).platform === 'windows' &&
@@ -166,35 +183,22 @@ class WzConfigurationIntegrityMonitoringMonitored extends Component {
           currentConfig &&
           currentConfig['syscheck-syscheck'] &&
           currentConfig['syscheck-syscheck'].syscheck &&
-          currentConfig['syscheck-syscheck'].syscheck.registry && (
-              <Fragment>
-                {currentConfig['syscheck-syscheck'].syscheck.directories && currentConfig['syscheck-syscheck'].syscheck.directories.length && (
-                  <Fragment>
-                    <EuiSpacer />
-                    <WzConfigurationSettingsHeader
-                      title="Monitored registry entries"
-                      description="A list of registry entries that will be monitored"
-                    />
-                    <EuiBasicTable
-                      items={currentConfig['syscheck-syscheck'].syscheck.registry}
-                      columns={columnsAgentWin}
-                    />
-                  </Fragment>
-                ) || (
-                  <WzConfigurationSettingsTabSelector
-                    title="Monitored registry entries"
-                    description="A list of registry entries that will be monitored"
-                    currentConfig={currentConfig}
-                    minusHeight={this.props.agent.id === '000' ? 320 : 415}
-                    helpLinks={helpLinks}
-                  >
-                    <EuiBasicTable
-                      items={currentConfig['syscheck-syscheck'].syscheck.registry}
-                      columns={columnsAgentWin}
-                    />
-                  </WzConfigurationSettingsTabSelector>
-                )}
-              </Fragment>
+          currentConfig['syscheck-syscheck'].syscheck.registry &&
+          currentConfig['syscheck-syscheck'].syscheck.registry.length > 0 &&
+          ((currentConfig['syscheck-syscheck'].syscheck.directories && !currentConfig['syscheck-syscheck'].syscheck.directories.length)
+            || !currentConfig['syscheck-syscheck'].syscheck.directories) && (
+              <WzConfigurationSettingsTabSelector
+                title="Monitored registry entries"
+                description="A list of registry entries that will be monitored"
+                currentConfig={currentConfig}
+                minusHeight={this.props.agent.id === '000' ? 320 : 415}
+                helpLinks={helpLinks}
+              >
+                <EuiBasicTable
+                  items={currentConfig['syscheck-syscheck'].syscheck.registry}
+                  columns={columnsAgentWin}
+                />
+              </WzConfigurationSettingsTabSelector>
           )}
       </Fragment>
     );

--- a/public/controllers/management/components/management/configuration/integrity-monitoring/integrity-monitoring.js
+++ b/public/controllers/management/components/management/configuration/integrity-monitoring/integrity-monitoring.js
@@ -45,7 +45,8 @@ class WzConfigurationIntegrityMonitoring extends Component {
     );
   }
   render() {
-    const { currentConfig } = this.props;
+    const { currentConfig, agent } = this.props;
+    const agentPlatform = ((agent || {}).os || {}).platform;
     return (
       <Fragment>
         {currentConfig['syscheck-syscheck'] &&
@@ -76,17 +77,19 @@ class WzConfigurationIntegrityMonitoring extends Component {
               <WzTabSelectorTab label="No diff">
                 <WzConfigurationIntegrityMonitoringNoDiff {...this.props} />
               </WzTabSelectorTab>
-              <WzTabSelectorTab label="Who-data">
-                <WzConfigurationIntegrityMonitoringWhoData {...this.props} />
-              </WzTabSelectorTab>
+              {agentPlatform !== 'windows' && (
+                <WzTabSelectorTab label="Who-data">
+                  <WzConfigurationIntegrityMonitoringWhoData {...this.props} />
+                </WzTabSelectorTab>
+              )}
               <WzTabSelectorTab label="Synchronization">
                 <WzConfigurationIntegrityMonitoringSynchronization
                   {...this.props}
                 />
               </WzTabSelectorTab>
-              {/* <WzTabSelectorTab label="File limit">
+              <WzTabSelectorTab label="File limit">
                 <WzConfigurationIntegrityMonitoringFileLimit {...this.props} />
-              </WzTabSelectorTab> */}
+              </WzTabSelectorTab>
             </WzTabSelector>
           )}
       </Fragment>

--- a/public/controllers/management/components/management/configuration/policy-monitoring/policy-monitoring-general.js
+++ b/public/controllers/management/components/management/configuration/policy-monitoring/policy-monitoring-general.js
@@ -43,9 +43,9 @@ const allSettings = [
   { field: 'skip_nfs', label: 'Skip scan on CIFS/NFS mounts' },
   { field: 'rootkit_files', label: 'Rootkit files database path' },
   { field: 'rootkit_trojans', label: 'Rootkit trojans database path' },
-  { field: 'windows_audit', label: 'Rootkit trojans database path' },
-  { field: 'windows_apps', label: 'Rootkit trojans database path' },
-  { field: 'windows_malware', label: 'Rootkit trojans database path' }
+  { field: 'windows_audit', label: 'Windows audit definition file path' },
+  { field: 'windows_apps', label: 'Windows application definition file path' },
+  { field: 'windows_malware', label: 'Windows malware definitions file path' }
 ];
 
 class WzConfigurationPolicyMonitoringGeneral extends Component {

--- a/public/controllers/management/components/management/configuration/util-components/tab-selector.js
+++ b/public/controllers/management/components/management/configuration/util-components/tab-selector.js
@@ -29,13 +29,13 @@ class WzTabSelector extends Component {
   render() {
     const { selectedTab } = this.state;
     const { children, container, spacer } = this.props;
-    const activeTabContent = children.find(
+    const activeTabContent = children.filter(child => child).find(
       child => child.props.label === selectedTab
     );
     return (
       <Fragment>
         <EuiTabs>
-          {children.map(child => {
+          {children.filter(child => child).map(child => {
             const { label } = child.props;
             return (
               <EuiTab


### PR DESCRIPTION
Hi team, this PR resolves:
- Enable **File limit** tab in `Configuration/Integrity monitoring`. Checked with new API changes.
- Added some missing tables to `Configuration/Integrity monitoring/Ignored` for a Windows agent.
- Removed duplicated `Settings/JSON/XML` selector in `Configuration/Integrity monitoring/Monitored`.
- Renamed `Monitored` to `Monitored registry entries` section in `Configuration/Integrity monitoring/Monitored`.