### PR TITLE
Fix/2626 replace call manager files by cluster rules decoders cdblists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to the Wazuh app project will be documented in this file.
 
 - [4.0-7.9] Run as with no wazuh-wui API user [#2576](https://github.com/wazuh/wazuh-kibana-app/issues/2576)
 
+### Fixed
+
+- Changes done via a worker's API are overwritten [#2626](https://github.com/wazuh/wazuh-kibana-app/issues/2626)
+
 ## Wazuh v4.0.1 - Kibana v7.9.1, v7.9.3 - Revision 4009
 
 ### Changed


### PR DESCRIPTION
Hello team, this PR resolves:
- upload/delete files in Rules/Decoders and CDB Lists depends on if the cluster mode is enabled or not

closes #2626 