### PR TITLE
fix route in getCurrentUser when AWS Elasticsearch is used

### DIFF
--- a/server/lib/security-factory/factories/opendistro-factory.ts
+++ b/server/lib/security-factory/factories/opendistro-factory.ts
@@ -11,7 +11,7 @@ export class OpendistroFactory implements ISecurityFactory {
     try {
       const elasticRequest = this.server.plugins.elasticsearch.getCluster('data');
       const params = {
-        path: `_opendistro/_security/api/account`,
+        path: `/_opendistro/_security/api/account`,
         method: 'GET',
       };
       


### PR DESCRIPTION
When using AWS Elasticsearch 7.9.1 error "bad request" appearing. All works if "path" in OpendistroFactory.getCurrentUser() starts with "/".
![image](https://user-images.githubusercontent.com/37391150/103096073-c6e2b000-4613-11eb-962f-3deae7f0c5bb.png)
![image](https://user-images.githubusercontent.com/37391150/103096056-b8949400-4613-11eb-8cf1-f716c30cc742.png)

