### PR TITLE
4.0-7.10 - Fix metrics are not updated after a bad request in search input

### DIFF
--- a/public/components/overview/metrics/metrics.tsx
+++ b/public/components/overview/metrics/metrics.tsx
@@ -138,7 +138,7 @@ export class Metrics extends Component {
       filterParams["time"] = this.timefilter.getTime(); 
       filterParams["query"] = searchBarQuery; 
       filterParams["filters"] = this.filterManager.getFilters(); 
-      this.setState({filterParams, loading: true, results:{}})
+      this.setState({filterParams, loading: true});
       const newOnClick = {};
       
       const result = this.metricsList[this.props.section].map(async(item)=> {
@@ -250,7 +250,9 @@ export class Metrics extends Component {
           const key = Object.keys(item)[0]
           newResults[key] = item[key];
         });
-        this.setState({results: newResults, loading:false, buildingMetrics: false, metricsOnClicks: newOnClick})
+        this.setState({results: newResults, loading:false, buildingMetrics: false, metricsOnClicks: newOnClick});
+      }).catch(error => {
+        this.setState({loading: false, buildingMetrics: false});
       });
     
   }


### PR DESCRIPTION
Hi team, this PR resolves:
- Fix the metrics are not updated after a bad request with a bad query in the search input

Closes #2822