### PR TITLE
Mitre active by default

### DIFF
--- a/public/components/settings/modules/modules.js
+++ b/public/components/settings/modules/modules.js
@@ -44,10 +44,10 @@ export default class EnableModules extends Component {
           title: 'Threat Detection and Response',
           modules: [
             { name: 'vuls', default: true, agent: false },
+            { name: 'mitre', default: true, agent: false },
             { name: 'virustotal', default: false, agent: false },
             { name: 'osquery', default: false, agent: false },
             { name: 'docker', default: false, agent: false },
-            { name: 'mitre', default: true, agent: false },
           ]
         },
         {

--- a/public/components/wz-menu/wz-menu-overview.js
+++ b/public/components/wz-menu/wz-menu-overview.js
@@ -154,10 +154,10 @@ class WzMenuOverview extends Component {
       this.overviewSections.sca
     ];
     let threatDetectionItems = [
-      this.overviewSections.mitre,
       this.overviewSections.virustotal,
       this.overviewSections.osquery,
       this.overviewSections.docker,
+      this.overviewSections.mitre
     ];
     securityInformationItems.splice(2, 0, this.overviewSections.aws);
     threatDetectionItems.unshift(this.overviewSections.vuls);

--- a/public/components/wz-menu/wz-menu-overview.js
+++ b/public/components/wz-menu/wz-menu-overview.js
@@ -154,10 +154,10 @@ class WzMenuOverview extends Component {
       this.overviewSections.sca
     ];
     let threatDetectionItems = [
+      this.overviewSections.mitre,
       this.overviewSections.virustotal,
       this.overviewSections.osquery,
       this.overviewSections.docker,
-      this.overviewSections.mitre
     ];
     securityInformationItems.splice(2, 0, this.overviewSections.aws);
     threatDetectionItems.unshift(this.overviewSections.vuls);

--- a/server/lib/default-ext.js
+++ b/server/lib/default-ext.js
@@ -22,6 +22,5 @@ export const defaultExt = {
   gcp: false,
   virustotal: false,
   osquery: false,
-  mitre: true,
   docker: false
 };

--- a/server/lib/default-ext.js
+++ b/server/lib/default-ext.js
@@ -22,6 +22,6 @@ export const defaultExt = {
   gcp: false,
   virustotal: false,
   osquery: false,
-  mitre: false,
+  mitre: true,
   docker: false
 };


### PR DESCRIPTION
Hi team,

With this PR we fixed a bug that, having MITRE by default, did not let us activate it and in a clean installation it never appeared in the menu.