### PR TITLE
[3.13-7.9] Fix flyouts

### DIFF
--- a/public/components/agents/fim/events.tsx
+++ b/public/components/agents/fim/events.tsx
@@ -179,7 +179,7 @@ export class EventsFim extends Component {
       this.state.isFlyoutVisible &&
       <EuiOverlayMask
         // @ts-ignore
-        onClick={(e: Event) => { e.target.className === 'euiOverlayMask' && this.closeFlyout() }} >
+        onClick={() => this.closeFlyout()} >
         <FlyoutDetail
           fileName={this.state.currentFile}
           agentId={this.state.currentAgent}

--- a/public/components/agents/fim/inventory/registry-table.tsx
+++ b/public/components/agents/fim/inventory/registry-table.tsx
@@ -230,7 +230,7 @@ export class RegistryTable extends Component {
         {registryTable}
         {this.state.isFlyoutVisible && (
           <EuiOverlayMask
-            onClick={(e: Event) => e.target.className === 'euiOverlayMask' && this.closeFlyout()}
+            onClick={() => this.closeFlyout()}
           >
             <FlyoutDetail
             fileName={this.state.currentFile.file}

--- a/public/components/agents/fim/inventory/table.tsx
+++ b/public/components/agents/fim/inventory/table.tsx
@@ -274,7 +274,7 @@ export class InventoryTable extends Component {
         {filesTable}
         {this.state.isFlyoutVisible &&
           <EuiOverlayMask
-            onClick={(e: Event) => { e.target.className === 'euiOverlayMask' && this.closeFlyout() }} >
+            onClick={() => this.closeFlyout() } >
             <FlyoutDetail
               fileName={this.state.currentFile}
               agentId={this.props.agent.id}

--- a/public/components/common/modules/mitre-events.tsx
+++ b/public/components/common/modules/mitre-events.tsx
@@ -195,7 +195,7 @@ export class EventsMitre extends Component {
       this.state.isFlyoutVisible &&
       <EuiOverlayMask
         // @ts-ignore
-        onClick={(e: Event) => { e.target.className === 'euiOverlayMask' && this.closeFlyout() }} >
+        onClick={() => this.closeFlyout()} >
 
 
         <FlyoutTechnique

--- a/public/components/common/welcome/components/fim_events_table/fim_events_table.tsx
+++ b/public/components/common/welcome/components/fim_events_table/fim_events_table.tsx
@@ -88,7 +88,7 @@ function FimTable({ agent }) {
         noItemsMessage="No recent events" />
         {isOpen && (
           <EuiOverlayMask
-            onClick={(e: Event) => e.target.className === 'euiOverlayMask' && setIsOpen(false)}
+            onClick={() => setIsOpen(false)}
           >
             <FlyoutDetail
             agentId={agent.id}

--- a/public/components/common/welcome/components/mitre_top/mitre_top.tsx
+++ b/public/components/common/welcome/components/mitre_top/mitre_top.tsx
@@ -245,7 +245,7 @@ export class MitreTopTactics extends Component {
         {!selectedTactic || alertsCount.length === 0 ? tacticsTop : tecniquesTop}
         {alertsCount.length === 0 && emptyPrompt}
         {flyoutOn &&
-        <EuiOverlayMask onClick={(e: Event) => { e.target.className === 'euiOverlayMask' && this.closeFlyout() }} >
+        <EuiOverlayMask onClick={() => this.closeFlyout() } >
           <FlyoutTechnique 
             openDashboard={(e,itemId) => this.openDashboard(e,itemId)}
             openDiscover={(e,itemId) => this.openDiscover(e,itemId)}

--- a/public/components/overview/compliance-table/components/subrequirements/subrequirements.tsx
+++ b/public/components/overview/compliance-table/components/subrequirements/subrequirements.tsx
@@ -31,7 +31,6 @@ import { getServices } from '../../../../../../../../src/plugins/discover/public
 import { AppNavigate } from '../../../../../react-services/app-navigate';
 import { RequirementFlyout } from '../requirement-flyout/requirement-flyout'
 
-
 export class ComplianceSubrequirements extends Component {
   _isMount = false;
   state: {
@@ -277,7 +276,7 @@ export class ComplianceSubrequirements extends Component {
         </div>
 
         {this.state.flyoutOn &&
-          <EuiOverlayMask onClick={(e: Event) => { e.target.className === 'euiOverlayMask' && this.closeFlyout() }} >
+          <EuiOverlayMask onClick={() => this.closeFlyout() } >
             <RequirementFlyout
               currentRequirement={this.state.selectedRequirement}
               onChangeFlyout={this.onChangeFlyout}

--- a/public/components/overview/mitre/components/techniques/techniques.tsx
+++ b/public/components/overview/mitre/components/techniques/techniques.tsx
@@ -410,7 +410,7 @@ export const Techniques = withWindowSize(class Techniques extends Component {
         { isFlyoutVisible &&
           <EuiOverlayMask
             // @ts-ignore
-            onClick={(e: Event) => { e.target.className === 'euiOverlayMask' && this.onChangeFlyout(false) }} >
+            onClick={() => this.onChangeFlyout(false) } >
           
             <FlyoutTechnique
               openDashboard={(e,itemId) => this.openDashboard(e,itemId)}

--- a/public/components/wz-agent-selector/wz-agent-selector.js
+++ b/public/components/wz-agent-selector/wz-agent-selector.js
@@ -117,7 +117,7 @@ class WzAgentSelector extends Component {
 
     if (this.props.state.showExploreAgentModalGlobal) {
       modal = (
-        <EuiOverlayMask onClick={(e) => { e.target.className === 'euiOverlayMask' && this.closeAgentModal() }}>
+        <EuiOverlayMask onClick={() => this.closeAgentModal()}>
           <EuiModal
             className="wz-select-agent-modal"
             onClose={() => this.closeAgentModal()}


### PR DESCRIPTION
Hi team,

this PR resolves:
- fix flyouts with the capability to close when clicks out of them

It seems the `@elastic/eui` version that Kibana 7.9 is using, it changed as the `onClink` function of `EuiOverlayMask` component. It doesn't now receive any parameters, while before it was receiving the HTML `event`.