### PR TITLE
[4.0] Configuration/Google Cloud Pub/Sub, Configuration fixes and and AWS related changes

### DIFF
--- a/public/components/common/welcome/components/menu-agent.js
+++ b/public/components/common/welcome/components/menu-agent.js
@@ -174,6 +174,7 @@ class WzMenuAgent extends Component {
     let securityInformationItems = [
       this.agentSections.general,
       this.agentSections.fim,
+      this.agentSections.aws,
       this.agentSections.gcp
     ];
     let auditingItems = [

--- a/public/controllers/management/components/management/configuration/aws-s3/aws-s3-buckets.js
+++ b/public/controllers/management/components/management/configuration/aws-s3/aws-s3-buckets.js
@@ -47,7 +47,7 @@ class WzConfigurationAmazonS3Buckets extends Component {
     return (
       <Fragment>
         {currentConfig &&
-        !wodleConfig['aws-s3'] /*&& !currentConfig['aws-s3'].buckets*/ && (
+        (!wodleConfig['aws-s3'] || (wodleConfig['aws-s3'] && !wodleConfig['aws-s3'].buckets)) && (
             <WzNoConfig error="not-present" help={helpLinks} />
           )}
         {wazuhNotReadyYet && (!currentConfig || !wodleConfig['aws-s3']) && (
@@ -58,7 +58,7 @@ class WzConfigurationAmazonS3Buckets extends Component {
           wodleConfig['aws-s3'].buckets && (
             <WzConfigurationSettingsTabSelector
               title="Main settings"
-              description="Common settings applied to all Amazon S3 buckets"
+              description="Amazon buckets from where logs are read"
               currentConfig={wodleConfig}
               minusHeight={320}
               helpLinks={helpLinks}

--- a/public/controllers/management/components/management/configuration/aws-s3/aws-s3-services.js
+++ b/public/controllers/management/components/management/configuration/aws-s3/aws-s3-services.js
@@ -43,7 +43,7 @@ class WzConfigurationAmazonS3Services extends Component {
     return (
       <Fragment>
         {currentConfig &&
-        !wodleConfig['aws-s3'] /*&& !currentConfig['aws-s3'].services*/ && (
+        (!wodleConfig['aws-s3'] || (wodleConfig['aws-s3'] && !wodleConfig['aws-s3'].services)) && (
             <WzNoConfig error="not-present" help={helpLinks} />
           )}
         {wazuhNotReadyYet && (!currentConfig || !wodleConfig['aws-s3']) && (

--- a/public/controllers/management/components/management/configuration/azure-logs/azure-logs.js
+++ b/public/controllers/management/components/management/configuration/azure-logs/azure-logs.js
@@ -92,7 +92,7 @@ class WzConfigurationAzure extends Component {
         {currentConfig && this.wodleConfig['azure-logs'] && (
           <WzConfigurationSettingsTabSelector
             title="Main settings"
-            description="Common settings applied to all Amazon S3 buckets"
+            description="Configuration for the Azure logs wodle"
             currentConfig={this.wodleConfig}
             minusHeight={260}
             helpLinks={helpLinks}

--- a/public/controllers/management/components/management/configuration/configuration-settings.js
+++ b/public/controllers/management/components/management/configuration/configuration-settings.js
@@ -199,9 +199,14 @@ export default [
       },
       {
         name: 'Azure Logs',
-        description: 'Configuration options of the Azure-Logs wodle',
+        description: 'Configuration options of the Azure Logs wodle',
         goto: 'azure-logs',
         when: 'manager'
+      },
+      {
+        name: 'Google Cloud Pub/Sub',
+        description: 'Configuration options of the Google Cloud Pub/Sub module',
+        goto: 'gcp-pubsub'
       }
     ]
   }

--- a/public/controllers/management/components/management/configuration/configuration-settings.js
+++ b/public/controllers/management/components/management/configuration/configuration-settings.js
@@ -194,8 +194,7 @@ export default [
         name: 'Amazon S3',
         description:
           'Security events related to Amazon AWS services, collected directly via AWS API',
-        goto: 'aws-s3',
-        when: 'manager'
+        goto: 'aws-s3'
       },
       {
         name: 'Azure Logs',

--- a/public/controllers/management/components/management/configuration/configuration-switch.js
+++ b/public/controllers/management/components/management/configuration/configuration-switch.js
@@ -41,6 +41,7 @@ import WzConfigurationIntegrityMonitoring from './integrity-monitoring/integrity
 import WzConfigurationIntegrityAgentless from './agentless/agentless';
 import WzConfigurationIntegrityAmazonS3 from './aws-s3/aws-s3';
 import WzConfigurationAzureLogs from './azure-logs/azure-logs';
+import WzConfigurationGoogleCloudPubSub from './google-cloud-pub-sub/google-cloud-pub-sub';
 import WzViewSelector, {
   WzViewSelectorSwitch
 } from './util-components/view-selector';
@@ -378,6 +379,14 @@ class WzConfigurationSwitch extends Component {
               </WzViewSelectorSwitch>
               <WzViewSelectorSwitch view="azure-logs">
                 <WzConfigurationAzureLogs
+                  clusterNodeSelected={this.props.clusterNodeSelected}
+                  agent={agent}
+                  updateBadge={this.updateBadge}
+                  updateConfigurationSection={this.updateConfigurationSection}
+                />
+              </WzViewSelectorSwitch>
+              <WzViewSelectorSwitch view="gcp-pubsub">
+                <WzConfigurationGoogleCloudPubSub
                   clusterNodeSelected={this.props.clusterNodeSelected}
                   agent={agent}
                   updateBadge={this.updateBadge}

--- a/public/controllers/management/components/management/configuration/google-cloud-pub-sub/google-cloud-pub-sub.js
+++ b/public/controllers/management/components/management/configuration/google-cloud-pub-sub/google-cloud-pub-sub.js
@@ -1,0 +1,103 @@
+
+
+import React, { Component, Fragment } from 'react';
+
+import WzConfigurationSettingsTabSelector from '../util-components/configuration-settings-tab-selector';
+import WzConfigurationSettingsGroup from '../util-components/configuration-settings-group';
+import WzNoConfig from '../util-components/no-config';
+
+import withWzConfig from '../util-hocs/wz-config';
+
+import { wodleBuilder } from '../utils/builders';
+
+import {
+  renderValueYesThenEnabled,
+  isString
+} from '../utils/utils';
+
+const helpLinks = [
+  {
+    text: 'Using Wazuh to monitor Google Cloud Pub/Sub',
+    href: 'https://documentation.wazuh.com/current/gcp/index.html'
+  },
+  {
+    text: 'Google Cloud Pub/Sub module reference',
+    href:
+      'https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/gcp-pubsub.html'
+  }
+];
+
+const mainSettings = [
+  {
+    field: 'enabled',
+    label: 'Google Cloud Pub/Sub integration status',
+    render: renderValueYesThenEnabled
+  },
+  { field: 'project_id', label: 'Project ID' },
+  { field: 'subscription_name', label: 'Subscription to read from' },
+  {
+    field: 'credentials_file',
+    label: 'Path of the credentials file'
+  },
+  { field: 'logging', label: 'Logging level' },
+  { field: 'max_messages', label: 'Maximum messages pulled in each iteration' },
+  { field: 'interval', label: 'Interval between module executions in seconds' },
+  { field: 'pull_on_start', label: 'Pull on start' },
+  { field: 'day', label: 'Day of the month to fetch logs' },
+  { field: 'wday', label: 'Day of the week to fetch logs' },
+  { field: 'time', label: 'Time of the day to fetch logs' },
+];
+
+class WzConfigurationGoogleCloudPubSub extends Component{
+  constructor(props) {
+    super(props);
+    this.wodleConfig = wodleBuilder(this.props.currentConfig, 'gcp-pubsub');
+  }
+  componentDidMount() {
+    this.props.updateBadge(this.badgeEnabled());
+  }
+  badgeEnabled() {
+    return (
+      this.wodleConfig &&
+      this.wodleConfig['gcp-pubsub'] &&
+      this.wodleConfig['gcp-pubsub'].enabled === 'yes'
+    );
+  }
+  render(){
+    const { currentConfig } = this.props;
+    return (
+      <Fragment>
+        {currentConfig['wmodules-wmodules'] &&
+          isString(currentConfig['wmodules-wmodules']) && (
+            <WzNoConfig
+              error={currentConfig['wmodules-wmodules']}
+              help={helpLinks}
+            />
+          )}
+        {currentConfig &&
+          !this.wodleConfig['gcp-pubsub'] && 
+          !isString(currentConfig['wmodules-wmodules']) && (
+            <WzNoConfig error="not-present" help={helpLinks} />
+        )}
+        {currentConfig && this.wodleConfig['gcp-pubsub'] && (
+          <WzConfigurationSettingsTabSelector
+            title="Main settings"
+            description="Configuration for the Google Cloud Pub/Sub module"
+            currentConfig={this.wodleConfig}
+            minusHeight={320}
+            helpLinks={helpLinks}
+          >
+            <WzConfigurationSettingsGroup
+              config={this.wodleConfig['gcp-pubsub']}
+              items={mainSettings}
+            />
+          </WzConfigurationSettingsTabSelector>
+        )}
+      </Fragment>
+    )
+  }
+}
+
+const sections = [{ component: 'wmodules', configuration: 'wmodules' }];
+
+export default withWzConfig(sections)(WzConfigurationGoogleCloudPubSub);

--- a/public/controllers/management/components/management/configuration/util-components/configuration-setting.js
+++ b/public/controllers/management/components/management/configuration/util-components/configuration-setting.js
@@ -14,8 +14,6 @@ import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 
 import {
-  EuiFlexGroup,
-  EuiFlexItem,
   EuiFieldText,
   EuiSpacer,
   EuiTextAlign
@@ -43,7 +41,7 @@ class WzConfigurationSetting extends Component {
   render() {
     const { isMobile } = this.state;
     const { keyItem, label, value } = this.props;
-    return value ? (
+    return (value || typeof value === 'number' || typeof value === 'boolean')  ? (
       <Fragment>
         <div
           style={{

--- a/server/lib/generate-alerts/generate-alerts-script.js
+++ b/server/lib/generate-alerts/generate-alerts-script.js
@@ -94,9 +94,7 @@ function generateAlert(params) {
         data: {},
         location: ""
     }
-    if(!params.aws) {
-        alert.agent = randomArrayItem(Agents);
-    }
+    alert.agent = randomArrayItem(Agents);
     alert.rule.description = randomArrayItem(ruleDescription);
     alert.rule.id = `${randomIntervalInteger(1,alertIDMax)}`;
     alert.rule.level = randomIntervalInteger(1,ruleMaxLevel);


### PR DESCRIPTION
Hi team,

this PR resolves:
- Added Google Cloud Pub/Sub to Configuration
- `WzConfigurationSetting` component used in Configuration now accepts these falsy values: `0` (number) and `false` (boolean). It continues to ignore the rendering of empty strings.
- Added Amazon S3 to agent menu
- Amazon sample data available for the agents
- Fixes:
  - Wrong descriptions for Configuration sections: Amazon S3/Buckets y Azure Logs
  - It doesn't render anything in Amazon S3/Services when the response has no `services` key. Same for Amazon S3/Buckets and `buckets` key.
  - Pinned modules in the agent menu could be a disabled app module (Settings/Modules). Now update the localstorage with the right ones and remove the disabled ones.