### PR TITLE
3.13-7.8 fix regex in QInterpeter of WzSearchBar for Kibana 7.8.x

### DIFF
--- a/public/components/wz-search-bar/lib/q-interpreter.ts
+++ b/public/components/wz-search-bar/lib/q-interpreter.ts
@@ -31,7 +31,7 @@ export class QInterpreter {
   }
 
   private descomposeQuery (query:string):queryObject[] {
-    const descomposeRegex = /((?<conjuntion>and |or )?(?<field>[\w\.\-]+)?(?<operator>=|!=|<|>|~)?(?<value>[\[\]\{\}\\\w\.\-\:\%\/\s]+)?)/i;
+    const descomposeRegex = new RegExp("((?<conjuntion>and |or )?(?<field>[\\w\\.\\-]+)?(?<operator>=|!=|<|>|~)?(?<value>[\\[\\]\\{\\}\\\\\\w\\.\\-\\:\\%\\/\\s]+)?)","i");
     const getQueryObjects = (query, queries=[]):queryObject[] => {
       const firstConjuntion = / and | or /i.exec(query);
       const currentQ = !!firstConjuntion ? query.slice(0,firstConjuntion.index) : query;


### PR DESCRIPTION
Hi team, this PR resolves:
- WzSearchBar suggestions aren't working when add the operator in search bar.

This issue doesn't happen in Kibana 7.7.x. It could be due to Typescript parser/compiler.