### PR TITLE
[4.0-7.9] Fix enhance discover table events

### DIFF
--- a/public/components/common/modules/events-enhance-discover-fields.ts
+++ b/public/components/common/modules/events-enhance-discover-fields.ts
@@ -110,36 +110,10 @@ export const EventsEnhanceDiscoverCell = {
 
 // Method to enhance a cell of discover table
 export const enhanceDiscoverEventsCell = (field, content, rowData, element, options) => {
-  if(!EventsEnhanceDiscoverCell[field]){ return };
+  if(!EventsEnhanceDiscoverCell[field] || !element || element.attributes[CUSTOM_ATTRIBUTE_ENHANCED_DISCOVER_FIELD]){ return };
   const elementCellEnhanced = EventsEnhanceDiscoverCell[field](content, rowData, element, options);
   if(elementCellEnhanced){
     elementCellEnhanced.setAttribute(CUSTOM_ATTRIBUTE_ENHANCED_DISCOVER_FIELD, ''); // Set a custom attribute to indentify that element was enhanced
     element.replaceWith(elementCellEnhanced);
   };
-}
-
-// Method to enhance the cells of discover table
-export const enhanceDiscoverEvents = (discoverRowsData, options) => {
-  // Get table headers
-  const discoverTableHeaders = document.querySelectorAll(`.kbn-table thead th`);
-  discoverTableHeaders.forEach((header, headerIndex) => {
-    // Ignore the columns whose field doesn't need to be enhanced
-    if(!EventsEnhanceDiscoverCell[header.textContent]){ return };
-    // Get cells of table header column to be enhanced
-    const elements = document.querySelectorAll(`.kbn-table tbody tr td:nth-child(${headerIndex+1}) div:not([${CUSTOM_ATTRIBUTE_ENHANCED_DISCOVER_FIELD}]) `);
-    const elementsFields = document.querySelectorAll(`.kbn-table tbody tr td .kbnDocViewer__field`);
-    elements.forEach((elementRow, elementRowIndex) => {
-      if(!elementRow.className.includes('kbnDocViewer__value')){
-        enhanceDiscoverEventsCell(header.textContent, elementRow.textContent, discoverRowsData[elementRowIndex], elementRow, options)
-      }
-    })
-    elementsFields.forEach((row, rowIdx) => {
-      const parentNode = row.parentNode;
-      const currentRowField = row.childNodes[0].childNodes[1].textContent || "";
-      const valueElement = parentNode.childNodes && parentNode.childNodes[2];
-      if(EventsEnhanceDiscoverCell[currentRowField]){
-        enhanceDiscoverEventsCell(currentRowField, (valueElement || {}).textContent || '', discoverRowsData[rowIdx], valueElement, options)
-      }
-    })
-  });
 }

--- a/public/components/common/modules/events.tsx
+++ b/public/components/common/modules/events.tsx
@@ -18,10 +18,10 @@ import store from '../../../redux/store';
 
 import { EuiOverlayMask } from '@elastic/eui';
 
-import { enhanceDiscoverEvents } from './events-enhance-discover-fields';
+import { enhanceDiscoverEventsCell } from './events-enhance-discover-fields';
 
 export class Events extends Component {
-  intervalTimeEnhancedDiscoverFields: number = 1000;
+  intervalCheckExistsDiscoverTableTime: number = 200;
   isMount: boolean;
   state: {
     flyout: false | {component: any, props: any }
@@ -59,11 +59,24 @@ export class Events extends Component {
       this.fetchWatch = scope.$watchCollection('fetchStatus',
         (fetchStatus) => {
           if (scope.fetchStatus === 'complete') {
-            setTimeout(() => { ModulesHelper.cleanAvailableFields() }, 1000);
+            setTimeout(() => { 
+              ModulesHelper.cleanAvailableFields();
+              
+            
+            }, 1000);
+            // Check the discover table is in the DOM and enhance the initial table cells
+            this.intervalCheckExistsDiscoverTable = setInterval(() => {
+              const discoverTableTBody = document.querySelector('.kbn-table tbody');
+              if(discoverTableTBody){
+                const options = {setFlyout: this.setFlyout, closeFlyout: this.closeFlyout};
+                this.enhanceDiscoverTableCurrentRows(this.state.discoverRowsData, options, true);
+                this.enhanceDiscoverTableAddObservers(options);
+                clearInterval(this.intervalCheckExistsDiscoverTable);
+              }
+            }, this.intervalCheckExistsDiscoverTableTime);
           }
           this.setState( { discoverRowsData: scope.rows } );
         });
-      this.enhanceDiscoverRowsInterval = setInterval(this.enhanceDiscoverRows, this.intervalTimeEnhancedDiscoverFields);
     }
   }
 
@@ -73,11 +86,117 @@ export class Events extends Component {
     this.$rootScope.showModuleEvents = false;
     this.$rootScope.moduleDiscoverReady = false;
     this.$rootScope.$applyAsync();
-    clearInterval(this.enhanceDiscoverRowsInterval);
+    this.discoverTableRowsObserver && this.discoverTableRowsObserver.disconnect();
+    this.discoverTableColumnsObserver && this.discoverTableColumnsObserver.disconnect();
+    this.intervalCheckExistsDiscoverTableTime && clearInterval(this.intervalCheckExistsDiscoverTable);
   }
 
-  enhanceDiscoverRows = () => {
-    enhanceDiscoverEvents(this.state.discoverRowsData, {setFlyout: this.setFlyout, closeFlyout: this.closeFlyout});
+  enhanceDiscoverTableAddObservers = (options) => {
+    // Scrolling table observer, when load more events
+    this.discoverTableRowsObserver = new MutationObserver((mutationsList) => {
+      mutationsList.forEach(mutation => {
+        if (mutation.type === 'childList' && mutation.addedNodes && mutation.addedNodes[0]) {
+          this.enhanceDiscoverTableScrolling(mutation.addedNodes[0], this.state.discoverRowsData, options);
+        };
+      });
+    });
+    const discoverTableTBody = document.querySelector('.kbn-table tbody');
+    this.discoverTableRowsObserver.observe(discoverTableTBody, { childList: true });
+
+    // Add observer when add or remove table header column
+    this.discoverTableColumnsObserver = new MutationObserver((mutationsList) => {
+      mutationsList.forEach(mutation => {
+        if (mutation.type === 'childList') {
+          this.enhanceDiscoverTableCurrentRows(this.state.discoverRowsData, options);
+        }
+      })
+    });
+    const discoverTableTHead = document.querySelector('.kbn-table thead tr');
+    this.discoverTableColumnsObserver.observe(discoverTableTHead, { childList: true });
+  }
+
+  enhanceDiscoverTableCurrentRows = (discoverRowsData, options, addObserverDetails = false) => {
+    // Get table headers
+    const discoverTableHeaders = document.querySelectorAll(`.kbn-table thead th`);
+    // Get table rows
+    const discoverTableRows = document.querySelectorAll(`.kbn-table tbody tr.kbnDocTable__row`);
+
+    discoverTableRows.forEach((row, rowIndex) => {
+      // Enhance each cell of table rows
+      discoverTableHeaders.forEach((header, headerIndex) => {
+        const cell = row.querySelector(`td:nth-child(${headerIndex+1}) div`);
+        if(cell){
+          enhanceDiscoverEventsCell(header.textContent, cell.textContent, discoverRowsData[rowIndex], cell, options);
+        };
+      });
+      // Add observer to row details 
+      if (addObserverDetails){
+        const rowDetails = row.nextElementSibling;
+        this.enhanceDiscoverTableRowDetailsAddObserver(rowDetails, discoverRowsData, options);
+      };
+    });
+
+  }
+
+  enhanceDiscoverTableRowDetailsAddObserver(element, discoverRowsData, options){
+    // Open for first time the row details
+    const observer = new MutationObserver((mutationsList) => {
+      mutationsList.forEach(mutation => {
+        if (mutation.type === 'childList' && mutation.addedNodes && mutation.addedNodes[0]) {
+          const rowTable = element.previousElementSibling;
+          const discoverTableRows = document.querySelectorAll(`.kbn-table tbody tr.kbnDocTable__row`);
+          const rowIndex = Array.from(discoverTableRows).indexOf(rowTable);
+          const rowDetailsFields = mutation.addedNodes[0].querySelectorAll('.kbnDocViewer__field');
+          if(rowDetailsFields){
+            rowDetailsFields.forEach((rowDetailField) => {
+              const fieldName = rowDetailField.childNodes[0].childNodes[1].textContent || "";
+              const fieldCell = rowDetailField.parentNode.childNodes && rowDetailField.parentNode.childNodes[2].childNodes[0];
+              if(!fieldCell){ return };
+              enhanceDiscoverEventsCell(fieldName, (fieldCell || {}).textContent || '', discoverRowsData[rowIndex], fieldCell, options);
+            });
+          };
+          // Add observer when switch between the tabs of Table and JSON
+          (new MutationObserver(mutationList => {
+            if(mutation.addedNodes[0].querySelector('div[role=tabpanel]').getAttribute('aria-labelledby') === 'kbn_doc_viewer_tab_0'){
+              const rowTable = element.previousElementSibling;
+              const discoverTableRows = document.querySelectorAll(`.kbn-table tbody tr.kbnDocTable__row`);
+              const rowIndex = Array.from(discoverTableRows).indexOf(rowTable);
+              const rowDetailsFields = mutation.addedNodes[0].querySelectorAll('.kbnDocViewer__field');
+              if(rowDetailsFields){
+                rowDetailsFields.forEach((rowDetailField) => {
+                  const fieldName = rowDetailField.childNodes[0].childNodes[1].textContent || "";
+                  const fieldCell = rowDetailField.parentNode.childNodes && rowDetailField.parentNode.childNodes[2].childNodes[0];
+                  if(!fieldCell){ return };
+                  enhanceDiscoverEventsCell(fieldName, (fieldCell || {}).textContent || '', discoverRowsData[rowIndex], fieldCell, options);
+                });
+              };
+            }
+          })).observe(mutation.addedNodes[0].querySelector('div[role=tabpanel]'), { attributes: true});
+        }
+      });
+    });
+    observer.observe(element, { childList: true });
+  }
+
+  enhanceDiscoverTableScrolling = (mutationElement, discoverRowsData, options) => {
+    // Get table headers
+    const discoverTableHeaders = document.querySelectorAll(`.kbn-table thead th`);
+    // Get table rows
+    const discoverTableRows = document.querySelectorAll(`.kbn-table tbody tr.kbnDocTable__row`);
+    try{
+      const rowIndex = Array.from(discoverTableRows).indexOf(mutationElement);
+      if(rowIndex !== -1){
+        // It is a discover table row
+        discoverTableHeaders.forEach((header, headerIndex) => {
+          const cell = mutationElement.querySelector(`td:nth-child(${headerIndex+1}) div`);
+          if(!cell){return};
+          enhanceDiscoverEventsCell(header.textContent, cell.textContent, discoverRowsData[rowIndex], cell, options);
+        });
+      }else{
+        // It is a details table row
+        this.enhanceDiscoverTableRowDetailsAddObserver(mutationElement, discoverRowsData, options);
+      }
+    }catch(error){};
   }
 
   setFlyout = (flyout) => {


### PR DESCRIPTION
Hi team, this PR resolves:  

Fix enhance discover table events:
  - `agent.name` link was wrongly generated. The row used information was not corresponding to the event.
  - Removed interval function to enhance the cells/fields.
  - Added MutationObservers logic to enhance the cell/fields.

close #2551 