### PR TITLE
Fixed wrong cookie value validation on getToken

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ All notable changes to the Wazuh app project will be documented in this file.
 
 - Support new fields of Windows Registry at FIM inventory panel [#2679](https://github.com/wazuh/wazuh-kibana-app/issues/2679)
 
+### Fixed
+
+- Fix server error Invalid token specified: Cannot read property 'replace' of undefined [#2899](https://github.com/wazuh/wazuh-kibana-app/issues/2899)
 
 ## Wazuh v4.0.4 - Kibana 7.10.0 , 7.10.2 - Revision 4017
 

--- a/server/controllers/wazuh-api.ts
+++ b/server/controllers/wazuh-api.ts
@@ -41,7 +41,7 @@ export class WazuhApiCtrl {
       const { force, idHost } = request.body;
       const { username } = await context.wazuh.security.getCurrentUser(request, context);
       if (!force && request.headers.cookie && username === getCookieValueByName(request.headers.cookie, 'wz-user') && idHost === getCookieValueByName(request.headers.cookie,'wz-api')) {
-        const wzToken = getCookieValueByName(request.headers.cookie, 'wz-user');
+        const wzToken = getCookieValueByName(request.headers.cookie, 'wz-token');
         if (wzToken) {
           try { // if the current token is not a valid jwt token we ask for a new one
             const decodedToken = jwtDecode(wzToken);


### PR DESCRIPTION
Hi team, this resolves
- Invalid token specified: Cannot read property 'replace' of undefined error

Closes #2899  