### PR TITLE
4.0-7.10 - Fix imports of index type constants in saved-objects.js

### DIFF
--- a/public/react-services/saved-objects.js
+++ b/public/react-services/saved-objects.js
@@ -11,9 +11,11 @@
  */
 
 import { GenericRequest } from './generic-request';
-import { KnownFields } from '../utils/known-fields'
-import { FieldsStatistics } from '../utils/statistics-fields'
-import { FieldsMonitoring } from '../utils/monitoring-fields'
+import { KnownFields } from '../utils/known-fields';
+import { FieldsStatistics } from '../utils/statistics-fields';
+import { FieldsMonitoring } from '../utils/monitoring-fields';
+import { WAZUH_INDEX_TYPE_MONITORING, WAZUH_INDEX_TYPE_STATISTICS, WAZUH_INDEX_TYPE_ALERTS} from '../../common/constants';
+
 export class SavedObject {
   /**
    *


### PR DESCRIPTION
Hi team, this PR resolves:

- Fix imports of index type constants in `saved-objects.js`