### PR TITLE
Fixed disabled switch visual edit when json is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fixed number agents not show on pie onMouseEvent [#2890](https://github.com/wazuh/wazuh-kibana-app/issues/2890)
 - Fixed off Kibana Query Language in search bar of Controls/Inventory modules. [#2945](https://github.com/wazuh/wazuh-kibana-app/pull/2945)
 - Fixed number of agents do not show on the pie chart tooltip in agents preview [#2890](https://github.com/wazuh/wazuh-kibana-app/issues/2890)
+- Fix disabled switch visual edit when json is empty [#2957](https://github.com/wazuh/wazuh-kibana-app/issues/2957)
 
 ## Wazuh v4.0.4 - Kibana 7.10.0 , 7.10.2 - Revision 4017
 

--- a/public/components/security/roles-mapping/components/rule-editor.tsx
+++ b/public/components/security/roles-mapping/components/rule-editor.tsx
@@ -113,15 +113,29 @@ export const RuleEditor = ({ save, initialRule, isLoading, isReserved, internalU
   };
 
   const getRulesFromJson = jsonRule => {
-    const { customRules, internalUsersRules, wrongFormat, logicalOperator } = decodeJsonRule(
-      jsonRule,
-      internalUsers
-    );
-    setLogicalOperator(logicalOperator);
-    setHasWrongFormat(wrongFormat);
-    return { customRules, internalUsersRules, wrongFormat, logicalOperator };
-  };
 
+    if(jsonRule !== '{}'){ // empty json is valid
+      const { customRules, internalUsersRules, wrongFormat, logicalOperator } = decodeJsonRule(
+        jsonRule,
+        internalUsers
+      );
+      setLogicalOperator(logicalOperator);
+      setHasWrongFormat(wrongFormat);  
+
+      return { customRules, internalUsersRules, wrongFormat, logicalOperator };
+    }else{     
+      setLogicalOperator('');
+      setHasWrongFormat(false); 
+
+      return {
+        customRules: [],
+        internalUsersRules: [],
+        wrongFormat: false,
+        logicalOperator: 'OR' 
+      }
+    }
+    
+  };
   const printRules = () => {
     const rulesList = rules.map((item, idx) => {
       return (

--- a/public/components/security/roles-mapping/components/rule-editor.tsx
+++ b/public/components/security/roles-mapping/components/rule-editor.tsx
@@ -113,7 +113,7 @@ export const RuleEditor = ({ save, initialRule, isLoading, isReserved, internalU
   };
   
   const getRulesFromJson = (jsonRule) => {
-    if (jsonRule !== '{}') {
+    if (jsonRule !== '{}' && jsonRule !== '') {
       // empty json is valid
       const { customRules, internalUsersRules, wrongFormat, logicalOperator } = decodeJsonRule(
         jsonRule,
@@ -241,6 +241,10 @@ export const RuleEditor = ({ save, initialRule, isLoading, isReserved, internalU
 
   const saveRule = () => {
     if (isJsonEditor) {
+      // if json editor is empty
+      if (ruleJson === '') {
+        setRuleJson('{}');
+      }
       save(JSON.parse(ruleJson));
     } else {
       save(getJsonFromRule(internalUserRules, rules, logicalOperator));

--- a/public/components/security/roles-mapping/components/rule-editor.tsx
+++ b/public/components/security/roles-mapping/components/rule-editor.tsx
@@ -111,30 +111,29 @@ export const RuleEditor = ({ save, initialRule, isLoading, isReserved, internalU
     rulesTmp.splice(id, 1);
     setRules(rulesTmp);
   };
-
-  const getRulesFromJson = jsonRule => {
-
-    if(jsonRule !== '{}'){ // empty json is valid
+  
+  const getRulesFromJson = (jsonRule) => {
+    if (jsonRule !== '{}') {
+      // empty json is valid
       const { customRules, internalUsersRules, wrongFormat, logicalOperator } = decodeJsonRule(
         jsonRule,
         internalUsers
       );
       setLogicalOperator(logicalOperator);
-      setHasWrongFormat(wrongFormat);  
+      setHasWrongFormat(wrongFormat);
 
       return { customRules, internalUsersRules, wrongFormat, logicalOperator };
-    }else{     
+    } else {
       setLogicalOperator('');
-      setHasWrongFormat(false); 
+      setHasWrongFormat(false);
 
       return {
         customRules: [],
         internalUsersRules: [],
         wrongFormat: false,
-        logicalOperator: 'OR' 
-      }
+        logicalOperator: 'OR',
+      };
     }
-    
   };
   const printRules = () => {
     const rulesList = rules.map((item, idx) => {


### PR DESCRIPTION
Hi team, this resolves

 - Fixed disabled switch visual editor button in Rules mapping editor

Closes #2957
