### PR TITLE
fix getListOfIndexPatterns() when required patterns are not on 1st page

### DIFF
--- a/public/react-services/saved-objects.js
+++ b/public/react-services/saved-objects.js
@@ -22,7 +22,7 @@ export class SavedObject {
     try {
       const result = await GenericRequest.request(
         'GET',
-        `/api/saved_objects/_find?type=index-pattern&search_fields=title`
+        `/api/saved_objects/_find?type=index-pattern&search_fields=title&per_page=9999`
       );
       const indexPatterns = ((result || {}).data || {}).saved_objects || [];
 


### PR DESCRIPTION
Wazuh UI retrieves index patterns and checks that at least one from list with required fields exists. By default in getListOfIndexPatterns() there is no "per page" parameter sending, so only first 20 index patterns are returning even if there are more than 20 index patterns. So in situation with >20 index patterns and when required index patterns are not on 1st page, Wazuh UI shows error "Sorry but no valid index patterns were found" even if valid index patterns are exist.
![image](https://user-images.githubusercontent.com/37391150/103096271-70c23c80-4614-11eb-9c95-ba59a947b77d.png)
![image](https://user-images.githubusercontent.com/37391150/103096281-79b30e00-4614-11eb-819f-3dad870fb9aa.png)
![image](https://user-images.githubusercontent.com/37391150/103096283-7ddf2b80-4614-11eb-817a-91d77a96d610.png)
This PR changes getListOfIndexPatterns() method to retrieve 9999 index-patterns, so required index patterns will be always returned on check by Web UI.

