### PR TITLE
Bugfix/2840 search file editor gone

### DIFF
--- a/public/components/security/roles-mapping/components/rule-editor.tsx
+++ b/public/components/security/roles-mapping/components/rule-editor.tsx
@@ -30,6 +30,7 @@ import { WAZUH_SECURITY_PLUGIN_OPEN_DISTRO_FOR_ELASTICSEARCH } from '../../../..
 import 'brace/mode/json';
 import 'brace/snippets/json';
 import 'brace/ext/language_tools';
+import "brace/ext/searchbox";
 
 export const RuleEditor = ({ save, initialRule, isLoading, isReserved, internalUsers, currentPlatform }) => {
   const [logicalOperator, setLogicalOperator] = useState('OR');

--- a/public/components/settings/configuration/components/categories/components/category/components/field-form.tsx
+++ b/public/components/settings/configuration/components/categories/components/category/components/field-form.tsx
@@ -24,6 +24,7 @@ import { ISetting } from '../../../../../configuration';
 import 'brace/mode/javascript';
 import 'brace/snippets/javascript';
 import 'brace/ext/language_tools';
+import "brace/ext/searchbox";
 
 interface IFieldForm {
   item: ISetting

--- a/public/components/tools/devtools/devToolsHistory.tsx
+++ b/public/components/tools/devtools/devToolsHistory.tsx
@@ -27,6 +27,7 @@ import {
 import 'brace/mode/json';
 import 'brace/snippets/json';
 import 'brace/ext/language_tools';
+import "brace/ext/searchbox";
 
 
 export function DevToolsHistory({ localStorage, closeHistory, addRequest }) {

--- a/public/controllers/dev-tools/components/test-configuration.js
+++ b/public/controllers/dev-tools/components/test-configuration.js
@@ -23,6 +23,7 @@ import {
 } from '@elastic/eui';
 import { DynamicHeight } from '../../../utils/dynamic-height';
 import 'brace/theme/textmate';
+import "brace/ext/searchbox";
 
 export class TestConfiguration extends Component {
   constructor(props) {

--- a/public/controllers/management/components/management/configuration/util-components/code-editor.js
+++ b/public/controllers/management/components/management/configuration/util-components/code-editor.js
@@ -23,6 +23,7 @@ import 'brace/snippets/json';
 import 'brace/mode/javascript';
 import 'brace/snippets/javascript';
 import 'brace/ext/language_tools';
+import "brace/ext/searchbox";
 
 class WzCodeEditor extends Component {
   constructor(props) {

--- a/public/controllers/management/components/management/groups/groups-editor.js
+++ b/public/controllers/management/components/management/groups/groups-editor.js
@@ -38,6 +38,7 @@ import 'brace/theme/textmate';
 import 'brace/mode/xml';
 import 'brace/snippets/xml';
 import 'brace/ext/language_tools';
+import "brace/ext/searchbox";
 
 class WzGroupsEditor extends Component {
   _isMounted = false;

--- a/public/controllers/management/components/management/ruleset/ruleset-editor.js
+++ b/public/controllers/management/components/management/ruleset/ruleset-editor.js
@@ -45,6 +45,7 @@ import 'brace/theme/textmate';
 import 'brace/mode/xml';
 import 'brace/snippets/xml';
 import 'brace/ext/language_tools';
+import "brace/ext/searchbox";
 
 class WzRulesetEditor extends Component {
   _isMounted = false;


### PR DESCRIPTION
Hi team, this PR fixes:

The **search feature** in the configuration file editor.
**Elastic UI Code editor** requires to load the search module externally.

Closes: #2840  

Additional information:
https://github.com/thlorenz/brace/issues/62#issuecomment-243238406