### PR TITLE
The WzSearchBar breaks when mounted with filters

### DIFF
--- a/public/components/common/util/grouping-components/grouping-components.tsx
+++ b/public/components/common/util/grouping-components/grouping-components.tsx
@@ -32,7 +32,7 @@ const Direction: {[key: string]: 'row' | 'column'} = {
 
 export const GroupingComponents: React.FunctionComponent<IGroupingComponents> = ({children, buttonLabel, width = 0.5, direction = 'vertical'}) => {
   const [isOpen, setIsOpen] = useState(false);
-  const {parentWidth, ref} = useParentWidth(children);
+  const {parentWidth, ref} = useParentWidth();
   const childrenObj = divideChildren(children, ref, parentWidth, width)
   const label = buttonLabel(childrenObj.hide.length) 
   return (

--- a/public/components/common/util/grouping-components/hooks/use-parent-width.ts
+++ b/public/components/common/util/grouping-components/hooks/use-parent-width.ts
@@ -14,12 +14,12 @@
 import { useRef, useState, useEffect } from "react";
 
 
-export const useParentWidth = (children) => {
+export const useParentWidth = () => {
     const ref = useRef(null);
     const [parentWidth, setParentWidth] = useState(0);
 
     useEffect(() => {
         setParentWidth((((ref || {}).current || {}).parentNode || {}).offsetWidth || 0);
-    }, [children]);
+    });
     return {parentWidth, ref};
 }

--- a/public/components/common/util/grouping-components/lib/divide-children.ts
+++ b/public/components/common/util/grouping-components/lib/divide-children.ts
@@ -14,8 +14,10 @@
 export const divideChildren = (children, ref, parentWidth, width):{
   show: [], hide: [], width: number
 } => {
+  if(!parentWidth) return {show: children, hide: [], width: 0};
   return children.reduce((acc, child, key) => {
-    const currentChild = ((ref || {}).current || {}).childNodes[key]
+    const childs = ((ref || {}).current || {}).childNodes
+    const currentChild = !!childs && childs[0];
     const isPopOver = !!currentChild && !!currentChild.classList && currentChild.classList.contains('euiPopover');
     const currentWidth = acc.width + ((isPopOver) ? 5000 : (currentChild || {}).offsetWidth || 100) ;
     const newAcc = {

--- a/public/components/eui-suggest/suggest_input.js
+++ b/public/components/eui-suggest/suggest_input.js
@@ -91,6 +91,7 @@ export class EuiSuggestInput extends Component {
       <EuiFieldText
         value={this.state.value}
         fullWidth
+        onFocus={onPopoverFocus}
         append={appendArray}
         isLoading={status === 'loading' ? true : false}
         onChange={this.onFieldChange}
@@ -103,7 +104,6 @@ export class EuiSuggestInput extends Component {
         <EuiInputPopover
           id="popover"
           input={customInput}
-          onFocus={onPopoverFocus}
           isOpen={isPopoverOpen}
           panelPaddingSize="none"
           fullWidth

--- a/public/components/wz-search-bar/wz-search-buttons.tsx
+++ b/public/components/wz-search-bar/wz-search-buttons.tsx
@@ -78,11 +78,14 @@ export class WzSearchButtons extends Component {
     const { options } = this.state;
     const { filters } = this.props;
     return Object.keys(IconSelectedMap).reduce((acc: IFilter[], label) => {
+      const newFilters = [...filters];
       const { field, value } = options[label];
-      const filter = filters.find(filter => filter.field === field);
-      ((filter && IconSelectedMap[label]) || IconSelectedMap[label]) && acc.push({ field, value })
-      return acc;
-    }, [])
+      const filterIdx = filters.findIndex(filter => filter.field === field);
+      (filterIdx !== -1 && !IconSelectedMap[label]) 
+      ? newFilters.splice(filterIdx, 1)
+      : newFilters.push({ field, value })
+      return newFilters;
+    }, filters)
   }
 
   checkFilters() {


### PR DESCRIPTION
This commit fix:
- The WzSearchBar does not break when created with filters.
- Grouping-components do not group components when the width of the parent element is 0.
- WzSearchBar buttons correctly remove or add filters
- When the "+n Filters" button is clicked,
the suggestion popover does not open.