### PR TITLE
Remove components console warnings

### DIFF
--- a/public/components/overview/mitre/components/tactics/tactics.tsx
+++ b/public/components/overview/mitre/components/tactics/tactics.tsx
@@ -287,7 +287,7 @@ export class Tactics extends Component {
 
           <EuiFlexItem grow={false} style={{marginTop:'15px', marginRight:8}}> 
             <EuiPopover
-              button={(<EuiButtonIcon iconType="gear" onClick={() => this.onGearButtonClick()}></EuiButtonIcon>)}
+              button={(<EuiButtonIcon iconType="gear" onClick={() => this.onGearButtonClick()} aria-label={'tactics options'}></EuiButtonIcon>)}
               isOpen={this.state.isPopoverOpen}
               panelPaddingSize="none"
               withTitle

--- a/public/components/overview/mitre/components/techniques/techniques.tsx
+++ b/public/components/overview/mitre/components/techniques/techniques.tsx
@@ -258,7 +258,7 @@ export const Techniques = withWindowSize(class Techniques extends Component {
     if(this.state.isSearching || this.state.loadingAlerts || this.props.isLoading){
       return (
         <EuiFlexItem style={{ height: "calc(100vh - 410px)", alignItems: 'center' }} >
-          <EuiLoadingSpinner size='xl' style={{ margin: 0, position: 'absolute', top: '50%', transform: 'translateY(-50%)' }} />
+          <EuiLoadingSpinner size='xl'/>
         </EuiFlexItem>
       )
     }

--- a/public/components/settings/settings-logs/logs.js
+++ b/public/components/settings/settings-logs/logs.js
@@ -42,12 +42,14 @@ export default class SettingsLogs extends Component {
   };
 
   componentDidMount() {
+    this._isMounted = true;
     this.refresh();
     this.height = window.innerHeight - this.offset; //eslint-disable-line
     window.addEventListener('resize', this.updateHeight); //eslint-disable-line
   }
 
   componentWillUnmount() {
+    this._isMounted = false;
     window.removeEventListener('resize', this.updateHeight); //eslint-disable-line
   }
 
@@ -56,7 +58,7 @@ export default class SettingsLogs extends Component {
       refreshingEntries: true
     });
     const logs = await this.props.getLogs();
-    this.setState({
+    this._isMounted && this.setState({
       refreshingEntries: false,
       logs
     });

--- a/public/controllers/agent/components/agents-table.js
+++ b/public/controllers/agent/components/agents-table.js
@@ -81,7 +81,7 @@ export class AgentsTable extends Component {
   onTableChange = ({ page = {}, sort = {} }) => {
     const { index: pageIndex, size: pageSize } = page;
     const { field: sortField, direction: sortDirection } = sort;
-    this.setState({
+    this._isMount && this.setState({
       pageIndex,
       pageSize,
       sortField,
@@ -96,7 +96,7 @@ export class AgentsTable extends Component {
       'agents_preview_selected_options',
       JSON.stringify(selectedOptions)
     );
-    this.setState({
+    this._isMount && this.setState({
       q,
       search,
       selectedOptions,
@@ -114,7 +114,7 @@ export class AgentsTable extends Component {
     const filterVersion = await this.filterBarModelWazuhVersion();
     const filterOsPlatform = await this.filterBarModelOsPlatform();
     const filterNodes = await this.filterBarModelNodes();
-    this.setState({
+    this._isMount && this.setState({
       filterStatus,
       filterGroups,
       filterOs,
@@ -124,9 +124,13 @@ export class AgentsTable extends Component {
     });
   }
 
+  componentWillUnmount(){
+    this._isMount = false;
+  }
+  
   async reloadAgents() {
     const totalAgent = await WzRequest.apiReq('GET', '/agents', {});
-    this.setState({
+    this._isMount && this.setState({
       isProcessing: true,
       isLoading: true,
       avaibleAgents: totalAgent.data.data.items
@@ -136,7 +140,7 @@ export class AgentsTable extends Component {
 
   async componentDidUpdate(prevProps, prevState) {
     if(this.props.filters && this.props.filters.length){
-      this.setState({selectedOptions: this.props.filters, 
+      this._isMount && this.setState({selectedOptions: this.props.filters, 
         q:`${this.props.filters[0].group}=${ this.props.filters[0].label_}`,
         isProcessing: true,
         isLoading: false});
@@ -146,12 +150,12 @@ export class AgentsTable extends Component {
       const { q, search } = this.state;
       const { q: prevQ, search: prevSearch } = prevState;
       if (prevQ !== q || prevSearch !== search) {
-        this.setState({ pageIndex: 0 });
+        this._isMount && this.setState({ pageIndex: 0 });
       }
       await this.getItems();
     }
     if (prevState.allSelected === false && this.state.allSelected === true) {
-      this.setState({ loadingAllItem: true });
+      this._isMount && this.setState({ loadingAllItem: true });
       this.getAllItems();
     }
   }
@@ -194,7 +198,7 @@ export class AgentsTable extends Component {
     const agentsFiltered = await this.props
       .wzReq('GET', '/agents', filterAll)
       .then(() => {
-        this.setState({ loadingAllItem: false });
+        this._isMount && this.setState({ loadingAllItem: false });
       });
 
     const formatedAgents = (
@@ -345,7 +349,7 @@ export class AgentsTable extends Component {
   }
 
   reloadAgent = () => {
-    this.setState({
+    this._isMount && this.setState({
       isProcessing: true,
       isLoading: true
     });
@@ -400,10 +404,10 @@ export class AgentsTable extends Component {
     });
 
     selectedItems.length !== pageSize
-      ? this.setState({ allSelected: false })
+      ? this._isMount && this.setState({ allSelected: false })
       : false;
 
-    this.setState({ selectedItems });
+    this._isMount && this.setState({ selectedItems });
   };
 
   renderUpgradeButton() {
@@ -557,7 +561,7 @@ export class AgentsTable extends Component {
           iconType="trash"
           color="danger"
           onClick={() => {
-            this.setState({ purgeModal: true });
+            this._isMount && this.setState({ purgeModal: true });
           }}
         >
           Delete all agents
@@ -587,7 +591,7 @@ export class AgentsTable extends Component {
               <EuiFlexItem grow={false}>
                 <EuiButton
                   onClick={() => {
-                    this.setState(prevState => ({
+                    this._isMount && this.setState(prevState => ({
                       allSelected: !prevState.allSelected
                     }));
                   }}
@@ -610,7 +614,7 @@ export class AgentsTable extends Component {
     agents.forEach(element => {
       element.id === agentID ? (element.upgrading = true) : false;
     });
-    this.setState({ agents });
+    this._isMount && this.setState({ agents });
   }
 
   changeUpgradingState = agentID => {
@@ -620,7 +624,7 @@ export class AgentsTable extends Component {
         ? (element.upgrading = false)
         : false;
     });
-    this.setState(() => ({ agents }));
+    this._isMount && this.setState(() => ({ agents }));
   };
 
   onClickUpgrade = () => {
@@ -685,7 +689,7 @@ export class AgentsTable extends Component {
         this.getAllItems();
         this.reloadAgents();
       });
-    this.setState({ purgeModal: false });
+    this._isMount && this.setState({ purgeModal: false });
   };
 
   onClickPurgeAll = () => {
@@ -719,7 +723,7 @@ export class AgentsTable extends Component {
         this.reloadAgents();
       });
 
-    this.setState({ purgeModal: false });
+    this._isMount && this.setState({ purgeModal: false });
   };
 
   columns() {

--- a/public/controllers/management/components/management/groups/groups-table.js
+++ b/public/controllers/management/components/management/groups/groups-table.js
@@ -68,8 +68,8 @@ class WzGroupsTable extends Component {
   }
 
   async componentDidMount() {
-    await this.getItems();
     this._isMounted = true;
+    await this.getItems();
   }
 
   shouldComponentUpdate(nextProps, nextState) {
@@ -106,7 +106,7 @@ class WzGroupsTable extends Component {
       const rawItems = await this.groupsHandler.listGroups(this.buildFilter());
       const { items, totalItems } = ((rawItems || {}).data || {}).data;
 
-      this.setState({
+      this._isMounted && this.setState({
         items,
         totalItems,
       });
@@ -142,7 +142,7 @@ class WzGroupsTable extends Component {
   onTableChange = ({ page = {}, sort = {} }) => {
     const { index: pageIndex, size: pageSize } = page;
     const { field: sortField, direction: sortDirection } = sort;
-    this.setState({ pageSize });
+    this._isMounted && this.setState({ pageSize });
     this.props.updatePageIndex(pageIndex);
     this.props.updateSortDirection(sortDirection);
     this.props.updateSortField(sortField);
@@ -193,7 +193,7 @@ class WzGroupsTable extends Component {
         <WzSearchBar
           filters={filters}
           suggestions={this.suggestions}
-          onFiltersChange={(filters) => this.setState({ filters })} />
+          onFiltersChange={(filters) => this._isMounted && this.setState({ filters })} />
         <EuiBasicTable
           itemId="id"
           items={items}

--- a/public/controllers/overview/components/overview-actions/agents-selection-table.js
+++ b/public/controllers/overview/components/overview-actions/agents-selection-table.js
@@ -131,21 +131,22 @@ export class AgentSelectionTable extends Component {
   }
 
   onChangeItemsPerPage = async itemsPerPage => {
-    this.setState({ itemsPerPage }, async () => await this.getItems());
+    this._isMounted && this.setState({ itemsPerPage }, async () => await this.getItems());
   };
 
   onChangePage = async pageIndex => {
-    this.setState({ pageIndex }, async () => await this.getItems());
+    this._isMounted && this.setState({ pageIndex }, async () => await this.getItems());
   };
 
   async componentDidMount() {
+    this._isMounted = true;
     const $injector = await chrome.dangerouslyGetActiveInjector();
     this.router = $injector.get('$route');
     const tmpSelectedAgents = {};
     if(!store.getState().appStateReducers.currentAgentData.id){
       tmpSelectedAgents[store.getState().appStateReducers.currentAgentData.id] = true;
     }
-    this.setState({itemIdToSelectedMap: this.props.selectedAgents});
+    this._isMounted && this.setState({itemIdToSelectedMap: this.props.selectedAgents});
     try{
       await this.getItems();
       const filterStatus = this.filterBarModelStatus();
@@ -154,7 +155,7 @@ export class AgentSelectionTable extends Component {
       const filterVersion = await this.filterBarModelWazuhVersion();
       const filterOsPlatform = await this.filterBarModelOsPlatform();
       const filterNodes = await this.filterBarModelNodes();
-      this.setState({
+      this._isMounted && this.setState({
         filterStatus,
         filterGroups,
         filterOs,
@@ -163,6 +164,10 @@ export class AgentSelectionTable extends Component {
         filterNodes
       });
     }catch(error){}
+  }
+
+  componentWillUnmount(){
+    this._isMounted = false;
   }
 
   getArrayFormatted(arrayText) {
@@ -178,7 +183,7 @@ export class AgentSelectionTable extends Component {
 
   async getItems() {
     try{
-      this.setState({isLoading: true});
+      this._isMounted && this.setState({isLoading: true});
       const rawData = await WzRequest.apiReq('GET', '/agents', this.buildFilter());
       const data = (((rawData || {}).data || {}).data || {}).items;
       const totalItems = (((rawData || {}).data || {}).data || {}).totalItems;
@@ -192,10 +197,9 @@ export class AgentSelectionTable extends Component {
           group: item.group || '-',
         };
       });
-  
-      this.setState({ agents: formattedData, totalItems, isLoading: false });
+      this._isMounted && this.setState({ agents: formattedData, totalItems, isLoading: false });
     }catch(err){
-      this.setState({ isLoading: false });
+      this._isMounted && this.setState({ isLoading: false });
     }
   }
 
@@ -261,11 +265,11 @@ export class AgentSelectionTable extends Component {
         ? 'desc'
         : 'asc';
 
-    this.setState({ sortField, sortDirection }, async () => await this.getItems());
+    this._isMounted && this.setState({ sortField, sortDirection }, async () => await this.getItems());
   };
 
   toggleItem = itemId => {
-    this.setState(previousState => {
+    this._isMounted && this.setState(previousState => {
       const newItemIdToSelectedMap = {
         [itemId]: !previousState.itemIdToSelectedMap[itemId],
       };
@@ -280,8 +284,7 @@ export class AgentSelectionTable extends Component {
     const allSelected = this.areAllItemsSelected();
     const newItemIdToSelectedMap = {};
     this.state.agents.forEach(item => (newItemIdToSelectedMap[item.id] = !allSelected));
-
-    this.setState({
+    this._isMounted && this.setState({
       itemIdToSelectedMap: newItemIdToSelectedMap,
     });
   };
@@ -304,7 +307,7 @@ export class AgentSelectionTable extends Component {
   };
 
   togglePopover = itemId => {
-    this.setState(previousState => {
+    this._isMounted && this.setState(previousState => {
       const newItemIdToOpenActionsPopoverMap = {
         ...previousState.itemIdToOpenActionsPopoverMap,
         [itemId]: !previousState.itemIdToOpenActionsPopoverMap[itemId],
@@ -319,7 +322,7 @@ export class AgentSelectionTable extends Component {
   closePopover = itemId => {
     // only update the state if this item's popover is open
     if (this.isPopoverOpen(itemId)) {
-      this.setState(previousState => {
+      this._isMounted && this.setState(previousState => {
         const newItemIdToOpenActionsPopoverMap = {
           ...previousState.itemIdToOpenActionsPopoverMap,
           [itemId]: false,
@@ -515,11 +518,11 @@ export class AgentSelectionTable extends Component {
     //   'agents_preview_selected_options',
     //   JSON.stringify(result.selectedOptions)
     // );
-    this.setState({ isLoading: true, ...result}, async () => {
+    this._isMounted && this.setState({ isLoading: true, ...result}, async () => {
       try{
         await this.getItems()
       }catch(error){
-        this.setState({ isLoading: false});
+        this._isMounted && this.setState({ isLoading: false});
       }
     });
   }
@@ -531,7 +534,7 @@ export class AgentSelectionTable extends Component {
   }
 
   unselectAgents(){
-    this.setState({itemIdToSelectedMap: {}});
+    this._isMounted && this.setState({itemIdToSelectedMap: {}});
     this.props.removeAgentsFilter(true);      
     store.dispatch(updateCurrentAgentData({}));
   }
@@ -565,7 +568,7 @@ export class AgentSelectionTable extends Component {
   }
 
   showContextMenu(id){
-    this.setState({contextMenuId: id})
+    this._isMounted && this.setState({contextMenuId: id})
   }
 
   addIconPlatformRender(os) {


### PR DESCRIPTION
Hi team, this PR resolves:
- fix loading animation position in Mitre techniques
- removed some console warning of React components:
  - Tactics
  - AgentsTable
  - WzGroupsTable
  - AgentSelectionTable
  - SettingsLogs