### PR TITLE
Fix spinner Events to Dashboards tabs

### DIFF
--- a/public/templates/visualize/dashboards.html
+++ b/public/templates/visualize/dashboards.html
@@ -10,12 +10,6 @@
                     name="MainModule"
                     props="getMainProps(resultState)" ></react-component>
                     <react-component style="visibility: hidden;" flex name="WzCurrentOverviewSectionWrapper" props="octrl.currentOverviewSectionProps" ></react-component>
-                <div ng-if='!loadingDashboard'>
-                    <div ng-show='showModuleDashboard || showModuleEvents'>
-                        <div ng-if='showModuleEvents && !moduleDiscoverReady' style="margin: 0 auto; width: 32px">
-                        </div>
-                    </div>
-                </div>
             </div>
 
             <div ng-class="{'no-opacity': !moduleDiscoverReady}">

--- a/public/templates/visualize/dashboards.html
+++ b/public/templates/visualize/dashboards.html
@@ -13,9 +13,7 @@
                 <div ng-if='!loadingDashboard'>
                     <div ng-show='showModuleDashboard || showModuleEvents'>
                         <div ng-if='showModuleEvents && !moduleDiscoverReady' style="margin: 0 auto; width: 32px">
-                            <span class="euiLoadingSpinner euiLoadingSpinner--xLarge" style="margin-top: 24px"></span>
                         </div>
-
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
Hello team,

With this PR we corrected an error that when moving between Events and Dashboards in some modules 2 spinners were shown loading. Now only one spinner is shown in the loads.