### PR TITLE
[4.0.4-7.10.0] solaris should not show vulnerabilities module

### DIFF
--- a/public/utils/components-os-support.js
+++ b/public/utils/components-os-support.js
@@ -14,6 +14,6 @@ export const UnsupportedComponents = {
   linux: [],
   windows: ['audit', 'oscap', 'docker'],
   darwin: ['audit', 'oscap', 'vuls', 'docker'],
-  sunos: [],
+  sunos: ['vuls'],
   other: ['audit', 'oscap', 'vuls', 'docker']
 };


### PR DESCRIPTION
Hi team, this resolves

- The Vulnerabilities module should not show for agent Solaris.

Closes #2819 