### PR TITLE
[4.0-7.9] Remove admin mode references

### DIFF
--- a/public/services/resolves/get-config.js
+++ b/public/services/resolves/get-config.js
@@ -52,7 +52,6 @@ export async function getWzConfig($q, genericReq, wazuhConfig) {
     'cron.statistics.interval': '0 0 * * * *',
     'cron.statistics.index.name': 'statistics',
     'cron.statistics.index.creation': 'w',
-    admin: true,
     hideManagerAlerts: false,
     'logs.level': 'info',
     'enrollment.dns': ''

--- a/server/controllers/wazuh-api.js
+++ b/server/controllers/wazuh-api.js
@@ -1155,25 +1155,6 @@ export class WazuhApiCtrl {
       //Path doesn't start with '/'
       return ErrorResponse('Request path is not valid.', 3015, 400, reply);
     } else {
-      // if (req.payload.method !== 'GET' && !adminMode) {
-      //   log('wazuh-api:requestApi', 'Forbidden action, allowed methods: GET');
-      //   return ErrorResponse(
-      //     req.payload.body && req.payload.body.devTools
-      //       ? 'Allowed method: [GET]'
-      //       : `Forbidden (${req.payload.method} ${req.payload.path}`,
-      //     3029,
-      //     400,
-      //     reply
-      //   );
-      // }
-      // if (req.payload.body.devTools) {
-      //   //delete req.payload.body.devTools;
-      //   const keyRegex = new RegExp(/.*agents\/\d*\/key.*/);
-      //   if (typeof req.payload.path === 'string' && keyRegex.test(req.payload.path) && !adminMode) {
-      //     log('wazuh-api:makeRequest', 'Forbidden route /agents/:id/key');
-      //     return ErrorResponse('Forbidden route /agents/:id/key', 3028, 400, reply);
-      //   }
-      // }
       return this.makeRequest(
         req.payload.method,
         req.payload.path,

--- a/server/lib/initial-wazuh-config.js
+++ b/server/lib/initial-wazuh-config.js
@@ -64,7 +64,7 @@ export const initialWazuhConfig = `---
 #extensions.osquery   : false
 #extensions.docker    : false
 #
-# ---------------------------------- Time out ----------------------------------
+# ---------------------------------- Timeout ----------------------------------
 #
 # Defines maximum timeout to be used on the Wazuh app requests.
 # It will be ignored if it is bellow 1500.
@@ -143,9 +143,6 @@ export const initialWazuhConfig = `---
 #
 # Define the interval in which the index will be created
 #cron.statistics.index.creation: w
-#
-# ------------------------------- App privileges --------------------------------
-#admin: true
 #
 # ---------------------------- Hide manager alerts ------------------------------
 # Hide the alerts of the manager in all dashboards and discover


### PR DESCRIPTION
Hello team,

this PR resolves:
- Remove `admin` mode references in `wazuh.yml` initial configuration and cached app configuration #2546 
- Remove commented old `adminMode` logic in `/api/request` endpoint

close #2546 