### PR TITLE
Fix sample data callout showing

### DIFF
--- a/public/components/visualize/wz-visualize.js
+++ b/public/components/visualize/wz-visualize.js
@@ -276,7 +276,7 @@ export class WzVisualize extends Component {
     return (
       <Fragment>
         {/* Sample alerts Callout */}
-        {this.state.thereAreSampleAlerts && (
+        {this.state.thereAreSampleAlerts && this.props.resultState === 'ready' && (
           <EuiCallOut title='This dashboard contains sample data' color='warning' iconType='alert' style={{ margin: '0 8px 16px 8px' }}>
             <p>The data displayed may contain sample alerts. {this.state.adminMode && (
               <Fragment>


### PR DESCRIPTION
Hi team, this PR resolves:
- Sample data callout in Dashboards were showed when no alerts is avaliable for selected time range