### PR TITLE
Fix Security section

### DIFF
--- a/public/components/security/roles-mapping/roles-mapping.tsx
+++ b/public/components/security/roles-mapping/roles-mapping.tsx
@@ -60,7 +60,9 @@ export const RolesMapping = () => {
 
   let editFlyout;
   if (isEditingRule) {
-    editFlyout = (<EuiOverlayMask onClick={() => {
+    editFlyout = (<EuiOverlayMask
+        headerZindexLocation="below"
+        onClick={() => {
       setIsEditingRule(false)
     }}>
       <RolesMappingEdit rule={selectedRule} closeFlyout={(isVisible) => { setIsEditingRule(isVisible); initData() }} rolesEquivalences={rolesEquivalences} roles={roles} />
@@ -68,7 +70,9 @@ export const RolesMapping = () => {
   }
   let createFlyout;
   if (isCreatingRule) {
-    editFlyout = (<EuiOverlayMask onClick={() => {
+    editFlyout = (<EuiOverlayMask
+        headerZindexLocation="below"
+        onClick={() => {
       setIsCreatingRule(false)
     }}>
       <RolesMappingCreate closeFlyout={(isVisible) => { setIsCreatingRule(isVisible); initData() }} rolesEquivalences={rolesEquivalences} roles={roles} />

--- a/public/components/security/roles/edit-role-table.tsx
+++ b/public/components/security/roles/edit-role-table.tsx
@@ -10,28 +10,28 @@ import { ErrorHandler } from '../../../react-services/error-handler';
 
 
 
-export const EditRolesTable = ({ policies, role, onChange, isDisabled }) => {
+export const EditRolesTable = ({ policies, role, onChange, isDisabled, loading}) => {
     const [isLoading, setIsLoading] = useState(false);
     const [pageIndex, setPageIndex] = useState(0);
     const [pageSize, setPageSize] = useState(10);
-    const [sortField, setSortField] = useState('role');
-    const [sortDirection, setSortDirection] = useState('asc');
     const [itemIdToExpandedRowMap, setItemIdToExpandedRowMap] = useState({});
 
     const onTableChange = ({ page = {}, sort = {} }) => {
         const { index: pageIndex, size: pageSize } = page;
-    
-        const { field: sortField, direction: sortDirection } = sort;
-    
         setPageIndex(pageIndex);
         setPageSize(pageSize);
-        setSortField(sortField);
-        setSortDirection(sortDirection);
       };
 
+      const formatPolicies = (policiesArray) => {
+        return policiesArray.map(policy => {
+          return policies.find(item => item.id === policy)
+        })
+      }
+
       const getItems = () => {
-          const items = policies.slice(pageIndex*pageSize, pageIndex*pageSize + pageSize);
-          return { pageOfItems: items, totalItemCount: policies.length}
+        if(loading) return { pageOfItems: [], totalItemCount: 0};
+        const items = formatPolicies(role.policies.slice(pageIndex*pageSize, pageIndex*pageSize + pageSize));
+        return { pageOfItems: items, totalItemCount: role.policies.length}
       }
 
       const { pageOfItems, totalItemCount } = getItems();
@@ -125,24 +125,17 @@ export const EditRolesTable = ({ policies, role, onChange, isDisabled }) => {
     pageSizeOptions: [5, 10, 20],
   };
 
-  const sorting = {
-    sort: {
-      field: sortField,
-      direction: sortDirection,
-    },
-  };
   return (
     <>
       <EuiBasicTable
         items={pageOfItems}
         itemId="id"
-        loading={isLoading}
+        loading={isLoading || loading}
         itemIdToExpandedRowMap={itemIdToExpandedRowMap}
         isExpandable={true}
         hasActions={true}
         columns={columns}
         pagination={pagination}
-        sorting={sorting}
         isSelectable={true}
         onChange={onTableChange}
       />

--- a/public/components/security/roles/edit-role.tsx
+++ b/public/components/security/roles/edit-role.tsx
@@ -23,6 +23,7 @@ const reservedRoles = ['administrator', 'readonly', 'users_admin', 'agents_reado
 
 
 export const EditRole = ({ role, closeFlyout }) => {
+    const [isLoading, setIsLoading] = useState(true);
     const [currentRole, setCurrentRole] = useState({});
     const [isReserved, setIsReserved] = useState(reservedRoles.includes(role.name))
     const [policies, setPolicies] = useState([]);
@@ -32,6 +33,7 @@ export const EditRole = ({ role, closeFlyout }) => {
 
     async function getData() {
         try{
+            setIsLoading(true);
             const roleDataResponse = await WzRequest.apiReq(
                 'GET',
                 '/security/roles',            
@@ -65,6 +67,7 @@ export const EditRole = ({ role, closeFlyout }) => {
         }catch(error){
             ErrorHandler.handle( error, 'Error');
         }
+        setIsLoading(false);
     }
 
     useEffect(() => {
@@ -162,7 +165,7 @@ export const EditRole = ({ role, closeFlyout }) => {
                 <EuiSpacer />
             </EuiForm>
                 <div style={{ margin: 20 }}>
-                    <EditRolesTable policies={assignedPolicies} role={role} onChange={update} isDisabled={isReserved}/>
+                    <EditRolesTable policies={assignedPolicies} role={currentRole} onChange={update} isDisabled={isReserved} loading={isLoading}/>
                 </div>
             </EuiFlyoutBody>
         </EuiFlyout>


### PR DESCRIPTION
Hi team,
This PR fixes the z-index in the role-mapping section flyouts as it wasn't being shown correctly.
It also orders the list of policies in order of precedence instead of being ordered by name.