### PR TITLE
fix(frontend): add the metafields when refreshing the index pattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 
 - Create index pattern even if there aren´t available indices [#2620](https://github.com/wazuh/wazuh-kibana-app/issues/2620)
 - Top bar overlayed over expanded visualizations [#2667](https://github.com/wazuh/wazuh-kibana-app/issues/2667)
+- fix(frontend): add the metafields when refreshing the index pattern [#2681](https://github.com/wazuh/wazuh-kibana-app/pull/2681)
 
 ## Wazuh v4.0.3 - Kibana v7.9.1, v7.9.2, v7.9.3 - Revision 4014
 

--- a/public/react-services/saved-objects.js
+++ b/public/react-services/saved-objects.js
@@ -221,7 +221,7 @@ export class SavedObject {
   static getIndicesFields = async (pattern) => GenericRequest.request(
     //we check if indices exist before creating the index pattern
     'GET',
-    `/api/index_patterns/_fields_for_wildcard?pattern=${pattern}`,
+    `/api/index_patterns/_fields_for_wildcard?pattern=${pattern}&meta_fields=_source&meta_fields=_id&meta_fields=_type&meta_fields=_index&meta_fields=_score`,
     {}
   ).then(response => response.data.fields).catch(() => KnownFields)
 }

--- a/public/utils/known-fields.js
+++ b/public/utils/known-fields.js
@@ -1,5 +1,52 @@
 export const KnownFields = [
   {
+    "name": "_id",
+    "type": "string",
+    "esTypes": [
+      "_id"
+    ],
+    "searchable": true,
+    "aggregatable": true,
+    "readFromDocValues": false
+  },
+  {
+    "name": "_index",
+    "type": "string",
+    "esTypes": [
+      "_index"
+    ],
+    "searchable": true,
+    "aggregatable": true,
+    "readFromDocValues": false
+  },
+  {
+    "name": "_score",
+    "type": "number",
+    "searchable": false,
+    "aggregatable": false,
+    "readFromDocValues": false
+  },
+  {
+    "name": "_source",
+    "type": "_source",
+    "esTypes": [
+      "_source"
+    ],
+    "searchable": false,
+    "aggregatable": false,
+    "readFromDocValues": false
+  },
+  {
+    "name": "_type",
+    "type": "string",
+    "esTypes": [
+    "_type"
+    ],
+    "searchable": true,
+    "aggregatable": true,
+    "readFromDocValues": false
+  },
+  {
     "name": "@timestamp",
     "type": "date",
     "esTypes": [


### PR DESCRIPTION
Hi team, 

this PR resolves:
- Add the metafields `_id`, `_index`,  `_score` `_source`, `_type` when refreshing index patterns. Included in the known fields too.