### PR TITLE
[4.0-7.9] Fixed search filter in search bar in Module/SCA wasn't working

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the Wazuh app project will be documented in this file.
 
+## Wazuh v4.0.0 - Kibana v7.9.1, v7.9.2, v7.9.3 - Revision 4008
+
+### Fixed
+
+- Fixed search filter in search bar in Module/SCA wasn't working [#2601](https://github.com/wazuh/wazuh-kibana-app/pull/2601)
+
 ## Wazuh v4.0.0 - Kibana v7.9.1, v7.9.2, v7.9.3 - Revision 4007
 
 ### Fixed

--- a/public/components/agents/sca/inventory.tsx
+++ b/public/components/agents/sca/inventory.tsx
@@ -301,8 +301,10 @@ export class Inventory extends Component {
   }
 
   getItems = () => !!this.checks && this.checks.filter(check =>
-      this.state.filters.every(filter =>
-        typeof check[filter.field] === 'string' && (filter.value === '' ? check[filter.field] === filter.value
+      this.state.filters.every(filter => 
+        filter.field === 'search'
+        ? Object.keys(check).some(key =>  ['string', 'number'].includes(typeof check[key]) && String(check[key]).toLowerCase().includes(filter.value.toLowerCase()))
+        : typeof check[filter.field] === 'string' && (filter.value === '' ? check[filter.field] === filter.value
           : check[filter.field].toLowerCase().includes(filter.value.toLowerCase())
         )
       )


### PR DESCRIPTION
Hi team! This resolves
- Search filter in the search bar in Module/SCA wasn't working

Related to #2460 