### PR TITLE
4.0-7.10 - Add agent id to the reports name in Agent Inventory and Modules

### DIFF
--- a/public/react-services/reporting.js
+++ b/public/react-services/reporting.js
@@ -93,7 +93,7 @@ export class ReportingService {
 
       const array = await this.vis2png.checkArray(idArray);
       const name = `wazuh-${
-        agents ? 'agents' : 'overview'
+        agents ?  `agent-${agents}` : 'overview'
       }-${tab}-${(Date.now() / 1000) | 0}.pdf`;
 
       const browserTimezone = moment.tz.guess(true);


### PR DESCRIPTION
Hi team, this PR resolves:
- Add the agent ID to the reports name in Agent Inventory and Modules

Closes https://github.com/wazuh/wazuh-kibana-app/issues/2813