### PR TITLE
Fix SCA selection policy showing information about another policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the Wazuh app project will be documented in this file.
 
+## Wazuh v4.1.1 - Kibana 7.10.0 , 7.10.2 - Revision 4103
+
+### Fixed
+
+- Fix SCA policy detail showing name and check results about another policy [#3007](https://github.com/wazuh/wazuh-kibana-app/pull/3007)
+
 ## Wazuh v4.1.1 - Kibana 7.10.0 , 7.10.2 - Revision 4102
 
 ### Added

--- a/public/components/agents/sca/inventory.tsx
+++ b/public/components/agents/sca/inventory.tsx
@@ -265,9 +265,13 @@ export class Inventory extends Component {
         const policyResponse = await WzRequest.apiReq(
           'GET',
           `/sca/${this.props.agent.id}`,
-          { "q": "policy_id=" + policy.policy_id }
-          );
-          const [policyData] = policyResponse.data.data.affected_items;
+          { 
+            params: {
+              "q": "policy_id=" + policy.policy_id
+            } 
+          }
+        );
+        const [policyData] = policyResponse.data.data.affected_items;
         // It queries all checks without filters, because the filters are applied in the results
         // due to the use of EuiInMemoryTable instead EuiTable components and do arequest with each change of filters.
         const checksResponse = await WzRequest.apiReq(


### PR DESCRIPTION
 Hi team, this PR resolves:
 
- Fixed a bug when an agent has more than 1 SCA policy and select one that is not the first in the SCA inventory table. The data about the first policy was shown in the policy details. The policy checks are working well.

Closes: #3000 