### PR TITLE
fix: Changed the Wazuh API default user to `wazuh-wui`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Each user can only view their own reports [#2686](https://github.com/wazuh/wazuh-kibana-app/issues/2686)
 - Show the wui_ rules belong to wazuh-wui API user [#2702](https://github.com/wazuh/wazuh-kibana-app/issues/2702)
 
+### Changed
+- Replaced `wazuh` Wazuh API user by `wazuh-wui` in the default configuration [#2852](https://github.com/wazuh/wazuh-kibana-app/issues/2852)
+
 ### Fixed
 
 - Create index pattern even if there aren´t available indices [#2620](https://github.com/wazuh/wazuh-kibana-app/issues/2620)

--- a/public/components/settings/api/api-is-down.js
+++ b/public/components/settings/api/api-is-down.js
@@ -110,8 +110,8 @@ hosts:
     - production:
         url: https://172.16.1.2
         port: 55000
-        username: wazuh
-        password: wazuh
+        username: wazuh-wui
+        password: wazuh-wui
         run_as: false
 `;
 

--- a/server/lib/initial-wazuh-config.ts
+++ b/server/lib/initial-wazuh-config.ts
@@ -207,7 +207,7 @@ hosts:
   - default:
      url: https://localhost
      port: 55000
-     username: wazuh
-     password: wazuh
+     username: wazuh-wui
+     password: wazuh-wui
      run_as: false
 `


### PR DESCRIPTION
Hi team, this PR resolves:
- Change the Wazuh API default user to `wazuh-wui`

Closes: #2852 