### PR TITLE
Fix body-payload of Sample Alerts POST endpoint

### DIFF
--- a/server/routes/wazuh-elastic.ts
+++ b/server/routes/wazuh-elastic.ts
@@ -123,7 +123,8 @@ export function WazuhElasticRoutes(router: IRouter) {
       validate: {
         params: schema.object({
           category: schemaSampleAlertsCategories,
-        })
+        }),
+        body: schema.any()
       },
     },
     async (context, request, response) => ctrl.createSampleAlerts(context, request, response)


### PR DESCRIPTION
Hi team, this PR fixes:

**Sample data doesn't use the current manager or cluster name.**
Turns out the endpoint wasn't receiving the payload to use the current manager, but the feature was already developed.

Closes: #2839 