### PR TITLE
[Fix] Empty inventory data in Solaris agents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 
 - fix(fronted): fixed the check of API and APP version in health check [#2655](https://github.com/wazuh/wazuh-kibana-app/pull/2655)
 - Replace user by username key in the monitoring logic [#2654](https://github.com/wazuh/wazuh-kibana-app/pull/2654)
+- fix(frontend): Empty inventory data in Solaris agents [#2680](https://github.com/wazuh/wazuh-kibana-app/pull/2680)
 
 ## Wazuh v4.0.3 - Kibana v7.9.1, v7.9.3 - Revision 4013
 

--- a/public/components/agents/syscollector/components/syscollector-metrics.tsx
+++ b/public/components/agents/syscollector/components/syscollector-metrics.tsx
@@ -1,8 +1,8 @@
 import React, {  useState } from "react";
 import {EuiPanel, EuiFlexGroup, EuiFlexItem, EuiText, EuiLoadingSpinner, EuiIcon} from "@elastic/eui";
+import mapValues from 'lodash';
 import {useGenericRequest} from '../../../common/hooks/useGenericRequest';
 import { TimeService } from '../../../../react-services/time-service';
-
 
 export function InventoryMetrics({agent}) {
     const [params, setParams] = useState({});
@@ -14,13 +14,18 @@ export function InventoryMetrics({agent}) {
         }
       }
     const syscollector = useGenericRequest('GET', `/api/syscollector/${agent.id}`, params, (result) => {return (result || {}).data || {};});
-    
-    if(!syscollector.isLoading && (!syscollector.data.hardware || !syscollector.data.os)){
-        return <EuiPanel paddingSize="s" style={{margin: 16, textAlign: "center"}}>
-           <EuiIcon type="iInCircle" /> Not enough hardware or operating system information
-        </EuiPanel>
-    }
-    
+
+  if (
+    !syscollector.isLoading &&
+    (mapValues.isEmpty(syscollector.data.hardware) || mapValues.isEmpty(syscollector.data.os))
+  ) {
+    return (
+      <EuiPanel paddingSize="s" style={{ margin: 16, textAlign: 'center' }}>
+        <EuiIcon type="iInCircle" /> Not enough hardware or operating system information
+      </EuiPanel>
+    );
+  }
+
     return (
         <EuiPanel paddingSize="s" style={{margin: 16}}>
             <EuiFlexGroup>
@@ -45,6 +50,6 @@ export function InventoryMetrics({agent}) {
             </EuiFlexGroup>
         </EuiPanel>
         );
-    
-    
+
+
 }

--- a/public/components/agents/syscollector/components/syscollector-table.tsx
+++ b/public/components/agents/syscollector/components/syscollector-table.tsx
@@ -81,6 +81,13 @@ export function SyscollectorTable({ tableParams }) {
       return `(${data.total_affected_items})`;
   }
 
+  const downloadCsv = async () => {
+    await AppState.downloadCsv(
+      tableParams.path,
+      tableParams.exportFormatted,
+      !!params.search ? [{ name: 'search', value: params.search }] : []
+    )
+  }
 
   return (
     <EuiPanel paddingSize="m" style={{ margin: '12px 16px 12px 16px' }}>
@@ -121,13 +128,7 @@ export function SyscollectorTable({ tableParams }) {
           <EuiFlexItem grow={true} />
           <EuiFlexItem grow={false}>
             <EuiButtonEmpty
-              onClick={async () =>
-                await AppState.downloadCsv(
-                  tableParams.path,
-                  tableParams.exportFormatted,
-                  !!params.search ? [{ name: 'search', value: params.search }] : []
-                )
-              }
+              onClick={downloadCsv}
               iconType="importAction"
             >
               Download CSV

--- a/public/components/agents/syscollector/components/syscollector-table.tsx
+++ b/public/components/agents/syscollector/components/syscollector-table.tsx
@@ -36,7 +36,7 @@ export function SyscollectorTable({ tableParams }) {
   };
 
   const buildColumns = () => {
-    const columns = (tableParams.columns || []).map(item => {
+    return (tableParams.columns || []).map(item => {
       return {
         field: item.id,
         name: KeyEquivalence[item.id] || item.id,
@@ -44,7 +44,6 @@ export function SyscollectorTable({ tableParams }) {
         width: item.width || undefined,
       };
     });
-    return columns ? columns : [];
   };
 
   const columns = buildColumns();

--- a/public/components/agents/syscollector/components/syscollector-table.tsx
+++ b/public/components/agents/syscollector/components/syscollector-table.tsx
@@ -36,16 +36,16 @@ export function SyscollectorTable({ tableParams }) {
   };
 
   const buildColumns = () => {
-    const columns = tableParams.columns.map(item => {
+    const columns = (tableParams.columns || []).map(item => {
       return {
         field: item.id,
         name: KeyEquivalence[item.id] || item.id,
         sortable: typeof item.sortable !== 'undefined' ? item.sortable : true,
         width: item.width || undefined,
-      }
+      };
     });
-    return columns;
-  }
+    return columns ? columns : [];
+  };
 
   const columns = buildColumns();
 
@@ -117,19 +117,25 @@ export function SyscollectorTable({ tableParams }) {
           />
         </EuiFlexItem>
       </EuiFlexGroup>
-      {tableParams.exportFormatted &&
-        <EuiFlexGroup >
-          <EuiFlexItem grow={true} > </EuiFlexItem>
-          <EuiFlexItem grow={false} >
+      {tableParams.exportFormatted && tableParams.columns && (
+        <EuiFlexGroup>
+          <EuiFlexItem grow={true} />
+          <EuiFlexItem grow={false}>
             <EuiButtonEmpty
-              onClick={async () => await AppState.downloadCsv(tableParams.path, tableParams.exportFormatted, !!params.search ? [{ name: 'search', value: params.search }] : [])}
-              iconType="importAction">
+              onClick={async () =>
+                await AppState.downloadCsv(
+                  tableParams.path,
+                  tableParams.exportFormatted,
+                  !!params.search ? [{ name: 'search', value: params.search }] : []
+                )
+              }
+              iconType="importAction"
+            >
               Download CSV
             </EuiButtonEmpty>
           </EuiFlexItem>
         </EuiFlexGroup>
-      }
-
+      )}
     </EuiPanel>
   );
 }


### PR DESCRIPTION
Hi team!
### Description
- When entering Inventory Data for a Solaris agent, the entire view was blank. 
- The necessary validations were carried out, to show all fields correctly, with their data empty.
eg: Solaris agent:
![image](https://user-images.githubusercontent.com/11060558/101635174-5e3ae700-3a08-11eb-840c-482688b0495c.png)
eg: Ubuntu agent:
![image](https://user-images.githubusercontent.com/11060558/101635337-96dac080-3a08-11eb-8db2-be85c49b9dac.png)

Issue: #2484 