### PR TITLE
Add wazuh-statistics index to error prompt

### DIFF
--- a/public/controllers/management/components/management/statistics/prompt-statistics-no-indices.tsx
+++ b/public/controllers/management/components/management/statistics/prompt-statistics-no-indices.tsx
@@ -10,15 +10,24 @@
  * Find more information about this on the LICENSE file.
  */
 
-import React, { useState, useEffect, useReducer } from 'react';
-import { EuiEmptyPrompt, EuiButton, EuiProgress } from '@elastic/eui';
+import React, { useState, useEffect } from 'react';
+import { EuiEmptyPrompt } from '@elastic/eui';
+import { WazuhConfig } from '../../../../../react-services/wazuh-config';
 
 
 export const PromptStatisticsNoIndices = () => {
+  const [indexName, setIndexName] = useState("");
+
+  useEffect(() => {
+    const wazuhConfig = new WazuhConfig();
+    const config = wazuhConfig.getConfig();
+    setIndexName(`${config["cron.prefix"] || 'wazuh'}-${config["cron.statistics.index.name"] || 'stastistics'}-*`)
+  }, []);
+
   return (
     <EuiEmptyPrompt
       iconType="securitySignalDetected"
-      title={<h2>Statistics has no indices</h2>}
+      title={<h2>{indexName} indices were not found.</h2>}
     />
   )
 }


### PR DESCRIPTION
This PR updates the error prompt shown when there are no wazuh-statistics-* indices