### PR TITLE
Remove the empty string from the metafields settings

### DIFF
--- a/public/components/health-check/lib/check-kibana-settings.ts
+++ b/public/components/health-check/lib/check-kibana-settings.ts
@@ -31,6 +31,6 @@ async function updateMetaFieldsSetting(isModified:boolean) {
   return !isModified && await GenericRequest.request(
     'POST',
     '/api/kibana/settings',
-    {"changes":{"metaFields":["_source",""]}}
+    {"changes":{"metaFields":["_source"]}}
   );
 }


### PR DESCRIPTION
An empty string has been removed from the list of `metafields` that was sent to the Kibana configuration.

This close https://github.com/wazuh/wazuh-kibana-app/issues/2588