### PR TITLE
Hide globalFilterGroup button

### DIFF
--- a/public/components/common/modules/discover/discover.less
+++ b/public/components/common/modules/discover/discover.less
@@ -34,10 +34,6 @@ div.euiPanel.euiComboBoxOptionsList.euiComboBoxOptionsList {
     width: 78%!important;
 }
 
-.wz-discover.hide-filter-controll .globalFilterGroup__branch {
-    display: none;
-}
-
 .hover-row{
     background-color: #fbfcfd;
 }

--- a/public/components/overview/compliance-table/compliance-table.tsx
+++ b/public/components/overview/compliance-table/compliance-table.tsx
@@ -338,7 +338,9 @@ export class ComplianceTable extends Component {
     return (<div>
       <EuiFlexGroup>
         <EuiFlexItem>
-          {this.getSearchBar()}
+          <div className='wz-discover hide-filter-controll' >
+            {this.getSearchBar()}
+          </div>
         </EuiFlexItem>
       </EuiFlexGroup>
 

--- a/public/components/overview/mitre/mitre.tsx
+++ b/public/components/overview/mitre/mitre.tsx
@@ -213,7 +213,9 @@ export class Mitre extends Component {
       <div>
         <EuiFlexGroup>
           <EuiFlexItem>
-            {this.getSearchBar()}
+            <div className='wz-discover hide-filter-controll' >
+              {this.getSearchBar()}
+            </div>
           </EuiFlexItem>
         </EuiFlexGroup>
 

--- a/public/less/common.less
+++ b/public/less/common.less
@@ -1467,7 +1467,11 @@ div.euiPopover__panel.euiPopover__panel-isOpen.euiPopover__panel--bottom.wz-menu
   padding: 0 3px;
 }
 
-  /* Change custom discover size */
+.wz-discover.hide-filter-controll .globalFilterGroup__branch {
+  display: none;
+}
+
+/* Change custom discover size */
 .wz-discover > .globalQueryBar > 
 .kbnQueryBar--withDatePicker > 
 .euiFlexItem.euiFlexItem--flexGrowZero >


### PR DESCRIPTION
Hi team

This PR hide the globalFilterGroup button in the next views:

* Compliances -> controls 
![Screenshot from 2020-06-25 16-43-54](https://user-images.githubusercontent.com/3064506/85744595-4f37d500-b705-11ea-9b40-4cc95eae1e2a.png)

* Mitre -> Framework
![Screenshot from 2020-06-25 16-43-05](https://user-images.githubusercontent.com/3064506/85744602-4fd06b80-b705-11ea-9c5e-b1295ded4b90.png)

Regards.