### PR TITLE
Adapt to X-Pack new platform

### DIFF
--- a/server/controllers/wazuh-api.js
+++ b/server/controllers/wazuh-api.js
@@ -131,10 +131,10 @@ export class WazuhApiCtrl {
 
       return { token };
     } catch (error){
-      const errorMessage = ((error .response || {}).data || {}).detail;
+      const errorMessage = ((error.response || {}).data || {}).detail;
       log('wazuh-api:getToken', errorMessage || error.message);
       return ErrorResponse(
-        `Error getting authorization token: ${errorMessage || ""}`,
+        `Error getting authorization token: ${errorMessage || error.message}`,
         3000,
         500,
         reply

--- a/server/controllers/wazuh-api.js
+++ b/server/controllers/wazuh-api.js
@@ -131,10 +131,10 @@ export class WazuhApiCtrl {
 
       return { token };
     } catch (error){
-      const errorMessage = ((error.response || {}).data || {}).detail;
-      log('wazuh-api:getToken', errorMessage || error.message);
+      const errorMessage = ((error.response || {}).data || {}).detail || error.message || error;
+      log('wazuh-api:getToken', errorMessage);
       return ErrorResponse(
-        `Error getting authorization token: ${errorMessage || error.message}`,
+        `Error getting authorization token: ${errorMessage}`,
         3000,
         500,
         reply

--- a/server/controllers/wazuh-elastic.js
+++ b/server/controllers/wazuh-elastic.js
@@ -386,7 +386,7 @@ export class WazuhElasticCtrl {
    */
   async getCurrentPlatform(req, reply) {
     try {
-      if(this._server.plugins.security) { // XPACK
+      if(this._server.newPlatform.setup.plugins.security ) { // XPACK
         return {platform: 'xpack'}
       }
       if(this._server.plugins.opendistro_security){

--- a/server/lib/security-factory/factories/xpack-factory.ts
+++ b/server/lib/security-factory/factories/xpack-factory.ts
@@ -9,7 +9,7 @@ export class XpackFactory implements ISecurityFactory {
 
   async getCurrentUser(req) {
     try {
-      const authInfo = await this.server.plugins.security.getUser(req);
+      const authInfo = await this.server.newPlatform.setup.plugins.security.authc.getCurrentUser(req);
       if(!authInfo) return { username: 'elastic'};
       return authInfo;
     } catch (error) {


### PR DESCRIPTION
Hi team,

this PR resolves:
- fix the `getCurrentUser` and `getCurrenPlatform` methods for X-Pack (it was migrated to Kibana `newPlatform`)
- improved the error message due to error getting the Wazuh authentication

Issue: #2521 