### PR TITLE
[4.0-7.9] Rebuild the registry when the revision are diferents

### DIFF
--- a/server/initialize.js
+++ b/server/initialize.js
@@ -102,6 +102,7 @@ export function Initialize(server) {
           'Wazuh configuration registry inserted',
           'debug'
         );
+        // Check 
       } catch (error) {
         log('initialize:saveConfiguration', error.message || error);
         server.log(
@@ -224,26 +225,22 @@ export function Initialize(server) {
         // Create the app registry file for the very first time
         saveConfiguration();
       } else {
-        // App registry file exists, just update it
-        const currentDate = new Date().toISOString();
-
         // If this function fails, it throws an exception
         const source = JSON.parse(fs.readFileSync(wazuhRegistry, 'utf8'));
 
         // Check if the stored revision differs from the package.json revision
         const isNewApp = packageJSON.revision !== source.revision;
 
-        // If it's an app with a different revision, it's a new installation
-        source['installationDate'] = isNewApp
-          ? currentDate
-          : source['installationDate'];
-
-        source['app-version'] = packageJSON.version;
-        source.revision = packageJSON.revision;
-        source.lastRestart = currentDate;
-
-        // If this function fails, it throws an exception
-        fs.writeFileSync(wazuhRegistry, JSON.stringify(source), 'utf-8');
+        // Rebuild the registry file if revision fields are differents
+        if (isNewApp) { 
+          log(
+            'initialize[checkwazuhRegistry]',
+            'Wazuh app revision changed, regenerating wazuh registry',
+            'info'
+          );
+          // Rebuild registry file in blank
+          saveConfiguration();
+        }
       }
     } catch (error) {
       return Promise.reject(error);

--- a/server/initialize.js
+++ b/server/initialize.js
@@ -102,7 +102,6 @@ export function Initialize(server) {
           'Wazuh configuration registry inserted',
           'debug'
         );
-        // Check 
       } catch (error) {
         log('initialize:saveConfiguration', error.message || error);
         server.log(
@@ -229,13 +228,13 @@ export function Initialize(server) {
         const source = JSON.parse(fs.readFileSync(wazuhRegistry, 'utf8'));
 
         // Check if the stored revision differs from the package.json revision
-        const isNewApp = packageJSON.revision !== source.revision;
+        const isUpgradedApp = packageJSON.revision !== source.revision || packageJSON.version !== source['app-version'];
 
-        // Rebuild the registry file if revision fields are differents
-        if (isNewApp) { 
+        // Rebuild the registry file if revision or version fields are differents
+        if (isUpgradedApp) { 
           log(
             'initialize[checkwazuhRegistry]',
-            'Wazuh app revision changed, regenerating wazuh registry',
+            'Wazuh app revision or version changed, regenerating wazuh-version registry',
             'info'
           );
           // Rebuild registry file in blank


### PR DESCRIPTION
Hi team, this PR resolves:
- Update the registry file when the `revision` fields are different in the `wazuh-registry.json` file and `package.json`

It belongs to https://github.com/wazuh/wazuh-kibana-app/issues/2555