### PR TITLE
Restrict the permissions of the wazuh configuration

### DIFF
--- a/server/lib/manage-hosts.js
+++ b/server/lib/manage-hosts.js
@@ -79,7 +79,7 @@ export class ManageHosts {
           path.join(__dirname, '../../../../optimize/wazuh/config/wazuh.yml')
         )
       ) {
-        await fs.writeFileSync(this.file, this.initialConfig, 'utf8');
+        await fs.writeFileSync(this.file, this.initialConfig, {encoding: 'utf8', mode: 0o600});
       }
       const raw = fs.readFileSync(this.file, { encoding: 'utf-8' });
       this.busy = false;


### PR DESCRIPTION
Hey, team!

This PR modified the creation of the "wazuh.yml" file to restrict read and write permissions to the owner user.
![image](https://user-images.githubusercontent.com/3064506/88537158-55271b80-d00d-11ea-9165-13e63d697f73.png)

Related Issue: #2402