### PR TITLE
Fix Agent Search Bar - Regex Query Interpreter

### DIFF
--- a/public/components/wz-search-bar/lib/q-interpreter.ts
+++ b/public/components/wz-search-bar/lib/q-interpreter.ts
@@ -36,7 +36,7 @@ export class QInterpreter {
       const firstConjuntion = / and | or /i.exec(query);
       const currentQ = !!firstConjuntion ? query.slice(0, firstConjuntion.index) : query;
       const descomposeQuery = currentQ && descomposeRegex.exec(currentQ);
-      const { 1: conjuntion = undefined, 2: field = '', 3: operator = undefined, 4: value = undefined } = descomposeQuery || [];
+      const { conjuntion = undefined, field = '', operator = undefined, value = undefined } = descomposeQuery.groups || [];
       const queryObj: queryObject = { conjuntion, field, operator, value }
       queries.push(queryObj)
       if (firstConjuntion) return getQueryObjects(query.slice(firstConjuntion.index + 1), queries);


### PR DESCRIPTION
Hi team, this PR fixes:

**Search bar filters in Agents view.**
Misreading of a regular expression caused misinterpretation o the search input value.
Closes: [#2810](https://github.com/wazuh/wazuh-kibana-app/issues/2810)