### PR TITLE
Refactored registry values for FIM

### DIFF
--- a/public/components/agents/fim/inventory.tsx
+++ b/public/components/agents/fim/inventory.tsx
@@ -154,7 +154,7 @@ export class Inventory extends Component {
     const filter = {
       ...filters,
       limit: type === 'file' ? '15' : '1',
-      ...(type === 'registry' ? {q: 'type=registry_key,type=registry_value'} : {type}),      
+      ...(type === 'registry' ? {q: 'type=registry_key'} : {type}),      
       ...(type === 'file' && {sort: '+file'})
     };
     return filter;

--- a/public/components/agents/fim/inventory/fileDetail.tsx
+++ b/public/components/agents/fim/inventory/fileDetail.tsx
@@ -33,6 +33,7 @@ import moment from 'moment-timezone';
 import { AppNavigate } from '../../../../react-services/app-navigate';
 import { TruncateHorizontalComponents } from '../../../common/util';
 import { getDataPlugin } from '../../../../kibana-services';
+import { RegistryValues } from './registryValues';
 
 export class FileDetails extends Component {
   props!: {
@@ -396,12 +397,12 @@ export class FileDetails extends Component {
   }
 
   render() {
-    const { fileName, type, implicitFilters, view } = this.props;
+    const { fileName, type, implicitFilters, view, currentFile, agent } = this.props;
     const inspectButtonText = view === 'extern' ? 'Inspect in FIM' : 'Inspect in Events';
     return (
       <Fragment>
         <EuiAccordion
-          id={fileName === undefined ? Math.random().toString() : fileName}
+          id={fileName === undefined ? Math.random().toString() : `${fileName}_details`}
           buttonContent={
             <EuiTitle size="s">
               <h3>Details</h3>
@@ -412,9 +413,32 @@ export class FileDetails extends Component {
         >
           <div className="flyout-row details-row">{this.getDetails()}</div>
         </EuiAccordion>
+        { type === 'registry_key' && <>
         <EuiSpacer size="s" />
         <EuiAccordion
-          id={fileName === undefined ? Math.random().toString() : fileName}
+          id={fileName === undefined ? Math.random().toString() : `${fileName}_values`}
+          buttonContent={
+            <EuiTitle size="s">
+              <h3>
+                Registry values                
+              </h3>
+            </EuiTitle>
+          }
+          paddingSize="none"
+          initialIsOpen={true}
+        >
+          <EuiFlexGroup className="flyout-row">
+            <EuiFlexItem>
+              <RegistryValues 
+                currentFile={currentFile}
+                agent={agent}
+              />
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        </EuiAccordion> </>}
+        <EuiSpacer />
+        <EuiAccordion
+          id={fileName === undefined ? Math.random().toString() : `${fileName}_events`}
           className="events-accordion"
           extraAction={
             <div style={{ marginBottom: 5 }}>

--- a/public/components/agents/fim/inventory/filterBar.tsx
+++ b/public/components/agents/fim/inventory/filterBar.tsx
@@ -41,7 +41,7 @@ export class FilterBar extends Component {
       {type: 'q', label: 'size', description:"Size of the file in Bytes", values: async (value) => getFilterValues('size', value, this.props.agent.id)}, 
     ],
     registry: [
-      {type: 'q', label: 'file', description:"Name of the registry_key or registry_value", operators:['=','!=', '~'], values: async (value) => getFilterValues('file', value, this.props.agent.id, {q:'type=registry_key,type=registry_value'})},
+      {type: 'q', label: 'file', description:"Name of the registry_key", operators:['=','!=', '~'], values: async (value) => getFilterValues('file', value, this.props.agent.id, {q:'type=registry_key'})},
     ]
   }
 

--- a/public/components/agents/fim/inventory/flyout.tsx
+++ b/public/components/agents/fim/inventory/flyout.tsx
@@ -17,7 +17,7 @@ import {
   EuiFlyoutBody,
   EuiTitle,
   EuiLoadingContent,
-  EuiCallOut
+  EuiCallOut,
 } from '@elastic/eui';
 import { WzRequest } from '../../../../react-services/wz-request';
 import { FileDetails } from './fileDetail';
@@ -25,19 +25,19 @@ import { AppState } from '../../../../react-services/app-state';
 
 export class FlyoutDetail extends Component {
   state: {
-    currentFile: boolean | {[key:string]: string}
-    clusterFilter: {}
-    isLoading: boolean
-    error: boolean
-    type: 'file' | 'registry_key' | 'registry_value'
-  }
+    currentFile: boolean | { [key: string]: string };
+    clusterFilter: {};
+    isLoading: boolean;
+    error: boolean;
+    type: 'file' | 'registry_key';
+  };
 
   props!: {
-    fileName: string
-    agentId: string
-    view: 'inventory' | 'events' | 'extern'
-    closeFlyout(): void
-  }
+    fileName: string;
+    agentId: string;
+    view: 'inventory' | 'events' | 'extern';
+    closeFlyout(): void;
+  };
 
   constructor(props) {
     super(props);
@@ -46,82 +46,101 @@ export class FlyoutDetail extends Component {
       clusterFilter: {},
       isLoading: true,
       error: false,
-      type: 'file'
-    }
+      type: 'file',
+    };
   }
 
   async componentDidMount() {
     try {
-      const isCluster = (AppState.getClusterInfo() || {}).status === "enabled";
+      const isCluster = (AppState.getClusterInfo() || {}).status === 'enabled';
       const clusterFilter = isCluster
-        ? { "cluster.name": AppState.getClusterInfo().cluster }
-        : { "manager.name": AppState.getClusterInfo().manager };
+        ? { 'cluster.name': AppState.getClusterInfo().cluster }
+        : { 'manager.name': AppState.getClusterInfo().manager };
       this.setState({ clusterFilter });
       let currentFile;
-      if (typeof this.props.item === "boolean" && typeof this.props.fileName !== undefined) {
+      if (typeof this.props.item === 'boolean' && typeof this.props.fileName !== undefined) {
         const regex = new RegExp('file=' + '[^&]*');
         const match = window.location.href.match(regex);
         if (match && match[0]) {
-          const file = decodeURIComponent(match[0].split('=')[1]);
+          let file = decodeURIComponent(match[0].split('=')[1]);
+          if (this.state.type === 'registry_key') {
+            file = encodeURIComponent(file).replaceAll('%5C', '\\\\');
+          }
           const data = await WzRequest.apiReq('GET', `/syscheck/${this.props.agentId}`, {
             params: {
-              q: `file=${file}`
-            }
+              q: `file=${file}`,
+            },
           });
           currentFile = ((((data || {}).data || {}).data || {}).affected_items || [])[0];
         }
-      } else if(this.props.item){
+      } else if (this.props.item) {
         currentFile = this.props.item;
-      }else{
+      } else {
+        let file = this.props.fileName;
+        if (this.state.type === 'registry_key') {
+          file = encodeURIComponent(file).replaceAll('%5C', '\\\\');
+        }
         const data = await WzRequest.apiReq('GET', `/syscheck/${this.props.agentId}`, {
           params: {
-            q: `file=${this.props.fileName}`
-          }
+            q: `file=${file}`,
+          },
         });
         currentFile = ((((data || {}).data || {}).data || {}).affected_items || [])[0];
       }
       if (!currentFile) {
-        throw (false);
+        throw false;
       }
       this.setState({ currentFile, type: currentFile.type, isLoading: false });
     } catch (err) {
-      this.setState({ error: `Data could not be fetched for ${this.props.fileName}`, currentFile: {file: this.props.fileName} })
+      this.setState({
+        error: `Data could not be fetched for ${this.props.fileName}`,
+        currentFile: { file: this.props.fileName },
+      });
     }
   }
 
   componentWillUnmount() {
-    window.location.href = window.location.href.replace(new RegExp("&file=" + "[^\&]*", 'g'), "");
+    window.location.href = window.location.href.replace(new RegExp('&file=' + '[^&]*', 'g'), '');
   }
 
   render() {
     const { type } = this.state;
     return (
-      <EuiFlyout onClose={() => this.props.closeFlyout()} size="l" aria-labelledby={this.state.currentFile.file} maxWidth="70%" className='wz-inventory wzApp'>
-        <EuiFlyoutHeader hasBorder className="flyout-header" >
+      <EuiFlyout
+        onClose={() => this.props.closeFlyout()}
+        size="l"
+        aria-labelledby={this.state.currentFile.file}
+        maxWidth="70%"
+        className="wz-inventory wzApp"
+      >
+        <EuiFlyoutHeader hasBorder className="flyout-header">
           <EuiTitle size="s">
-            <h2 id={this.state.currentFile.file }>{this.state.currentFile.file }</h2>
+            <h2 id={this.state.currentFile.file}>{this.state.currentFile.file}</h2>
           </EuiTitle>
         </EuiFlyoutHeader>
         {this.state.isLoading && (
-          <EuiFlyoutBody className="flyout-body" >
-            {this.state.error && (
+          <EuiFlyoutBody className="flyout-body">
+            {(this.state.error && (
               <EuiCallOut title={this.state.error} color="warning" iconType="alert" />
-            ) || (<EuiLoadingContent style={{ margin: 16 }} />)}
+            )) || <EuiLoadingContent style={{ margin: 16 }} />}
           </EuiFlyoutBody>
         )}
-        {this.state.currentFile && !this.state.isLoading &&
-          <EuiFlyoutBody className="flyout-body" >
+        {this.state.currentFile && !this.state.isLoading && (
+          <EuiFlyoutBody className="flyout-body">
             <FileDetails
               currentFile={this.state.currentFile}
               type={type}
               {...this.props}
-              implicitFilters={[{ 'rule.groups': "syscheck" },
-              { 'syscheck.path': this.state.currentFile.file },
-              { 'agent.id': this.props.agentId },
-              this.state.clusterFilter]} />
+              implicitFilters={[
+                { 'rule.groups': 'syscheck' },
+                { 'syscheck.path': this.state.currentFile.file },
+                { 'agent.id': this.props.agentId },
+                this.state.clusterFilter,
+              ]}
+            />
           </EuiFlyoutBody>
-        }
+        )}
       </EuiFlyout>
-    )
+    );
   }
 }

--- a/public/components/agents/fim/inventory/flyout.tsx
+++ b/public/components/agents/fim/inventory/flyout.tsx
@@ -63,7 +63,7 @@ export class FlyoutDetail extends Component {
         const match = window.location.href.match(regex);
         if (match && match[0]) {
           let file = decodeURIComponent(match[0].split('=')[1]);
-          if (this.state.type === 'registry_key') {
+          if (file.indexOf('\\') > -1) {
             file = encodeURIComponent(file).replaceAll('%5C', '\\\\');
           }
           const data = await WzRequest.apiReq('GET', `/syscheck/${this.props.agentId}`, {
@@ -75,9 +75,9 @@ export class FlyoutDetail extends Component {
         }
       } else if (this.props.item) {
         currentFile = this.props.item;
-      } else {
+      } else {          
         let file = this.props.fileName;
-        if (this.state.type === 'registry_key') {
+        if (file.indexOf('\\') > -1) {
           file = encodeURIComponent(file).replaceAll('%5C', '\\\\');
         }
         const data = await WzRequest.apiReq('GET', `/syscheck/${this.props.agentId}`, {

--- a/public/components/agents/fim/inventory/registry-table.tsx
+++ b/public/components/agents/fim/inventory/registry-table.tsx
@@ -153,7 +153,7 @@ export class RegistryTable extends Component {
       offset: pageIndex * pageSize,
       limit: pageSize,
       sort: this.buildSortFilter(),
-      q: 'type=registry_key,type=registry_value'
+      q: 'type=registry_key'
     };
 
     return filter;

--- a/public/components/agents/fim/inventory/registryValues/index.ts
+++ b/public/components/agents/fim/inventory/registryValues/index.ts
@@ -1,0 +1,3 @@
+import { RegistryValues } from "./registryValues";
+
+export * from './registryValues';

--- a/public/components/agents/fim/inventory/registryValues/registryValues.tsx
+++ b/public/components/agents/fim/inventory/registryValues/registryValues.tsx
@@ -1,0 +1,83 @@
+/*
+ * Wazuh app - Registry values components
+ * Copyright (C) 2015-2021 Wazuh, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Find more information about this on the LICENSE file.
+ */
+
+import { EuiBasicTableColumn, EuiInMemoryTable } from '@elastic/eui';
+import { WzRequest } from '../../../../../react-services';
+import React, { useEffect, useState } from 'react';
+
+export const RegistryValues = (props) => {
+  const [values, setValues] = useState<any[]>([]);  
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<any>();
+
+  useEffect(() => {
+    getValues().then(() => setIsLoading(false));
+  }, []);
+
+  const getValues = async () => {
+    const { agent, currentFile } = props;
+    try {
+      const values = await WzRequest.apiReq('GET', `/syscheck/${agent.id}`, {
+        params: { q: `type=registry_value;file=${encodeURIComponent(currentFile.file).replaceAll('%5C', '\\\\')}` },
+      });
+
+      setValues((((values || {}).data || {}).data || {}).affected_items || []);
+    } catch (error) {
+      setError(error);      
+    }
+  };
+
+  const columns: EuiBasicTableColumn<any>[]  = [
+    {
+      field: 'date',
+      name: 'Date',
+      sortable: true,
+      width: "100px"
+    },
+    {
+      field: 'value',
+      name: 'Value name',
+      sortable: true,
+      width: "100px",
+      render: (item) => item.name
+    },
+    {
+      field: 'value',
+      name: 'Value type',
+      sortable: true,
+      width: "100px",
+      render: (item) => item.type
+    },
+    {
+      field: 'sha1',
+      name: 'sha1',
+      sortable: false,
+      width: "100px"
+    },
+  ]
+  
+
+  const renderTable = () => {
+    const { currentFile } = props;
+    return (
+      <div>
+        <EuiInMemoryTable 
+          columns={columns}
+          items={values}
+          loading={isLoading}          
+        />
+      </div>
+    );
+  };
+
+  return <>{renderTable()}</>;
+};

--- a/public/components/agents/fim/inventory/registryValues/registryValues.tsx
+++ b/public/components/agents/fim/inventory/registryValues/registryValues.tsx
@@ -10,12 +10,14 @@
  * Find more information about this on the LICENSE file.
  */
 
-import { EuiBasicTableColumn, EuiInMemoryTable } from '@elastic/eui';
+import { EuiBasicTableColumn, EuiInMemoryTable, SortDirection } from '@elastic/eui';
 import { WzRequest } from '../../../../../react-services';
 import React, { useEffect, useState } from 'react';
+import valuesMock from './values.json';
+import { DIRECTIONS } from '@elastic/eui/src/components/flex/flex_group';
 
 export const RegistryValues = (props) => {
-  const [values, setValues] = useState<any[]>([]);  
+  const [values, setValues] = useState<any[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<any>();
 
@@ -27,57 +29,53 @@ export const RegistryValues = (props) => {
     const { agent, currentFile } = props;
     try {
       const values = await WzRequest.apiReq('GET', `/syscheck/${agent.id}`, {
-        params: { q: `type=registry_value;file=${encodeURIComponent(currentFile.file).replaceAll('%5C', '\\\\')}` },
+        params: {
+          q: `type=registry_value;file=${encodeURIComponent(currentFile.file).replaceAll(
+            '%5C',
+            '\\\\'
+          )}`,
+          sort: '-date',
+        },
       });
 
       setValues((((values || {}).data || {}).data || {}).affected_items || []);
     } catch (error) {
-      setError(error);      
+      setError(error);
     }
   };
 
-  const columns: EuiBasicTableColumn<any>[]  = [
+  const columns: EuiBasicTableColumn<any>[] = [
     {
       field: 'date',
       name: 'Date',
       sortable: true,
-      width: "100px"
     },
     {
       field: 'value',
       name: 'Value name',
       sortable: true,
-      width: "100px",
-      render: (item) => item.name
+      render: (item) => item.name,
     },
     {
       field: 'value',
       name: 'Value type',
       sortable: true,
-      width: "100px",
-      render: (item) => item.type
+      render: (item) => item.type,
     },
     {
       field: 'sha1',
       name: 'sha1',
       sortable: false,
-      width: "100px"
     },
-  ]
-  
+  ];
 
-  const renderTable = () => {
-    const { currentFile } = props;
-    return (
-      <div>
-        <EuiInMemoryTable 
-          columns={columns}
-          items={values}
-          loading={isLoading}          
-        />
-      </div>
-    );
-  };
-
-  return <>{renderTable()}</>;
+  return (
+    <EuiInMemoryTable
+      columns={columns}
+      items={values}
+      loading={isLoading}
+      pagination={{ pageSizeOptions: [5, 10, 20] }}
+      sorting={{ sort: { field: 'date', direction: SortDirection.DESC } }}
+    />
+  );
 };


### PR DESCRIPTION
Hi team, this resolves

Currently, the items for `registry_key` and `registry_value` types in FIM are displayed at the same level (table). But the items with the type `registry_value` should be displayed inside the detail of their corresponding `registry_key` item.

![image](https://user-images.githubusercontent.com/26828184/107405866-874e2580-6ae6-11eb-8997-0be4ca3ff6c9.png)
