### PR TITLE
Bugfix filter event rules

### DIFF
--- a/public/controllers/management/components/management/ruleset/main-ruleset.js
+++ b/public/controllers/management/components/management/ruleset/main-ruleset.js
@@ -50,11 +50,12 @@ export default class WzRuleset extends Component {
       fileContent,
       addingRulesetFile
     } = this.state;
-    if (
+    if (!window.location.href.includes('rules?tab=rules') &&
       (!ruleInfo && !decoderInfo && !listInfo && !fileContent,
-      !addingRulesetFile)
-    )
+        !addingRulesetFile)
+    ) {
       this.store.dispatch({ type: 'RESET' });
+    }
   }
 
   render() {


### PR DESCRIPTION
Hi team,
This PR resolve when clicking in the rule details links doesn't add a filter in the Management > Rules search bar when access from Modules/any/Events.

Issue [2877](https://github.com/wazuh/wazuh-kibana-app/issues/2877)