### PR TITLE
Fixed typing error

### DIFF
--- a/public/components/add-modules-data/guides/audit.js
+++ b/public/components/add-modules-data/guides/audit.js
@@ -60,7 +60,7 @@ export default {
           type: 'input-number',
           values: { min: 1 },
           default_value: '',
-          placeholder: 'Frecuency',
+          placeholder: 'Frequency',
           validate_error_message: 'Any positive number of seconds'
         },
         {

--- a/public/utils/config-equivalences.js
+++ b/public/utils/config-equivalences.js
@@ -84,7 +84,7 @@ export const nameEquivalence = {
   'ip.ignore': 'IP ignore',
   'xpack.rbac.enabled': 'X-Pack RBAC',
   'wazuh.monitoring.enabled': 'Status',
-  'wazuh.monitoring.frequency': 'Frecuency',
+  'wazuh.monitoring.frequency': 'Frequency',
   'wazuh.monitoring.shards': 'Index shards',
   'wazuh.monitoring.replicas': 'Index replicas',
   'wazuh.monitoring.creation': 'Interval creation',


### PR DESCRIPTION
Hi team! This PR solves one type error in Settings>Configuration>Monitoring. The error was that "frecuency" was written instead of "frequency"
 
![image](https://user-images.githubusercontent.com/46006326/100712194-a7f55300-33b2-11eb-8556-b8a12014faaa.png)

<img width="1237" alt="Captura de pantalla 2020-12-01 a las 8 54 18" src="https://user-images.githubusercontent.com/46006326/100712317-de32d280-33b2-11eb-9e07-3b8b31e2ff7f.png">
