### PR TITLE
[4.0-7.9] Fix visual bug in events search bar when opens the popup

### DIFF
--- a/public/components/common/modules/module.less
+++ b/public/components/common/modules/module.less
@@ -5,7 +5,7 @@
 .wz-module-header-agent-wrapper, .wz-module-header-nav-wrapper{
     width: 100%;
     position: fixed;
-    z-index: 999;
+    z-index: 3000;
     left: 0;
 }
 

--- a/public/less/common.less
+++ b/public/less/common.less
@@ -20,10 +20,6 @@
   display: none;
 }
 
-.kbnQueryBar__wrap {
-  z-index: 1!important;
-}
-
 .error-notify {
   font-size: 20px;
   color: black;


### PR DESCRIPTION
Hello team, this PR resolves:
- Fix Events search bar z-index visual bug (when opens the suggestions popup which contains previous searches)

closes #2563 