### PR TITLE
Fixed hover texts in CDB lists actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to the Wazuh app project will be documented in this file.
 
 - Support new fields of Windows Registry at FIM inventory panel [#2679](https://github.com/wazuh/wazuh-kibana-app/issues/2679)
 
+### Fixed
+- Fixed wrong hover texts in CDB lists actions [#2929](https://github.com/wazuh/wazuh-kibana-app/pull/2929)
+
+
 ## Wazuh v4.0.4 - Kibana 7.10.0 , 7.10.2 - Revision 4016
 
 ### Added

--- a/public/controllers/management/components/management/ruleset/list-editor.js
+++ b/public/controllers/management/components/management/ruleset/list-editor.js
@@ -486,7 +486,7 @@ class WzListEditor extends Component {
           if (this.state.editing === item.key) {
             return (
               <Fragment>
-                <EuiToolTip position="top" content={'Yes'}>
+                <EuiToolTip position="top" content={'Save'}>
                   <EuiButtonIcon
                     aria-label="Confirm value"
                     iconType="check"
@@ -496,7 +496,7 @@ class WzListEditor extends Component {
                     color="primary"
                   />
                 </EuiToolTip>
-                <EuiToolTip position="top" content={'No'}>
+                <EuiToolTip position="top" content={'Discard'}>
                   <EuiButtonIcon
                     aria-label="Cancel edition"
                     iconType="cross"

--- a/public/controllers/management/components/management/ruleset/utils/columns.js
+++ b/public/controllers/management/components/management/ruleset/utils/columns.js
@@ -325,7 +325,7 @@ export default class RulesetColumns {
                   permissions={getEditButtonPermissions(item)}
                   aria-label="Export list"
                   iconType="exportAction"
-                  tooltip={{position: 'top', content: `Edit ${item.filename} content`}}
+                  tooltip={{position: 'top', content: `Export ${item.filename} content`}}
                   onClick={async (ev) => {
                     ev.stopPropagation();
                     await exportCsv(`/lists`, [{_isCDBList: true, name: 'filename', value: `${item.filename}`}], item.filename)


### PR DESCRIPTION
Hi team,
This PR resolves the wrong labels in CDB lists actions. "Export", "Save" and "Discard" labels.

Issue #2896 