### PR TITLE
Fixed diff parsed datetime between agent detail and agents table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 
 - Fix server error Invalid token specified: Cannot read property 'replace' of undefined [#2899](https://github.com/wazuh/wazuh-kibana-app/issues/2899)
 - Fixed wrong hover texts in CDB lists actions [#2929](https://github.com/wazuh/wazuh-kibana-app/pull/2929)
+- Fixed diff parsed datetime between agent detail and agents table [#2940](https://github.com/wazuh/wazuh-kibana-app/pull/2940)
 
 ## Wazuh v4.0.4 - Kibana 7.10.0 , 7.10.2 - Revision 4017
 

--- a/public/components/common/welcome/agents-info.js
+++ b/public/components/common/welcome/agents-info.js
@@ -19,6 +19,7 @@ import {
   EuiBadge
 } from '@elastic/eui';
 import { WzRequest } from '../../../react-services/wz-request';
+import { TimeService } from '../../../react-services/time-service';
 
 import WzTextWithTooltipIfTruncated from '../wz-text-with-tooltip-if-truncated';
 import { WzStat } from '../../wz-stat';
@@ -29,6 +30,7 @@ export class AgentInfo extends Component {
     super(props);
 
     this.state = {};
+    this.timeService = TimeService;
   }
 
   async componentDidMount() {
@@ -155,10 +157,21 @@ export class AgentInfo extends Component {
     return stats;
   }
 
+
+  parseDateTime(datetime){
+    try {
+      return this.timeService.offset(datetime);
+    } catch (error) {
+      return datetime;
+    }
+  }
+
   render() {
     const { agent } = this.props;
 
     let arrayStats;
+
+    
 
     if (this.props.isCondensed) {
       arrayStats = [
@@ -183,8 +196,15 @@ export class AgentInfo extends Component {
           description: 'Operating system',
           style: {}
         },
-        { title: agent.dateAdd, description: 'Registration date', style: { maxWidth: 150 } },
-        { title: agent.lastKeepAlive, description: 'Last keep alive', style: { maxWidth: 150 } },
+        { 
+          title: this.parseDateTime(agent.dateAdd), 
+          description: 'Registration date', 
+          style: { maxWidth: 150 } },
+        { 
+          title: this.parseDateTime(agent.lastKeepAlive), 
+          description: 'Last keep alive', 
+          style: { maxWidth: 150 } 
+        },
       ];
     }
 


### PR DESCRIPTION
Hi team, this resolves

 - This PR fixed differencies beetween "lastKeepAlive" field in Agents Table and Agents Welcome in Agent detail page.
 In Agents Welcome, fields "lastKeepAlive" and "addDate" has been parsed by TimeService.

Closes #2917