### PR TITLE
Fixed bug in the table on Agents->Table-> Actions->Config icon

### DIFF
--- a/public/controllers/agent/components/agents-table.js
+++ b/public/controllers/agent/components/agents-table.js
@@ -260,9 +260,9 @@ export class AgentsTable extends Component {
           position="left"
         >
           <EuiButtonIcon
-            onClick={() => ev => {
+            onClick={ev => {
               ev.stopPropagation();
-              this.props.clickAction(agent, 'discover');
+              this.props.clickAction(agent, 'default');
             }}
             iconType="eye"
             color={'primary'}
@@ -856,7 +856,10 @@ export class AgentsTable extends Component {
       };
     };
 
-    const getCellProps = item => {
+    const getCellProps = (item, column) => {
+      if(column.field=="actions"){
+        return 
+      }
       return {
         onMouseDown: (ev) => {
           AppNavigate.navigateToModule(ev, 'agents', { "tab": "welcome", "agent": item.id, }); ev.stopPropagation()


### PR DESCRIPTION
Hello team, we solved a bug that when clicking on the agents table, in the actions column, on the icon that redirects you to configuration, it took you to the dashboard. This has been fixed by excluding onmoussedown from the actions column.
Closes: #2848 