### PR TITLE
fix(frontend): Fix searching in groups

### DIFF
--- a/public/controllers/management/components/management/groups/groups-table.js
+++ b/public/controllers/management/components/management/groups/groups-table.js
@@ -23,7 +23,6 @@ import { compose } from 'redux';
 import GroupsHandler from './utils/groups-handler';
 import { getToasts }  from '../../../../../kibana-services';
 import { WzSearchBar, filtersToObject } from '../../../../../components/wz-search-bar';
-import { WzRequest } from '../../../../../react-services/wz-request';
 import { withUserPermissions } from '../../../../../components/common/hocs/withUserPermissions';
 import { WzUserPermissions } from '../../../../../react-services/wz-user-permissions';
 
@@ -65,7 +64,7 @@ class WzGroupsTable extends Component {
 
   shouldComponentUpdate(nextProps, nextState) {
     const { items, filters } = this.state;
-    const { isProcessing, showModal } = this.props.state;
+    const { isProcessing, showModal, isLoading } = this.props.state;
     if (showModal !== nextProps.state.showModal)
       return true;
     if (isProcessing !== nextProps.state.isProcessing)
@@ -73,6 +72,8 @@ class WzGroupsTable extends Component {
     if (JSON.stringify(items) !== JSON.stringify(nextState.items))
       return true;
     if (JSON.stringify(filters) !== JSON.stringify(nextState.filters))
+      return true;
+    if (isLoading !== nextProps.state.isLoading)
       return true;
     return false;
   }
@@ -95,19 +96,29 @@ class WzGroupsTable extends Component {
    * Loads the initial information
    */
   async getItems() {
-    try {
-      const rawItems = await this.groupsHandler.listGroups({ params: this.buildFilter() });
-      const { affected_items, total_affected_items } = ((rawItems || {}).data || {}).data;
-
-      this.setState({
-        items : affected_items,
-        totalItems : total_affected_items
-      });
-      this.props.state.isProcessing && this.props.updateIsProcessing(false);
-    } catch (error) {
-      this.props.state.isProcessing && this.props.updateIsProcessing(false);
-      return Promise.reject(error);
-    }
+    this.setState({items:[], totalItems: 0}, async () => {
+      try {
+        this.props.updateLoadingStatus(true);
+        const rawItems = await this.groupsHandler.listGroups({ params: this.buildFilter() });
+        const { affected_items, total_affected_items } = ((rawItems || {}).data || {}).data;
+  
+        this.setState({
+          items : affected_items,
+          totalItems : total_affected_items
+        });
+        this.props.updateLoadingStatus(false);
+        this.props.state.isProcessing && this.props.updateIsProcessing(false);
+      } catch (error) {
+        this.props.updateLoadingStatus(false);
+        this.props.state.isProcessing && this.props.updateIsProcessing(false);
+        getToasts().add({
+          color: 'danger',
+          title: 'Error getting groups',
+          text: error.message || String(error)
+        });
+        return Promise.reject(error);
+      }
+    })
   }
 
   buildFilter() {


### PR DESCRIPTION
Hi team, this PR resolves:
- Fix searching of groups in Management > Groups
  - Reset to 0 the items after search.
  - Add loading status.
  - Add toast when getting the groups fails.
  
Closes: #2812