### PR TITLE
Fixed error due to new use of path in the export of lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Top bar overlayed over expanded visualizations [#2667](https://github.com/wazuh/wazuh-kibana-app/issues/2667)
 - Wrong permissions on edit CDB list [#2665](https://github.com/wazuh/wazuh-kibana-app/pull/2665)
 - fix(frontend): add the metafields when refreshing the index pattern [#2681](https://github.com/wazuh/wazuh-kibana-app/pull/2681)
+- Error 500 on Export formatted CDB list [#2692](https://github.com/wazuh/wazuh-kibana-app/pull/2692)
 
 ## Wazuh v4.0.3 - Kibana v7.9.1, v7.9.2, v7.9.3 - Revision 4014
 

--- a/public/controllers/management/components/management/ruleset/list-editor.js
+++ b/public/controllers/management/components/management/ruleset/list-editor.js
@@ -593,12 +593,17 @@ class WzListEditor extends Component {
                         try {
                           this.setState({ generatingCsv: true });
                           await exportCsv(
-                            `/lists?path=${path}/${name}`,
+                            `/lists`,
                             [
                               {
                                 _isCDBList: true,
-                                name: 'path',
-                                value: `${path}/${name}`
+                                name: 'relative_dirname',
+                                value: `${path}`
+                              },
+                              {
+                                _isCDBList: true,
+                                name: 'filename',
+                                value: `${name}`
                               }
                             ],
                             name

--- a/public/controllers/management/components/management/ruleset/list-editor.js
+++ b/public/controllers/management/components/management/ruleset/list-editor.js
@@ -598,12 +598,12 @@ class WzListEditor extends Component {
                               {
                                 _isCDBList: true,
                                 name: 'relative_dirname',
-                                value: `${path}`
+                                value: path
                               },
                               {
                                 _isCDBList: true,
                                 name: 'filename',
-                                value: `${name}`
+                                value: name
                               }
                             ],
                             name


### PR DESCRIPTION
Hi team, we resolve the issue #2692 with this steps:
- We change `path` to `relative_dirname` and `filename` (which is the new way to use it) and instead of concatenating name, we pass another filter passing this name to filename