### PR TITLE
[Fix] Discover supports private tenant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 
 - fix(fronted): fixed the check of API and APP version in health check [#2655](https://github.com/wazuh/wazuh-kibana-app/pull/2655)
 - Replace user by username key in the monitoring logic [#2654](https://github.com/wazuh/wazuh-kibana-app/pull/2654)
+- Security alerts and reporting issues when using private tenants [#2639](https://github.com/wazuh/wazuh-kibana-app/issues/2639)
 
 ## Wazuh v4.0.3 - Kibana v7.9.1, v7.9.3 - Revision 4013
 

--- a/public/components/common/hooks/index.ts
+++ b/public/components/common/hooks/index.ts
@@ -25,3 +25,5 @@ export { useWindowSize } from './useWindowSize';
 export { useUserPermissions, useUserPermissionsRequirements, useUserPermissionsPrivate } from './useUserPermissions';
 
 export { useUserRoles, useUserRolesRequirements, useUserRolesPrivate } from './useUserRoles';
+
+export { useRefreshAngularDiscover } from './useResfreshAngularDiscover'

--- a/public/components/common/hooks/useResfreshAngularDiscover.ts
+++ b/public/components/common/hooks/useResfreshAngularDiscover.ts
@@ -18,7 +18,7 @@ export function useRefreshAngularDiscover(): number {
     let subscription;
     ModulesHelper.getDiscoverScope()
       .then(scope => {
-        subscription = scope.$watchCollection('fetchStatus',
+        subscription = scope.$watch('fetchStatus',
           (fetchStatus) => {
             (fetchStatus === 'loading') && (refresh !== Date.now()) && setRefresh(Date.now())
           });

--- a/public/components/common/hooks/useResfreshAngularDiscover.ts
+++ b/public/components/common/hooks/useResfreshAngularDiscover.ts
@@ -1,0 +1,29 @@
+/*
+ * Wazuh app - React hook to get when Angular Discover started to loading
+ * Copyright (C) 2015-2020 Wazuh, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Find more information about this on the LICENSE file.
+ */
+import { useState, useEffect } from 'react';
+import { ModulesHelper } from '../modules/modules-helper';
+
+export function useRefreshAngularDiscover(): number {
+  const [refresh, setRefresh] = useState(Date.now());
+  useEffect(() => {
+    let subscription;
+    ModulesHelper.getDiscoverScope()
+      .then(scope => {
+        subscription = scope.$watchCollection('fetchStatus',
+          (fetchStatus) => {
+            (fetchStatus === 'loading') && (refresh !== Date.now()) && setRefresh(Date.now())
+          });
+      });
+    return () => { subscription && subscription(); }
+  }, []);
+  return refresh;
+}

--- a/public/components/common/modules/discover/discover.tsx
+++ b/public/components/common/modules/discover/discover.tsx
@@ -106,6 +106,7 @@ export const Discover = compose(
     includeFilters?: string,
     initialColumns: string[],
     shareFilterManager: object[],
+    refreshAngularDiscover?: number
   }
   constructor(props) {
     super(props);
@@ -172,7 +173,7 @@ export const Discover = compose(
     try {
       this.setState({columns: this.getColumns(), searchBarFilters: this.props.shareFilterManager || []}) //initial columns
       await this.getIndexPattern(); 
-      this.getAlerts();
+      await this.getAlerts();
     } catch (err) {
       console.log(err);
     }
@@ -186,12 +187,30 @@ export const Discover = compose(
     if (!this._isMount) { return; }
     if((!prevProps.currentAgentData.id && this.props.currentAgentData.id) || (prevProps.currentAgentData.id && !this.props.currentAgentData.id)){
       this.setState({ columns: this.getColumns() }); // Updates the columns to be rendered if you change the selected agent to none or vice versa
+      return;
     }
-    try {
-      await this.getAlerts();
-    } catch (err) {
-      console.log(err);
-    }
+    if(JSON.stringify(this.props.query) !== JSON.stringify(prevProps.query)){
+      this.setState({ query: {...this.props.query}});
+      return;
+    };
+    if((JSON.stringify(this.props.shareFilterManager) !== JSON.stringify(prevProps.shareFilterManager))
+      || (this.props.currentAgentData.id !== prevProps.currentAgentData.id)
+      || (JSON.stringify(this.state.query) !== JSON.stringify(prevState.query))
+      || (JSON.stringify(this.state.searchBarFilters) !== JSON.stringify(prevState.searchBarFilters))
+      || (JSON.stringify(this.state.dateRange) !== JSON.stringify(prevState.dateRange))
+      || (this.props.refreshAngularDiscover !== prevProps.refreshAngularDiscover)
+    ){
+      this.setState({ pageIndex: 0 , tsUpdated: Date.now()});
+      return;
+    };
+
+    if(['pageIndex', 'pageSize', 'sortField', 'sortDirection'].some(field => this.state[field] !== prevState[field]) || (this.state.tsUpdated !== prevState.tsUpdated)){
+      try {
+        await this.getAlerts();
+      } catch (err) {
+        console.log(err);
+      };
+    };
   }
 
   getColumns () {
@@ -265,7 +284,7 @@ export const Discover = compose(
   buildFilter() {
     const dateParse = ds => /\d+-\d+-\d+T\d+:\d+:\d+.\d+Z/.test(ds) ? DateMatch.parse(ds).toDate().getTime() : ds;
     const { searchBarFilters } = this.state;
-    const { query = this.state.query } = this.props;
+    const { query } = this.state;
     const { hideManagerAlerts } = this.wazuhConfig.getConfig();
     const extraFilters = [];
     if (hideManagerAlerts) extraFilters.push({
@@ -290,14 +309,36 @@ export const Discover = compose(
         [...searchBarFilters, ...extraFilters, ...shareFilterManager],
         getEsQueryConfig(npSetup.core.uiSettings)
       );
-    const pattern = AppState.getCurrentPattern();
-    const { filters, sortField, sortDirection } = this.state;
-    const { from: oldFrom, to: oldTo } = this.timefilter.getTime();
-    const sort = { ...(sortField && { [sortField]: { "order": sortDirection } }) };
-    const offset = Math.floor((this.state.pageIndex * this.state.pageSize) / this.state.requestSize) * this.state.requestSize;
-    const from = dateParse(oldFrom);
-    const to = dateParse(oldTo);
-    return { filters, sort, from, to, offset, pattern, elasticQuery };
+
+    const { sortField, sortDirection } = this.state;
+
+    const range = {
+      range: {
+        timestamp: {
+          gte: dateParse(this.timefilter.getTime().from),
+          lte: dateParse(this.timefilter.getTime().to),
+          format: 'epoch_millis'
+        }
+      }
+    }
+    elasticQuery.bool.must.push(range);
+
+    if(this.props.implicitFilters){
+      this.props.implicitFilters.map(impicitFilter => elasticQuery.bool.must.push({
+        match: impicitFilter
+      }));
+    };
+    if(this.props.currentAgentData.id){
+      elasticQuery.bool.must.push({
+        match: {"agent.id": this.props.currentAgentData.id}
+      });
+    };
+    return {
+      query: elasticQuery,
+      size: this.state.pageSize,
+      from: this.state.pageIndex*this.state.pageSize,
+      ...(sortField ? {sort: { [sortField]: { "order": sortDirection } }}: {})
+    };
   }
 
   async getAlerts() {
@@ -305,30 +346,21 @@ export const Discover = compose(
     //compare filters so we only make a request into Elasticsearch if needed
     const newFilters = this.buildFilter();
     try {
-      if (JSON.stringify(newFilters) !== JSON.stringify(this.state.requestFilters)) {
-        if (newFilters.offset === this.state.requestFilters.offset) // we only reset pageIndex to 0 if the requestFilters has changed but the offset is the same
-          this.setState({ isLoading: true, pageIndex: 0 });
-        else
-          this.setState({ isLoading: true});
-          let filtersReq = [...newFilters['filters'], ...this.props.implicitFilters];
-        if(this.props.currentAgentData.id){
-          filtersReq.push({"agent.id": this.props.currentAgentData.id})
-        } 
+        this.setState({ isLoading: true});
 
         const alerts = await GenericRequest.request(
           'POST',
-          `/elastic/alerts`,
+          `/elastic/esAlerts`,
           {
-            ...newFilters,
-            filters: filtersReq
+            index: AppState.getCurrentPattern(),
+            body: newFilters
           }
         );
-        if (this._isMount) {
-          this.setState({ alerts: alerts.data.alerts, total: alerts.data.hits, isLoading: false, requestFilters: newFilters, filters: newFilters.filters });
-          this.props.updateTotalHits(alerts.data.hits);
 
+        if (this._isMount) {
+          this.setState({ alerts: alerts.data.hits.hits, total: alerts.data.hits.total.value, isLoading: false, requestFilters: newFilters, filters: newFilters.filters });
+          this.props.updateTotalHits(alerts.data.hits.total.value);
         }
-      }
     } catch (err) {
       if (this._isMount) {
         this.setState({ alerts: [], total: 0, isLoading: false, requestFilters: newFilters, filters: newFilters.filters });
@@ -477,23 +509,8 @@ export const Discover = compose(
       pageSize,
       sortField,
       sortDirection,
-    }, async () => this.getAlerts())
+    });
   };
-
-
-  getpageIndexItems() {
-    let items: {}[] = [];
-
-    const start = (this.state.pageIndex * this.state.pageSize) % this.state.requestSize;
-    const end = start + this.state.pageSize
-    for (let i = start; i < end && (this.state.pageIndex * this.state.pageSize) < this.state.total; i++) {
-      if (this.state.alerts[i] && this.state.alerts[i]._source) {
-        items.push({ ...this.state.alerts[i]._source, _id: this.state.alerts[i]._id })
-      }
-    }
-    return items;
-
-  }
 
   getFiltersAsObject(filters) {
     var result = {};
@@ -545,7 +562,7 @@ export const Discover = compose(
   }
 
   onQuerySubmit = (payload: { dateRange: TimeRange, query: Query | undefined }) => {
-    this.setState(payload);
+    this.setState({...payload, tsUpdated: Date.now()});
   }
 
   onFiltersUpdated = (filters: Filter[]) => {
@@ -582,7 +599,6 @@ export const Discover = compose(
       };
     };
 
-    const pageIndexItems = this.getpageIndexItems();
     const columns = this.columns();
 
     const sorting: EuiTableSortingType<{}> = {
@@ -622,9 +638,9 @@ export const Discover = compose(
         {total
           ? <EuiFlexGroup>
             <EuiFlexItem>
-              {pageIndexItems.length && (
+              {this.state.alerts.length && (
                 <EuiBasicTable
-                  items={pageIndexItems}
+                  items={this.state.alerts.map(alert => ({...alert._source, _id: alert._id}))}
                   className="module-discover-table"
                   itemId="_id"
                   itemIdToExpandedRowMap={itemIdToExpandedRowMap}

--- a/public/components/common/modules/discover/discover.tsx
+++ b/public/components/common/modules/discover/discover.tsx
@@ -29,6 +29,7 @@ import { FlyoutTechnique } from '../../../../components/overview/mitre/component
 import { withReduxProvider } from '../../../common/hocs';
 import { connect } from 'react-redux';
 import { compose } from 'redux';
+import _ from 'lodash';
 
 import {
   EuiBasicTable,
@@ -189,15 +190,15 @@ export const Discover = compose(
       this.setState({ columns: this.getColumns() }); // Updates the columns to be rendered if you change the selected agent to none or vice versa
       return;
     }
-    if(JSON.stringify(this.props.query) !== JSON.stringify(prevProps.query)){
+    if(!_.isEqual(this.props.query,prevProps.query)){
       this.setState({ query: {...this.props.query}});
       return;
     };
-    if((JSON.stringify(this.props.shareFilterManager) !== JSON.stringify(prevProps.shareFilterManager))
+    if((!_.isEqual(this.props.shareFilterManager, prevProps.shareFilterManager))
       || (this.props.currentAgentData.id !== prevProps.currentAgentData.id)
-      || (JSON.stringify(this.state.query) !== JSON.stringify(prevState.query))
-      || (JSON.stringify(this.state.searchBarFilters) !== JSON.stringify(prevState.searchBarFilters))
-      || (JSON.stringify(this.state.dateRange) !== JSON.stringify(prevState.dateRange))
+      || (!_.isEqual(this.state.query, prevState.query))
+      || (!_.isEqual(this.state.searchBarFilters, prevState.searchBarFilters))
+      || (!_.isEqual(this.state.dateRange, prevState.dateRange))
       || (this.props.refreshAngularDiscover !== prevProps.refreshAngularDiscover)
     ){
       this.setState({ pageIndex: 0 , tsUpdated: Date.now()});

--- a/public/components/visualize/components/security-alerts.tsx
+++ b/public/components/visualize/components/security-alerts.tsx
@@ -11,12 +11,13 @@
  */
 
 import React from 'react';
-import { useFilterManager, useQuery } from '../../common/hooks';
+import { useFilterManager, useQuery, useRefreshAngularDiscover } from '../../common/hooks';
 import { Discover } from '../../common/modules/discover';
 
 export const SecurityAlerts = () => {
   const [query] = useQuery();
   const filterManager = useFilterManager();
+  const refreshAngularDiscover = useRefreshAngularDiscover();
 
   return (
     <Discover
@@ -25,6 +26,8 @@ export const SecurityAlerts = () => {
       initialColumns={["icon", "timestamp", 'rule.mitre.id', 'rule.mitre.tactic', 'rule.description', 'rule.level', 'rule.id']}
       implicitFilters={[]}
       initialFilters={[]}
-      updateTotalHits={(total) => { }} />
+      updateTotalHits={(total) => { }}
+      refreshAngularDiscover={refreshAngularDiscover}
+      />
   )
 }


### PR DESCRIPTION
Hi team,

this PR resolves:
- The Discover component uses `/elastic/esAlerts` and supports Private tennant in ODFE. This solves the table in Modules/Security Events.
- Added support when push the Refresh button to refresh the table

It is part of #2639