### PR TITLE
Bugfix agents are not unchecked

### DIFF
--- a/public/components/management/groups/multiple-agent-selector.tsx
+++ b/public/components/management/groups/multiple-agent-selector.tsx
@@ -345,7 +345,7 @@ export class MultipleAgentSelector extends Component {
   };
 
   unselectElementsOfSelectByID(containerID) {
-    document.getElementById(containerID).selectedOptions.forEach(option => {
+    document.getElementById(containerID).options.forEach(option => {
       option.selected = false
     });
   }


### PR DESCRIPTION
Hi team,
This PR fixed when you change selections options of right select or left select the options are not unchecked.
- Changed `selectedOptions` for `options`, because after editing the first option in the forEach, it was ignoring a selected option.

Closes: #2889 