### PR TITLE
Change agents table field os_name to os.name,os.version to make it sortable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 ### Fixed
 
 - Fix server error Invalid token specified: Cannot read property 'replace' of undefined [#2899](https://github.com/wazuh/wazuh-kibana-app/issues/2899)
+- Fix agents table OS field sorting: Changes agents table field `os_name` to `os.name,os.version` to make it sortable. [#2939](https://github.com/wazuh/wazuh-kibana-app/pull/2939)
 
 ## Wazuh v4.0.4 - Kibana 7.10.0 , 7.10.2 - Revision 4017
 

--- a/public/controllers/agent/components/agents-table.js
+++ b/public/controllers/agent/components/agents-table.js
@@ -743,7 +743,7 @@ export class AgentsTable extends Component {
       {
         field: 'os_name',
         name: 'OS',
-        sortable: true,
+        sortable: false,
         width: '15%',
         truncateText: true,
         render: this.addIconPlatformRender

--- a/public/controllers/agent/components/agents-table.js
+++ b/public/controllers/agent/components/agents-table.js
@@ -216,7 +216,7 @@ export class AgentsTable extends Component {
   buildSortFilter() {
     const { sortField, sortDirection } = this.state;
 
-    const field = sortField === 'os_name' ? '' : sortField;
+    const field = sortField === 'os_name' ? 'os.name,os.version' : sortField;
     const direction = sortDirection === 'asc' ? '+' : '-';
 
     return direction + field;
@@ -743,7 +743,7 @@ export class AgentsTable extends Component {
       {
         field: 'os_name',
         name: 'OS',
-        sortable: false,
+        sortable: true,
         width: '15%',
         truncateText: true,
         render: this.addIconPlatformRender

--- a/public/controllers/overview/components/overview-actions/agents-selection-table.js
+++ b/public/controllers/overview/components/overview-actions/agents-selection-table.js
@@ -242,7 +242,7 @@ export class AgentSelectionTable extends Component {
     const sortFilter = {};
     if (sortField) {
       const direction = sortDirection === 'asc' ? '+' : '-';
-      sortFilter['sort'] = direction + sortField;
+      sortFilter['sort'] = direction + (sortField === 'os'? 'os.name,os.version' : sortField);
     }
 
     return sortFilter;


### PR DESCRIPTION
Hi team, this fixes:

**Agent view: sort by agent OS doesn't work**
To make the field sortable I had to change the field name to _os.name,os.version_ so as the backend is able to parse it.

Closes #2920 