### PR TITLE
Set index patterns name as constants

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@
 
 import { resolve } from 'path';
 import { WazuhPlugin, LegacySetup } from './server/plugin';
+import { WAZUH_ALERTS_PATTERN, WAZUH_MONITORING_PATTERN } from './util/constants'
 
 export default (kibana) => {
   return new kibana.Plugin({
@@ -70,8 +71,8 @@ export default (kibana) => {
               app: [featureId],
               api: [],
               savedObject: {
-                all: ['wazuh-alerts-3.x-*', 'wazuh-monitoring-3.x-*'],
-                read: ['wazuh-alerts-3.x-*', 'wazuh-monitoring-3.x-*']
+                all: [WAZUH_ALERTS_PATTERN, WAZUH_MONITORING_PATTERN],
+                read: [WAZUH_ALERTS_PATTERN, WAZUH_MONITORING_PATTERN]
               },
               ui: ['save', 'show']
             },
@@ -80,7 +81,7 @@ export default (kibana) => {
               api: [],
               savedObject: {
                 all: [],
-                read: ['wazuh-alerts-3.x-*', 'wazuh-monitoring-3.x-*']
+                read: [WAZUH_ALERTS_PATTERN, WAZUH_MONITORING_PATTERN]
               },
               ui: ['show']
             }

--- a/public/components/health-check/health-check.tsx
+++ b/public/components/health-check/health-check.tsx
@@ -11,6 +11,7 @@ import { ApiRequest } from '../../react-services/api-request';
 import { SavedObject } from '../../react-services/saved-objects';
 import { ErrorHandler } from '../../react-services/error-handler';
 import { toastNotifications } from 'ui/notify';
+import { WAZUH_MONITORING_PATTERN } from '../../../util/constants';
 
 export class HealthCheck extends Component {
     constructor(props) {
@@ -59,14 +60,14 @@ export class HealthCheck extends Component {
                 let patternData = patternId ? await SavedObject.existsIndexPattern(patternId) : false;
                 if (!patternData) patternData = {};
                 patternTitle = patternData.title;
-                /* This extra check will work as long as Wazuh monitoring index ID is wazuh-monitoring-3.x-*.
+                /* This extra check will work as long as Wazuh monitoring index ID is wazuh-monitoring-*.
                    Currently is not possible to change that index pattern as it has always been created on our backend.
                    This extra check checks if the index pattern exists for the current logged in user
                    in case it doesn't exist, the index pattern is automatically created. This is necessary to make it work with Opendistro multinenancy
                    as every index pattern is stored in its current tenant .kibana-tenant-XX index. 
                    */
                 try {
-                    await SavedObject.existsMonitoringIndexPattern('wazuh-monitoring-3.x-*'); //this checks if it exists, if not it automatically creates the index pattern
+                    await SavedObject.existsMonitoringIndexPattern(WAZUH_MONITORING_PATTERN); //this checks if it exists, if not it automatically creates the index pattern
                 } catch (err) { }
                 if (!patternData.status) {
                     const patternList = await PatternHandler.getPatternList("healthcheck");

--- a/public/components/overview/compliance-table/components/subrequirements/subrequirements.tsx
+++ b/public/components/overview/compliance-table/components/subrequirements/subrequirements.tsx
@@ -30,7 +30,7 @@ import {
 import { getServices } from 'plugins/kibana/discover/kibana_services';
 import { AppNavigate } from '../../../../../react-services/app-navigate';
 import { RequirementFlyout } from '../requirement-flyout/requirement-flyout'
-
+import { WAZUH_ALERTS_PATTERN } from '../../../../../../util/constants';
 
 export class ComplianceSubrequirements extends Component {
   _isMount = false;
@@ -71,7 +71,7 @@ export class ComplianceSubrequirements extends Component {
         "params": { "query": filter.value },
         "type": "phrase",
         "negate": filter.negate || false,
-        "index": "wazuh-alerts-3.x-*"
+        "index": WAZUH_ALERTS_PATTERN
       },
       "query": { "match_phrase": matchPhrase },
       "$state": { "store": "appState" }

--- a/public/components/overview/mitre/components/techniques/techniques.tsx
+++ b/public/components/overview/mitre/components/techniques/techniques.tsx
@@ -34,6 +34,7 @@ import { ITactic } from '../../';
 import { getServices } from 'plugins/kibana/discover/kibana_services';
 import { withWindowSize } from '../../../../../components/common/hocs/withWindowSize';
 import { WzRequest } from '../../../../../react-services/wz-request';
+import {WAZUH_ALERTS_PATTERN} from '../../../../../../util/constants';
 
 export const Techniques = withWindowSize(class Techniques extends Component {
   _isMount = false;
@@ -299,7 +300,7 @@ export const Techniques = withWindowSize(class Techniques extends Component {
         "params": { "query": filter.value },
         "type": "phrase",
         "negate": filter.negate || false,
-        "index": "wazuh-alerts-3.x-*"
+        "index": WAZUH_ALERTS_PATTERN
       },
       "query": { "match_phrase": matchPhrase },
       "$state": { "store": "appState" }

--- a/public/components/wz-agent-selector/wz-agent-selector.js
+++ b/public/components/wz-agent-selector/wz-agent-selector.js
@@ -24,6 +24,7 @@ import store from '../../redux/store';
 import { AgentSelectionTable } from '../../controllers/overview/components/overview-actions/agents-selection-table';
 import chrome from 'ui/chrome';
 import { getServices } from 'plugins/kibana/discover/kibana_services';
+import { WAZUH_ALERTS_PATTERN } from '../../../util/constants';
 
 class WzAgentSelector extends Component {
   constructor(props) {
@@ -68,7 +69,7 @@ class WzAgentSelector extends Component {
             "negate": false,
             "params": { "query": agentIdList[0] },
             "type": "phrase",
-            "index": "wazuh-alerts-3.x-*"
+            "index": WAZUH_ALERTS_PATTERN
           },
           "query": {
             "match": {

--- a/public/controllers/agent/agents.js
+++ b/public/controllers/agent/agents.js
@@ -31,6 +31,7 @@ import { ErrorHandler } from '../../react-services/error-handler';
 import { GroupHandler } from '../../react-services/group-handler';
 import store from '../../redux/store';
 import { updateGlobalBreadcrumb } from '../../redux/actions/globalBreadcrumbActions';
+import { WAZUH_ALERTS_PATTERN } from '../../../util/constants';
 
 export class AgentsController {
   /**
@@ -630,7 +631,7 @@ export class AgentsController {
    * @param {*} id
    */
   addMitrefilter(id) {
-    const filter = `{"meta":{"index":"wazuh-alerts-3.x-*"},"query":{"match":{"rule.mitre.id":{"query":"${id}","type":"phrase"}}}}`;
+    const filter = `{"meta":{"index":${WAZUH_ALERTS_PATTERN}},"query":{"match":{"rule.mitre.id":{"query":"${id}","type":"phrase"}}}}`;
     this.$rootScope.$emit('addNewKibanaFilter', {
       filter: JSON.parse(filter)
     });

--- a/public/controllers/overview/components/alerts-stats.js
+++ b/public/controllers/overview/components/alerts-stats.js
@@ -20,6 +20,7 @@ import { buildPhrasesFilter, buildRangeFilter } from '../../../../../../src/plug
 import { esFilters } from '../../../../../../src/plugins/data/common';
 import { getIndexPattern } from '../../../../public/components/overview/mitre/lib';
 import '../../../../public/less/loader';
+import { WAZUH_ALERTS_PATTERN } from '../../../../util/constants';
 
 
 class AlertsStats extends Component {
@@ -90,7 +91,7 @@ class AlertsStats extends Component {
         "params": { "query": filter.value },
         "type": "phrase",
         "negate": filter.negate || false,
-        "index": "wazuh-alerts-3.x-*"
+        "index": WAZUH_ALERTS_PATTERN
       },
       "query": { "match_phrase": matchPhrase },
       "$state": { "store": "appState" }

--- a/public/controllers/overview/components/overview-actions/overview-actions.js
+++ b/public/controllers/overview/components/overview-actions/overview-actions.js
@@ -30,6 +30,7 @@ import {
 } from '@elastic/eui';
 import './agents-selector.less';
 import { AgentSelectionTable } from './agents-selection-table';
+import { WAZUH_ALERTS_PATTERN } from '../../../../../util/constants';
 class OverviewActions extends Component {
   constructor(props) {
     super(props);
@@ -112,7 +113,7 @@ class OverviewActions extends Component {
             "negate": false,
             "params": { "query": agentIdList[0] },
             "type": "phrase",
-            "index": "wazuh-alerts-3.x-*"
+            "index": WAZUH_ALERTS_PATTERN
           },
           "query": {
             "match": {

--- a/public/controllers/overview/overview.js
+++ b/public/controllers/overview/overview.js
@@ -24,6 +24,7 @@ import { VisFactoryHandler } from '../../react-services/vis-factory-handler';
 import { WzRequest } from '../../react-services/wz-request';
 import { RawVisualizations } from '../../factories/raw-visualizations';
 import store from '../../redux/store';
+import { WAZUH_ALERTS_PATTERN } from '../../../util/constants';
 
 export class OverviewController {
   /**
@@ -335,7 +336,7 @@ export class OverviewController {
    * @param {*} id
    */
   addMitrefilter(id) {
-    const filter = `{"meta":{"index":"wazuh-alerts-3.x-*"},"query":{"match":{"rule.mitre.id":{"query":"${id}","type":"phrase"}}}}`;
+    const filter = `{"meta":{"index":${WAZUH_ALERTS_PATTERN}},"query":{"match":{"rule.mitre.id":{"query":"${id}","type":"phrase"}}}}`;
     this.$rootScope.$emit('addNewKibanaFilter', { filter: JSON.parse(filter) });
   }
 

--- a/public/kibana-integrations/kibana-discover.js
+++ b/public/kibana-integrations/kibana-discover.js
@@ -80,6 +80,7 @@ import {
   search,
 } from '../../../../src/plugins/data/public';
 import { addFatalError } from '../../../../src/plugins/kibana_legacy/public';
+import { WAZUH_ALERTS_PATTERN } from '../../util/constants';
 
 const fetchStatuses = {
   UNINITIALIZED: 'uninitialized',
@@ -498,7 +499,7 @@ function discoverController(
                         negate: true,
                         params: { query: '000' },
                         type: 'phrase',
-                        index: 'wazuh-alerts-3.x-*'
+                        index: WAZUH_ALERTS_PATTERN
                       },
                       query: { match_phrase: { 'agent.id': '000' } },
                       $state: { store: 'appState' }

--- a/public/react-services/pattern-handler.js
+++ b/public/react-services/pattern-handler.js
@@ -48,7 +48,7 @@ export class PatternHandler {
         }
       }
       if (!patternList.length) {
-        // if no valid index patterns are found we try to create the wazuh-alerts-3.x-*
+        // if no valid index patterns are found we try to create the wazuh-alerts-*
         try {
           const wazuhConfig = new WazuhConfig();
           const { pattern } = wazuhConfig.getConfig();

--- a/public/react-services/saved-objects.js
+++ b/public/react-services/saved-objects.js
@@ -17,7 +17,6 @@ export class SavedObject {
   /**
    *
    * Returns the full list of index patterns
-   * ONLY indices that matches the pattern "wazuh*" will be returned
    */
   static async getListOfIndexPatterns() {
     try {
@@ -193,7 +192,7 @@ export class SavedObject {
   }
 
   /**
-   * Creates the 'wazuh-alerts-3.x-*'  index pattern
+   * Creates the 'wazuh-alerts-*'  index pattern
    */
   static async createWazuhIndexPattern(pattern) {
     try {

--- a/public/services/resolves/get-config.js
+++ b/public/services/resolves/get-config.js
@@ -10,10 +10,12 @@
  * Find more information about this on the LICENSE file.
  */
 
+import { WAZUH_ALERTS_PATTERN, WAZUH_MONITORING_PATTERN } from "../../../util/constants";
+
 export async function getWzConfig($q, genericReq, wazuhConfig) {
   // Remember to keep this values equal to default wazuh.yml values
   const defaultConfig = {
-    pattern: 'wazuh-alerts-3.x-*',
+    pattern: WAZUH_ALERTS_PATTERN,
     'checks.pattern': true,
     'checks.template': true,
     'checks.api': true,
@@ -42,7 +44,7 @@ export async function getWzConfig($q, genericReq, wazuhConfig) {
     'wazuh.monitoring.shards': 2,
     'wazuh.monitoring.replicas': 0,
     'wazuh.monitoring.creation': 'd',
-    'wazuh.monitoring.pattern': 'wazuh-monitoring-3.x-*',
+    'wazuh.monitoring.pattern': WAZUH_MONITORING_PATTERN,
     'cron.prefix': 'wazuh',
     'cron.statistics.status': true,
     'cron.statistics.apis': [],

--- a/public/utils/config-equivalences.js
+++ b/public/utils/config-equivalences.js
@@ -38,9 +38,9 @@ export const configEquivalences = {
   'wazuh.monitoring.frequency':
     'Define in seconds the frequency the app generates a new document on the wazuh-monitoring index.',
   'wazuh.monitoring.shards':
-    'Define the number of shards to use for the wazuh-monitoring-3.x-* indices.',
+    'Define the number of shards to use for the wazuh-monitoring-* indices.',
   'wazuh.monitoring.replicas':
-    'Define the number of replicas to use for the wazuh-monitoring-3.x-* indices.',
+    'Define the number of replicas to use for the wazuh-monitoring-* indices.',
   'wazuh.monitoring.creation':
     'Define the interval in which the wazuh-monitoring index will be created.',
   'wazuh.monitoring.pattern':

--- a/server/controllers/wazuh-elastic.js
+++ b/server/controllers/wazuh-elastic.js
@@ -23,6 +23,7 @@ import { Base } from '../reporting/base-query';
 import { checkKnownFields } from '../lib/refresh-known-fields';
 import { generateAlerts } from '../lib/generate-alerts/generate-alerts-script';
 import { result } from '../lib/generate-alerts/sample-data/ciscat';
+import { WAZUH_MONITORING_PATTERN, WAZUH_ALERTS_PREFIX, WAZUH_ALERTS_PATTERN } from '../../util/constants';
 
 export class WazuhElasticCtrl {
   /**
@@ -37,8 +38,8 @@ export class WazuhElasticCtrl {
       'auditing-policy-monitoring': [{ rootcheck: true }, { audit: true }, { openscap: true }, { ciscat: true }],
       'threat-detection': [{ vulnerabilities: true }, { virustotal: true }, { osquery: true }, { docker: true }, { mitre: true }]
     };
-    this.wzSampleAlertsIndexPrefix = 'wazuh-alerts-3.x-';
-    this.buildSampleIndexByCategory = (category) => `${this.wzSampleAlertsIndexPrefix}sample-${category}` // wazuh-alerts-3.x-sample-security, wazuh-alerts-3.x-sample-auditing-policy-monitoring, wazuh-alerts-3.x-threat-detection
+    this.wzSampleAlertsIndexPrefix = WAZUH_ALERTS_PREFIX;
+    this.buildSampleIndexByCategory = (category) => `${this.wzSampleAlertsIndexPrefix}sample-${category}` // wazuh-alerts-sample-security, wazuh-alerts-sample-auditing-policy-monitoring, wazuh-alerts-threat-detection
     this.defaultNumSampleAlerts = 3000;
   }
 
@@ -499,7 +500,7 @@ export class WazuhElasticCtrl {
     try {
       const config = getConfiguration();
       let monitoringPattern =
-        (config || {})['wazuh.monitoring.pattern'] || 'wazuh-monitoring-3.x-*';
+        (config || {})['wazuh.monitoring.pattern'] || WAZUH_MONITORING_PATTERN;
       log(
         'wazuh-elastic:buildVisualizationsRaw',
         `Building ${app_objects.length} visualizations`,
@@ -801,7 +802,7 @@ export class WazuhElasticCtrl {
    *   filters: [{rule.groups: "syscheck"}, {agent.id: "001"} ]
    *   from: "now-1y"
    *   offset: 0
-   *   pattern: "wazuh-alerts-3.x-*"
+   *   pattern: "wazuh-alerts-*"
    *   sort: {timestamp: {order: "asc"}}
    *   to: "now"
    * }
@@ -810,7 +811,7 @@ export class WazuhElasticCtrl {
    */
   async alerts(req, reply) {
     try {
-      const pattern = req.payload.pattern || 'wazuh-alerts-3.x-*';
+      const pattern = req.payload.pattern || WAZUH_ALERTS_PATTERN;
       const from = req.payload.from || 'now-1d';
       const to = req.payload.to || 'now';
       const size = req.payload.size || 500;

--- a/server/controllers/wazuh-reporting.js
+++ b/server/controllers/wazuh-reporting.js
@@ -40,6 +40,7 @@ import {
 } from '../integration-files/visualizations';
 
 import { log } from '../logger';
+import { WAZUH_ALERTS_PATTERN } from '../../util/constants';
 
 const BASE_OPTIMIZE_PATH = '../../../../optimize';
 const REPORTING_PATH = `${BASE_OPTIMIZE_PATH}/wazuh/downloads/reports`;
@@ -804,7 +805,7 @@ export class WazuhReportingCtrl {
     from,
     to,
     filters,
-    pattern = 'wazuh-alerts-3.x-*',
+    pattern = WAZUH_ALERTS_PATTERN,
     agent = null
   ) {
     try {

--- a/server/initialize.js
+++ b/server/initialize.js
@@ -19,6 +19,7 @@ import { totalmem } from 'os';
 import fs from 'fs';
 import { ManageHosts } from './lib/manage-hosts';
 import { UpdateRegistry } from './lib/update-registry';
+import { WAZUH_ALERTS_PATTERN } from '../util/constants';
 
 const manageHosts = new ManageHosts();
 const wazuhRegistry = new UpdateRegistry().file;
@@ -40,7 +41,7 @@ export function Initialize(server) {
     pattern =
       configurationFile && typeof configurationFile.pattern !== 'undefined'
         ? configurationFile.pattern
-        : 'wazuh-alerts-3.x-*';
+        : WAZUH_ALERTS_PATTERN;
     global.XPACK_RBAC_ENABLED =
       configurationFile &&
       typeof configurationFile['xpack.rbac.enabled'] !== 'undefined'
@@ -65,7 +66,7 @@ export function Initialize(server) {
     );
   }
 
-  const defaultIndexPattern = pattern || 'wazuh-alerts-3.x-*';
+  const defaultIndexPattern = pattern || WAZUH_ALERTS_PATTERN;
 
   // Save Wazuh App setup
   const saveConfiguration = () => {

--- a/server/lib/elastic-wrapper.js
+++ b/server/lib/elastic-wrapper.js
@@ -13,6 +13,7 @@
 import { knownFields } from '../integration-files/known-fields';
 import { monitoringKnownFields } from '../integration-files/monitoring-known-fields';
 import { IndexPatternsFetcher } from '../../../../src/plugins/data/server/';
+import { WAZUH_ALERTS_PATTERN, WAZUH_MONITORING_PATTERN } from '../../util/constants';
 
 export class ElasticWrapper {
   constructor(server) {
@@ -75,7 +76,7 @@ export class ElasticWrapper {
 
   /**
    * This function creates a new index pattern.
-   * @param {*} title Eg: 'wazuh-alerts-3.x-*'
+   * @param {*} title Eg: 'wazuh-alerts-
    * @param {*} id Optional.
    */
   async createIndexPattern(title, id) {
@@ -394,7 +395,7 @@ export class ElasticWrapper {
         false;
 
       const data = await this.elasticRequest.callWithInternalUser('search', {
-        index: title || 'wazuh-alerts-3.x-*',
+        index: title || WAZUH_ALERTS_PATTERN,
         type: '_doc',
         body: payload
       });
@@ -632,7 +633,7 @@ export class ElasticWrapper {
       const data = await this.elasticRequest.callWithInternalUser('delete', {
         index: this.WZ_KIBANA_INDEX,
         type: '_doc',
-        id: 'index-pattern:wazuh-monitoring-*'
+        id: `index-pattern:${WAZUH_MONITORING_PATTERN}`
       });
 
       return data;

--- a/server/lib/initial-wazuh-config.js
+++ b/server/lib/initial-wazuh-config.js
@@ -33,7 +33,7 @@ export const initialWazuhConfig = `---
 # ------------------------------- Index patterns -------------------------------
 #
 # Default index pattern to use.
-#pattern: wazuh-alerts-3.x-*
+#pattern: wazuh-alerts-*
 #
 # ----------------------------------- Checks -----------------------------------
 #
@@ -107,17 +107,17 @@ export const initialWazuhConfig = `---
 # Default: 900 (s)
 #wazuh.monitoring.frequency: 900
 #
-# Configure wazuh-monitoring-3.x-* indices shards and replicas.
+# Configure wazuh-monitoring-* indices shards and replicas.
 #wazuh.monitoring.shards: 2
 #wazuh.monitoring.replicas: 0
 #
-# Configure wazuh-monitoring-3.x-* indices custom creation interval.
+# Configure wazuh-monitoring-* indices custom creation interval.
 # Values: h (hourly), d (daily), w (weekly), m (monthly)
 # Default: d
 #wazuh.monitoring.creation: d
 #
 # Default index pattern to use for Wazuh monitoring
-#wazuh.monitoring.pattern: wazuh-monitoring-3.x-*
+#wazuh.monitoring.pattern: wazuh-monitoring-*
 #
 # --------------------------------- wazuh-cron ----------------------------------
 #

--- a/server/lib/refresh-known-fields.js
+++ b/server/lib/refresh-known-fields.js
@@ -10,6 +10,8 @@
  * Find more information about this on the LICENSE file.
  */
 
+import { WAZUH_MONITORING_PATTERN } from "../../util/constants";
+
 /**
  * Refresh known fields for all valid index patterns.
  * Optionally forces the default index pattern creation.
@@ -117,8 +119,8 @@ export async function checkKnownFields(
 
     for (const item of list) {
       if (
-        item.title.includes('wazuh-monitoring-*') ||
-        item.id.includes('wazuh-monitoring-*')
+        item.title.includes(WAZUH_MONITORING_PATTERN) ||
+        item.id.includes(WAZUH_MONITORING_PATTERN)
       ) {
         continue;
       }

--- a/server/monitoring.js
+++ b/server/monitoring.js
@@ -21,6 +21,7 @@ import { BuildBody } from './lib/replicas-shards-helper';
 import * as ApiHelper from './lib/api-helper';
 import { WazuhHostsCtrl } from '../server/controllers/wazuh-hosts';
 import { ApiInterceptor } from './lib/api-interceptor';
+import { WAZUH_ALERTS_PATTERN, WAZUH_MONITORING_PREFIX, WAZUH_MONITORING_PATTERN } from '../util/constants';
 
 const blueWazuh = '\u001b[34mwazuh\u001b[39m';
 const monitoringErrorLogColors = [blueWazuh, 'monitoring', 'error'];
@@ -36,8 +37,8 @@ export class Monitoring {
     this.FREQUENCY = 900;
     this.CRON_FREQ = '0 1 * * * *';
     this.CREATION = 'd';
-    this.index_pattern = 'wazuh-monitoring-3.x-*';
-    this.index_prefix = 'wazuh-monitoring-3.x-';
+    this.index_pattern = WAZUH_MONITORING_PATTERN;
+    this.index_prefix = WAZUH_MONITORING_PREFIX;
     this.wzWrapper = new ElasticWrapper(server);
     this.wazuhHosts = new WazuhHostsCtrl();
     this.agentsArray = [];
@@ -346,7 +347,7 @@ export class Monitoring {
 
   /**
    * Creating wazuh-monitoring index
-   * @param {String} datedIndex The name for the index (e.g. daily: wazuh-monitoring-3.x-YYYY.MM.DD)
+   * @param {String} datedIndex The name for the index (e.g. daily: wazuh-monitoring-YYYY.MM.DD)
    * @param {String} clusterName Wazuh cluster name.
    */
   async createIndex(datedIndex, clusterName) {
@@ -402,7 +403,7 @@ export class Monitoring {
 
   /**
    * Inserting one document per agent into Elastic. Bulk.
-   * @param {String} datedIndex The name for the index (e.g. daily: wazuh-monitoring-3.x-YYYY.MM.DD)
+   * @param {String} datedIndex The name for the index (e.g. daily: wazuh-monitoring-YYYY.MM.DD)
    * @param {String} clusterName Wazuh cluster name.
    */
   async insertDocument(datedIndex, clusterName) {
@@ -549,7 +550,7 @@ export class Monitoring {
           currentTemplate['wazuh-agent'].index_patterns;
       } catch (error) {
         // Init with the default index pattern
-        monitoringTemplate.index_patterns = ['wazuh-monitoring-3.x-*'];
+        monitoringTemplate.index_patterns = [WAZUH_MONITORING_PATTERN];
       }
 
       // Check if the user is using a custom pattern
@@ -602,7 +603,7 @@ export class Monitoring {
         !this.quiet &&
           log(
             'monitoring:init',
-            'Checking if wazuh-monitoring-3.x-* index pattern exists...',
+            'Checking if wazuh-monitoring-* index pattern exists...',
             'debug'
           );
 
@@ -617,7 +618,7 @@ export class Monitoring {
         await this.wzWrapper.updateMonitoringIndexPatternKnownFields(patternId);
       } catch (error) {
         const didNotFindMsg =
-          "Didn't find wazuh-monitoring-3.x-* index pattern for Kibana. Proceeding to create it...";
+          "Didn't find wazuh-monitoring- index pattern for Kibana. Proceeding to create it...";
         !this.quiet && log('monitoring:init', didNotFindMsg, 'info');
         !this.quiet && this.server.log(monitoringErrorLogColors, didNotFindMsg);
         return this.createWazuhMonitoring();

--- a/server/reporting/audit-request.js
+++ b/server/reporting/audit-request.js
@@ -12,6 +12,7 @@
 import { ElasticWrapper } from '../lib/elastic-wrapper';
 import { Base } from './base-query';
 import AuditMap from './audit-map';
+import { WAZUH_ALERTS_PATTERN } from '../../util/constants';
 
 export class AuditRequest {
   /**
@@ -33,7 +34,7 @@ export class AuditRequest {
     gte,
     lte,
     filters,
-    pattern = 'wazuh-alerts-3.x-*'
+    pattern = WAZUH_ALERTS_PATTERN
   ) {
     try {
       const base = {};
@@ -98,7 +99,7 @@ export class AuditRequest {
     gte,
     lte,
     filters,
-    pattern = 'wazuh-alerts-3.x-*'
+    pattern = WAZUH_ALERTS_PATTERN
   ) {
     try {
       const base = {};
@@ -170,7 +171,7 @@ export class AuditRequest {
     gte,
     lte,
     filters,
-    pattern = 'wazuh-alerts-3.x-*'
+    pattern = WAZUH_ALERTS_PATTERN
   ) {
     try {
       const base = {};

--- a/server/reporting/gdpr-request.js
+++ b/server/reporting/gdpr-request.js
@@ -11,6 +11,7 @@
  */
 import { ElasticWrapper } from '../lib/elastic-wrapper';
 import { Base } from './base-query';
+import { WAZUH_ALERTS_PATTERN } from '../../util/constants';
 
 export class GdprRequest {
   /**
@@ -28,7 +29,7 @@ export class GdprRequest {
    * @param {String} filters E.g: cluster.name: wazuh AND rule.groups: vulnerability
    * @returns {Array<String>}
    */
-  async topGDPRRequirements(gte, lte, filters, pattern = 'wazuh-alerts-3.x-*') {
+  async topGDPRRequirements(gte, lte, filters, pattern = WAZUH_ALERTS_PATTERN){
     if (filters.includes('rule.gdpr: exists')) {
       const first = filters.split('AND rule.gdpr: exists')[0];
       const second = filters.split('AND rule.gdpr: exists')[1];
@@ -83,7 +84,7 @@ export class GdprRequest {
     lte,
     filters,
     requirement,
-    pattern = 'wazuh-alerts-3.x-*'
+    pattern = WAZUH_ALERTS_PATTERN
   ) {
     if (filters.includes('rule.gdpr: exists')) {
       const first = filters.split('AND rule.gdpr: exists')[0];

--- a/server/reporting/overview-request.js
+++ b/server/reporting/overview-request.js
@@ -11,6 +11,7 @@
  */
 import { ElasticWrapper } from '../lib/elastic-wrapper';
 import { Base } from './base-query';
+import { WAZUH_ALERTS_PATTERN } from '../../util/constants';
 
 export class OverviewRequest {
   /**
@@ -28,7 +29,7 @@ export class OverviewRequest {
    * @param {String} filters E.g: cluster.name: wazuh AND rule.groups: vulnerability
    * @returns {Array<String>} E.g:['000','130','300']
    */
-  async topLevel15(gte, lte, filters, pattern = 'wazuh-alerts-3.x-*') {
+  async topLevel15(gte, lte, filters, pattern = WAZUH_ALERTS_PATTERN){
     try {
       const base = {};
 

--- a/server/reporting/pci-request.js
+++ b/server/reporting/pci-request.js
@@ -11,6 +11,7 @@
  */
 import { ElasticWrapper } from '../lib/elastic-wrapper';
 import { Base } from './base-query';
+import { WAZUH_ALERTS_PATTERN } from '../../util/constants';
 
 export class PciRequest {
   /**
@@ -28,7 +29,7 @@ export class PciRequest {
    * @param {String} filters E.g: cluster.name: wazuh AND rule.groups: vulnerability
    * @returns {Array<String>}
    */
-  async topPCIRequirements(gte, lte, filters, pattern = 'wazuh-alerts-3.x-*') {
+  async topPCIRequirements(gte, lte, filters, pattern = WAZUH_ALERTS_PATTERN){
     if (filters.includes('rule.pci_dss: exists')) {
       const first = filters.split('AND rule.pci_dss: exists')[0];
       const second = filters.split('AND rule.pci_dss: exists')[1];
@@ -98,7 +99,7 @@ export class PciRequest {
     lte,
     filters,
     requirement,
-    pattern = 'wazuh-alerts-3.x-*'
+    pattern = WAZUH_ALERTS_PATTERN
   ) {
     if (filters.includes('rule.pci_dss: exists')) {
       const first = filters.split('AND rule.pci_dss: exists')[0];

--- a/server/reporting/rootcheck-request.js
+++ b/server/reporting/rootcheck-request.js
@@ -11,6 +11,7 @@
  */
 import { ElasticWrapper } from '../lib/elastic-wrapper';
 import { Base } from './base-query';
+import { WAZUH_ALERTS_PATTERN } from '../../util/constants';
 
 export class RootcheckRequest {
   /**
@@ -32,7 +33,7 @@ export class RootcheckRequest {
     gte,
     lte,
     filters,
-    pattern = 'wazuh-alerts-3.x-*',
+    pattern = WAZUH_ALERTS_PATTERN,
     size = 5
   ) {
     try {
@@ -85,7 +86,7 @@ export class RootcheckRequest {
     gte,
     lte,
     filters,
-    pattern = 'wazuh-alerts-3.x-*'
+    pattern = WAZUH_ALERTS_PATTERN
   ) {
     try {
       const base = {};
@@ -132,7 +133,7 @@ export class RootcheckRequest {
     gte,
     lte,
     filters,
-    pattern = 'wazuh-alerts-3.x-*'
+    pattern = WAZUH_ALERTS_PATTERN
   ) {
     try {
       const base = {};

--- a/server/reporting/syscheck-request.js
+++ b/server/reporting/syscheck-request.js
@@ -11,6 +11,7 @@
  */
 import { ElasticWrapper } from '../lib/elastic-wrapper';
 import { Base } from './base-query';
+import { WAZUH_ALERTS_PATTERN } from '../../util/constants';
 
 export class SyscheckRequest {
   /**
@@ -28,7 +29,7 @@ export class SyscheckRequest {
    * @param {String} filters E.g: cluster.name: wazuh AND rule.groups: vulnerability
    * @returns {Array<String>}
    */
-  async top3agents(gte, lte, filters, pattern = 'wazuh-alerts-3.x-*') {
+  async top3agents(gte, lte, filters, pattern = WAZUH_ALERTS_PATTERN){
     try {
       const base = {};
 
@@ -74,7 +75,7 @@ export class SyscheckRequest {
    * @param {String} filters E.g: cluster.name: wazuh AND rule.groups: vulnerability
    * @returns {Array<String>}
    */
-  async top3Rules(gte, lte, filters, pattern = 'wazuh-alerts-3.x-*') {
+  async top3Rules(gte, lte, filters, pattern = WAZUH_ALERTS_PATTERN){
     try {
       const base = {};
 
@@ -132,7 +133,7 @@ export class SyscheckRequest {
     }
   }
 
-  async lastTenDeletedFiles(gte, lte, filters, pattern = 'wazuh-alerts-3.x-*') {
+  async lastTenDeletedFiles(gte, lte, filters, pattern = WAZUH_ALERTS_PATTERN){
     try {
       const base = {};
 
@@ -185,7 +186,7 @@ export class SyscheckRequest {
     gte,
     lte,
     filters,
-    pattern = 'wazuh-alerts-3.x-*'
+    pattern = WAZUH_ALERTS_PATTERN
   ) {
     try {
       const base = {};

--- a/server/reporting/tsc-request.js
+++ b/server/reporting/tsc-request.js
@@ -11,6 +11,7 @@
  */
 import { ElasticWrapper } from '../lib/elastic-wrapper';
 import { Base } from './base-query';
+import { WAZUH_ALERTS_PATTERN } from '../../util/constants';
 
 export class TSCRequest {
   /**
@@ -28,7 +29,7 @@ export class TSCRequest {
    * @param {String} filters E.g: cluster.name: wazuh AND rule.groups: vulnerability
    * @returns {Array<String>}
    */
-  async topTSCRequirements(gte, lte, filters, pattern = 'wazuh-alerts-3.x-*') {
+  async topTSCRequirements(gte, lte, filters, pattern = WAZUH_ALERTS_PATTERN) {
     if (filters.includes('rule.tsc: exists')) {
       const first = filters.split('AND rule.tsc: exists')[0];
       const second = filters.split('AND rule.tsc: exists')[1];
@@ -98,7 +99,7 @@ export class TSCRequest {
     lte,
     filters,
     requirement,
-    pattern = 'wazuh-alerts-3.x-*'
+    pattern = WAZUH_ALERTS_PATTERN
   ) {
     if (filters.includes('rule.tsc: exists')) {
       const first = filters.split('AND rule.tsc: exists')[0];

--- a/server/reporting/vulnerability-request.js
+++ b/server/reporting/vulnerability-request.js
@@ -11,6 +11,7 @@
  */
 import { ElasticWrapper } from '../lib/elastic-wrapper';
 import { Base } from './base-query';
+import { WAZUH_ALERTS_PATTERN } from '../../util/constants';
 
 export class VulnerabilityRequest {
   /**
@@ -34,7 +35,7 @@ export class VulnerabilityRequest {
     lte,
     severity,
     filters,
-    pattern = 'wazuh-alerts-3.x-*'
+    pattern = WAZUH_ALERTS_PATTERN
   ) {
     try {
       const base = {};
@@ -80,7 +81,7 @@ export class VulnerabilityRequest {
    * @param {String} filters E.g: cluster.name: wazuh AND rule.groups: vulnerability
    * @returns {Array<Number>}
    */
-  async topCVECount(gte, lte, filters, pattern = 'wazuh-alerts-3.x-*') {
+  async topCVECount(gte, lte, filters, pattern = WAZUH_ALERTS_PATTERN) {
     try {
       const base = {};
 
@@ -123,7 +124,7 @@ export class VulnerabilityRequest {
     lte,
     severity,
     filters,
-    pattern = 'wazuh-alerts-3.x-*'
+    pattern = WAZUH_ALERTS_PATTERN
   ) {
     try {
       const base = {};
@@ -168,7 +169,7 @@ export class VulnerabilityRequest {
     lte,
     severity,
     filters,
-    pattern = 'wazuh-alerts-3.x-*'
+    pattern = WAZUH_ALERTS_PATTERN
   ) {
     try {
       const base = {};
@@ -215,7 +216,7 @@ export class VulnerabilityRequest {
     lte,
     severity,
     filters,
-    pattern = 'wazuh-alerts-3.x-*'
+    pattern = WAZUH_ALERTS_PATTERN
   ) {
     try {
       const base = {};

--- a/test/functional/apps/overview/_integrity_monitoring.ts
+++ b/test/functional/apps/overview/_integrity_monitoring.ts
@@ -13,6 +13,7 @@
 import expect from '@kbn/expect';
 import { FtrProviderContext } from '../../../../../../test/functional/ftr_provider_context';
 import { SearchParams } from 'elasticsearch';
+import { WAZUH_ALERTS_PATTERN } from '../../../../util/constants';
 
 export default function({getService, getPageObjects, }: FtrProviderContext) {
   const areaChart = getService('areaChart');
@@ -32,7 +33,7 @@ export default function({getService, getPageObjects, }: FtrProviderContext) {
     let es_index: string;
     before(async () => {
       await PageObjects.wazuhCommon.OpenIntegrityMonitoring();
-      es_index = 'wazuh-alerts-3.x-*';
+      es_index = WAZUH_ALERTS_PATTERN;
     });
 
     beforeEach(async () => {

--- a/test/functional/apps/overview/_security_events.ts
+++ b/test/functional/apps/overview/_security_events.ts
@@ -13,6 +13,7 @@
 import expect from '@kbn/expect';
 import { FtrProviderContext } from '../../../../../../test/functional/ftr_provider_context';
 import { SearchParams } from 'elasticsearch';
+import { WAZUH_ALERTS_PATTERN } from '../../../../util/constants';
 
 export default function({getService, getPageObjects, }: FtrProviderContext) {
   const areaChart = getService('areaChart');
@@ -33,7 +34,7 @@ export default function({getService, getPageObjects, }: FtrProviderContext) {
     let es_index: string;
     before(async () => {
       await PageObjects.wazuhCommon.OpenSecurityEvents();
-      es_index = 'wazuh-alerts-3.x-*';
+      es_index = WAZUH_ALERTS_PATTERN;
     });
 
     beforeEach(async () => {

--- a/test/server/alerts.js
+++ b/test/server/alerts.js
@@ -10,7 +10,7 @@ const headers = {
 const date = new Date();
 const day = date.getDate();
 const month = date.getMonth() + 1;
-const index = `wazuh-alerts-3.x-2018.${month >= 10 ? month : `0${month}`}.${
+const index = `wazuh-alerts-2018.${month >= 10 ? month : `0${month}`}.${
   day >= 10 ? day : `0${day}`
 }`;
 

--- a/test/server/wazuh-elastic.js
+++ b/test/server/wazuh-elastic.js
@@ -1,5 +1,6 @@
 const chai = require('chai');
 const needle = require('needle');
+const { WAZUH_ALERTS_PATTERN } = require('../../util/constants');
 
 const kibanaServer = process.env.KIBANA_IP || 'localhost';
 
@@ -28,7 +29,7 @@ describe('wazuh-elastic', () => {
     it('GET /elastic/known-fields/{pattern}', async () => {
       const res = await needle(
         'get',
-        `${kibanaServer}:5601/elastic/known-fields/wazuh-alerts-3.x-*`,
+        `${kibanaServer}:5601/elastic/known-fields/${WAZUH_ALERTS_PATTERN}`,
         {},
         headers
       );
@@ -36,7 +37,7 @@ describe('wazuh-elastic', () => {
       res.body.output.should.be.a('object');
       //res.body.output._index.should.be.eql('.kibana');
       res.body.output._type.should.be.eql('doc');
-      res.body.output._id.should.be.eql('index-pattern:wazuh-alerts-3.x-*');
+      res.body.output._id.should.be.eql(`index-pattern:${WAZUH_ALERTS_PATTERN}`);
     });
   });
 
@@ -44,7 +45,7 @@ describe('wazuh-elastic', () => {
     it('GET /elastic/visualizations/{tab}/{pattern}', async () => {
       const res = await needle(
         'get',
-        `${kibanaServer}:5601/elastic/visualizations/overview-general/wazuh-alerts-3.x-*`,
+        `${kibanaServer}:5601/elastic/visualizations/overview-general/${WAZUH_ALERTS_PATTERN}`,
         {},
         headers
       );
@@ -59,7 +60,7 @@ describe('wazuh-elastic', () => {
     it('POST /elastic/visualizations/{tab}/{pattern}', async () => {
       const res = await needle(
         'post',
-        `${kibanaServer}:5601/elastic/visualizations/cluster-monitoring/wazuh-alerts-3.x-*`,
+        `${kibanaServer}:5601/elastic/visualizations/cluster-monitoring/${WAZUH_ALERTS_PATTERN}`,
         { nodes: { items: [], name: 'node01' } },
         headers
       );
@@ -76,19 +77,19 @@ describe('wazuh-elastic', () => {
     it('GET /elastic/template/{pattern}', async () => {
       const res = await needle(
         'get',
-        `${kibanaServer}:5601/elastic/template/wazuh-alerts-3.x-*`,
+        `${kibanaServer}:5601/elastic/template/${WAZUH_ALERTS_PATTERN}`,
         {},
         headers
       );
       res.body.statusCode.should.be.eql(200);
       res.body.status.should.be.eql(true);
-      res.body.data.should.be.eql('Template found for wazuh-alerts-3.x-*');
+      res.body.data.should.be.eql(`Template found for ${WAZUH_ALERTS_PATTERN}`);
     });
 
     it('GET /elastic/index-patterns/{pattern}', async () => {
       const res = await needle(
         'get',
-        `${kibanaServer}:5601/elastic/index-patterns/wazuh-alerts-3.x-*`,
+        `${kibanaServer}:5601/elastic/index-patterns/${WAZUH_ALERTS_PATTERN}`,
         {},
         headers
       );

--- a/util/constants.js
+++ b/util/constants.js
@@ -1,0 +1,16 @@
+/*
+ * Wazuh app - Wazuh Constants file
+ * Copyright (C) 2015-2020 Wazuh, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Find more information about this on the LICENSE file.
+ */
+
+export const WAZUH_ALERTS_PREFIX = "wazuh-alerts-";
+export const WAZUH_ALERTS_PATTERN = "wazuh-alerts-*";
+export const WAZUH_MONITORING_PREFIX = "wazuh-monitoring-";
+export const WAZUH_MONITORING_PATTERN = "wazuh-monitoring-*";


### PR DESCRIPTION
Hi team,

**DO NOT MERGE UNTIL https://github.com/wazuh/wazuh/pull/5796 IS MERGED**

With the imminent arrival of the new version of Wazuh 4.0, the default index-pattern will be renamed to `wazuh-alerts-*`, so that the app will be able to read and show alerts from the new version 4.0, as well as from the previous versions.

We've created a global variable containing the index-pattern to make the code more maintainable, and we've replaced all the old occurrences with this variable.

This PR closes #2443 

Regards,