### PR TITLE
Hide/show modules by os support

### DIFF
--- a/public/components/common/welcome/agents-welcome.js
+++ b/public/components/common/welcome/agents-welcome.js
@@ -53,6 +53,7 @@ import { TabVisualizations } from '../../../factories/tab-visualizations';
 import chrome from 'ui/chrome';
 import { updateCurrentAgentData } from '../../../redux/actions/appStateActions';
 import WzTextWithTooltipIfTruncated from '../wz-text-with-tooltip-if-truncated';
+import { UnsupportedComponents } from './../../../utils/components-os-support';
 
 export class AgentsWelcome extends Component {
   _isMount = false;
@@ -74,6 +75,7 @@ export class AgentsWelcome extends Component {
       widthWindow: window.innerWidth
     };
 
+    this.platform = false;
   }
 
   updateWidth = () => {
@@ -139,6 +141,9 @@ export class AgentsWelcome extends Component {
     const $injector = await chrome.dangerouslyGetActiveInjector();
     this.router = $injector.get('$route');
     window.addEventListener('resize', this.updateWidth); //eslint-disable-line
+    if (Object.keys(this.props.agent).length) {
+      this.platform = ((this.props.agent.os || {}).uname || '').includes('Linux') ? 'linux' : ((this.props.agent.os || {}).platform || false);
+    }
   }
 
   updateMenuAgents() {
@@ -185,6 +190,10 @@ export class AgentsWelcome extends Component {
     this.setState({ menuAgent: menuAgent});
   }
 
+  showModuleByPlatform(menu) {
+    return !this.platform ? false : !UnsupportedComponents[this.platform].includes(menu.id);
+  }
+
   renderModules() {
     const menuAgent = [...Object.keys(this.state.menuAgent).map((item) => { return this.state.menuAgent[item] })];
 
@@ -192,7 +201,7 @@ export class AgentsWelcome extends Component {
       <Fragment>
         {
           menuAgent.map((menuAgent, i) => {
-            if(i < this.state.maxModules) {
+            if(i < this.state.maxModules && this.showModuleByPlatform(menuAgent)) {
             return (
             <EuiFlexItem key={i} grow={false} style={{ marginLeft: 0, marginTop: 7 }}>
               <EuiButtonEmpty

--- a/public/components/common/welcome/components/menu-agent.js
+++ b/public/components/common/welcome/components/menu-agent.js
@@ -178,31 +178,33 @@ class WzMenuAgent extends Component {
     ];
     let auditingItems = [
       this.agentSections.pm,
-      this.agentSections.audit,
-      this.agentSections.oscap,
       this.agentSections.ciscat,
       this.agentSections.sca
     ];
     let threatDetectionItems = [
       this.agentSections.virustotal,
       this.agentSections.osquery,
-      this.agentSections.docker,
       this.agentSections.mitre
     ];
 
-    securityInformationItems.splice(2, 0, this.agentSections.aws);
-    threatDetectionItems.unshift(this.agentSections.vuls);
-    /*  DO NOT HIDE ANY SECTION EVEN IF IT'S NOT COMPATIBLE WITH THE CURRENT AGENT
-    if (!this.props.isAgent) {
-      securityInformationItems.splice(2, 0, this.agentSections.aws);
-      threatDetectionItems.unshift(this.agentSections.vuls);
-    } else {
-      auditingItems.splice(1, 0, this.agentSections.sca);
-      if (!(UnsupportedComponents[this.props.isAgent.agentPlatform] || UnsupportedComponents['other']).includes('vuls') || !this.props.isAgent.agentPlatform) {
-        threatDetectionItems.unshift(this.agentSections.vuls);
-      }
+    const agent = store.getState().appStateReducers.currentAgentData;
+
+    let platform = false;
+
+    if (Object.keys(agent).length) {
+      platform = ((agent.os || {}).uname || '').includes('Linux') ? 'linux' : ((agent.os || {}).platform || false);
     }
-    */
+
+    if( !platform || !UnsupportedComponents[platform].includes('audit')) {
+      auditingItems.splice(1, 0, this.agentSections.audit);
+      auditingItems.splice(2, 0, this.agentSections.oscap);
+    }
+    if(!platform || !UnsupportedComponents[platform].includes('docker')) {
+      threatDetectionItems.splice(2, 0, this.agentSections.docker);
+    }
+    if(!platform || !UnsupportedComponents[platform].includes('vuls')) {
+      threatDetectionItems.unshift(this.agentSections.vuls);
+    }
 
     const securityInformation = [
       this.createItem(this.agentSections.securityInformation, {

--- a/public/components/wz-menu/wz-menu-overview.js
+++ b/public/components/wz-menu/wz-menu-overview.js
@@ -144,36 +144,39 @@ class WzMenuOverview extends Component {
     let securityInformationItems = [
       this.overviewSections.general,
       this.overviewSections.fim,
+      this.overviewSections.aws,
       this.overviewSections.gcp
     ];
     let auditingItems = [
       this.overviewSections.pm,
-      this.overviewSections.audit,
-      this.overviewSections.oscap,
       this.overviewSections.ciscat,
       this.overviewSections.sca
     ];
     let threatDetectionItems = [
       this.overviewSections.virustotal,
       this.overviewSections.osquery,
-      this.overviewSections.docker,
       this.overviewSections.mitre
     ];
-    securityInformationItems.splice(2, 0, this.overviewSections.aws);
-    threatDetectionItems.unshift(this.overviewSections.vuls);
-
-    /*  DO NOT HIDE ANY SECTION EVEN IF IT'S NOT COMPATIBLE WITH THE CURRENT AGENT
 
     const agent = store.getState().appStateReducers.currentAgentData;
-    if (!agent.id) {
-      securityInformationItems.splice(2, 0, this.overviewSections.aws);
-      threatDetectionItems.unshift(this.overviewSections.vuls);
-    } else {
-      if (!(UnsupportedComponents[agent.agentPlatform] || UnsupportedComponents['other']).includes('vuls') || !agent.agentPlatform) {
-        threatDetectionItems.unshift(this.overviewSections.vuls);
-      }
-    }*/
 
+    let platform = false;
+
+    if (Object.keys(agent).length) {
+      platform = ((agent.os || {}).uname || '').includes('Linux') ? 'linux' : ((agent.os || {}).platform || false);
+    }
+
+    if( !platform || !UnsupportedComponents[platform].includes('audit')) {
+      auditingItems.splice(1, 0, this.overviewSections.audit);
+      auditingItems.splice(2, 0, this.overviewSections.oscap);
+    }
+    if(!platform || !UnsupportedComponents[platform].includes('docker')) {
+      threatDetectionItems.splice(2, 0, this.overviewSections.docker);
+    }
+    if(!platform || !UnsupportedComponents[platform].includes('vuls')) {
+      threatDetectionItems.unshift(this.overviewSections.vuls);
+    }
+    
     const securityInformation = [
       this.createItem(this.overviewSections.securityInformation, {
         disabled: true,


### PR DESCRIPTION
Hi team!

With this PR, we show only the modules compatible with the agent's platform if it is selected. 