### PR TITLE
[4.0-7.9] Add modal remove buttons to Security and fixes

### DIFF
--- a/public/components/common/buttons/button.tsx
+++ b/public/components/common/buttons/button.tsx
@@ -1,0 +1,49 @@
+/*
+ * Wazuh app - React component for base button that wraps the EuiButton components
+ * Copyright (C) 2015-2020 Wazuh, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Find more information about this on the LICENSE file.
+ */
+import React from 'react';
+import {
+  EuiButton,
+  EuiButtonEmpty,
+  EuiButtonIcon,
+  EuiLink,
+  EuiToolTip
+} from '@elastic/eui';
+
+enum WzButtonType{
+  default = 'default',
+  empty = 'empty',
+  icon = 'icon',
+  link = 'link'
+}
+
+interface WzButtonProps{
+  buttonType?: WzButtonType
+  tooltip?: any
+  rest?: any
+};
+
+export const WzButton = ({buttonType = WzButtonType.default, tooltip, ...rest}: WzButtonProps) => {
+  const Button = buttonType === 'default' ? EuiButton
+    : buttonType === 'empty' ? EuiButtonEmpty 
+    : buttonType === 'icon' ? EuiButtonIcon 
+    : buttonType === 'link' ? EuiLink 
+    : null;
+  
+  const button = <Button {...rest} />
+  return tooltip ? 
+    <EuiToolTip
+      {...tooltip}
+    >
+      {button}
+    </EuiToolTip>
+  : button
+}

--- a/public/components/common/buttons/button.tsx
+++ b/public/components/common/buttons/button.tsx
@@ -31,12 +31,15 @@ interface WzButtonProps{
   rest?: any
 };
 
+const WzButtons: {[key in WzButtonType]: React.FunctionComponent} = {
+  'default': EuiButton,
+  'empty': EuiButtonEmpty,
+  'icon': EuiButtonIcon,
+  'link': EuiLink,
+}
+
 export const WzButton = ({buttonType = WzButtonType.default, tooltip, ...rest}: WzButtonProps) => {
-  const Button = buttonType === 'default' ? EuiButton
-    : buttonType === 'empty' ? EuiButtonEmpty 
-    : buttonType === 'icon' ? EuiButtonIcon 
-    : buttonType === 'link' ? EuiLink 
-    : null;
+  const Button = WzButtons[buttonType];
   
   const button = <Button {...rest} />
   return tooltip ? 

--- a/public/components/common/buttons/index.ts
+++ b/public/components/common/buttons/index.ts
@@ -1,0 +1,14 @@
+/*
+ * Wazuh app - Index of Wazuh buttons
+ * Copyright (C) 2015-2020 Wazuh, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Find more information about this on the LICENSE file.
+ */
+
+export { WzButton } from './button';
+export { WzButtonModalConfirm } from './modal-confirm';

--- a/public/components/common/buttons/modal-confirm.tsx
+++ b/public/components/common/buttons/modal-confirm.tsx
@@ -1,0 +1,65 @@
+/*
+ * Wazuh app - React component for button that opens a modal
+ * Copyright (C) 2015-2020 Wazuh, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Find more information about this on the LICENSE file.
+ */
+import React from 'react';
+
+import {
+  EuiOverlayMask,
+  EuiConfirmModal
+} from '@elastic/eui';
+
+import { withButtonOpenOnClick } from '../hocs';
+import { WzButton } from './button';
+
+export const WzButtonOpenOnClick = withButtonOpenOnClick(WzButton);
+
+interface WzButtonModalConfirmProps{
+  onConfirm: (ev) => void
+  onCancel?: (ev) => void
+  modalTitle: string
+  modalConfirmText: string
+  modalCancelText: string
+  modalProps: any
+  [key: string]: any
+};
+
+export const WzButtonModalConfirm: React.FunctionComponent<WzButtonModalConfirmProps> = ({onConfirm, onCancel, modalTitle, modalConfirmText = 'Confirm', modalCancelText = 'Cancel', modalProps = {}, ...rest }) => {
+  return (
+    <WzButtonOpenOnClick
+      {...rest}
+      render={({close}) => {
+        const onModalConfirm = () => {
+          close();
+          onConfirm && onConfirm();
+        };
+        const onModalCancel = () => {
+          close();
+          onCancel && onCancel();
+        };
+        return (
+          <EuiOverlayMask onClick={close}>
+            <EuiConfirmModal
+              title={modalTitle}
+              onCancel={onModalCancel}
+              onConfirm={onModalConfirm}
+              cancelButtonText={modalCancelText}
+              confirmButtonText={modalConfirmText}
+              defaultFocusedButton={modalProps.defaultFocusedButton || "confirm"}
+              {...modalProps}
+              >
+            </EuiConfirmModal>
+          </EuiOverlayMask>
+        )
+      }}
+    />
+  )
+};
+

--- a/public/components/common/hocs/index.ts
+++ b/public/components/common/hocs/index.ts
@@ -24,3 +24,5 @@ export { withGlobalBreadcrumb  } from './withGlobalBreadcrumb';
 export { withReduxProvider  } from './withReduxProvider';
 
 export { withGuard } from './withGuard';
+
+export { withButtonOpenOnClick } from './withButtonOpenOnClick';

--- a/public/components/common/hocs/withButtonOpenOnClick.tsx
+++ b/public/components/common/hocs/withButtonOpenOnClick.tsx
@@ -1,0 +1,29 @@
+/*
+ * Wazuh app - React HOC to add open modal/flyout logic to othe component
+ * Copyright (C) 2015-2020 Wazuh, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Find more information about this on the LICENSE file.
+ */
+import React, { useState } from 'react';
+
+
+export const withButtonOpenOnClick = WrappedComponent => ({render, ...rest} : {render?:any, [x:string]: any}) => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const open = ev => setIsOpen(true);
+  const close = ev => setIsOpen(false);
+
+  return (
+    <>
+      <WrappedComponent {...rest} onClick={open}/>
+      {isOpen && (
+        render({open, close})
+      )}
+    </>
+  )
+}

--- a/public/components/security/policies/policies-table.tsx
+++ b/public/components/security/policies/policies-table.tsx
@@ -8,6 +8,7 @@ import {
 } from '@elastic/eui';
 import { WzRequest } from '../../../react-services/wz-request';
 import { ErrorHandler } from '../../../react-services/error-handler';
+import { WzButtonModalConfirm } from '../../common/buttons';
 
 export const PoliciesTable = ({policies, loading, editPolicy, updatePolicies}) => {
 
@@ -68,13 +69,14 @@ export const PoliciesTable = ({policies, loading, editPolicy, updatePolicies}) =
           align: 'right',
           width: '5%',
           name: 'Actions',
-          render: item => {return <EuiToolTip
-            content={item.id < 100 ? "Reserved policies can't be deleted" : 'Delete policy'}
-            position="left">
-            <EuiButtonIcon
-              isDisabled={item.id < 100}
-              onClick={async(ev) => {
-                    ev.stopPropagation();
+          render: item => (
+            <div onClick={ev => ev.stopPropagation()}>
+                <WzButtonModalConfirm
+                buttonType='icon'
+                tooltip={{content: item.id < 100 ? "Reserved policies can't be deleted" : 'Delete policy', position: 'left'}}
+                isDisabled={item.id < 100}
+                modalTitle={`Do you want to delete the ${item.name} policy?`}
+                onConfirm={async () => {
                     try{
                         const response = await WzRequest.apiReq(
                         'DELETE',
@@ -94,19 +96,21 @@ export const PoliciesTable = ({policies, loading, editPolicy, updatePolicies}) =
                 }catch(error){
                     ErrorHandler.handle(error, 'Error deleting policy');
                 }
-              }}
-              iconType="trash"
-              color={'danger'}
-              aria-label="Delete policy"
-            />
-          </EuiToolTip>}
+                }}
+                modalProps={{buttonColor: 'danger'}}
+                iconType='trash'
+                color='danger'
+                aria-label='Delete policy'
+          />
+            </div>
+            )
         }
     ];
 
     const sorting = {
         sort: {
-            field: 'user',
-            direction: 'desc',
+            field: 'id',
+            direction: 'asc',
         },
     };
 

--- a/public/components/security/roles-mapping/roles-mapping-create.tsx
+++ b/public/components/security/roles-mapping/roles-mapping-create.tsx
@@ -88,7 +88,7 @@ export const RolesMappingCreate = ({ closeFlyout, rolesEquivalences, roles }) =>
             error={'At least one role must be selected.'}
             helpText="Assign roles to your users.">
             <EuiComboBox
-              placeholder="Select policies"
+              placeholder="Select roles"
               options={getRolesList(roles)}
               isDisabled={false}
               selectedOptions={selectedRoles}

--- a/public/components/security/roles-mapping/roles-mapping-edit.tsx
+++ b/public/components/security/roles-mapping/roles-mapping-edit.tsx
@@ -118,7 +118,7 @@ export const RolesMappingEdit = ({ rule, closeFlyout, rolesEquivalences, roles }
             error={'At least one role must be selected.'}
             helpText="Assign roles to your users.">
             <EuiComboBox
-              placeholder="Select policies"
+              placeholder="Select roles"
               options={getRolesList(roles)}
               isDisabled={rule.id < 3}
               selectedOptions={selectedRoles}

--- a/public/components/security/roles-mapping/roles-mapping-table.tsx
+++ b/public/components/security/roles-mapping/roles-mapping-table.tsx
@@ -9,6 +9,7 @@ import {
 } from '@elastic/eui';
 import { WzRequest } from '../../../react-services/wz-request';
 import { ErrorHandler } from '../../../react-services/error-handler';
+import { WzButtonModalConfirm } from '../../common/buttons';
 
 export const RolesMappingTable = ({ rolesEquivalences, rules, loading, editRule, updateRules }) => {
   const getRowProps = item => {
@@ -63,14 +64,14 @@ export const RolesMappingTable = ({ rolesEquivalences, rules, loading, editRule,
       align: 'right',
       width: '5%',
       name: 'Actions',
-      render: item => {
-        return <EuiToolTip
-          content={item.id < 3 ? "Reserved policies can't be deleted" : 'Delete policy'}
-          position="left">
-          <EuiButtonIcon
+      render: item => (
+        <div onClick={ev => ev.stopPropagation()}>
+          <WzButtonModalConfirm
+            buttonType='icon'
+            tooltip={{content: item.id < 3 ? "Reserved role mapping can't be deleted" : 'Delete role mapping', position: 'left'}}
             isDisabled={item.id < 3}
-            onClick={async (ev) => {
-              ev.stopPropagation();
+            modalTitle={`Do you want to delete the ${item.name} role mapping?`}
+            onConfirm={async () => {
               try {
                 const response = await WzRequest.apiReq(
                   'DELETE',
@@ -85,18 +86,19 @@ export const RolesMappingTable = ({ rolesEquivalences, rules, loading, editRule,
                 if (data.failed_items && data.failed_items.length) {
                   return;
                 }
-                ErrorHandler.info('Rule was successfully deleted');
+                ErrorHandler.info('Role mapping was successfully deleted');
                 updateRules();
               } catch (err) {
                 ErrorHandler.error(err);
-              }
+              }  
             }}
-            iconType="trash"
-            color={'danger'}
-            aria-label="Delete policy"
-          />
-        </EuiToolTip>
-      }
+            modalProps={{buttonColor: 'danger'}}
+            iconType='trash'
+            color='danger'
+            aria-label='Delete role mapping'
+      />
+        </div>
+        )
     }
   ];
 

--- a/public/components/security/roles-mapping/rule-editor.tsx
+++ b/public/components/security/roles-mapping/rule-editor.tsx
@@ -253,16 +253,17 @@ export const RuleEditor = ({ save, initialRule, isLoading, isReserved }) => {
         <EuiTitle><h1>Mapping rules</h1></EuiTitle>
         <EuiFlexGroup>
           <EuiFlexItem>
-            <EuiText>Assign roles to users who match these rules.
-                        <EuiLink href="https://documentation.wazuh.com/current/user-manual/api/rbac/auth_context.html" external target="_blank">
-                Learn more
-                        </EuiLink>
+            <EuiText>
+              <span>Assign roles to users who match these rules. </span> 
+              <EuiLink href="https://documentation.wazuh.com/current/user-manual/api/rbac/auth_context.html" external target="_blank">
+                  Learn more
+              </EuiLink>
             </EuiText>
           </EuiFlexItem>
         </EuiFlexGroup>
         <EuiFlexGroup>
           <EuiFlexItem>
-            <EuiPanel style={{ backgroundColor: "#F5F7FA" }}>
+            <EuiPanel>
               {isJsonEditor &&
                 <div >
                   <EuiCodeEditor

--- a/public/components/security/roles/roles-table.tsx
+++ b/public/components/security/roles/roles-table.tsx
@@ -12,7 +12,7 @@ import {
 } from '@elastic/eui';
 import { WzRequest } from '../../../react-services/wz-request';
 import { ErrorHandler } from '../../../react-services/error-handler';
-
+import { WzButtonModalConfirm } from '../../common/buttons';
 
 export const RolesTable = ({roles, policiesData, loading, editRole, updateRoles}) => {
    
@@ -88,13 +88,14 @@ export const RolesTable = ({roles, policiesData, loading, editRole, updateRoles}
           align: 'right',
           width: '5%',
           name: 'Actions',
-          render: item => {return <EuiToolTip
-            content={item.id < 100 ? "Reserved roles can't be deleted" : 'Delete role'}
-            position="left">
-            <EuiButtonIcon
-              isDisabled={item.id < 100}
-              onClick={async(ev) => {
-                    ev.stopPropagation();
+          render: item => (
+            <div onClick={ev => ev.stopPropagation()}>
+                <WzButtonModalConfirm
+                buttonType='icon'
+                tooltip={{content: item.id < 100 ? "Reserved roles can't be deleted" : 'Delete role', position: 'left'}}
+                isDisabled={item.id < 100}
+                modalTitle={`Do you want to delete the ${item.name} role?`}
+                onConfirm={async () => {
                     try{
                         const response = await WzRequest.apiReq(
                         'DELETE',
@@ -112,19 +113,21 @@ export const RolesTable = ({roles, policiesData, loading, editRole, updateRoles}
                     ErrorHandler.info('Role was successfully deleted');
                     await updateRoles();
                 }catch(error){}
-              }}
-              iconType="trash"
-              color={'danger'}
-              aria-label="Delete role"
-            />
-          </EuiToolTip>}
+                }}
+                modalProps={{buttonColor: 'danger'}}
+                iconType='trash'
+                color='danger'
+                aria-label='Delete role'
+                />
+            </div>
+            )
         }
     ];
 
     const sorting = {
         sort: {
-            field: 'user',
-            direction: 'desc',
+            field: 'id',
+            direction: 'asc',
         },
     };
 


### PR DESCRIPTION
Hello team, this PR resolves:

- Created a button component to open modal
- Created a HOC to add logic to open modal/flyout
- Replaced buttons in Security section tables to remove role/policy/role mapping with the component that opens a confirm modal
- Fixes in the Security section:
  - Sorting of EuiMemoryTables in Security
  - Text in the Role mapping tab
  - Removed fixed color in rule panel of Role mapping editor
  - Added a space to the link `Learn more` in the Role mapping editor

close #2553 