### PR TITLE
[4.1-7.10] Allow access to agents section with agent:group permission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 ### Fixed
 
 - Fix the decoder detail view is not displayed [#2888](https://github.com/wazuh/wazuh-kibana-app/issues/2888)
+- Allow access to Agents section with agent:group action permission [#2933](https://github.com/wazuh/wazuh-kibana-app/issues/2933)
 
 ### Changed
 

--- a/public/controllers/agent/components/agents-preview.js
+++ b/public/controllers/agent/components/agents-preview.js
@@ -43,7 +43,7 @@ import { compose } from 'redux';
 export const AgentsPreview = compose(
   withReduxProvider,
   withGlobalBreadcrumb([{ text: '' }, { text: 'Agents' }]),
-  withUserAuthorizationPrompt([{action: 'agent:read', resource: 'agent:id:*'}])
+  withUserAuthorizationPrompt([[{action: 'agent:read', resource: 'agent:id:*'},{action: 'agent:read', resource: 'agent:group:*'}]])
 )(class AgentsPreview extends Component {
   _isMount = false;
   constructor(props) {


### PR DESCRIPTION
Hi team, this PR resolves:
- Allow access to Agents section with `agent:group` permission

Closes: https://github.com/wazuh/wazuh-kibana-app/issues/2933

How to check:
- Create a group in Management/Group
- Add an agent to the group created
- Create a Role mapping to an Elasticsearch user giving the permission with `agent:group` action and id the name of the group
- Enable `run_as` to use the authentication context.
- Go to check the `Agents` section
- It should be visible the section without showing the prompt