### PR TITLE
[4.0.4-7.10.0] Fix mitre framework tab crash

### DIFF
--- a/public/components/kbn-search-bar/kbn-search-bar.tsx
+++ b/public/components/kbn-search-bar/kbn-search-bar.tsx
@@ -12,7 +12,8 @@
 
 import React from 'react';
 import { I18nProvider } from '@kbn/i18n/react';
-import { SearchBar, TimeRange, Query, Filter } from '../../../../../src/plugins/data/public';
+import { TimeRange, Query, Filter } from '../../../../../src/plugins/data/public';
+
 import { KibanaContextProvider } from '../../../../../src/plugins/kibana_react/public';
 import { withKibanaContext, withKibanaContextExtendsProps } from '../common/hocs';
 import { storage } from './lib';
@@ -24,6 +25,8 @@ export interface IKbnSearchBarProps {
   onQuerySubmit?: (payload: { dateRange: TimeRange; query: Query }) => void;
   onFiltersUpdated?: (filters: Filter[]) => void;
 }
+
+const SearchBar = getDataPlugin().ui.SearchBar;
 
 const KbnSearchBar: React.FunctionComponent<IKbnSearchBarProps> = (
   props: IKbnSearchBarProps & withKibanaContextExtendsProps

--- a/public/types.ts
+++ b/public/types.ts
@@ -23,6 +23,7 @@ export type WazuhSetupPlugins = {
   uiActions: UiActionsSetup;
   visualizations: VisualizationsSetup;
   data: DataPublicPluginSetup;
+  navigation: NavigationPublicPluginStart;
 }
 
 export type WazuhStartPlugins = AppPluginStartDependencies;


### PR DESCRIPTION
Hi team, this resolves
- Mitre module crash when tab Framework is opened in Kibana prod

The same fix solve the same problem in PCI DSS , HIPPA , GDPR , TSC , NIST 800-53

Closes #2808 