### PR TITLE
[Fix] Wrong permissions on edit CDB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 ### Fixed
 
 - Top bar overlayed over expanded visualizations [#2667](https://github.com/wazuh/wazuh-kibana-app/issues/2667)
+- Wrong permissions on edit CDB list [#2665](https://github.com/wazuh/wazuh-kibana-app/pull/2665)
 
 ## Wazuh v4.0.3 - Kibana v7.9.1, v7.9.2, v7.9.3 - Revision 4014
 

--- a/public/controllers/management/components/management/ruleset/actions-buttons.js
+++ b/public/controllers/management/components/management/ruleset/actions-buttons.js
@@ -304,7 +304,7 @@ class WzRulesetActionButtons extends Component {
         buttonType="empty"
         permissions={[
           {
-            action: `${((this.props || {}).clusterStatus || {}).contextConfigServer}::upload_file`,
+            action: `${((this.props || {}).clusterStatus || {}).contextConfigServer}:upload_file`,
             resource: `file:path:/etc/${section}`,
           },
           {

--- a/public/controllers/management/components/management/ruleset/actions-buttons.js
+++ b/public/controllers/management/components/management/ruleset/actions-buttons.js
@@ -178,7 +178,12 @@ class WzRulesetActionButtons extends Component {
     // Add new rule button
     const addNewRuleButton = (
       <WzButtonPermissions
-        permissions={[{action: 'manager:upload_file', resource: `file:path:/etc/${section}`}]}
+        permissions={[
+          {
+            action: `${((this.props || {}).clusterStatus || {}).contextConfigServer}:upload_file`,
+            resource: `file:path:/etc/${section}`,
+          },
+        ]}
         buttonType='empty'
         iconType="plusInCircle"
         onClick={() =>
@@ -197,7 +202,12 @@ class WzRulesetActionButtons extends Component {
     const addNewCdbListButton = (
       <WzButtonPermissions
         buttonType='empty'
-        permissions={[{action: 'manager:upload_file', resource: 'file:path:/etc/lists/files'}]}
+        permissions={[
+          {
+            action: `${((this.props || {}).clusterStatus || {}).contextConfigServer}:upload_file`,
+            resource: 'file:path:/etc/lists/files',
+          },
+        ]}
         iconType="plusInCircle"
         onClick={() =>
           this.props.updateListContent({
@@ -215,7 +225,12 @@ class WzRulesetActionButtons extends Component {
     const manageFiles = (
       <WzButtonPermissions
         buttonType='empty'
-        permissions={[{action: 'manager:upload_file', resource: `file:path:/etc/${section}`}]}
+        permissions={[
+          {
+            action: `${((this.props || {}).clusterStatus || {}).contextConfigServer}::upload_file`,
+            resource: `file:path:/etc/${section}`,
+          },
+        ]}
         iconType={showingFiles ? 'apmTrace' : 'folderClosed'}
         onClick={async () => await this.toggleFiles()}
       >
@@ -252,6 +267,7 @@ class WzRulesetActionButtons extends Component {
         {(section === 'lists' || showingFiles) && (
           <EuiFlexItem grow={false}>
             <UploadFiles
+              clusterStatus={this.props.clusterStatus}
               msg={section}
               path={`etc/${section}`}
               upload={uploadFile}

--- a/public/controllers/management/components/management/ruleset/actions-buttons.js
+++ b/public/controllers/management/components/management/ruleset/actions-buttons.js
@@ -302,24 +302,7 @@ class WzRulesetActionButtons extends Component {
     const manageFiles = (
       <WzButtonPermissions
         buttonType="empty"
-        permissions={[
-          {
-            action: `${((this.props || {}).clusterStatus || {}).contextConfigServer}:upload_file`,
-            resource: `file:path:/etc/${section}`,
-          },
-          {
-            action: `${((this.props || {}).clusterStatus || {}).contextConfigServer}:read`,
-            resource: `file:path:/etc/${this.props.msg}`,
-          },
-          {
-            action: `${((this.props || {}).clusterStatus || {}).contextConfigServer}:read_file`,
-            resource: `file:path:/etc/${this.props.msg}`,
-          },
-          {
-            action: `cluster:status`,
-            resource: `*:*:*`,
-          },
-        ]}
+        permissions={getPermissionsFiles()}
         iconType={showingFiles ? 'apmTrace' : 'folderClosed'}
         onClick={async () => await this.toggleFiles()}
       >

--- a/public/controllers/management/components/management/ruleset/actions-buttons.js
+++ b/public/controllers/management/components/management/ruleset/actions-buttons.js
@@ -225,7 +225,7 @@ class WzRulesetActionButtons extends Component {
     );
 
     const getPermissionsNewFile = () => {
-      let permissions = [
+      const permissions = [
         {
           action: `${((this.props || {}).clusterStatus || {}).contextConfigServer}:upload_file`,
           resource: `file:path:/etc/${section}`,

--- a/public/controllers/management/components/management/ruleset/actions-buttons.js
+++ b/public/controllers/management/components/management/ruleset/actions-buttons.js
@@ -170,11 +170,11 @@ class WzRulesetActionButtons extends Component {
         permissions={[
           {
             action: `${((this.props || {}).clusterStatus || {}).contextConfigServer}:read`,
-            resource: `file:path:/etc/${this.props.msg}`,
+            resource: `file:path:/etc/${section}`,
           },
           {
             action: `${((this.props || {}).clusterStatus || {}).contextConfigServer}:read_file`,
-            resource: `file:path:/etc/${this.props.msg}`,
+            resource: `file:path:/etc/${section}`,
           },
           {
             action: `cluster:status`,
@@ -199,24 +199,24 @@ class WzRulesetActionButtons extends Component {
           },
           {
             action: `${((this.props || {}).clusterStatus || {}).contextConfigServer}:read`,
-            resource: `file:path:/etc/${this.props.msg}`,
+            resource: `file:path:*`,
           },
           {
             action: `${((this.props || {}).clusterStatus || {}).contextConfigServer}:read_file`,
-            resource: `file:path:/etc/${this.props.msg}`,
+            resource: `file:path:*`,
           },
           {
             action: `cluster:status`,
             resource: `*:*:*`,
           },
         ]}
-        buttonType='empty'
+        buttonType="empty"
         iconType="plusInCircle"
         onClick={() =>
           this.props.updteAddingRulesetFile({
             name: '',
             content: '<!-- Modify it at your will. -->',
-            path: `etc/${section}`
+            path: `etc/${section}`,
           })
         }
       >
@@ -224,34 +224,54 @@ class WzRulesetActionButtons extends Component {
       </WzButtonPermissions>
     );
 
-    //Add new CDB list button
-    const addNewCdbListButton = (
-      <WzButtonPermissions
-        buttonType='empty'
-        permissions={[
+    const getPermissionsNewFile = () => {
+      let permissions = [
+        {
+          action: `${((this.props || {}).clusterStatus || {}).contextConfigServer}:upload_file`,
+          resource: `file:path:/etc/${section}`,
+        },
+        {
+          action: `${((this.props || {}).clusterStatus || {}).contextConfigServer}:read_file`,
+          resource: `file:path:/etc/${section}`,
+        },
+        {
+          action: `cluster:status`,
+          resource: `*:*:*`,
+        },
+      ];
+
+      if (((this.props || {}).clusterStatus || {}).contextConfigServer === 'cluster') {
+        permissions.push(
           {
-            action: `${((this.props || {}).clusterStatus || {}).contextConfigServer}:upload_file`,
-            resource: 'file:path:/etc/lists/files',
+            action: `${((this.props || {}).clusterStatus || {}).contextConfigServer}:read`,
+            resource: `node:id:*`,
           },
           {
             action: `${((this.props || {}).clusterStatus || {}).contextConfigServer}:read`,
-            resource: `file:path:/etc/${this.props.msg}`,
-          },
-          {
-            action: `${((this.props || {}).clusterStatus || {}).contextConfigServer}:read_file`,
-            resource: `file:path:/etc/${this.props.msg}`,
-          },
-          {
-            action: `cluster:status`,
-            resource: `*:*:*`,
-          },
-        ]}
+            resource: `node:id:*&file:path:*`,
+          }
+        );
+      } else {
+        permissions.push({
+          action: `${((this.props || {}).clusterStatus || {}).contextConfigServer}:read`,
+          resource: `*:*:*`,
+        });
+      }
+
+      return permissions;
+    };
+
+    //Add new CDB list button
+    const addNewCdbListButton = (
+      <WzButtonPermissions
+        buttonType="empty"
+        permissions={getPermissionsNewFile()}
         iconType="plusInCircle"
         onClick={() =>
           this.props.updateListContent({
             name: false,
             content: '',
-            path: 'etc/lists'
+            path: 'etc/lists',
           })
         }
       >
@@ -262,7 +282,7 @@ class WzRulesetActionButtons extends Component {
     // Manage files
     const manageFiles = (
       <WzButtonPermissions
-        buttonType='empty'
+        buttonType="empty"
         permissions={[
           {
             action: `${((this.props || {}).clusterStatus || {}).contextConfigServer}::upload_file`,

--- a/public/controllers/management/components/management/ruleset/actions-buttons.js
+++ b/public/controllers/management/components/management/ruleset/actions-buttons.js
@@ -11,7 +11,7 @@
  */
 import React, { Component, Fragment } from 'react';
 // Eui components
-import { EuiFlexItem, EuiButtonEmpty, EuiGlobalToastList } from '@elastic/eui';
+import { EuiFlexItem, EuiButtonEmpty } from '@elastic/eui';
 import { toastNotifications } from 'ui/notify';
 
 import { connect } from 'react-redux';
@@ -22,11 +22,10 @@ import {
   updteAddingRulesetFile,
   updateListContent,
   updateIsProcessing,
-  updatePageIndex
+  updatePageIndex,
 } from '../../../../../redux/actions/rulesetActions';
 
 import { WzRequest } from '../../../../../react-services/wz-request';
-import { ErrorHandler } from '../../../../../react-services/error-handler';
 import exportCsv from '../../../../../react-services/wz-csv';
 import { UploadFiles } from '../../upload-files';
 import columns from './utils/columns';
@@ -166,13 +165,28 @@ class WzRulesetActionButtons extends Component {
 
     // Export button
     const exportButton = (
-      <EuiButtonEmpty
+      <WzButtonPermissions
+        buttonType="empty"
+        permissions={[
+          {
+            action: `${((this.props || {}).clusterStatus || {}).contextConfigServer}:read`,
+            resource: `file:path:/etc/${this.props.msg}`,
+          },
+          {
+            action: `${((this.props || {}).clusterStatus || {}).contextConfigServer}:read_file`,
+            resource: `file:path:/etc/${this.props.msg}`,
+          },
+          {
+            action: `cluster:status`,
+            resource: `*:*:*`,
+          },
+        ]}
         iconType="exportAction"
+        iconSide="left"
         onClick={async () => await this.generateCsv()}
-        isLoading={this.state.generatingCsv}
       >
         Export formatted
-      </EuiButtonEmpty>
+      </WzButtonPermissions>
     );
 
     // Add new rule button
@@ -182,6 +196,18 @@ class WzRulesetActionButtons extends Component {
           {
             action: `${((this.props || {}).clusterStatus || {}).contextConfigServer}:upload_file`,
             resource: `file:path:/etc/${section}`,
+          },
+          {
+            action: `${((this.props || {}).clusterStatus || {}).contextConfigServer}:read`,
+            resource: `file:path:/etc/${this.props.msg}`,
+          },
+          {
+            action: `${((this.props || {}).clusterStatus || {}).contextConfigServer}:read_file`,
+            resource: `file:path:/etc/${this.props.msg}`,
+          },
+          {
+            action: `cluster:status`,
+            resource: `*:*:*`,
           },
         ]}
         buttonType='empty'
@@ -207,6 +233,18 @@ class WzRulesetActionButtons extends Component {
             action: `${((this.props || {}).clusterStatus || {}).contextConfigServer}:upload_file`,
             resource: 'file:path:/etc/lists/files',
           },
+          {
+            action: `${((this.props || {}).clusterStatus || {}).contextConfigServer}:read`,
+            resource: `file:path:/etc/${this.props.msg}`,
+          },
+          {
+            action: `${((this.props || {}).clusterStatus || {}).contextConfigServer}:read_file`,
+            resource: `file:path:/etc/${this.props.msg}`,
+          },
+          {
+            action: `cluster:status`,
+            resource: `*:*:*`,
+          },
         ]}
         iconType="plusInCircle"
         onClick={() =>
@@ -229,6 +267,18 @@ class WzRulesetActionButtons extends Component {
           {
             action: `${((this.props || {}).clusterStatus || {}).contextConfigServer}::upload_file`,
             resource: `file:path:/etc/${section}`,
+          },
+          {
+            action: `${((this.props || {}).clusterStatus || {}).contextConfigServer}:read`,
+            resource: `file:path:/etc/${this.props.msg}`,
+          },
+          {
+            action: `${((this.props || {}).clusterStatus || {}).contextConfigServer}:read_file`,
+            resource: `file:path:/etc/${this.props.msg}`,
+          },
+          {
+            action: `cluster:status`,
+            resource: `*:*:*`,
           },
         ]}
         iconType={showingFiles ? 'apmTrace' : 'folderClosed'}

--- a/public/controllers/management/components/management/ruleset/actions-buttons.js
+++ b/public/controllers/management/components/management/ruleset/actions-buttons.js
@@ -163,24 +163,54 @@ class WzRulesetActionButtons extends Component {
   render() {
     const { section, showingFiles } = this.props.state;
 
+    const getPermissionsFiles = () => {
+      const permissions = [
+        {
+          action: `cluster:status`,
+          resource: `*:*:*`,
+        },
+      ];
+
+      if (((this.props || {}).clusterStatus || {}).contextConfigServer === 'cluster') {
+        permissions.push(
+          {
+            action: `cluster:upload_file`,
+            resource: `node:id:*`,
+          },
+          {
+            action: `cluster:read`,
+            resource: `node:id:*`,
+          },
+          {
+            action: `cluster:read_file`,
+            resource: `node:id:*&file:path:*`,
+          }
+        );
+      } else {
+        permissions.push(
+          {
+            action: `manager:upload_file`,
+            resource: `file:path:/etc/${section}`,
+          },
+          {
+            action: `manager:read`,
+            resource: `file:path:/etc/${section}`,
+          },
+          {
+            action: `manager:read_file`,
+            resource: `file:path:/etc/${section}`,
+          }
+        );
+      }
+
+      return permissions;
+    };
+
     // Export button
     const exportButton = (
       <WzButtonPermissions
         buttonType="empty"
-        permissions={[
-          {
-            action: `${((this.props || {}).clusterStatus || {}).contextConfigServer}:read`,
-            resource: `file:path:/etc/${section}`,
-          },
-          {
-            action: `${((this.props || {}).clusterStatus || {}).contextConfigServer}:read_file`,
-            resource: `file:path:/etc/${section}`,
-          },
-          {
-            action: `cluster:status`,
-            resource: `*:*:*`,
-          },
-        ]}
+        permissions={getPermissionsFiles()}
         iconType="exportAction"
         iconSide="left"
         onClick={async () => await this.generateCsv()}
@@ -192,24 +222,7 @@ class WzRulesetActionButtons extends Component {
     // Add new rule button
     const addNewRuleButton = (
       <WzButtonPermissions
-        permissions={[
-          {
-            action: `${((this.props || {}).clusterStatus || {}).contextConfigServer}:upload_file`,
-            resource: `file:path:/etc/${section}`,
-          },
-          {
-            action: `${((this.props || {}).clusterStatus || {}).contextConfigServer}:read`,
-            resource: `file:path:*`,
-          },
-          {
-            action: `${((this.props || {}).clusterStatus || {}).contextConfigServer}:read_file`,
-            resource: `file:path:*`,
-          },
-          {
-            action: `cluster:status`,
-            resource: `*:*:*`,
-          },
-        ]}
+        permissions={getPermissionsFiles()}
         buttonType="empty"
         iconType="plusInCircle"
         onClick={() =>
@@ -224,16 +237,8 @@ class WzRulesetActionButtons extends Component {
       </WzButtonPermissions>
     );
 
-    const getPermissionsNewFile = () => {
+    const getPermissionsNewFileCDB = () => {
       const permissions = [
-        {
-          action: `${((this.props || {}).clusterStatus || {}).contextConfigServer}:upload_file`,
-          resource: `file:path:/etc/${section}`,
-        },
-        {
-          action: `${((this.props || {}).clusterStatus || {}).contextConfigServer}:read_file`,
-          resource: `file:path:/etc/${section}`,
-        },
         {
           action: `cluster:status`,
           resource: `*:*:*`,
@@ -243,19 +248,33 @@ class WzRulesetActionButtons extends Component {
       if (((this.props || {}).clusterStatus || {}).contextConfigServer === 'cluster') {
         permissions.push(
           {
-            action: `${((this.props || {}).clusterStatus || {}).contextConfigServer}:read`,
+            action: `cluster:upload_file`,
             resource: `node:id:*`,
           },
           {
-            action: `${((this.props || {}).clusterStatus || {}).contextConfigServer}:read`,
+            action: `cluster:read`,
+            resource: `node:id:*`,
+          },
+          {
+            action: `cluster:read_file`,
             resource: `node:id:*&file:path:*`,
           }
         );
       } else {
-        permissions.push({
-          action: `${((this.props || {}).clusterStatus || {}).contextConfigServer}:read`,
-          resource: `*:*:*`,
-        });
+        permissions.push(
+          {
+            action: `manager:read_file`,
+            resource: `file:path:/etc/${section}`,
+          },
+          {
+            action: `manager:read`,
+            resource: `*:*:*`,
+          },
+          {
+            action: `manager:upload_file`,
+            resource: `file:path:/etc/${section}`,
+          }
+        );
       }
 
       return permissions;
@@ -265,7 +284,7 @@ class WzRulesetActionButtons extends Component {
     const addNewCdbListButton = (
       <WzButtonPermissions
         buttonType="empty"
-        permissions={getPermissionsNewFile()}
+        permissions={getPermissionsNewFileCDB()}
         iconType="plusInCircle"
         onClick={() =>
           this.props.updateListContent({

--- a/public/controllers/management/components/management/ruleset/list-editor.js
+++ b/public/controllers/management/components/management/ruleset/list-editor.js
@@ -151,8 +151,7 @@ class WzListEditor extends Component {
       }
       await this.rulesetHandler.sendCdbList(name, path, raw, overwrite, addingNew);
       if (!addingNew) {
-        const result = await this.rulesetHandler.getCdbList(`${path}/${name}`);
-        const file = { name: name, content: result, path: path };
+        const file = { name: name, content: raw, path: path };
         this.props.updateListContent(file);
         this.setState({ showWarningRestart: true });
         this.showToast(

--- a/public/controllers/management/components/management/ruleset/list-editor.js
+++ b/public/controllers/management/components/management/ruleset/list-editor.js
@@ -320,7 +320,10 @@ class WzListEditor extends Component {
         permissions={[
           {
             action: `${((this.props || {}).clusterStatus || {}).contextConfigServer}:upload_file`,
-            resource: `file:path:${path}/${name}`,
+            resource:
+              ((this.props || {}).clusterStatus || {}).contextConfigServer === 'cluster'
+                ? 'node:id:*'
+                : `file:path:${path}/${name}`,
           },
         ]}
         fill
@@ -343,7 +346,10 @@ class WzListEditor extends Component {
                   action: `${
                     ((this.props || {}).clusterStatus || {}).contextConfigServer
                   }:upload_file`,
-                  resource: `file:path:${path}/${name}`,
+                  resource:
+                    ((this.props || {}).clusterStatus || {}).contextConfigServer === 'cluster'
+                      ? 'node:id:*'
+                      : `file:path:${path}/${name}`,
                 },
               ]}
               iconType="plusInCircle"
@@ -513,7 +519,10 @@ class WzListEditor extends Component {
                       action: `${
                         ((this.props || {}).clusterStatus || {}).contextConfigServer
                       }:upload_file`,
-                      resource: `file:path:${path}/${fileName}`,
+                      resource:
+                        ((this.props || {}).clusterStatus || {}).contextConfigServer === 'cluster'
+                          ? 'node:id:*'
+                          : `file:path:${path}/${fileName}`,
                     },
                   ]}
                   tooltip={{position: 'top', content: `Edit ${item.key}`}}
@@ -534,7 +543,10 @@ class WzListEditor extends Component {
                       action: `${
                         ((this.props || {}).clusterStatus || {}).contextConfigServer
                       }:upload_file`,
-                      resource: `file:path:${path}/${fileName}`,
+                      resource:
+                        ((this.props || {}).clusterStatus || {}).contextConfigServer === 'cluster'
+                          ? 'node:id:*'
+                          : `file:path:${path}/${fileName}`,
                     },
                   ]}
                   tooltip={{position: 'top', content: `Remove ${item.key}`}}

--- a/public/controllers/management/components/management/ruleset/list-editor.js
+++ b/public/controllers/management/components/management/ruleset/list-editor.js
@@ -317,7 +317,12 @@ class WzListEditor extends Component {
 
     const saveButton = (
       <WzButtonPermissions
-        permissions={[{action: 'manager:upload_file', resource: `file:path:${path}/${name}`}]}
+        permissions={[
+          {
+            action: `${((this.props || {}).clusterStatus || {}).contextConfigServer}:upload_file`,
+            resource: `file:path:${path}/${name}`,
+          },
+        ]}
         fill
         isDisabled={items.length === 0}
         iconType="save"
@@ -333,7 +338,14 @@ class WzListEditor extends Component {
         {!this.state.isPopoverOpen && (
           <EuiFlexItem grow={false}>
             <WzButtonPermissions
-              permissions={[{action: 'manager:upload_file', resource: `file:path:${path}/${name}`}]}
+              permissions={[
+                {
+                  action: `${
+                    ((this.props || {}).clusterStatus || {}).contextConfigServer
+                  }:upload_file`,
+                  resource: `file:path:${path}/${name}`,
+                },
+              ]}
               iconType="plusInCircle"
               onClick={() => this.openAddEntry()}
             >
@@ -496,7 +508,14 @@ class WzListEditor extends Component {
                   buttonType='icon'
                   aria-label="Edit content"
                   iconType="pencil"
-                  permissions={[{action: 'manager:upload_file', resource: `file:path:${path}/${fileName}`}]}
+                  permissions={[
+                    {
+                      action: `${
+                        ((this.props || {}).clusterStatus || {}).contextConfigServer
+                      }:upload_file`,
+                      resource: `file:path:${path}/${fileName}`,
+                    },
+                  ]}
                   tooltip={{position: 'top', content: `Edit ${item.key}`}}
                   onClick={() => {
                     this.setState({
@@ -510,7 +529,14 @@ class WzListEditor extends Component {
                   buttonType='icon'
                   aria-label="Remove content"
                   iconType="trash"
-                  permissions={[{action: 'manager:upload_file', resource: `file:path:${path}/${fileName}`}]}
+                  permissions={[
+                    {
+                      action: `${
+                        ((this.props || {}).clusterStatus || {}).contextConfigServer
+                      }:upload_file`,
+                      resource: `file:path:${path}/${fileName}`,
+                    },
+                  ]}
                   tooltip={{position: 'top', content: `Remove ${item.key}`}}
                   onClick={() => this.deleteItem(item.key)}
                   color="danger"

--- a/public/controllers/management/components/management/ruleset/main-ruleset.js
+++ b/public/controllers/management/components/management/ruleset/main-ruleset.js
@@ -70,9 +70,9 @@ export default class WzRuleset extends Component {
       <WzReduxProvider>
         {(ruleInfo && <WzRuleInfo />) ||
           (decoderInfo && <WzDecoderInfo />) ||
-          (listInfo && <WzListEditor />) ||
-          ((fileContent || addingRulesetFile) && <WzRulesetEditor />) || (
-            <WzRulesetOverview />
+          (listInfo && <WzListEditor clusterStatus={this.props.clusterStatus} />) ||
+          ((fileContent || addingRulesetFile) && <WzRulesetEditor clusterStatus={this.props.clusterStatus}/>) || (
+            <WzRulesetOverview clusterStatus={this.props.clusterStatus} />
           )}
       </WzReduxProvider>
     );

--- a/public/controllers/management/components/management/ruleset/ruleset-overview.js
+++ b/public/controllers/management/components/management/ruleset/ruleset-overview.js
@@ -48,7 +48,7 @@ class WzRulesetOverview extends Component {
               </EuiTitle>
             </EuiFlexItem>
             <EuiFlexItem></EuiFlexItem>
-            <WzRulesetActionButtons />
+            <WzRulesetActionButtons clusterStatus={this.props.clusterStatus} />
           </EuiFlexGroup>
           <EuiFlexGroup>
             <EuiFlexItem>
@@ -60,7 +60,11 @@ class WzRulesetOverview extends Component {
           <WzRulesetSearchBar />
           <EuiFlexGroup>
             <EuiFlexItem>
-              <WzRulesetTable request={section} updateTotalItems={(totalItems) => this.setState({totalItems})} />
+              <WzRulesetTable
+                clusterStatus={this.props.clusterStatus}
+                request={section}
+                updateTotalItems={(totalItems) => this.setState({ totalItems })}
+              />
             </EuiFlexItem>
           </EuiFlexGroup>
         </EuiPanel>

--- a/public/controllers/management/components/management/ruleset/ruleset-table.js
+++ b/public/controllers/management/components/management/ruleset/ruleset-table.js
@@ -38,8 +38,6 @@ import { filtersToObject } from '../../../../../components/wz-search-bar';
 import { withUserPermissions } from '../../../../../components/common/hocs/withUserPermissions';
 import { WzUserPermissions } from '../../../../../react-services/wz-user-permissions';
 import { compose } from 'redux';
-import { clusterReq } from '../configuration/utils/wz-fetch';
-import { updateClusterStatus } from '../../../../../redux/actions/appStateActions';
 
 class WzRulesetTable extends Component {
   _isMounted = false;
@@ -93,7 +91,6 @@ class WzRulesetTable extends Component {
         this._isMounted && this.setState({ isRedirect: false });
       }
     }
-    await this.isClusterOrManager();
   }
 
   async componentDidUpdate(prevProps) {
@@ -124,33 +121,6 @@ class WzRulesetTable extends Component {
   componentWillUnmount() {
     this._isMounted = false;
   }
-
-  isClusterOrManager = async () => {
-    await clusterReq()
-      .then((clusterStatus) => {
-        if (
-          clusterStatus.data.data.enabled === 'yes' &&
-          clusterStatus.data.data.running === 'yes'
-        ) {
-          this.props.updateClusterStatus({
-            status: true,
-            contextConfigServer: 'cluster',
-          });
-        } else {
-          this.props.updateClusterStatus({
-            status: false,
-            contextConfigServer: 'manager',
-          });
-        }
-      })
-      .catch((error) => {
-        console.warn(`Error when try to get cluster status`, error);
-        this.props.updateClusterStatus({
-          status: false,
-          contextConfigServer: 'manager',
-        });
-      });
-  };
 
   async getItems() {
     const { section, showingFiles } = this.props.state;
@@ -274,11 +244,11 @@ class WzRulesetTable extends Component {
             [
               [
                 {
-                  action: `${((this.tableProps || {}).clusterStatus || {}).contextConfigServer}:read_file`,
+                  action: `${((this.props || {}).clusterStatus || {}).contextConfigServer}:read_file`,
                   resource: `file:path:${item.relative_dirname}/${item.filename}`,
                 },
                 {
-                  action: `${((this.tableProps || {}).clusterStatus || {}).contextConfigServer}:read`,
+                  action: `${((this.props || {}).clusterStatus || {}).contextConfigServer}:read`,
                   resource: `file:path:${item.relative_dirname}/${item.filename}`,
                 },
                 {
@@ -389,7 +359,6 @@ class WzRulesetTable extends Component {
 const mapStateToProps = (state) => {
   return {
     state: state.rulesetReducers,
-    clusterStatus: state.appStateReducers.clusterStatus,
   };
 };
 
@@ -403,7 +372,6 @@ const mapDispatchToProps = (dispatch) => {
     updateListItemsForRemove: (itemList) => dispatch(updateListItemsForRemove(itemList)),
     updateRuleInfo: (rule) => dispatch(updateRuleInfo(rule)),
     updateDecoderInfo: (rule) => dispatch(updateDecoderInfo(rule)),
-    updateClusterStatus: (clusterStatus) => dispatch(updateClusterStatus(clusterStatus)),
   };
 };
 

--- a/public/controllers/management/components/management/ruleset/ruleset-table.js
+++ b/public/controllers/management/components/management/ruleset/ruleset-table.js
@@ -274,11 +274,11 @@ class WzRulesetTable extends Component {
             [
               [
                 {
-                  action: `${this.tableProps?.clusterStatus?.contextConfigServer}:read_file`,
+                  action: `${((this.tableProps || {}).clusterStatus || {}).contextConfigServer}:read_file`,
                   resource: `file:path:${item.relative_dirname}/${item.filename}`,
                 },
                 {
-                  action: `${this.tableProps?.clusterStatus?.contextConfigServer}:read`,
+                  action: `${((this.tableProps || {}).clusterStatus || {}).contextConfigServer}:read`,
                   resource: `file:path:${item.relative_dirname}/${item.filename}`,
                 },
                 {

--- a/public/controllers/management/components/management/ruleset/ruleset-table.js
+++ b/public/controllers/management/components/management/ruleset/ruleset-table.js
@@ -395,6 +395,7 @@ const mapStateToProps = (state) => {
 
 const mapDispatchToProps = (dispatch) => {
   return {
+    updateDefaultItems: (defaultItems) => dispatch(updateDefaultItems(defaultItems)), //TODO: Research to remove
     updateIsProcessing: (isProcessing) => dispatch(updateIsProcessing(isProcessing)),
     updateShowModal: (showModal) => dispatch(updateShowModal(showModal)),
     updateFileContent: (fileContent) => dispatch(updateFileContent(fileContent)),

--- a/public/controllers/management/components/management/ruleset/ruleset-table.js
+++ b/public/controllers/management/components/management/ruleset/ruleset-table.js
@@ -237,7 +237,7 @@ class WzRulesetTable extends Component {
         const { id, name } = item;
 
         const getRequiredPermissions = (item) => {
-          let permissions = [
+          const permissions = [
             {
               action: `${((this.props || {}).clusterStatus || {}).contextConfigServer}:read_file`,
               resource: `file:path:${item.relative_dirname}/${item.filename}`,

--- a/public/controllers/management/components/management/ruleset/ruleset-table.js
+++ b/public/controllers/management/components/management/ruleset/ruleset-table.js
@@ -233,7 +233,7 @@ class WzRulesetTable extends Component {
     if (!error) {
       const itemList = this.props.state.itemList;
 
-      const getRowProps = item => {
+      const getRowProps = (item) => {
         const { id, name } = item;
 
         const extraSectionPermissions = this.extraSectionPrefixResource[this.props.state.section];
@@ -242,48 +242,56 @@ class WzRulesetTable extends Component {
           className: 'customRowClass',
           onClick: !WzUserPermissions.checkMissingUserPermissions(
             [
-              [
-                {
-                  action: `${((this.props || {}).clusterStatus || {}).contextConfigServer}:read_file`,
-                  resource: `file:path:${item.relative_dirname}/${item.filename}`,
-                },
-                {
-                  action: `${((this.props || {}).clusterStatus || {}).contextConfigServer}:read`,
-                  resource: `file:path:${item.relative_dirname}/${item.filename}`,
-                },
-                {
-                  action: `cluster:status`,
-                  resource: `*:*:*`,
-                },
-                {
-                  action: `${this.props.state.section}:read`,
-                  resource: `${extraSectionPermissions}:${item.filename}`,
-                },
-              ],
+              {
+                action: `${((this.props || {}).clusterStatus || {}).contextConfigServer}:read_file`,
+                resource: `file:path:${item.relative_dirname}/${item.filename}`,
+              },
+              {
+                action: `${((this.props || {}).clusterStatus || {}).contextConfigServer}:read`,
+                resource: `file:path:${item.relative_dirname}/${item.filename}`,
+              },
+              {
+                action: `cluster:status`,
+                resource: `*:*:*`,
+              },
+              {
+                action: `${this.props.state.section}:read`,
+                resource: `${extraSectionPermissions}:${item.filename}`,
+              },
             ],
             this.props.userPermissions
           )
             ? async () => {
-            if(this.isLoading) return;
-            this.setState({isLoading: true});
-            const { section } = this.props.state;
-            window.location.href = `${window.location.href}&redirectRule=${id}`;
-            if (section === 'rules') {
-              const result = await this.rulesetHandler.getRuleInformation(
-                item.filename,
-                id
-              );
-              this.props.updateRuleInfo(result);
-            } else if (section === 'decoders') {
-              const result = await this.rulesetHandler.getDecoderInformation(item.filename, name);
-              this.props.updateDecoderInfo(result);
-            } else {
-              const result = await this.rulesetHandler.getCdbList(`${item.relative_dirname}/${item.filename}`);
-              const file = { name: item.filename, content: result, path: item.relative_dirname };
-              this.props.updateListContent(file);
-            }
-            this.setState({isLoading: false});
-          } : undefined
+                if (this.isLoading) return;
+                this.setState({ isLoading: true });
+                const { section } = this.props.state;
+                window.location.href = `${window.location.href}&redirectRule=${id}`;
+                if (section === 'rules') {
+                  const result = await this.rulesetHandler.getRuleInformation(
+                    item.filename,
+                    id
+                  );
+                  this.props.updateRuleInfo(result);
+                } else if (section === 'decoders') {
+                  const result = await this.rulesetHandler.getDecoderInformation(
+                    item.filename,
+                    name
+                  );
+                  this.props.updateDecoderInfo(result);
+                } else {
+                  const result = await this.rulesetHandler.getCdbList(
+                    `${item.relative_dirname}/${item.filename}`
+                  );
+                  const file = {
+                    name: item.filename,
+                    content: result,
+                    path: item.relative_dirname,
+                  };
+                  this.props.updateListContent(file);
+                }
+                this.setState({ isLoading: false });
+              }
+            : undefined,
         };
       };
 

--- a/public/controllers/management/components/management/ruleset/ruleset-table.js
+++ b/public/controllers/management/components/management/ruleset/ruleset-table.js
@@ -256,7 +256,7 @@ class WzRulesetTable extends Component {
                 resource: `node:id:*`,
               },
               {
-                action: `${((this.props || {}).clusterStatus || {}).contextConfigServer}:read`,
+                action: `${((this.props || {}).clusterStatus || {}).contextConfigServer}:read_file`,
                 resource: `node:id:*&file:path:*`,
               }
             );

--- a/public/controllers/management/components/management/ruleset/utils/columns.js
+++ b/public/controllers/management/components/management/ruleset/utils/columns.js
@@ -249,14 +249,12 @@ export default class RulesetColumns {
       };
 
       const getEditButtonPermissions = (item) => {
-        return [
+        let permissions = [
           {
-            action: `${((this.tableProps || {}).clusterStatus || {}).contextConfigServer}:read_file`,
+            action: `${
+              ((this.tableProps || {}).clusterStatus || {}).contextConfigServer
+            }:read_file`,
             resource: `file:path:${item.relative_dirname}/${item.filename}`,
-          },
-          {
-            action: `${((this.tableProps || {}).clusterStatus || {}).contextConfigServer}:read`,
-            resource: `node:id:*`,
           },
           { action: 'lists:read', resource: `list:path:${item.filename}` },
           {
@@ -264,6 +262,26 @@ export default class RulesetColumns {
             resource: `*:*:*`,
           },
         ];
+
+        if (((this.tableProps || {}).clusterStatus || {}).contextConfigServer === 'cluster') {
+          permissions.push(
+            {
+              action: `${((this.tableProps || {}).clusterStatus || {}).contextConfigServer}:read`,
+              resource: `node:id:*`,
+            },
+            {
+              action: `${((this.tableProps || {}).clusterStatus || {}).contextConfigServer}:read`,
+              resource: `node:id:*&file:path:*`,
+            }
+          );
+        } else {
+          permissions.push({
+            action: `${((this.tableProps || {}).clusterStatus || {}).contextConfigServer}:read`,
+            resource: `*:*:*`,
+          });
+        }
+
+        return permissions;
       };
 
       this.columns.lists[2] =

--- a/public/controllers/management/components/management/ruleset/utils/columns.js
+++ b/public/controllers/management/components/management/ruleset/utils/columns.js
@@ -302,17 +302,18 @@ export default class RulesetColumns {
                   color="danger"
                   isDisabled={defaultItems.indexOf(`${item.relative_dirname}`) !== -1}
                 />
-                <EuiToolTip position="top" content={`Export ${item.filename}`}>
-                  <EuiButtonIcon
-                    aria-label="Export list"
-                    iconType="exportAction"
-                    onClick={async (ev) => {
-                      ev.stopPropagation();
-                      await exportCsv(`/lists`, [{_isCDBList: true, name: 'filename', value: `${item.filename}`}], item.filename)
-                    }}
-                    color="primary"
-                  />
-                </EuiToolTip>
+                <WzButtonPermissions
+                  buttonType='icon'
+                  permissions={getEditButtonPermissions(item)}
+                  aria-label="Export list"
+                  iconType="exportAction"
+                  tooltip={{position: 'top', content: `Edit ${item.filename} content`}}
+                  onClick={async (ev) => {
+                    ev.stopPropagation();
+                    await exportCsv(`/lists`, [{_isCDBList: true, name: 'filename', value: `${item.filename}`}], item.filename)
+                  }}
+                  color="primary"
+                />
               </div>
             )
           }

--- a/public/controllers/management/components/management/ruleset/utils/columns.js
+++ b/public/controllers/management/components/management/ruleset/utils/columns.js
@@ -270,7 +270,7 @@ export default class RulesetColumns {
               resource: `node:id:*`,
             },
             {
-              action: `${((this.tableProps || {}).clusterStatus || {}).contextConfigServer}:read`,
+              action: `${((this.tableProps || {}).clusterStatus || {}).contextConfigServer}:read_file`,
               resource: `node:id:*&file:path:*`,
             }
           );

--- a/public/controllers/management/components/management/ruleset/utils/columns.js
+++ b/public/controllers/management/components/management/ruleset/utils/columns.js
@@ -42,7 +42,7 @@ export default class RulesetColumns {
               }
               return (
               <div>
-                {haveTooltip === false ? 
+                {haveTooltip === false ?
                 <span dangerouslySetInnerHTML={{ __html: value}} /> :
                 <EuiToolTip position="bottom" content={toolTipDescription}>
                   <span dangerouslySetInnerHTML={{ __html: value}} />
@@ -78,9 +78,9 @@ export default class RulesetColumns {
             width: '15%',
             render: (value, item) => {
               return (
-                <WzButtonPermissions 
+                <WzButtonPermissions
                   buttonType='link'
-                  permissions={[[{action: 'manager:read_file', resource: `file:path:${item.relative_dirname}/${item.filename}`}, {action: 'manager:read', resource: `file:path:${item.relative_dirname}/${item.filename}`}, { action: 'rules:read', resource: `rule:file:${item.filename}`}]]}
+                  permissions={[[{action: `${this.tableProps?.clusterStatus?.contextConfigServer}:read_file`, resource: `file:path:${item.relative_dirname}/${item.filename}`}, {action: `${this.tableProps?.clusterStatus?.contextConfigServer}:read`, resource: `file:path:${item.relative_dirname}/${item.filename}`}, { action: 'rules:read', resource: `rule:file:${item.filename}`}]]}
                   tooltip={{position:'top', content: `Show ${value} content`}}
                   onClick={async (ev) => {
                     ev.stopPropagation();
@@ -130,7 +130,7 @@ export default class RulesetColumns {
               return (
                 <WzButtonPermissions
                   buttonType='link'
-                  permissions={[[{action: 'manager:read_file', resource: `file:path:${item.relative_dirname}/${item.filename}`}, {action: 'manager:read', resource: `file:path:${item.relative_dirname}/${item.filename}`}, { action: 'decoders:read', resource: `decoder:file:${item.filename}`}]]}
+                  permissions={[[{action: `${this.tableProps?.clusterStatus?.contextConfigServer}:read_file`, resource: `file:path:${item.relative_dirname}/${item.filename}`}, {action: `${this.tableProps?.clusterStatus?.contextConfigServer}:read`, resource: `file:path:${item.relative_dirname}/${item.filename}`}, { action: 'decoders:read', resource: `decoder:file:${item.filename}`}]]}
                   tooltip={{position:'top', content: `Show ${value} content`}}
                   onClick={async (ev) => {
                     ev.stopPropagation();
@@ -197,7 +197,7 @@ export default class RulesetColumns {
                 return (
                   <WzButtonPermissions
                     buttonType='icon'
-                    permissions={[[{action: 'manager:read_file', resource: `file:path:${item.relative_dirname}/${item.filename}`}, {action: 'manager:read', resource: `file:path:${item.relative_dirname}/${item.filename}`}, { action: 'lists:read', resource: `list:path:${item.filename}`}]]}
+                    permissions={[[{action: `${this.tableProps?.clusterStatus?.contextConfigServer}:read_file`, resource: `file:path:${item.relative_dirname}/${item.filename}`}, {action: `${this.tableProps?.clusterStatus?.contextConfigServer}:read`, resource: `file:path:${item.relative_dirname}/${item.filename}`}, { action: 'lists:read', resource: `list:path:${item.filename}`}]]}
                     aria-label="Show content"
                     iconType="eye"
                     tooltip={{position: 'top', content:`Edit ${item.filename} content`}}
@@ -215,7 +215,7 @@ export default class RulesetColumns {
                   <div>
                     <WzButtonPermissions
                       buttonType='icon'
-                      permissions={[[{action: 'manager:read_file', resource: `file:path:${item.relative_dirname}/${item.filename}`}, {action: 'manager:read', resource: `file:path:${item.relative_dirname}/${item.filename}`}, { action: 'lists:read', resource: `list:path:${item.filename}`}]]}
+                      permissions={[[{action: `${this.tableProps?.clusterStatus?.contextConfigServer}:read_file`, resource: `file:path:${item.relative_dirname}/${item.filename}`}, {action: `${this.tableProps?.clusterStatus?.contextConfigServer}:read`, resource: `file:path:${item.relative_dirname}/${item.filename}`}, { action: 'lists:read', resource: `list:path:${item.filename}`}]]}
                       aria-label="Edit content"
                       iconType="pencil"
                       tooltip={{position: 'top', content:`Edit ${item.filename} content`}}
@@ -229,7 +229,7 @@ export default class RulesetColumns {
                     />
                     <WzButtonPermissions
                       buttonType='icon'
-                      permissions={[{action: 'manager:delete_file', resource: `file:path:${item.relative_dirname}/${item.filename}`}]}
+                      permissions={[{action: `${this.tableProps?.clusterStatus?.contextConfigServer}:delete_file`, resource: `file:path:${item.relative_dirname}/${item.filename}`}]}
                       aria-label="Delete content"
                       iconType="trash"
                       tooltip={{position: 'top', content:`Remove ${item.filename} file`}}
@@ -248,6 +248,24 @@ export default class RulesetColumns {
         ]
       };
 
+      const getEditButtonPermissions = (item) => {
+        return [
+          {
+            action: `${this.tableProps?.clusterStatus?.contextConfigServer}:read_file`,
+            resource: `file:path:${item.relative_dirname}/${item.filename}`,
+          },
+          {
+            action: `${this.tableProps?.clusterStatus?.contextConfigServer}:read`,
+            resource: `node:id:*`,
+          },
+          { action: 'lists:read', resource: `list:path:${item.filename}` },
+          {
+            action: `cluster:status`,
+            resource: `*:*:*`,
+          },
+        ];
+      };
+
       this.columns.lists[2] =
         {
           name: 'Actions',
@@ -258,7 +276,7 @@ export default class RulesetColumns {
               <div>
                 <WzButtonPermissions
                   buttonType='icon'
-                  permissions={[[{action: 'manager:read_file', resource: `file:path:${item.relative_dirname}/${item.filename}`}, {action: 'manager:read', resource: `file:path:${item.relative_dirname}/${item.filename}`}, { action: 'lists:read', resource: `list:path:${item.filename}`}]]}
+                  permissions={getEditButtonPermissions(item)}
                   aria-label="Edit content"
                   iconType="pencil"
                   tooltip={{position: 'top', content: `Edit ${item.filename} content`}}
@@ -272,7 +290,7 @@ export default class RulesetColumns {
                 />
                 <WzButtonPermissions
                   buttonType='icon'
-                  permissions={[{action: 'manager:delete_file', resource: `file:path:${item.relative_dirname}/${item.filename}`}]}
+                  permissions={[{action: `${this.tableProps?.clusterStatus?.contextConfigServer}:delete_file`, resource: `file:path:${item.relative_dirname}/${item.filename}`}]}
                   aria-label="Show content"
                   iconType="trash"
                   tooltip={{position: 'top', content:(defaultItems.indexOf(`${item.relative_dirname}`) === -1) ? `Delete ${item.filename}` : `The ${item.filename} list cannot be deleted`}}
@@ -300,7 +318,7 @@ export default class RulesetColumns {
           }
         }
       };
-      
+
 
     this.buildColumns();
   }

--- a/public/controllers/management/components/management/ruleset/utils/columns.js
+++ b/public/controllers/management/components/management/ruleset/utils/columns.js
@@ -249,7 +249,7 @@ export default class RulesetColumns {
       };
 
       const getEditButtonPermissions = (item) => {
-        let permissions = [
+        const permissions = [
           {
             action: `${
               ((this.tableProps || {}).clusterStatus || {}).contextConfigServer

--- a/public/controllers/management/components/management/ruleset/utils/columns.js
+++ b/public/controllers/management/components/management/ruleset/utils/columns.js
@@ -80,7 +80,7 @@ export default class RulesetColumns {
               return (
                 <WzButtonPermissions
                   buttonType='link'
-                  permissions={[[{action: `${this.tableProps?.clusterStatus?.contextConfigServer}:read_file`, resource: `file:path:${item.relative_dirname}/${item.filename}`}, {action: `${this.tableProps?.clusterStatus?.contextConfigServer}:read`, resource: `file:path:${item.relative_dirname}/${item.filename}`}, { action: 'rules:read', resource: `rule:file:${item.filename}`}]]}
+                  permissions={[[{action: `${((this.tableProps || {}).clusterStatus || {}).contextConfigServer}:read_file`, resource: `file:path:${item.relative_dirname}/${item.filename}`}, {action: `${((this.tableProps || {}).clusterStatus || {}).contextConfigServer}:read`, resource: `file:path:${item.relative_dirname}/${item.filename}`}, { action: 'rules:read', resource: `rule:file:${item.filename}`}]]}
                   tooltip={{position:'top', content: `Show ${value} content`}}
                   onClick={async (ev) => {
                     ev.stopPropagation();
@@ -130,7 +130,7 @@ export default class RulesetColumns {
               return (
                 <WzButtonPermissions
                   buttonType='link'
-                  permissions={[[{action: `${this.tableProps?.clusterStatus?.contextConfigServer}:read_file`, resource: `file:path:${item.relative_dirname}/${item.filename}`}, {action: `${this.tableProps?.clusterStatus?.contextConfigServer}:read`, resource: `file:path:${item.relative_dirname}/${item.filename}`}, { action: 'decoders:read', resource: `decoder:file:${item.filename}`}]]}
+                  permissions={[[{action: `${((this.tableProps || {}).clusterStatus || {}).contextConfigServer}:read_file`, resource: `file:path:${item.relative_dirname}/${item.filename}`}, {action: `${((this.tableProps || {}).clusterStatus || {}).contextConfigServer}:read`, resource: `file:path:${item.relative_dirname}/${item.filename}`}, { action: 'decoders:read', resource: `decoder:file:${item.filename}`}]]}
                   tooltip={{position:'top', content: `Show ${value} content`}}
                   onClick={async (ev) => {
                     ev.stopPropagation();
@@ -197,7 +197,7 @@ export default class RulesetColumns {
                 return (
                   <WzButtonPermissions
                     buttonType='icon'
-                    permissions={[[{action: `${this.tableProps?.clusterStatus?.contextConfigServer}:read_file`, resource: `file:path:${item.relative_dirname}/${item.filename}`}, {action: `${this.tableProps?.clusterStatus?.contextConfigServer}:read`, resource: `file:path:${item.relative_dirname}/${item.filename}`}, { action: 'lists:read', resource: `list:path:${item.filename}`}]]}
+                    permissions={[[{action: `${((this.tableProps || {}).clusterStatus || {}).contextConfigServer}:read_file`, resource: `file:path:${item.relative_dirname}/${item.filename}`}, {action: `${((this.tableProps || {}).clusterStatus || {}).contextConfigServer}:read`, resource: `file:path:${item.relative_dirname}/${item.filename}`}, { action: 'lists:read', resource: `list:path:${item.filename}`}]]}
                     aria-label="Show content"
                     iconType="eye"
                     tooltip={{position: 'top', content:`Edit ${item.filename} content`}}
@@ -215,7 +215,7 @@ export default class RulesetColumns {
                   <div>
                     <WzButtonPermissions
                       buttonType='icon'
-                      permissions={[[{action: `${this.tableProps?.clusterStatus?.contextConfigServer}:read_file`, resource: `file:path:${item.relative_dirname}/${item.filename}`}, {action: `${this.tableProps?.clusterStatus?.contextConfigServer}:read`, resource: `file:path:${item.relative_dirname}/${item.filename}`}, { action: 'lists:read', resource: `list:path:${item.filename}`}]]}
+                      permissions={[[{action: `${((this.tableProps || {}).clusterStatus || {}).contextConfigServer}:read_file`, resource: `file:path:${item.relative_dirname}/${item.filename}`}, {action: `${((this.tableProps || {}).clusterStatus || {}).contextConfigServer}:read`, resource: `file:path:${item.relative_dirname}/${item.filename}`}, { action: 'lists:read', resource: `list:path:${item.filename}`}]]}
                       aria-label="Edit content"
                       iconType="pencil"
                       tooltip={{position: 'top', content:`Edit ${item.filename} content`}}
@@ -229,7 +229,7 @@ export default class RulesetColumns {
                     />
                     <WzButtonPermissions
                       buttonType='icon'
-                      permissions={[{action: `${this.tableProps?.clusterStatus?.contextConfigServer}:delete_file`, resource: `file:path:${item.relative_dirname}/${item.filename}`}]}
+                      permissions={[{action: `${((this.tableProps || {}).clusterStatus || {}).contextConfigServer}:delete_file`, resource: `file:path:${item.relative_dirname}/${item.filename}`}]}
                       aria-label="Delete content"
                       iconType="trash"
                       tooltip={{position: 'top', content:`Remove ${item.filename} file`}}
@@ -251,11 +251,11 @@ export default class RulesetColumns {
       const getEditButtonPermissions = (item) => {
         return [
           {
-            action: `${this.tableProps?.clusterStatus?.contextConfigServer}:read_file`,
+            action: `${((this.tableProps || {}).clusterStatus || {}).contextConfigServer}:read_file`,
             resource: `file:path:${item.relative_dirname}/${item.filename}`,
           },
           {
-            action: `${this.tableProps?.clusterStatus?.contextConfigServer}:read`,
+            action: `${((this.tableProps || {}).clusterStatus || {}).contextConfigServer}:read`,
             resource: `node:id:*`,
           },
           { action: 'lists:read', resource: `list:path:${item.filename}` },
@@ -290,7 +290,7 @@ export default class RulesetColumns {
                 />
                 <WzButtonPermissions
                   buttonType='icon'
-                  permissions={[{action: `${this.tableProps?.clusterStatus?.contextConfigServer}:delete_file`, resource: `file:path:${item.relative_dirname}/${item.filename}`}]}
+                  permissions={[{action: `${((this.tableProps || {}).clusterStatus || {}).contextConfigServer}:delete_file`, resource: `file:path:${item.relative_dirname}/${item.filename}`}]}
                   aria-label="Show content"
                   iconType="trash"
                   tooltip={{position: 'top', content:(defaultItems.indexOf(`${item.relative_dirname}`) === -1) ? `Delete ${item.filename}` : `The ${item.filename} list cannot be deleted`}}

--- a/public/controllers/management/components/upload-files.js
+++ b/public/controllers/management/components/upload-files.js
@@ -251,7 +251,12 @@ export class UploadFiles extends Component {
     const button = (
       <WzButtonPermissions
         buttonType='empty'
-        permissions={[{action: 'manager:upload_file', resource: `file:path:/etc/${this.props.msg}`}]}
+        permissions={[
+          {
+            action: `${((this.props || {}).clusterStatus || {}).contextConfigServer}:upload_file`,
+            resource: `file:path:/etc/${this.props.msg}`,
+          },
+        ]}
         iconType="importAction"
         iconSide="left"
         onClick={() => this.onButtonClick()}

--- a/public/controllers/management/components/upload-files.js
+++ b/public/controllers/management/components/upload-files.js
@@ -256,6 +256,10 @@ export class UploadFiles extends Component {
             action: `${((this.props || {}).clusterStatus || {}).contextConfigServer}:upload_file`,
             resource: `file:path:/etc/${this.props.msg}`,
           },
+          {
+            action: `cluster:status`,
+            resource: `*:*:*`,
+          },
         ]}
         iconType="importAction"
         iconSide="left"

--- a/public/controllers/management/components/upload-files.js
+++ b/public/controllers/management/components/upload-files.js
@@ -248,19 +248,33 @@ export class UploadFiles extends Component {
     });
   }
   render() {
+    const getPermissionsImportFiles = () => {
+      const permissions = [
+        {
+          action: 'cluster:status',
+          resource: `*:*:*`,
+        },
+      ];
+
+      if (((this.props || {}).clusterStatus || {}).contextConfigServer === 'cluster') {
+        permissions.push({
+          action: 'cluster:upload_file',
+          resource: `node:id:*`,
+        });
+      } else {
+        permissions.push({
+          action: 'manager:upload_file',
+          resource: `file:path:/etc/${this.props.msg}`,
+        });
+      }
+
+      return permissions;
+    };
+
     const button = (
       <WzButtonPermissions
-        buttonType='empty'
-        permissions={[
-          {
-            action: `${((this.props || {}).clusterStatus || {}).contextConfigServer}:upload_file`,
-            resource: `file:path:/etc/${this.props.msg}`,
-          },
-          {
-            action: `cluster:status`,
-            resource: `*:*:*`,
-          },
-        ]}
+        buttonType="empty"
+        permissions={getPermissionsImportFiles()}
         iconType="importAction"
         iconSide="left"
         onClick={() => this.onButtonClick()}

--- a/public/react-services/wz-user-permissions.test.ts
+++ b/public/react-services/wz-user-permissions.test.ts
@@ -17,8 +17,8 @@
  * under the License.
  */
 
-//import { WzUserPermissions } from './wz-user-permissions';
-import { checkMissingUserPermissions } from './wz-user-permissions1';
+import { WzUserPermissions } from './wz-user-permissions';
+//import { checkMissingUserPermissions } from './wz-user-permissions1';
 
 const requiredPermissionsCluster = [
   {
@@ -48,46 +48,34 @@ const requiredPermissionsManager = [
 
 const userClusterTest = {
   'lists:read': {
-    'list:path:*': 'allow',
     '*:*:*': 'allow',
+    'list:path:*': 'allow',
     'node:id:*': 'allow',
-    'file:path:etc/lists/audit-keys': 'allow',
-    'node:id:*&file:path:*': 'allow',
   },
   'cluster:status': {
-    'list:path:*': 'allow',
     '*:*:*': 'allow',
+    'list:path:*': 'allow',
     'node:id:*': 'allow',
-    'file:path:etc/lists/audit-keys': 'allow',
-    'node:id:*&file:path:*': 'allow',
   },
   'cluster:read': {
-    'list:path:*': 'allow',
     '*:*:*': 'allow',
+    'list:path:*': 'allow',
     'node:id:*': 'allow',
-    'file:path:etc/lists/audit-keys': 'allow',
-    'node:id:*&file:path:*': 'allow',
   },
   'cluster:read_file': {
-    'list:path:*': 'allow',
     '*:*:*': 'allow',
+    'list:path:*': 'allow',
     'node:id:*': 'allow',
-    'file:path:etc/lists/audit-keys': 'allow',
-    'node:id:*&file:path:*': 'allow',
   },
   'cluster:delete_file': {
-    'list:path:*': 'allow',
     '*:*:*': 'allow',
+    'list:path:*': 'allow',
     'node:id:*': 'allow',
-    'file:path:etc/lists/audit-keys': 'allow',
-    'node:id:*&file:path:*': 'allow',
   },
   'cluster:upload_file': {
-    'list:path:*': 'allow',
     '*:*:*': 'allow',
+    'list:path:*': 'allow',
     'node:id:*': 'allow',
-    'file:path:etc/lists/audit-keys': 'allow',
-    'node:id:*&file:path:*': 'allow',
   },
   rbac_mode: 'white',
 };
@@ -142,7 +130,7 @@ describe('Wazuh User Permissions', () => {
             resource: '*:*:*',
           },
         ];
-        const result = checkMissingUserPermissions(simplePermission, {
+        const result = WzUserPermissions.checkMissingUserPermissions(simplePermission, {
           'lists:read': {
             'list:path:*': 'allow',
           },
@@ -158,7 +146,7 @@ describe('Wazuh User Permissions', () => {
             resource: '*:*:*',
           },
         ];
-        const result = checkMissingUserPermissions(simplePermission, {
+        const result = WzUserPermissions.checkMissingUserPermissions(simplePermission, {
           'lists:read': {
             'list:path:*': 'allow',
           },
@@ -176,32 +164,41 @@ describe('Wazuh User Permissions', () => {
             resource: 'file:path:/etc/lists',
           },
         ];
-        const result = checkMissingUserPermissions(simplePermission, userManagerTest);
+        const result = WzUserPermissions.checkMissingUserPermissions(
+          simplePermission,
+          userManagerTest
+        );
         expect(result).toEqual(false); // false === all permissions OK
       });
 
       // it('Should return a simple missing permissions for cluster user', () => {
       //   const simplePermission = [
       //     {
-      //       action: 'cluster:read_file',
-      //       resource: 'node:id:*&file:path:*',
+      //       action: 'cluster:read',
+      //       resource: 'node:id:*',
       //     },
       //   ];
-      //   const result = checkMissingUserPermissions(simplePermission, userClusterTest);
+      //   const result = WzUserPermissions.checkMissingUserPermissions(
+      //     simplePermission,
+      //     userClusterTest
+      //   );
       //   expect(result).toEqual(false);
       // });
     });
 
-    // describe('Should return all the required permissions to show on view', () => {
-    //   it('Should return missing permissions for manager user', () => {
-    //     const result = checkMissingUserPermissions(requiredPermissionsManager, userClusterTest);
-    //     expect(result).toEqual(missingPermissionsForManagerUser);
-    //   });
-    //
-    //   it('Should return missing permissions for cluster user', () => {
-    //     const result = checkMissingUserPermissions(requiredPermissionsCluster, userClusterTest);
-    //     expect(result).toEqual(missingPermissionsForClusterUser);
-    //   });
-    // });
+    describe('Should return all the required permissions to show on view', () => {
+      it('Should return missing permissions for manager user', () => {
+        const result = WzUserPermissions.checkMissingUserPermissions(
+          requiredPermissionsManager,
+          userClusterTest
+        );
+        expect(result).toEqual(missingPermissionsForManagerUser);
+      });
+
+      it('Should return missing permissions for cluster user', () => {
+        const result = WzUserPermissions.checkMissingUserPermissions(requiredPermissionsCluster, userClusterTest);
+        expect(result).toEqual(missingPermissionsForClusterUser);
+      });
+    });
   });
 });

--- a/public/react-services/wz-user-permissions.test.ts
+++ b/public/react-services/wz-user-permissions.test.ts
@@ -1,0 +1,207 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+//import { WzUserPermissions } from './wz-user-permissions';
+import { checkMissingUserPermissions } from './wz-user-permissions1';
+
+const requiredPermissionsCluster = [
+  {
+    action: 'cluster:delete_file',
+    resource: 'file:path:etc/lists/security-eventchannel',
+  },
+];
+
+const requiredPermissionsManager = [
+  {
+    action: 'cluster:status',
+    resource: '*:*:*',
+  },
+  {
+    action: 'manager:read_file',
+    resource: 'file:path:/etc/lists',
+  },
+  {
+    action: 'manager:read',
+    resource: '*:*:*',
+  },
+  {
+    action: 'manager:upload_file',
+    resource: 'file:path:/etc/lists',
+  },
+];
+
+const userClusterTest = {
+  'lists:read': {
+    'list:path:*': 'allow',
+    '*:*:*': 'allow',
+    'node:id:*': 'allow',
+    'file:path:etc/lists/audit-keys': 'allow',
+    'node:id:*&file:path:*': 'allow',
+  },
+  'cluster:status': {
+    'list:path:*': 'allow',
+    '*:*:*': 'allow',
+    'node:id:*': 'allow',
+    'file:path:etc/lists/audit-keys': 'allow',
+    'node:id:*&file:path:*': 'allow',
+  },
+  'cluster:read': {
+    'list:path:*': 'allow',
+    '*:*:*': 'allow',
+    'node:id:*': 'allow',
+    'file:path:etc/lists/audit-keys': 'allow',
+    'node:id:*&file:path:*': 'allow',
+  },
+  'cluster:read_file': {
+    'list:path:*': 'allow',
+    '*:*:*': 'allow',
+    'node:id:*': 'allow',
+    'file:path:etc/lists/audit-keys': 'allow',
+    'node:id:*&file:path:*': 'allow',
+  },
+  'cluster:delete_file': {
+    'list:path:*': 'allow',
+    '*:*:*': 'allow',
+    'node:id:*': 'allow',
+    'file:path:etc/lists/audit-keys': 'allow',
+    'node:id:*&file:path:*': 'allow',
+  },
+  'cluster:upload_file': {
+    'list:path:*': 'allow',
+    '*:*:*': 'allow',
+    'node:id:*': 'allow',
+    'file:path:etc/lists/audit-keys': 'allow',
+    'node:id:*&file:path:*': 'allow',
+  },
+  rbac_mode: 'white',
+};
+
+const userManagerTest = [
+  {
+    'manager:read': {
+      '*:*:*': 'allow',
+      'file:path:*': 'allow',
+    },
+    'manager:upload_file': {
+      '*:*:*': 'allow',
+      'file:path:*': 'allow',
+    },
+    'manager:read_file': {
+      '*:*:*': 'allow',
+      'file:path:*': 'allow',
+    },
+    rbac_mode: 'white',
+  },
+];
+
+const missingPermissionsForClusterUser = [
+  {
+    action: 'cluster:delete_file',
+    resource: 'file:path:etc/lists/security-eventchannel',
+  },
+];
+
+const missingPermissionsForManagerUser = [
+  {
+    action: 'manager:read_file',
+    resource: 'file:path:/etc/lists',
+  },
+  {
+    action: 'manager:read',
+    resource: '*:*:*',
+  },
+  {
+    action: 'manager:upload_file',
+    resource: 'file:path:/etc/lists',
+  },
+];
+
+describe('Wazuh User Permissions', () => {
+  describe('Given a Json with permissions that the user does not have', () => {
+    describe('Should return a simple required permissions to show on view', () => {
+      it('Should return a simple missing permissions for manager user', () => {
+        const simplePermission = [
+          {
+            action: 'manager:status',
+            resource: '*:*:*',
+          },
+        ];
+        const result = checkMissingUserPermissions(simplePermission, {
+          'lists:read': {
+            'list:path:*': 'allow',
+          },
+          rbac_mode: 'white',
+        });
+        expect(result).toEqual(simplePermission);
+      });
+
+      it('Should return a simple missing permissions for cluster user', () => {
+        const simplePermission = [
+          {
+            action: 'cluster:status',
+            resource: '*:*:*',
+          },
+        ];
+        const result = checkMissingUserPermissions(simplePermission, {
+          'lists:read': {
+            'list:path:*': 'allow',
+          },
+          rbac_mode: 'white',
+        });
+        expect(result).toEqual(simplePermission);
+      });
+    });
+
+    describe('Should return all permissions ok', () => {
+      it('Should return all permissions ok for manager user', () => {
+        const simplePermission = [
+          {
+            action: 'manager:read_file',
+            resource: 'file:path:/etc/lists',
+          },
+        ];
+        const result = checkMissingUserPermissions(simplePermission, userManagerTest);
+        expect(result).toEqual(false); // false === all permissions OK
+      });
+
+      // it('Should return a simple missing permissions for cluster user', () => {
+      //   const simplePermission = [
+      //     {
+      //       action: 'cluster:read_file',
+      //       resource: 'node:id:*&file:path:*',
+      //     },
+      //   ];
+      //   const result = checkMissingUserPermissions(simplePermission, userClusterTest);
+      //   expect(result).toEqual(false);
+      // });
+    });
+
+    // describe('Should return all the required permissions to show on view', () => {
+    //   it('Should return missing permissions for manager user', () => {
+    //     const result = checkMissingUserPermissions(requiredPermissionsManager, userClusterTest);
+    //     expect(result).toEqual(missingPermissionsForManagerUser);
+    //   });
+    //
+    //   it('Should return missing permissions for cluster user', () => {
+    //     const result = checkMissingUserPermissions(requiredPermissionsCluster, userClusterTest);
+    //     expect(result).toEqual(missingPermissionsForClusterUser);
+    //   });
+    // });
+  });
+});

--- a/public/react-services/wz-user-permissions.test.ts
+++ b/public/react-services/wz-user-permissions.test.ts
@@ -25,6 +25,10 @@ const requiredPermissionsCluster = [
     action: 'cluster:delete_file',
     resource: 'file:path:etc/lists/security-eventchannel',
   },
+  {
+    action: `cluster:read_file`,
+    resource: `node:id:*&file:path:*`,
+  },
 ];
 
 const requiredPermissionsManager = [
@@ -103,6 +107,10 @@ const missingPermissionsForClusterUser = [
     action: 'cluster:delete_file',
     resource: 'file:path:etc/lists/security-eventchannel',
   },
+  {
+    action: 'cluster:read_file',
+    resource: 'node:id:*&file:path:*',
+  },
 ];
 
 const missingPermissionsForManagerUser = [
@@ -171,19 +179,19 @@ describe('Wazuh User Permissions', () => {
         expect(result).toEqual(false); // false === all permissions OK
       });
 
-      // it('Should return a simple missing permissions for cluster user', () => {
-      //   const simplePermission = [
-      //     {
-      //       action: 'cluster:read',
-      //       resource: 'node:id:*',
-      //     },
-      //   ];
-      //   const result = WzUserPermissions.checkMissingUserPermissions(
-      //     simplePermission,
-      //     userClusterTest
-      //   );
-      //   expect(result).toEqual(false);
-      // });
+      it('Should return a simple missing permissions for cluster user', () => {
+        const simplePermission = [
+          {
+            action: 'cluster:status',
+            resource: '*:*:*',
+          },
+        ];
+        const result = WzUserPermissions.checkMissingUserPermissions(
+          simplePermission,
+          userClusterTest
+        );
+        expect(result).toEqual(false);
+      });
     });
 
     describe('Should return all the required permissions to show on view', () => {
@@ -196,7 +204,10 @@ describe('Wazuh User Permissions', () => {
       });
 
       it('Should return missing permissions for cluster user', () => {
-        const result = WzUserPermissions.checkMissingUserPermissions(requiredPermissionsCluster, userClusterTest);
+        const result = WzUserPermissions.checkMissingUserPermissions(
+          requiredPermissionsCluster,
+          userClusterTest
+        );
         expect(result).toEqual(missingPermissionsForClusterUser);
       });
     });

--- a/public/react-services/wz-user-permissions.test.ts
+++ b/public/react-services/wz-user-permissions.test.ts
@@ -1,20 +1,13 @@
 /*
- * Licensed to Elasticsearch B.V. under one or more contributor
- * license agreements. See the NOTICE file distributed with
- * this work for additional information regarding copyright
- * ownership. Elasticsearch B.V. licenses this file to you under
- * the Apache License, Version 2.0 (the "License"); you may
- * not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Wazuh app - React hook for get query of Kibana searchBar
+ * Copyright (C) 2015-2020 Wazuh, Inc.
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
  *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
+ * Find more information about this on the LICENSE file.
  */
 
 import { WzUserPermissions } from './wz-user-permissions';

--- a/public/react-services/wz-user-permissions.test.ts
+++ b/public/react-services/wz-user-permissions.test.ts
@@ -18,7 +18,6 @@
  */
 
 import { WzUserPermissions } from './wz-user-permissions';
-//import { checkMissingUserPermissions } from './wz-user-permissions1';
 
 const requiredPermissionsCluster = [
   {

--- a/public/react-services/wz-user-permissions.ts
+++ b/public/react-services/wz-user-permissions.ts
@@ -975,38 +975,27 @@ export class WzUserPermissions{
           )
         : undefined;
 
-      if(userPermissions.rbac_mode === RBAC_MODE_BLACK){
-        // API RBAC mode = 'black'
-        if(!userPermissions[actionName]){ return false };
-        return userPermissions[actionName][actionResource] ? !isAllow(userPermissions[actionName][actionResource])
-        : userPermissions[actionName][actionResourceAll] ? !isAllow(userPermissions[actionName][actionResourceAll])
-        : userPartialResources ? userPartialResources.some(resource => !isAllow(userPermissions[actionName][resource]))
-        : wazuhPermissions[actionName].resources.find(resource => resource === RESOURCE_ANY_SHORT) && userPermissions[actionName][RESOURCE_ANY] ? !isAllow(userPermissions[actionName][RESOURCE_ANY])
-        : false
-      } else {
-        // API RBAC mode = 'white'
-        if (!userPermissions[actionName]) {
-          return true;
-        }
-
-        return userPermissions[actionName][actionResource]
-          ? !isAllow(userPermissions[actionName][actionResource])
-          : Object.keys(userPermissions[actionName]).some((resource) => {
-              return resource.match(actionResourceAll.replace('*', '\\*')) !== null;
-            })
-          ? Object.keys(userPermissions[actionName]).some((resource) => {
-              if (resource.match(actionResourceAll.replace('*', '\\*'))) {
-                return !isAllow(userPermissions[actionName][resource]);
-              }
-            })
-          : userPartialResources?.length
-          ? userPartialResources.some((resource) => !isAllow(userPermissions[actionName][resource]))
-          : wazuhPermissions[actionName].resources.find(
-              (resource) => resource === RESOURCE_ANY_SHORT
-            ) && userPermissions[actionName][RESOURCE_ANY]
-          ? !isAllow(userPermissions[actionName][RESOURCE_ANY])
-          : true;
+      if (!userPermissions[actionName]) {
+        return userPermissions.rbac_mode === RBAC_MODE_WHITE;
       }
+
+      return userPermissions[actionName][actionResource]
+        ? !isAllow(userPermissions[actionName][actionResource])
+        : Object.keys(userPermissions[actionName]).some((resource) => {
+            return resource.match(actionResourceAll.replace('*', '\\*')) !== null;
+          })
+        ? Object.keys(userPermissions[actionName]).some((resource) => {
+            if (resource.match(actionResourceAll.replace('*', '\\*'))) {
+              return !isAllow(userPermissions[actionName][resource]);
+            }
+          })
+        : userPartialResources?.length
+        ? userPartialResources.some((resource) => !isAllow(userPermissions[actionName][resource]))
+        : wazuhPermissions[actionName].resources.find(
+            (resource) => resource === RESOURCE_ANY_SHORT
+          ) && userPermissions[actionName][RESOURCE_ANY]
+        ? !isAllow(userPermissions[actionName][RESOURCE_ANY])
+        : userPermissions.rbac_mode === RBAC_MODE_WHITE;
     });
 
     return filtered.length ? filtered : false;

--- a/public/redux/actions/appStateActions.js
+++ b/public/redux/actions/appStateActions.js
@@ -157,4 +157,15 @@ export const updateToastNotificationsModal = toastNotification => {
     type: 'UPDATE_TOAST_NOTIFICATIONS_MODAL',
     toastNotification
   };
- };
+};
+
+/**
+ * Updates ClusterOrManagerConfiguration in the appState store
+ * @param clusterStatus
+ */
+export const updateClusterStatus = (clusterStatus) => {
+  return {
+    type: 'UPDATE_CLUSTER_STATUS',
+    clusterStatus,
+  };
+};

--- a/public/redux/reducers/appStateReducers.js
+++ b/public/redux/reducers/appStateReducers.js
@@ -120,6 +120,13 @@ const appStateReducers = (state = initialState, action) => {
     };
   }
 
+  if (action.type === 'UPDATE_CLUSTER_STATUS') {
+    return {
+      ...state,
+      clusterStatus: action.clusterStatus,
+    };
+  }
+
   return state;
 };
 

--- a/public/redux/reducers/appStateReducers.js
+++ b/public/redux/reducers/appStateReducers.js
@@ -23,7 +23,11 @@ const initialState = {
   showExploreAgentModalGlobal: false,
   userPermissions: {},
   userRoles: [],
-  toastNotification: false
+  toastNotification: false,
+  clusterStatus: {
+    status: false,
+    contextConfigServer: 'manager',
+  },
 };
 
 const appStateReducers = (state = initialState, action) => {
@@ -33,7 +37,7 @@ const appStateReducers = (state = initialState, action) => {
       currentAPI: action.currentAPI
     };
   }
-  
+
   if (action.type === 'SHOW_MENU') {
     return {
       ...state,

--- a/server/controllers/wazuh-api.js
+++ b/server/controllers/wazuh-api.js
@@ -111,7 +111,7 @@ export class WazuhApiCtrl {
             log('wazuh-api:getToken', error.message || error);
           }
         }
-      }  
+      }
       let token;
       if(await APIUserAllowRunAs.canUse(idHost)){
         token = await this.apiInterceptor.authenticateApi(idHost, authContext)
@@ -181,7 +181,7 @@ export class WazuhApiCtrl {
           'get',
           `${api.url}:${api.port}/agents`,
           { params: { agents_list: '000' } },
-          { idHost: id}          
+          { idHost: id}
         );
 
         if (responseAgents.status === 200) {
@@ -191,7 +191,7 @@ export class WazuhApiCtrl {
             'get',
             `${api.url}:${api.port}/cluster/status`,
             {},
-            { idHost: id }      
+            { idHost: id }
           );
           if (responseClusterStatus.status === 200) {
             if (responseClusterStatus.data.data.enabled === 'yes') {
@@ -1055,7 +1055,7 @@ export class WazuhApiCtrl {
         ? { message: responseBody.detail, code: responseError }
         : new Error('Unexpected error fetching data from the Wazuh API');
     } catch (error) {
-      if(error && error.response && error.response.status === 401){        
+      if(error && error.response && error.response.status === 401){
         return ErrorResponse(
           error.message || error,
           error.code ? `Wazuh API error: ${error.code}` : 3013,
@@ -1242,7 +1242,7 @@ export class WazuhApiCtrl {
       );
 
       const isList = req.payload.path.includes('/lists') && req.payload.filters && req.payload.filters.length && req.payload.filters.find(filter => filter._isCDBList);
-         
+
       const totalItems = (((output || {}).data || {}).data || {}).total_affected_items;
 
       if (totalItems && !isList) {
@@ -1327,7 +1327,7 @@ export class WazuhApiCtrl {
       } else if (output && output.data && output.data.data && !output.data.data.total_affected_items) {
         throw new Error('No results');
       } else {
-        throw new Error(`An error occurred fetching data from the Wazuh API${output && output.body && output.body.message ? `: ${output.body.message}` : ''}`);
+        throw new Error(`An error occurred fetching data from the Wazuh API ${output && output.data && output.data.detail ? `: ${output.data.detail}` : ''}`);
       }
     } catch (error) {
       log('wazuh-api:csv', error.message || error);


### PR DESCRIPTION
Hi team,

This PR resolves:
- Wrong permissions on edit CDB List with Cluster and Manager context configuration server.
- Added action to get context server and status.
- Context server is dynamically added to the CDBList edit button, add new, and delete.
Note: Policy `cluster:status` is necessary to get configuration context `manager` or `cluster`

Issue #2657 