### PR TITLE
Fixed Wui rules label should have only one tooltip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Error toast is showing about Elasticsearch users for environments without security [#2713](https://github.com/wazuh/wazuh-kibana-app/issues/2713)
 - Error about Handler.error in Role Mapping fixed [#2702](https://github.com/wazuh/wazuh-kibana-app/issues/2702)
 - Fixed message in reserved users actions [#2702](https://github.com/wazuh/wazuh-kibana-app/issues/2702)
-
+- Wui rules label should have only one tooltip [#2723](https://github.com/wazuh/wazuh-kibana-app/issues/2723)
 ## Wazuh v4.0.3 - Kibana v7.9.1, v7.9.2, v7.9.3 - Revision 4014
 
 ### Added

--- a/public/components/security/roles-mapping/components/roles-mapping-table.tsx
+++ b/public/components/security/roles-mapping/components/roles-mapping-table.tsx
@@ -67,7 +67,7 @@ export const RolesMappingTable = ({ rolesEquivalences, rules, loading, editRule,
               <EuiFlexGroup>
               <EuiBadge color="primary">Reserved</EuiBadge>
                 <EuiToolTip position="top" content="wui_ rules belong to wazuh-wui API user">
-                  <EuiBadge color="accent" style={{ marginLeft: 10 }}>wazuh-wui</EuiBadge>
+                  <EuiBadge color="accent" title="" style={{ marginLeft: 10 }}>wazuh-wui</EuiBadge>
                 </EuiToolTip>
               </EuiFlexGroup>
             );


### PR DESCRIPTION
Hi team, we resolve the bug that wui rules show double tooltip when it have to show only one.
Closes #2723 