### PR TITLE
Fix resources spacing in the policy tooltip from Security/Roles

### DIFF
--- a/public/components/security/roles/roles-table.tsx
+++ b/public/components/security/roles/roles-table.tsx
@@ -58,7 +58,7 @@ export const RolesTable = ({roles, policiesData, loading, editRole, updateRoles}
                                         <p>{((data.policy || {}).actions || []).join(", ")}</p>
                                         <EuiSpacer size="s" />
                                         <b>Resources</b>
-                                        <p>{(data.policy || {}).resources}</p>
+                                        <p>{((data.policy || {}).resources || []).join(", ")}</p>
                                         <EuiSpacer size="s" />
                                         <b>Effect</b>
                                         <p>{(data.policy || {}).effect}</p>


### PR DESCRIPTION
Hello team,

this PR resolves:
- resources spacing in the policy tooltip from Security/roles https://github.com/wazuh/wazuh-kibana-app/issues/2533