### PR TITLE
Fixed that alerts table is empty when switching pinned agents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to the Wazuh app project will be documented in this file.
 
+## Wazuh v4.1.1 - Kibana 7.10.0 , 7.10.2 - Revision 4103
+
+### Fixed
+
+- Fix SCA policy detail showing name and check results about another policy [#3007](https://github.com/wazuh/wazuh-kibana-app/pull/3007)
+- Fix pagination in SCA checks table when expand some row [#3018](https://github.com/wazuh/wazuh-kibana-app/pull/3018)
+- Fix manager is shown in suggestions in Agents section [#3025](https://github.com/wazuh/wazuh-kibana-app/pull/3025)
+- Fix disabled loading on inventory when request fail [#3016](https://github.com/wazuh/wazuh-kibana-app/issues/3016)
+- Fix restarting selected cluster instead of all of them [#3032](https://github.com/wazuh/wazuh-kibana-app/pull/3032)
+- Fixed that alerts table is empty when switching pinned agents [#3008](https://github.com/wazuh/wazuh-kibana-app/pull/3008)
+
 ## Wazuh v4.1.1 - Kibana 7.10.0 , 7.10.2 - Revision 4102
 
 ### Added

--- a/public/components/agents/fim/inventory/fileDetail.tsx
+++ b/public/components/agents/fim/inventory/fileDetail.tsx
@@ -32,9 +32,10 @@ import { getIndexPattern } from '../../../overview/mitre/lib';
 import moment from 'moment-timezone';
 import { AppNavigate } from '../../../../react-services/app-navigate';
 import { TruncateHorizontalComponents } from '../../../common/util';
-import { getDataPlugin } from '../../../../kibana-services';
+import { getDataPlugin,getUiSettings } from '../../../../kibana-services';
 import { RegistryValues } from './registryValues';
 import { TimeService } from '../../../../react-services/time-service';
+import { FilterManager } from '../../../../../../../src/plugins/data/public/';
 
 export class FileDetails extends Component {
   props!: {
@@ -68,6 +69,8 @@ export class FileDetails extends Component {
     </svg>
   );
   indexPattern!: IIndexPattern;
+  discoverFilterManager: FilterManager;
+
   constructor(props) {
     super(props);
 
@@ -76,6 +79,8 @@ export class FileDetails extends Component {
       totalHits: 0,
     };
     this.viewInEvents.bind(this);
+
+    this.discoverFilterManager = new FilterManager(getUiSettings());
   }
 
   componentDidMount() {
@@ -475,6 +480,8 @@ export class FileDetails extends Component {
           <EuiFlexGroup className="flyout-row">
             <EuiFlexItem>
               <Discover
+                kbnSearchBar
+                shareFilterManager={this.discoverFilterManager}
                 initialColumns={[
                   'icon',
                   'timestamp',

--- a/public/components/common/modules/discover/discover.tsx
+++ b/public/components/common/modules/discover/discover.tsx
@@ -253,10 +253,6 @@ export const Discover = compose(
     return result;
   }
 
-  // onFiltersChange = (filters) => {
-  //   this.setState({ filters: this.filtersAsArray(filters) });
-  // }
-
   toggleDetails = item => {
     const itemIdToExpandedRowMap = { ...this.state.itemIdToExpandedRowMap };
     if (itemIdToExpandedRowMap[item._id]) {
@@ -273,7 +269,6 @@ export const Discover = compose(
 
   buildFilter() {
     const dateParse = ds => /\d+-\d+-\d+T\d+:\d+:\d+.\d+Z/.test(ds) ? DateMatch.parse(ds).toDate().getTime() : ds;
-    // const { searchBarFilters } = this.state;
     const { query } = this.state;
     const { hideManagerAlerts } = this.wazuhConfig.getConfig();
     const extraFilters = [];

--- a/public/components/common/modules/discover/discover.tsx
+++ b/public/components/common/modules/discover/discover.tsx
@@ -169,7 +169,7 @@ export const Discover = compose(
     this._isMount = true;
     try {
       this.setState({columns: this.getColumns(), searchBarFilters: this.props.shareFilterManager || []}) //initial columns
-      await this.getIndexPattern(); 
+      await this.getIndexPattern();
       await this.getAlerts();
     } catch (err) {
       console.log(err);
@@ -182,7 +182,9 @@ export const Discover = compose(
 
   async componentDidUpdate(prevProps, prevState) {
     if (!this._isMount) { return; }
-    if((!prevProps.currentAgentData.id && this.props.currentAgentData.id) || (prevProps.currentAgentData.id && !this.props.currentAgentData.id)){
+    if((!prevProps.currentAgentData.id && this.props.currentAgentData.id) 
+     || (prevProps.currentAgentData.id && !this.props.currentAgentData.id)
+     || prevProps.currentAgentData.id !== this.props.currentAgentData.id){
       this.setState({ columns: this.getColumns() }); // Updates the columns to be rendered if you change the selected agent to none or vice versa
       return;
     }

--- a/public/components/common/modules/discover/discover.tsx
+++ b/public/components/common/modules/discover/discover.tsx
@@ -69,7 +69,7 @@ export const Discover = compose(
   };
 
   KibanaServices: { [key: string]: any };
-  filterManager: FilterManager;
+  // filterManager: FilterManager;
   state: {
     sort: object
     selectedTechnique: string,
@@ -108,7 +108,7 @@ export const Discover = compose(
   constructor(props) {
     super(props);
     this.KibanaServices = getDataPlugin();
-    this.filterManager = props.shareFilterManager ? this.KibanaServices.query.filterManager : new FilterManager(getUiSettings());
+    // this.filterManager = props.shareFilterManager;
     this.timefilter = this.KibanaServices.query.timefilter.timefilter;
     this.state = {
       sort: {},
@@ -190,8 +190,7 @@ export const Discover = compose(
       this.setState({ query: {...this.props.query}});
       return;
     };
-    if((!_.isEqual(this.props.shareFilterManager, prevProps.shareFilterManager))
-      || (this.props.currentAgentData.id !== prevProps.currentAgentData.id)
+    if((this.props.currentAgentData.id !== prevProps.currentAgentData.id)
       || (!_.isEqual(this.state.query, prevState.query))
       || (!_.isEqual(this.state.searchBarFilters, prevState.searchBarFilters))
       || (!_.isEqual(this.state.dateRange, prevState.dateRange))
@@ -532,8 +531,8 @@ export const Discover = compose(
       filters.push(formattedFilter);
     })
 
-    this.filterManager.setFilters(filters);
-    if (!this.props.shareFilterManager) this.setState({ searchBarFilters: filters });
+    this.props.shareFilterManager.setFilters(filters);
+    // if (!this.props.shareFilterManager) this.setState({ searchBarFilters: filters });
   }
 
   /**
@@ -552,8 +551,8 @@ export const Discover = compose(
       }
       filters.push(formattedFilter);
     })
-    this.filterManager.addFilters(filters);
-    if (!this.props.shareFilterManager) this.setState({ searchBarFilters: filters });
+    this.props.shareFilterManager.addFilters(filters);
+    // if (!this.props.shareFilterManager) this.setState({ searchBarFilters: filters });
 
   }
 
@@ -624,9 +623,9 @@ export const Discover = compose(
     return (
       <div
         className='wz-discover hide-filter-control wz-inventory' >
-        {!this.props.shareFilterManager && <KbnSearchBar
+        {this.props.filterManagerKbnSearchBar && <KbnSearchBar
           indexPattern={this.indexPattern}
-          filterManager={this.filterManager}
+          filterManager={this.props.filterManagerKbnSearchBar}
           onQuerySubmit={this.onQuerySubmit}
           onFiltersUpdated={this.onFiltersUpdated}
           query={query} />

--- a/public/components/common/modules/discover/discover.tsx
+++ b/public/components/common/modules/discover/discover.tsx
@@ -182,9 +182,7 @@ export const Discover = compose(
 
   async componentDidUpdate(prevProps, prevState) {
     if (!this._isMount) { return; }
-    if((!prevProps.currentAgentData.id && this.props.currentAgentData.id) 
-     || (prevProps.currentAgentData.id && !this.props.currentAgentData.id)
-     || prevProps.currentAgentData.id !== this.props.currentAgentData.id){
+    if((!prevProps.currentAgentData.id && this.props.currentAgentData.id) || (prevProps.currentAgentData.id && !this.props.currentAgentData.id) || prevProps.currentAgentData.id !== this.props.currentAgentData.id){
       this.setState({ columns: this.getColumns() }); // Updates the columns to be rendered if you change the selected agent to none or vice versa
       return;
     }

--- a/public/components/overview/compliance-table/components/requirement-flyout/requirement-flyout.tsx
+++ b/public/components/overview/compliance-table/components/requirement-flyout/requirement-flyout.tsx
@@ -30,6 +30,8 @@ import {
 import { Discover } from '../../../../common/modules/discover';
 import { AppState } from '../../../../../react-services/app-state';
 import { requirementGoal } from '../../requirement-goal';
+import { getUiSettings } from '../../../../../kibana-services';
+import { FilterManager } from '../../../../../../../../src/plugins/data/public/';
 
 
 
@@ -41,10 +43,13 @@ export class RequirementFlyout extends Component {
     props!: {
     };
 
+    filterManager: FilterManager;
+
     constructor(props) {
         super(props);
         this.state = {
         }
+        this.filterManager = new FilterManager(getUiSettings());
     }
 
     componentDidMount() {
@@ -164,7 +169,7 @@ export class RequirementFlyout extends Component {
                     initialIsOpen={true}>
                     <EuiFlexGroup className="flyout-row">
                         <EuiFlexItem>
-                            <Discover initialColumns={["icon", "timestamp", this.props.getRequirementKey(), 'rule.level', 'rule.id', 'rule.description']} implicitFilters={implicitFilters} initialFilters={[]} updateTotalHits={(total) => this.updateTotalHits(total)} />
+                            <Discover filterManagerKbnSearchBar={this.filterManager} shareFilterManager={[...((this.filterManager || {}).filters) || []]} initialColumns={["icon", "timestamp", this.props.getRequirementKey(), 'rule.level', 'rule.id', 'rule.description']} implicitFilters={implicitFilters} initialFilters={[]} updateTotalHits={(total) => this.updateTotalHits(total)} />
                         </EuiFlexItem>
                     </EuiFlexGroup>
                 </EuiAccordion>

--- a/public/components/overview/compliance-table/components/requirement-flyout/requirement-flyout.tsx
+++ b/public/components/overview/compliance-table/components/requirement-flyout/requirement-flyout.tsx
@@ -169,7 +169,7 @@ export class RequirementFlyout extends Component {
                     initialIsOpen={true}>
                     <EuiFlexGroup className="flyout-row">
                         <EuiFlexItem>
-                            <Discover filterManagerKbnSearchBar={this.filterManager} shareFilterManager={[...((this.filterManager || {}).filters) || []]} initialColumns={["icon", "timestamp", this.props.getRequirementKey(), 'rule.level', 'rule.id', 'rule.description']} implicitFilters={implicitFilters} initialFilters={[]} updateTotalHits={(total) => this.updateTotalHits(total)} />
+                            <Discover kbnSearchBar shareFilterManager={this.filterManager} initialColumns={["icon", "timestamp", this.props.getRequirementKey(), 'rule.level', 'rule.id', 'rule.description']} implicitFilters={implicitFilters} initialFilters={[]} updateTotalHits={(total) => this.updateTotalHits(total)} />
                         </EuiFlexItem>
                     </EuiFlexGroup>
                 </EuiAccordion>

--- a/public/components/overview/mitre/components/techniques/components/flyout-technique/flyout-technique.tsx
+++ b/public/components/overview/mitre/components/techniques/components/flyout-technique/flyout-technique.tsx
@@ -39,6 +39,8 @@ import { WzRequest } from '../../../../../../../react-services/wz-request';
 import { AppState } from '../../../../../../../react-services/app-state';
 import { AppNavigate } from '../../../../../../../react-services/app-navigate';
 import { Discover } from '../../../../../../common/modules/discover';
+import { getUiSettings } from '../../../../../../../kibana-services';
+import { FilterManager } from '../../../../../../../../../../src/plugins/data/public/';
 
 export class FlyoutTechnique extends Component {
   _isMount = false;
@@ -56,6 +58,8 @@ export class FlyoutTechnique extends Component {
     currentTechnique: string
   }
 
+  filterManager: FilterManager;
+
   constructor(props) {
     super(props);
     this.state = {
@@ -64,6 +68,7 @@ export class FlyoutTechnique extends Component {
       },
       loading: false
     }
+    this.filterManager = new FilterManager(getUiSettings());
   }
 
   async componentDidMount() {
@@ -315,7 +320,7 @@ export class FlyoutTechnique extends Component {
             initialIsOpen={true}>
           <EuiFlexGroup className="flyout-row">
             <EuiFlexItem>
-              <Discover initialColumns={["icon", "timestamp", 'rule.mitre.id', 'rule.mitre.tactic', 'rule.level', 'rule.id', 'rule.description']} implicitFilters={implicitFilters} initialFilters={[]} updateTotalHits={(total) => this.updateTotalHits(total)}/>
+              <Discover filterManagerKbnSearchBar={this.filterManager} shareFilterManager={[...((this.filterManager || {}).filters) || []]} initialColumns={["icon", "timestamp", 'rule.mitre.id', 'rule.mitre.tactic', 'rule.level', 'rule.id', 'rule.description']} implicitFilters={implicitFilters} initialFilters={[]} updateTotalHits={(total) => this.updateTotalHits(total)}/>
             </EuiFlexItem>
           </EuiFlexGroup>
         </EuiAccordion>

--- a/public/components/overview/mitre/components/techniques/components/flyout-technique/flyout-technique.tsx
+++ b/public/components/overview/mitre/components/techniques/components/flyout-technique/flyout-technique.tsx
@@ -320,7 +320,7 @@ export class FlyoutTechnique extends Component {
             initialIsOpen={true}>
           <EuiFlexGroup className="flyout-row">
             <EuiFlexItem>
-              <Discover filterManagerKbnSearchBar={this.filterManager} shareFilterManager={[...((this.filterManager || {}).filters) || []]} initialColumns={["icon", "timestamp", 'rule.mitre.id', 'rule.mitre.tactic', 'rule.level', 'rule.id', 'rule.description']} implicitFilters={implicitFilters} initialFilters={[]} updateTotalHits={(total) => this.updateTotalHits(total)}/>
+              <Discover kbnSearchBar shareFilterManager={this.filterManager} initialColumns={["icon", "timestamp", 'rule.mitre.id', 'rule.mitre.tactic', 'rule.level', 'rule.id', 'rule.description']} implicitFilters={implicitFilters} initialFilters={[]} updateTotalHits={(total) => this.updateTotalHits(total)}/>
             </EuiFlexItem>
           </EuiFlexGroup>
         </EuiAccordion>

--- a/public/components/visualize/components/security-alerts.tsx
+++ b/public/components/visualize/components/security-alerts.tsx
@@ -21,7 +21,7 @@ export const SecurityAlerts = () => {
 
   return (
     <Discover
-      shareFilterManager={[...((filterManager || {}).filters) || []]}
+      shareFilterManager={filterManager}
       query={query}
       initialColumns={["icon", "timestamp", 'rule.mitre.id', 'rule.mitre.tactic', 'rule.description', 'rule.level', 'rule.id']}
       implicitFilters={[]}

--- a/public/kibana-integrations/kibana-discover.js
+++ b/public/kibana-integrations/kibana-discover.js
@@ -299,7 +299,7 @@ function discoverController(
         next: () => {
           //Patch empty fields
           const filters = filterManager.getAppFilters();
-          if(filters.filter(item=>item.meta.params.query==='').length){
+          if(filters.filter(item=> item.meta.params && item.meta.params.query === '').length){
             getToasts().add({
               color: 'warning',
               title: 'Invalid field value',


### PR DESCRIPTION
Hi guys,
We have fixed a bug that caused alerts not to be displayed if you switch from one pinned agent to another in the explore agent submenu.