### PR TITLE
Fix clear visualizations list when changing tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 ### Fixed
 
 - Fix server error Invalid token specified: Cannot read property 'replace' of undefined [#2899](https://github.com/wazuh/wazuh-kibana-app/issues/2899)
+- Fixed clear visualizations manager list when switching tabs. Fixes PDF reports filters [#2932](https://github.com/wazuh/wazuh-kibana-app/pull/2932)
 
 ## Wazuh v4.0.4 - Kibana 7.10.0 , 7.10.2 - Revision 4017
 

--- a/public/components/visualize/wz-visualize.js
+++ b/public/components/visualize/wz-visualize.js
@@ -72,7 +72,7 @@ export class WzVisualize extends Component {
 
   async componentDidMount() {
     this._isMount = true;
-    // visHandler.removeAll();
+    visHandler.removeAll();
     this.agentsStatus = false;
     if (!this.monitoringEnabled) {
       const data = await this.wzReq.apiReq('GET', '/agents/summary/status', {});


### PR DESCRIPTION
Hi team, this fixes:

**Filters applied to PDF reports.** 
Clears the visualizations list when changing tabs so as to check which filter is applied to the current chart list.

closes #2874 