### PR TITLE
Avoid the blanc page in the agent detail view

### DIFF
--- a/public/components/common/welcome/agents-welcome.js
+++ b/public/components/common/welcome/agents-welcome.js
@@ -191,7 +191,11 @@ export class AgentsWelcome extends Component {
   }
 
   showModuleByPlatform(menu) {
-    return !this.platform ? false : !UnsupportedComponents[this.platform].includes(menu.id);
+    try {
+      return !this.platform ? false : !UnsupportedComponents[this.platform].includes(menu.id);
+    } catch (error) {
+      return !UnsupportedComponents['other'].includes(menu.id);
+    }
   }
 
   renderModules() {


### PR DESCRIPTION
Hi team!

This PR solved this Issue: https://github.com/wazuh/wazuh-kibana-app/issues/2398

For the first case, I modified the "VisRequest" component to show an error when the request to Elasticsearch does not return the object of the aggregation.

The second case occurs because the platform name is not defined in the "UnsupportedComponents" object. In this case, we return the list of the "other" key by default.

Regards, 
Jose
