### PR TITLE
Fixed permissions to access agents

### DIFF
--- a/public/react-services/wz-user-permissions.test.ts
+++ b/public/react-services/wz-user-permissions.test.ts
@@ -223,5 +223,63 @@ describe('Wazuh User Permissions', () => {
         expect(result).toEqual(missingPermissionsForClusterUser);
       });
     });
+
+    describe('Should return all the required permissions to show Agent and Groups view', () => {
+      const requiredAgentView = [
+        {
+          action: 'agent:read',
+          resource: 'agent:id:*',
+        },
+        {
+          action: 'group:read',
+          resource: 'group:id:*',
+        },
+      ];
+      const userAgent1 = {
+        'agent:read': {
+          'agent:id:001': 'allow',
+        },
+        'group:read': {
+          'group:id:001': 'allow',
+        },
+        rbac_mode: 'white',
+      };
+      it('Should return OK for particular agent and group id', () => {
+        const result = WzUserPermissions.checkMissingUserPermissions(
+          requiredAgentView,
+          userAgent1
+        );
+        expect(result).toEqual(false);
+      });
+    });
+
+    describe('Should return all the required permissions to show Agent and Groups view', () => {
+      const requiredAgentView = [
+        {
+          action: 'agent:read',
+          resource: 'agent:id:*',
+        },
+        {
+          action: 'group:read',
+          resource: 'group:id:*',
+        },
+      ];
+      const userAgent1 = {
+        'agent:read': {
+          'agent:id:*': 'allow',
+        },
+        'group:read': {
+          'group:id:*': 'allow',
+        },
+        rbac_mode: 'white',
+      };
+      it('Should return OK for all agents and groups', () => {
+        const result = WzUserPermissions.checkMissingUserPermissions(
+          requiredAgentView,
+          userAgent1
+        );
+        expect(result).toEqual(false);
+      });
+    });
   });
 });

--- a/public/react-services/wz-user-permissions.ts
+++ b/public/react-services/wz-user-permissions.ts
@@ -971,7 +971,7 @@ export class WzUserPermissions{
                 (resource.match(`/${actionResource}/`) || resource.match(`/${actionResourceAll}/`))
               : ![actionResource, actionResourceAll].includes(resource) &&
                 (resource.match(actionResource.replace('*', '\\*')) ||
-                  resource.match(actionResourceAll.replace('*', '\\*')))
+                  resource.match(actionResourceAll.replace('*', '\*')))
           )
         : undefined;
 


### PR DESCRIPTION
Hi team, this PR resolves:
- A user is able to see the list of its allowed agents, at first is only able to see agent 001 and by adding permissions to read agent 002 it appears in its list after refreshing.

Issue: https://github.com/wazuh/wazuh-kibana-app/issues/2801#issuecomment-765528832