### PR TITLE
Added new toast notifiacation to reload page

### DIFF
--- a/public/components/settings/configuration/configuration-table.js
+++ b/public/components/settings/configuration/configuration-table.js
@@ -10,7 +10,13 @@
  * Find more information about this on the LICENSE file.
  */
 import React, { Component } from 'react';
-import { EuiBasicTable, EuiCallOut } from '@elastic/eui';
+import {
+  EuiBasicTable,
+  EuiCallOut,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiButton
+} from '@elastic/eui';
 
 import ConfigurationHandler from './utils/configuration-handler';
 import { toastNotifications } from 'ui/notify';
@@ -98,6 +104,16 @@ export class WzConfigurationTable extends Component {
           'You must restart Kibana for the changes to take effect',
           3000
         );
+      } else if (response.needReload) {
+        toastNotifications.add({
+          color: 'success',
+          title: 'This settings require you to reload the page to take effect.',
+          text: <EuiFlexGroup justifyContent="flexEnd" gutterSize="s">
+            <EuiFlexItem grow={false}>
+              <EuiButton onClick={() => window.location.reload()} size="s">Reload page</EuiButton>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        })
       } else {
         this.showToast(
           'success',
@@ -152,7 +168,6 @@ export class WzConfigurationTable extends Component {
     }
   }
 
-  onTableChange = () => {};
 
   render() {
     const { isLoading, error } = this.state;
@@ -172,7 +187,6 @@ export class WzConfigurationTable extends Component {
             itemId="id"
             items={items}
             columns={columns}
-            onChange={this.onTableChange}
             loading={isLoading}
             message={message}
           />

--- a/server/controllers/wazuh-utils.js
+++ b/server/controllers/wazuh-utils.js
@@ -56,7 +56,7 @@ export class WazuhUtilsCtrl {
       return {
         statusCode: 200,
         error: 0,
-        data: { needRestart: result.needRestart }
+        data: result
       };
     } catch (error) {
       return ErrorResponse(error.message || error, 3021, 500, reply);

--- a/server/lib/update-configuration.js
+++ b/server/lib/update-configuration.js
@@ -22,7 +22,11 @@ const needRestartFields = [
   'wazuh.monitoring.replicas',
   'wazuh.monitoring.creation',
   'wazuh.monitoring.pattern',
-  'logs.level'
+  'logs.level',
+];
+
+const newReloadFields = [
+  'hideManagerAlerts',
 ];
 export class UpdateConfigurationFile {
   constructor() {
@@ -80,7 +84,10 @@ export class UpdateConfigurationFile {
         'Updating configuration',
         'debug'
       );
-      return { needRestart: needRestartFields.includes(key) };
+      return { 
+        needRestart: needRestartFields.includes(key), 
+        needReload: newReloadFields.includes(key)
+      };
     } catch (error) {
       log('update-configuration:updateConfiguration', error.message || error);
       this.busy = false;


### PR DESCRIPTION
Hi team!

Changing the configuration of `hideAlertsManager` requires reloading the page to be applied.

We have added a toast notification with a shortcut button to `location.reload`
![image](https://user-images.githubusercontent.com/3064506/85140167-2ca94600-b245-11ea-9cee-5a07ea1c2673.png)

Regards.