### PR TITLE
Fix scroll to references in MITRE flyout

### DIFF
--- a/public/components/overview/mitre/components/techniques/components/flyout-technique/flyout-technique.tsx
+++ b/public/components/overview/mitre/components/techniques/components/flyout-technique/flyout-technique.tsx
@@ -102,7 +102,7 @@ export class FlyoutTechnique extends Component {
         $(`.technique-reference-citation-${reference.index}`).each(function(){
           $(this).off();
           $(this).click(() => {
-            $(`.euiFlyoutBody__overflow`).scrollTop($(`#technique-reference-${reference.index}`).position().top);
+            $(`.euiFlyoutBody__overflow`).scrollTop($(`#technique-reference-${reference.index}`).position().top - 150);
           });
         })
       })


### PR DESCRIPTION
Hi team!

With this PR we solved a problem that occurred in Safari, which when scrolling to the reference in the MITRE flyout, was not adjusted.