### PR TITLE
[4.0] Number of shards and replicas of sample data, overflow EuiCodeBlock in Logs sections, prompts Management/Statistics

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -105,6 +105,7 @@ app.run([
         <div ng-view class="mainView"></div>
         <react-component name="WzMenuWrapper" props=""></react-component>
         <react-component name="WzAgentSelectorWrapper" props=""></react-component>
+        <react-component name="ToastNotificationsModal" props=""></react-component>
        </div>
         `
       )

--- a/public/components/index.js
+++ b/public/components/index.js
@@ -19,6 +19,7 @@ import { WzBlankScreen } from '../components/wz-blank-screen/wz-blank-screen';
 import { ClusterDisabled } from '../components/management/cluster/cluster-disabled';
 import { ClusterTimelions } from '../components/management/cluster/cluster-timelions';
 import { KibanaVisWrapper } from '../components/management/cluster/cluster-visualization';
+import { ToastNotificationsModal } from '../components/notifications/modal';
 
 const app = uiModules.get('app/wazuh', []);
 app.value('WzFilterBar', WzFilterBar);
@@ -29,3 +30,4 @@ app.value('WzBlankScreen', WzBlankScreen);
 app.value('ClusterDisabled', ClusterDisabled);
 app.value('ClusterTimelions', ClusterTimelions);
 app.value('KibanaVisualization', KibanaVisWrapper);
+app.value('ToastNotificationsModal', ToastNotificationsModal);

--- a/public/components/notifications/modal.tsx
+++ b/public/components/notifications/modal.tsx
@@ -1,0 +1,85 @@
+/*
+ * Wazuh app - Component that renders the toast notification modal
+ * Copyright (C) 2015-2020 Wazuh, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Find more information about this on the LICENSE file.
+ */
+import React, { Fragment, useState, useEffect } from 'react';
+
+import {
+  EuiModal,
+  EuiModalHeader,
+  EuiModalHeaderTitle,
+  EuiModalBody,
+  EuiCallOut,
+  EuiSpacer,
+  EuiCodeBlock,
+  EuiModalFooter,
+  EuiButton,
+  EuiOverlayMask,
+  EuiCopy
+} from '@elastic/eui';
+
+import { useSelector, useDispatch } from 'react-redux';
+import { updateToastNotificationsModal } from '../../redux/actions/appStateActions';
+import { withReduxProvider } from '../common/hocs'
+
+export const ToastNotificationsModal = withReduxProvider(() => {
+  const [isOpen, setIsOpen] = useState(false);
+  const toastNotification = useSelector(state => state.appStateReducers.toastNotification);
+  const dispatch = useDispatch();
+  const closeModal = () => setIsOpen(false);
+
+  useEffect(() => {
+    if(!isOpen){
+      dispatch(updateToastNotificationsModal(false));
+    }
+  }, [isOpen]);
+
+
+  useEffect(() => {
+    if(toastNotification){
+      setIsOpen(true);
+    }
+  }, [toastNotification]);
+  console.log('toastNotification',toastNotification)
+  if(!toastNotification){
+    return null;
+  };
+  const errorStack = (toastNotification.error && toastNotification.error.stack) || '';
+  const calloutTitle = toastNotification.path ? `[${toastNotification.path}] > ${toastNotification.error.message}` : toastNotification.error.message;
+  const copyMessage = `\`\`\`**${toastNotification.title}**
+  ${calloutTitle}
+  ${errorStack}
+  \`\`\``
+  return (
+    <EuiOverlayMask  onClick={(e: Event) => e.target.className === 'euiOverlayMask' && closeModal()}>
+      <EuiModal onClose={closeModal}>
+        <EuiModalHeader>
+          <EuiModalHeaderTitle>{toastNotification.title}</EuiModalHeaderTitle>
+        </EuiModalHeader>
+        <EuiModalBody>
+          <EuiCallOut size="s" color="danger" iconType="alert" title={calloutTitle}/>
+          {errorStack && (
+            <Fragment>
+              <EuiSpacer size="s" />
+              <EuiCodeBlock /*isCopyable={true}*/ paddingSize="s">
+                {errorStack}
+              </EuiCodeBlock>
+            </Fragment>
+          )}
+        </EuiModalBody>
+        <EuiModalFooter>
+          <EuiCopy textToCopy={copyMessage}>
+            {copy => <EuiButton fill onClick={copy}>Copy error</EuiButton>}
+          </EuiCopy>
+        </EuiModalFooter>
+      </EuiModal>
+    </EuiOverlayMask>
+  )
+})

--- a/public/components/settings/settings-logs/logs.js
+++ b/public/components/settings/settings-logs/logs.js
@@ -123,14 +123,16 @@ export default class SettingsLogs extends Component {
             <EuiProgress size="xs" color="primary" />
           )}
           {!this.state.refreshingEntries && (
-            <EuiCodeBlock
-              fontSize="s"
-              paddingSize="m"
-              color="dark"
-              overflowHeight={this.height}
-            >
-              {text}
-            </EuiCodeBlock>
+            <div className='code-block-log-viewer-container'>
+              <EuiCodeBlock
+                fontSize="s"
+                paddingSize="m"
+                color="dark"
+                overflowHeight={this.height}
+              >
+                {text}
+              </EuiCodeBlock>
+            </div>
           )}
         </EuiPanel>
       </EuiPage>

--- a/public/controllers/management/components/management/mg-logs/logs.js
+++ b/public/controllers/management/components/management/mg-logs/logs.js
@@ -46,7 +46,7 @@ export default compose(
 (class WzLogs extends Component {
   constructor(props) {
     super(props);
-    this.offset = 325;
+    this.offset = 350;
     this.state = {
       isCluster: false,
       selectedDaemon: '',
@@ -485,14 +485,16 @@ export default compose(
       <div>
         {(this.state.logsList && (
           <Fragment>
-            <EuiCodeBlock
-              fontSize="s"
-              paddingSize="m"
-              color="dark"
-              overflowHeight={this.height}
-            >
-              {this.state.logsList}
-            </EuiCodeBlock>
+            <div className='code-block-log-viewer-container'>
+              <EuiCodeBlock
+                fontSize="s"
+                paddingSize="m"
+                color="dark"
+                overflowHeight={this.height}
+              >
+                {this.state.logsList}
+              </EuiCodeBlock>
+            </div>
             <EuiSpacer size="m" />
             {(this.state.offset + 100 < this.state.totalItems && (
               <EuiFlexGroup justifyContent='center'>
@@ -524,7 +526,7 @@ export default compose(
     return (
       <EuiPage>
         <EuiPageBody>
-          <EuiPanel>
+          <EuiPanel paddingSize="l">
             {this.header()}
             <EuiSpacer size={'m'}></EuiSpacer>
             {(!this.state.isLoading && this.logsTable()) || (

--- a/public/controllers/management/components/management/statistics/prompt-statistics-disabled.tsx
+++ b/public/controllers/management/components/management/statistics/prompt-statistics-disabled.tsx
@@ -1,0 +1,33 @@
+/*
+ * Wazuh app - Prompt when Statistics is disabled
+ * Copyright (C) 2015-2020 Wazuh, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Find more information about this on the LICENSE file.
+ */
+
+import React from 'react';
+import { EuiEmptyPrompt, EuiButton } from '@elastic/eui';
+import { AppNavigate } from '../../../../../react-services/app-navigate';
+
+export const PromptStatisticsDisabled = () => {
+  const goToConfigure = e => {
+    AppNavigate.navigateToModule(e, 'settings', { tab: 'configuration', category: 'statistics' })
+  };
+
+  return (
+    <EuiEmptyPrompt
+      iconType="securitySignalDetected"
+      title={<h2>Statistics is disabled</h2>}
+      actions={
+        <EuiButton color="primary" fill iconType="gear" onMouseDown={goToConfigure}>
+          Go to configure
+        </EuiButton>  
+      }
+    />
+  )
+}

--- a/public/controllers/management/components/management/statistics/prompt-statistics-no-indices.tsx
+++ b/public/controllers/management/components/management/statistics/prompt-statistics-no-indices.tsx
@@ -1,0 +1,24 @@
+/*
+ * Wazuh app - Prompt when Statistics has not indices
+ * Copyright (C) 2015-2020 Wazuh, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Find more information about this on the LICENSE file.
+ */
+
+import React, { useState, useEffect, useReducer } from 'react';
+import { EuiEmptyPrompt, EuiButton, EuiProgress } from '@elastic/eui';
+
+
+export const PromptStatisticsNoIndices = () => {
+  return (
+    <EuiEmptyPrompt
+      iconType="securitySignalDetected"
+      title={<h2>Statistics has no indices</h2>}
+    />
+  )
+}

--- a/public/controllers/management/components/management/status/status-overview.js
+++ b/public/controllers/management/components/management/status/status-overview.js
@@ -19,7 +19,8 @@ import {
   EuiProgress,
   EuiPage,
   EuiSpacer,
-  EuiFlexGrid
+  EuiFlexGrid,
+  EuiButton
 } from '@elastic/eui';
 
 import { connect } from 'react-redux';
@@ -47,6 +48,7 @@ import { toastNotifications } from 'ui/notify';
 
 import { withUserAuthorizationPrompt, withGlobalBreadcrumb } from '../../../../../components/common/hocs';
 import { compose } from 'redux';
+import { ToastNotifications } from '../../../../../react-services/toast-notifications';
 
 export class WzStatusOverview extends Component {
   _isMounted = false;
@@ -156,7 +158,9 @@ export class WzStatusOverview extends Component {
       const [lastAgent] = lastAgentRaw.data.data.affected_items;
   
       this.props.updateAgentInfo(lastAgent);
-    }catch(error){/*Do nothing with error */}
+    }catch(error){
+      ToastNotifications.error('management:status:overview.fetchData', error);
+    }
     this.props.updateLoadingStatus(false);
   }
 

--- a/public/controllers/management/components/management/status/status-overview.js
+++ b/public/controllers/management/components/management/status/status-overview.js
@@ -156,8 +156,8 @@ export class WzStatusOverview extends Component {
       const [lastAgent] = lastAgentRaw.data.data.affected_items;
   
       this.props.updateAgentInfo(lastAgent);
-      this.props.updateLoadingStatus(false);
     }catch(error){/*Do nothing with error */}
+    this.props.updateLoadingStatus(false);
   }
 
   showToast = (color, text, time) => {

--- a/public/less/common.less
+++ b/public/less/common.less
@@ -1660,3 +1660,7 @@ iframe.width-changed {
     display: inline;
   } */
 } 
+
+.code-block-log-viewer-container{
+  max-width: calc(~"100vw - 41*2px");
+}

--- a/public/react-services/toast-notifications.tsx
+++ b/public/react-services/toast-notifications.tsx
@@ -1,0 +1,54 @@
+/*
+ * Wazuh app - Service to show notifications
+ * Copyright (C) 2015-2020 Wazuh, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Find more information about this on the LICENSE file.
+ */
+import React, { Fragment } from 'react';
+import  store  from '../redux/store';
+import { updateToastNotificationsModal } from '../redux/actions/appStateActions';
+import { toastNotifications } from 'ui/notify';
+import { EuiButton } from '@elastic/eui';
+
+export class ToastNotifications{
+  static add(toast){
+    toastNotifications.add(toast);
+  }
+  static success(toast){
+    ToastNotifications.add({
+      ...toast,
+      color: 'success',
+    });
+  }
+  static warning(toast){
+    ToastNotifications.add({
+      ...toast,
+      color: 'warning',
+    });
+  }
+  static danger(toast){
+    ToastNotifications.add({
+      ...toast,
+      color: 'danger',
+    });
+  }
+  static error(path, error, title = 'Error unexpected'){
+    ToastNotifications.danger({
+      title,
+      iconType: 'alert',
+      text: (
+        <Fragment>
+          <p data-test-subj="errorToastMessage">{error.message}</p>
+          <div className="eui-textRight">
+            <EuiButton color='danger' onClick={() => store.dispatch(updateToastNotificationsModal({path, error, title}))} size="s">See the full error</EuiButton>
+          </div>
+        </Fragment>
+      )
+    });
+  }
+}

--- a/public/redux/actions/appStateActions.js
+++ b/public/redux/actions/appStateActions.js
@@ -139,7 +139,7 @@ export const updateUserPermissions = userPermissions => {
 
 /**
 * Updates selectedSettingsSection in the appState store
-* @param extensions
+* @param selected_settings_section
 */
 export const updateSelectedSettingsSection = selected_settings_section => {
  return {
@@ -147,3 +147,14 @@ export const updateSelectedSettingsSection = selected_settings_section => {
    selected_settings_section
  };
 };
+
+/**
+* Updates toastNotification in the appState store
+* @param toastNotification
+*/
+export const updateToastNotificationsModal = toastNotification => {
+  return {
+    type: 'UPDATE_TOAST_NOTIFICATIONS_MODAL',
+    toastNotification
+  };
+ };

--- a/public/redux/reducers/appStateReducers.js
+++ b/public/redux/reducers/appStateReducers.js
@@ -22,7 +22,8 @@ const initialState = {
   showExploreAgentModal: false,
   showExploreAgentModalGlobal: false,
   userPermissions: {},
-  userRoles: []
+  userRoles: [],
+  toastNotification: false
 };
 
 const appStateReducers = (state = initialState, action) => {
@@ -109,6 +110,13 @@ const appStateReducers = (state = initialState, action) => {
     return {
       ...state,
       selected_settings_section: action.selected_settings_section
+    };
+  }
+
+  if (action.type === 'UPDATE_TOAST_NOTIFICATIONS_MODAL') {
+    return {
+      ...state,
+      toastNotification: action.toastNotification
     };
   }
 

--- a/server/controllers/wazuh-elastic.js
+++ b/server/controllers/wazuh-elastic.js
@@ -22,7 +22,7 @@ import {
 import { Base } from '../reporting/base-query';
 import { checkKnownFields } from '../lib/refresh-known-fields';
 import { generateAlerts } from '../lib/generate-alerts/generate-alerts-script';
-import { WAZUH_MONITORING_PATTERN, WAZUH_ALERTS_PATTERN, WAZUH_SAMPLE_ALERT_PREFIX, WAZUH_ROLE_ADMINISTRATOR_ID } from '../../util/constants';
+import { WAZUH_MONITORING_PATTERN, WAZUH_ALERTS_PATTERN, WAZUH_SAMPLE_ALERT_PREFIX, WAZUH_ROLE_ADMINISTRATOR_ID, WAZUH_SAMPLE_ALERTS_INDEX_SHARDS, WAZUH_SAMPLE_ALERTS_INDEX_REPLICAS } from '../../util/constants';
 import jwtDecode from 'jwt-decode';
 import { ManageHosts } from '../lib/manage-hosts';
 import { ApiInterceptor } from '../lib/api-interceptor';
@@ -954,9 +954,6 @@ export class WazuhElasticCtrl {
         return ErrorResponse('Token is not valid', 500, 500, reply);
       };
 
-      //Get configuration
-      const configFile = getConfiguration();
-
       const bulkPrefix = JSON.stringify({
         index: {
           _index: sampleAlertsIndex
@@ -974,21 +971,11 @@ export class WazuhElasticCtrl {
       if (!existsSampleIndex) {
         // Create wazuh sample alerts index
 
-        const shards =
-          typeof (configFile || {})['wazuh.alerts.shards'] !== 'undefined'
-            ? configFile['wazuh.alerts.shards']
-            : 3;
-
-        const replicas =
-          typeof (configFile || {})['wazuh.alerts.replicas'] !== 'undefined'
-            ? configFile['wazuh.alerts.replicas']
-            : 0;
-
         const configuration = {
           settings: {
             index: {
-              number_of_shards: shards,
-              number_of_replicas: replicas
+              number_of_shards: WAZUH_SAMPLE_ALERTS_INDEX_SHARDS,
+              number_of_replicas: WAZUH_SAMPLE_ALERTS_INDEX_REPLICAS
             }
           }
         };

--- a/server/controllers/wazuh-elastic.js
+++ b/server/controllers/wazuh-elastic.js
@@ -1076,15 +1076,16 @@ export class WazuhElasticCtrl {
     }
   }
 
+  // Check if there are indices for Statistics
   async existStatisticsIndices(req, reply) {
     try{
       const config = getConfiguration();
       const statisticsPattern = `${config['cron.prefix'] || 'wazuh'}-${config['cron.statistics.index.name'] || 'statistics'}*`; //TODO: replace by default as constants instead hardcoded ('wazuh' and 'statistics')
-      const data = await this.wzWrapper.checkIfIndexExists(statisticsPattern, { allow_no_indices: false});
+      const data = await this.wzWrapper.checkIfIndexExists(statisticsPattern, { allow_no_indices: false });
       return data;
     }catch(error){
       log('wazuh-elastic:existsStatisticsIndices', error.message || error);
-      return ErrorResponse(error.message || error, 4010, 500, reply);
+      return ErrorResponse(error.message || error, 1000, 500, reply);
     }
   }
 }

--- a/server/controllers/wazuh-elastic.js
+++ b/server/controllers/wazuh-elastic.js
@@ -1075,4 +1075,16 @@ export class WazuhElasticCtrl {
       return ErrorResponse(error.message || error, 4010, 500, reply);
     }
   }
+
+  async existStatisticsIndices(req, reply) {
+    try{
+      const config = getConfiguration();
+      const statisticsPattern = `${config['cron.prefix'] || 'wazuh'}-${config['cron.statistics.index.name'] || 'statistics'}*`; //TODO: replace by default as constants instead hardcoded ('wazuh' and 'statistics')
+      const data = await this.wzWrapper.checkIfIndexExists(statisticsPattern, { allow_no_indices: false});
+      return data;
+    }catch(error){
+      log('wazuh-elastic:existsStatisticsIndices', error.message || error);
+      return ErrorResponse(error.message || error, 4010, 500, reply);
+    }
+  }
 }

--- a/server/lib/elastic-wrapper.js
+++ b/server/lib/elastic-wrapper.js
@@ -532,13 +532,13 @@ export class ElasticWrapper {
    * Check if an index exists
    * @param {*} index
    */
-  async checkIfIndexExists(index) {
+  async checkIfIndexExists(index, params = {}) {
     try {
       if (!index) return Promise.reject(new Error('No valid index given'));
 
       const data = await this.elasticRequest.callWithInternalUser(
         'indices.exists',
-        { index: index }
+        { index: index, ...params }
       );
 
       return data;

--- a/server/routes/wazuh-elastic.js
+++ b/server/routes/wazuh-elastic.js
@@ -159,7 +159,7 @@ export function WazuhElasticRouter(server) {
       return ctrl.esAlerts(req, res);
     }
   });
-
+  // Check if there are indices for Statistics
   server.route({
     method: 'GET',
     path: '/elastic/statistics',

--- a/server/routes/wazuh-elastic.js
+++ b/server/routes/wazuh-elastic.js
@@ -159,4 +159,12 @@ export function WazuhElasticRouter(server) {
       return ctrl.esAlerts(req, res);
     }
   });
+
+  server.route({
+    method: 'GET',
+    path: '/elastic/statistics',
+    handler(req, res) {
+      return ctrl.existStatisticsIndices(req, res);
+    }
+  });
 }

--- a/util/constants.js
+++ b/util/constants.js
@@ -17,3 +17,5 @@ export const WAZUH_MONITORING_PATTERN = "wazuh-monitoring-*";
 export const WAZUH_SAMPLE_ALERT_PREFIX = "wazuh-alerts-4.x-";
 export const WAZUH_ROLE_ADMINISTRATOR_ID = 1;
 export const WAZUH_ROLE_ADMINISTRATOR_NAME = 'administrator';
+export const WAZUH_SAMPLE_ALERTS_INDEX_SHARDS = 1;
+export const WAZUH_SAMPLE_ALERTS_INDEX_REPLICAS = 0;


### PR DESCRIPTION
Hi team,

this PR resolves:
- Added a try/catch block to fetch data method (unhandled promise) in Management/Status https://github.com/wazuh/wazuh-kibana-app/issues/2458
- Set fixed values to `shards` and `replicas` of sample alerts indices configuration https://github.com/wazuh/wazuh-kibana-app/issues/2480
- Fix the horizontal overflow of EuiCodeBlock in Settings/Logs and Management/Logs sections https://github.com/wazuh/wazuh-kibana-app/issues/2479
- Added prompts to Management/Statistics when it is disabled or there are not indices for Statistics https://github.com/wazuh/wazuh-kibana-app/issues/2481

It partially resolves:
- Created the ToastNotifications service and modal to show the expanded information about toasts (with errors) https://github.com/wazuh/wazuh-kibana-app/issues/2487