### PR TITLE
[4.0-7.9] Added no security plugin installed prompt

### DIFF
--- a/public/components/agents/prompt-no-active-agent.tsx
+++ b/public/components/agents/prompt-no-active-agent.tsx
@@ -22,7 +22,7 @@ export const PromptNoActiveAgent = () => {
     <EuiEmptyPrompt
       iconType="watchesApp"
       title={<h2>Agent is not active</h2>}
-      body={<p>This section is only availabe for active agents.</p>}
+      body={<p>This section is only available for active agents.</p>}
       actions={
         <EuiButton color="primary" fill onClick={openAgentSelector}>
           Select agent

--- a/public/components/security/users/prompt-no-security-plugin.tsx
+++ b/public/components/security/users/prompt-no-security-plugin.tsx
@@ -1,0 +1,34 @@
+/*
+ * Wazuh app - Prompt component to notify when no security plugin is installed in Security/Users tab
+ * Copyright (C) 2015-2020 Wazuh, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Find more information about this on the LICENSE file.
+ */
+
+import React from 'react';
+import { EuiEmptyPrompt, EuiSpacer } from '@elastic/eui';
+import { WAZUH_SECURITY_PLUGINS } from '../../../../util/constants';
+
+export const PromptNoSecurityPluginUsers = () => {
+  return (
+    <EuiEmptyPrompt
+      iconType='securityApp'
+      title={<h2>No security plugin installed</h2>}
+      body={
+        <>
+          <p>A supported security plugin is required to see and manage the users.</p>
+          <div>Supported plugins:</div>
+          <EuiSpacer size='s'/>
+          <ul style={{listStyleType: 'none', margin: 0, padding: 0}}>
+            {WAZUH_SECURITY_PLUGINS.map(securityPlugin => <li key={`security-plugin-${securityPlugin}`}><strong>{securityPlugin}</strong></li>)}
+          </ul>
+        </>
+      }
+    />
+  )
+}

--- a/public/components/security/users/users.tsx
+++ b/public/components/security/users/users.tsx
@@ -15,8 +15,23 @@ import { UsersTable } from './users-table';
 import { WazuhSecurity } from '../../../factories/wazuh-security'
 import { EditUser } from './edit-user';
 import { WzRequest } from '../../../react-services/wz-request';
+import { compose } from 'redux';
+import { connect } from 'react-redux';
+import { withGuard } from '../../common/hocs';
+import { PromptNoSecurityPluginUsers } from './prompt-no-security-plugin';
 
-export const Users = () => {
+
+const mapStateToProps = state => ({currentPlatform: state.appStateReducers.currentPlatform});
+
+export const Users = compose(
+  connect(mapStateToProps),
+  withGuard(
+    (props) => {
+      return props.currentPlatform === 'elastic';
+    },
+    PromptNoSecurityPluginUsers
+  )
+)(() => {
   const [isEditFlyoutVisible, setIsEditFlyoutVisible] = useState(false);
   const [editingUser, setEditingUser] = useState(false);
   const [users, setUsers] = useState([]);
@@ -24,6 +39,7 @@ export const Users = () => {
   const [relationUserRole, setRelationUserRole] = useState({});
   const [roles, setRoles] = useState({});
   const [securityError, setSecurityError] = useState(false);
+
   const getUsers = async () => {
     const loadRoles = async (users) => {
       const rolesData = await WzRequest.apiReq(
@@ -119,4 +135,4 @@ export const Users = () => {
       {editFlyout}
     </EuiPageContent>
   );
-};
+});

--- a/util/constants.js
+++ b/util/constants.js
@@ -10,12 +10,26 @@
  * Find more information about this on the LICENSE file.
  */
 
+// Index patterns
 export const WAZUH_ALERTS_PREFIX = "wazuh-alerts-";
 export const WAZUH_ALERTS_PATTERN = "wazuh-alerts-*";
 export const WAZUH_MONITORING_PREFIX = "wazuh-monitoring-";
 export const WAZUH_MONITORING_PATTERN = "wazuh-monitoring-*";
-export const WAZUH_SAMPLE_ALERT_PREFIX = "wazuh-alerts-4.x-";
+
+// Permissions
 export const WAZUH_ROLE_ADMINISTRATOR_ID = 1;
 export const WAZUH_ROLE_ADMINISTRATOR_NAME = 'administrator';
+
+// Sample data
+export const WAZUH_SAMPLE_ALERT_PREFIX = "wazuh-alerts-4.x-";
 export const WAZUH_SAMPLE_ALERTS_INDEX_SHARDS = 1;
 export const WAZUH_SAMPLE_ALERTS_INDEX_REPLICAS = 0;
+
+// Security
+export const WAZUH_SECURITY_PLUGIN_XPACK = 'X-Pack Security';
+export const WAZUH_SECURITY_PLUGIN_OPENDISTRO_FOR_ELASTICSEARCH = 'Opendistro for Elasticsearch';
+
+export const WAZUH_SECURITY_PLUGINS = [
+  WAZUH_SECURITY_PLUGIN_XPACK,
+  WAZUH_SECURITY_PLUGIN_OPENDISTRO_FOR_ELASTICSEARCH
+];


### PR DESCRIPTION
Hi team, this PR resolves:  
- Create the prompt component for Security/Users section
- Guard the Security/Users component with the prompt
- Created Security app constants and improved the organization of the file
- Fix text in `prompt-no-active-agent` component

close #2503