### PR TITLE
Change devtools message when admin mode is disabled

### DIFF
--- a/public/controllers/dev-tools/dev-tools.js
+++ b/public/controllers/dev-tools/dev-tools.js
@@ -593,12 +593,17 @@ export class DevToolsController {
         if (typeof JSONraw === 'object') JSONraw.devTools = true;
         if (!firstTime) {
           const output = await this.apiReq.request(method, path, JSONraw);
-          this.apiOutputBox.setValue(
-            JSON.stringify((output || {}).data || {}, null, 2).replace(
-              /\\\\/g,
-              '\\'
-            )
-          );
+          if(output.includes('3029')) {
+            this.apiOutputBox.setValue('This method is not allowed without admin mode');
+          }
+          else {
+            this.apiOutputBox.setValue(
+              JSON.stringify((output || {}).data || {}, null, 2).replace(
+                /\\\\/g,
+                '\\'
+              )
+            );
+          }
         }
       }
 


### PR DESCRIPTION
Hi team!

With this PR we have modified the output of DevTools when we try to make a request that is not allowed with the admin mode disabled.