### PR TITLE
[4.0-7.9] [BUGFIX] Removed unnecessary function call

### DIFF
--- a/public/components/overview/metrics/metrics.tsx
+++ b/public/components/overview/metrics/metrics.tsx
@@ -109,7 +109,6 @@ export class Metrics extends Component {
     this.indexPattern = await getIndexPattern();
     this.scope = await this.modulesHelper.getDiscoverScope();
     this._isMount = true;
-    this.buildMetric();
   }
 
   async getResults(filterParams, aggs = {}){
@@ -257,11 +256,11 @@ export class Metrics extends Component {
 
   componentDidUpdate(){
     if(!this.state.buildingMetrics && this.props.resultState === 'ready' && this.state.resultState === 'loading'){
-      this.setState({ buildingMetrics: true, resultState: this.props.resultState}, () => {
+    this.setState({ buildingMetrics: true, resultState: this.props.resultState}, () => {
         this.stats = this.buildMetric();
       }); 
     }else if(this.props.resultState !== this.state.resultState){
-      const isLoading = this.props.resultState === 'loading' ? {loading:true} : {};
+    const isLoading = this.props.resultState === 'loading' ? {loading:true} : {};
       this.setState({resultState: this.props.resultState, ...isLoading});
     }
   }

--- a/public/components/overview/metrics/metrics.tsx
+++ b/public/components/overview/metrics/metrics.tsx
@@ -256,11 +256,11 @@ export class Metrics extends Component {
 
   componentDidUpdate(){
     if(!this.state.buildingMetrics && this.props.resultState === 'ready' && this.state.resultState === 'loading'){
-    this.setState({ buildingMetrics: true, resultState: this.props.resultState}, () => {
+      this.setState({ buildingMetrics: true, resultState: this.props.resultState}, () => {
         this.stats = this.buildMetric();
       }); 
     }else if(this.props.resultState !== this.state.resultState){
-    const isLoading = this.props.resultState === 'loading' ? {loading:true} : {};
+      const isLoading = this.props.resultState === 'loading' ? {loading:true} : {};
       this.setState({resultState: this.props.resultState, ...isLoading});
     }
   }


### PR DESCRIPTION
Hi team! This resolves: 
- Several calls to the same stats request (esAlerts)
Closes #2586 

Note:
The bug still happens when F5 is pressed, but I assume that is caused by joining AngularJs module life cycle with React component life cycle. However, this will be deprecated soon.