### PR TITLE
OpenSCAP and errors in Rules/Decoders/Groups editors

### DIFF
--- a/public/controllers/management/components/management/configuration/open-scap/open-scap-evaluations.js
+++ b/public/controllers/management/components/management/configuration/open-scap/open-scap-evaluations.js
@@ -57,8 +57,8 @@ class WzConfigurationOpenScapEvaluations extends Component {
             />
           )}
         {currentConfig &&
-          wodleConfig['open-scap'] &&
-          !wodleConfig['open-scap'].content &&
+          ((wodleConfig['open-scap'] &&
+          !wodleConfig['open-scap'].content) || !wodleConfig['open-scap']) &&
           !isString(currentConfig['wmodules-wmodules']) && (
             <WzNoConfig error="not-present" help={helpLinks} />
           )}

--- a/public/controllers/management/components/management/configuration/util-components/code-editor.js
+++ b/public/controllers/management/components/management/configuration/util-components/code-editor.js
@@ -56,7 +56,7 @@ class WzCodeEditor extends Component {
             onChange={onChange}
             isReadOnly={isReadOnly}
             setOptions={setOptions || {
-              fontSize: '16px',
+              fontSize: '14px',
               enableSnippets: true
             }}
             aria-label="Code Editor"

--- a/public/controllers/management/components/management/groups/groups-editor.js
+++ b/public/controllers/management/components/management/groups/groups-editor.js
@@ -9,7 +9,7 @@
  *
  * Find more information about this on the LICENSE file.
  */
-import React, { Component } from 'react';
+import React, { Component, Fragment } from 'react';
 
 import { connect } from 'react-redux';
 import { cleanFileContent } from '../../../../../redux/actions/groupsActions';
@@ -34,6 +34,7 @@ import GroupsHandler from './utils/groups-handler';
 
 import { toastNotifications } from 'ui/notify';
 import 'brace/theme/textmate';
+import { validateXML } from '../configuration/utils/xml';
 
 class WzGroupsEditor extends Component {
   _isMounted = false;
@@ -130,15 +131,16 @@ class WzGroupsEditor extends Component {
     const { name, content, isEditable, groupName } = this.state;
     const { adminMode } = this.props;
 
+    const xmlError = validateXML(content);
     const saveButton = (
       <EuiButton
         fill
-        iconType="save"
+        iconType={(isEditable && xmlError) ? "alert" : "save"}
         isLoading={this.state.isSaving}
-        isDisabled={name.length <= 4}
+        isDisabled={name.length <= 4 || (isEditable && xmlError ? true : false)}
         onClick={() => this.save(name)}
       >
-        Save
+        {(isEditable && xmlError) ? 'XML format error' : 'Save'}
       </EuiButton>
     );
 
@@ -171,6 +173,12 @@ class WzGroupsEditor extends Component {
                 )}
               </EuiFlexGroup>
               <EuiSpacer size="m" />
+              {xmlError && (
+                <Fragment>
+                  <span style={{ color: 'red' }}> {xmlError}</span>
+                  <EuiSpacer size='s'/>
+                </Fragment>
+              )}
               <EuiFlexGroup>
                 <EuiFlexItem>
                   <EuiFlexGroup>
@@ -179,7 +187,7 @@ class WzGroupsEditor extends Component {
                         <EuiCodeEditor
                           theme="textmate"
                           width="100%"
-                          height="calc(100vh - 175px)"
+                          height={`calc(100vh - ${(xmlError ? 195 : 175)}px)`}
                           value={content}
                           onChange={newContent =>
                             this.setState({ content: newContent })

--- a/public/controllers/management/components/management/ruleset/ruleset-editor.js
+++ b/public/controllers/management/components/management/ruleset/ruleset-editor.js
@@ -39,6 +39,7 @@ import validateConfigAfterSent from './utils/valid-configuration';
 import { toastNotifications } from 'ui/notify';
 import { updateWazuhNotReadyYet } from '../../../../../redux/actions/appStateActions';
 import WzRestartClusterManagerCallout from '../../../../../components/common/restart-cluster-manager-callout';
+import { validateXML } from '../configuration/utils/xml';
 
 class WzRulesetEditor extends Component {
   _isMounted = false;
@@ -171,15 +172,16 @@ class WzRulesetEditor extends Component {
       : `${nameForSaving}.xml`;
     const overwrite = fileContent ? true : false;
 
+    const xmlError = validateXML(content);
     const saveButton = (
       <EuiButton
         fill
-        iconType="save"
+        iconType={(isEditable && xmlError) ? "alert" : "save"}
         isLoading={this.state.isSaving}
-        isDisabled={nameForSaving.length <= 4}
+        isDisabled={nameForSaving.length <= 4 || (isEditable && xmlError ? true : false)}
         onClick={() => this.save(nameForSaving, overwrite)}
       >
-        Save
+        {(isEditable && xmlError) ? 'XML format error' : 'Save'}
       </EuiButton>
     );
 
@@ -254,6 +256,12 @@ class WzRulesetEditor extends Component {
                   <EuiSpacer size='s'/>
                 </Fragment>
               )}
+              {xmlError && (
+                <Fragment>
+                  <span style={{ color: 'red' }}> {xmlError}</span>
+                  <EuiSpacer size='s'/>
+                </Fragment>
+              )}
               <EuiFlexGroup>
                 <EuiFlexItem>
                   <EuiFlexGroup>
@@ -261,7 +269,7 @@ class WzRulesetEditor extends Component {
                       <EuiCodeEditor
                         theme="textmate"
                         width="100%"
-                        height={`calc(100vh - ${showWarningRestart || wazuhNotReadyYet ? 250 : 175}px)`}
+                        height={`calc(100vh - ${((showWarningRestart && !xmlError) || wazuhNotReadyYet) ? 250 : (xmlError ? (!showWarningRestart ? 195 : 270) : 175)}px)`}
                         value={content}
                         onChange={newContent =>
                           this.setState({ content: newContent })


### PR DESCRIPTION
Hi team, this PR resolves:
- fix Configuration/OpenSCAP/Evaluations is showing anything when configuration is missing
- Rules/Decoders/Groups show when there is a XML error, disable Save button and change the text of this for `XML format error`
- Configuration editor/code viewer font size is 14px