### PR TITLE
Feature/2713 error toast is showing about elasticsearch users for environments without security

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Top bar overlayed over expanded visualizations [#2667](https://github.com/wazuh/wazuh-kibana-app/issues/2667)
 - Wrong permissions on edit CDB list [#2665](https://github.com/wazuh/wazuh-kibana-app/pull/2665)
 - fix(frontend): add the metafields when refreshing the index pattern [#2681](https://github.com/wazuh/wazuh-kibana-app/pull/2681)
+- Error toast is showing about Elasticsearch users for environments without security [#2713](https://github.com/wazuh/wazuh-kibana-app/issues/2713)
 
 ## Wazuh v4.0.3 - Kibana v7.9.1, v7.9.2, v7.9.3 - Revision 4014
 

--- a/public/components/security/roles-mapping/roles-mapping.tsx
+++ b/public/components/security/roles-mapping/roles-mapping.tsx
@@ -79,7 +79,9 @@ export const RolesMapping = () => {
   const initData = async () => {
     setLoadingTable(true);
     await getRules();
-    await getInternalUsers();
+    if(currentPlatform !== "elastic"){
+      await getInternalUsers();
+    }
     setLoadingTable(false);
   };
 


### PR DESCRIPTION
Solving issue #2713 
For Elasticsearch without security, we are trying to get the Elasticsearch users when it shouldn't for this case.

- We have fixed it by creating a conditional that only if you have the security plugin can make the request
Closes #2713 