### PR TITLE
[4.0-7.9] [BUGFIX] Fixed formated fields missing in the default index-pattern

### DIFF
--- a/public/react-services/saved-objects.js
+++ b/public/react-services/saved-objects.js
@@ -210,7 +210,13 @@ export class SavedObject {
         {
           attributes: {
             title: pattern,
-            timeFieldName: 'timestamp'
+            timeFieldName: 'timestamp',
+            fieldFormatMap: `{
+              "data.virustotal.permalink":{"id":"url"},
+              "data.vulnerability.reference":{"id":"url"},
+              "data.url":{"id":"url"}
+            }`,
+            sourceFilters: '[{"value":"@timestamp"}]'
           }
         },
         fields


### PR DESCRIPTION
Hello team!
This PR resolves: 

- The formatedFields are missing from the index-pattern of wazuh-alerts-* 

Closes #2574 

