### PR TITLE
4.0-7.10 - Add a Kibana log when the <KIBANA_PATH>/data directory is missing

### DIFF
--- a/common/constants.ts
+++ b/common/constants.ts
@@ -90,8 +90,9 @@ export const WAZUH_INDEX_REPLICAS = 0;
 export const WAZUH_API_RESERVED_ID_LOWER_THAN = 100;
 
 // Wazuh data path
-export const WAZUH_DATA_PATH = 'data/wazuh';
-export const WAZUH_DATA_ABSOLUTE_PATH = path.join(__dirname, '../../../', WAZUH_DATA_PATH);
+const WAZUH_DATA_KIBANA_BASE_PATH = 'data';
+export const WAZUH_DATA_KIBANA_BASE_ABSOLUTE_PATH = path.join(__dirname, '../../../', WAZUH_DATA_KIBANA_BASE_PATH);
+export const WAZUH_DATA_ABSOLUTE_PATH = path.join(WAZUH_DATA_KIBANA_BASE_ABSOLUTE_PATH, 'wazuh');
 
 // Wazuh data path - config
 export const WAZUH_DATA_CONFIG_DIRECTORY_PATH = path.join(WAZUH_DATA_ABSOLUTE_PATH, 'config');

--- a/server/start/initialize/index.ts
+++ b/server/start/initialize/index.ts
@@ -16,7 +16,7 @@ import { getConfiguration } from '../../lib/get-configuration';
 import { totalmem } from 'os';
 import fs from 'fs';
 import { ManageHosts } from '../../lib/manage-hosts';
-import { WAZUH_ALERTS_PATTERN, WAZUH_DATA_CONFIG_REGISTRY_PATH, WAZUH_INDEX, WAZUH_VERSION_INDEX, WAZUH_KIBANA_TEMPLATE_NAME } from '../../../common/constants';
+import { WAZUH_ALERTS_PATTERN, WAZUH_DATA_CONFIG_REGISTRY_PATH, WAZUH_INDEX, WAZUH_VERSION_INDEX, WAZUH_KIBANA_TEMPLATE_NAME, WAZUH_DATA_KIBANA_BASE_ABSOLUTE_PATH } from '../../../common/constants';
 import { createDataDirectoryIfNotExists } from '../../lib/filesystem';
 
 const manageHosts = new ManageHosts();
@@ -204,6 +204,10 @@ export function jobInitializeRun(context) {
           'debug'
         );
       }
+
+      if(!fs.existsSync(WAZUH_DATA_KIBANA_BASE_ABSOLUTE_PATH)){
+        throw new Error(`The data directory is missing in the Kibana root instalation. Create the directory in ${WAZUH_DATA_KIBANA_BASE_ABSOLUTE_PATH} and give it the required permissions. (sudo mkdir ${WAZUH_DATA_KIBANA_BASE_ABSOLUTE_PATH};sudo chown -R kibana:kibana ${WAZUH_DATA_KIBANA_BASE_ABSOLUTE_PATH})`);
+      };
 
       if (!fs.existsSync(WAZUH_DATA_CONFIG_REGISTRY_PATH)) {
         log(


### PR DESCRIPTION
Hi team, this PR resolves:
- Add a Kibana log if the `<KIBANA_PATH>/data` directory doesn't exist when the plugin is started

![image](https://user-images.githubusercontent.com/34042064/105154241-a2420100-5b09-11eb-953e-88c520582744.png)
