### PR TITLE
[4.1-7.10] Fix the decoder details for keys as objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the Wazuh app project will be documented in this file.
 
 ## Wazuh v4.1.0 - Kibana 7.10.0 , 7.10.2 - Revision 4101
 
+### Fixed
+
+- Fix the decoder detail view is not displayed [#2888](https://github.com/wazuh/wazuh-kibana-app/issues/2888)
+
 ### Changed
 
 - Support new fields of Windows Registry at FIM inventory panel [#2679](https://github.com/wazuh/wazuh-kibana-app/issues/2679)

--- a/public/controllers/management/components/management/ruleset/decoder-info.js
+++ b/public/controllers/management/components/management/ruleset/decoder-info.js
@@ -141,6 +141,20 @@ class WzDecoderInfo extends Component {
         content = this.colorRegex(content);
       } else if (key === 'order') {
         content = this.colorOrder(content);
+      } else if (typeof details[key] === 'object'){
+        content = (
+          <ul>
+            <li>
+              {Object.keys(details[key]).map(k => (
+                <span key={k}>
+                  {k}:&nbsp;
+                  {details[key][k]}
+                  <br />
+                </span>
+              )).reduce((accum, item) => [accum, ', ', item])}
+            </li>
+          </ul>
+        )
       } else {
         content = <span className="subdued-color">{details[key]}</span>;
       }

--- a/public/controllers/management/components/management/ruleset/decoder-info.js
+++ b/public/controllers/management/components/management/ruleset/decoder-info.js
@@ -137,22 +137,18 @@ class WzDecoderInfo extends Component {
 
     Object.keys(details).forEach(key => {
       let content = details[key];
-      if (key === 'regex') {
-        content = this.colorRegex(content);
-      } else if (key === 'order') {
+      if (key === 'order') {
         content = this.colorOrder(content);
       } else if (typeof details[key] === 'object'){
         content = (
           <ul>
-            <li>
-              {Object.keys(details[key]).map(k => (
-                <span key={k}>
-                  {k}:&nbsp;
-                  {details[key][k]}
-                  <br />
-                </span>
-              )).reduce((accum, item) => [accum, ', ', item])}
-            </li>
+            {Object.keys(details[key]).map(k => (
+              <li key={k} style={{marginBottom: "4px"}} className="subdued-color">
+                {k}:&nbsp;
+                {details[key][k]}
+                <br />
+              </li>
+            ))}
           </ul>
         )
       } else {
@@ -257,7 +253,10 @@ class WzDecoderInfo extends Component {
                         color="primary"
                         iconSize="l"
                         iconType="arrowLeft"
-                        onClick={() => this.props.cleanInfo()}
+                        onClick={() => {
+                          window.location.href = window.location.href.replace(new RegExp('redirectRule=' + '[^&]*'), '');
+                          this.props.cleanInfo();
+                        }}
                       />
                     </EuiToolTip>
                     {name}


### PR DESCRIPTION
Hi team, this PR resolves:
- Fix the crash in the decoder details view when the property was an object

Closes: #2888