### PR TITLE
4.0-7.10 - Fix calls to undefined method ErrorHandler.error

### DIFF
--- a/public/components/security/roles-mapping/components/roles-mapping-table.tsx
+++ b/public/components/security/roles-mapping/components/roles-mapping-table.tsx
@@ -100,7 +100,7 @@ export const RolesMappingTable = ({ rolesEquivalences, rules, loading, editRule,
                 ErrorHandler.info('Role mapping was successfully deleted');
                 updateRules();
               } catch (err) {
-                ErrorHandler.error(err);
+                ErrorHandler.handle(err, 'Error deleting the role mapping');
               }
             }}
             modalProps={{ buttonColor: 'danger' }}

--- a/public/components/security/users/components/users-table.tsx
+++ b/public/components/security/users/components/users-table.tsx
@@ -79,7 +79,7 @@ export const UsersTable = ({ users, editUserFlyover, rolesLoading, roles, onSave
                 ErrorHandler.info('User was successfully deleted');
                 onSave();
               } catch (err) {
-                ErrorHandler.error(err);
+                ErrorHandler.handle(err, 'Error deleting the user');
               }
             }}
             modalProps={{ buttonColor: 'danger' }}


### PR DESCRIPTION
Hi team, this PR resolves:
- Remove calls to an undefined method `ErrorHandler.error`