### PR TITLE
Overlay Wazuh menu to Kibana menu when is opened or docked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the Wazuh app project will be documented in this file.
 
+## Wazuh v4.1.1 - Kibana 7.10.0 , 7.10.2 - Revision 4103
+
+### Fixed
+
+- Overlay Wazuh menu when Kibana menu is opened or docked [#3038](https://github.com/wazuh/wazuh-kibana-app/pull/3038)
+
 ## Wazuh v4.1.1 - Kibana 7.10.0 , 7.10.2 - Revision 4102
 
 ### Added

--- a/public/components/wz-menu/wz-menu.js
+++ b/public/components/wz-menu/wz-menu.js
@@ -437,8 +437,7 @@ class WzMenu extends Component {
   }
 
   switchMenuOpened = () => {
-    const kibanaMenuBlockedClass = document.getElementsByClassName('chrHeaderWrapper--navIsLocked');
-    const kibanaMenuBlocked = (kibanaMenuBlockedClass || []).length;
+    const kibanaMenuBlockedOrOpened = document.body.classList.contains('euiBody--collapsibleNavIsDocked') || document.body.classList.contains('euiBody--collapsibleNavIsOpen');
     if (!this.state.menuOpened && this.state.currentMenuTab === 'manager') {
       this.managementPopoverToggle();
     } else if (this.state.currentMenuTab === 'overview') {
@@ -450,7 +449,7 @@ class WzMenu extends Component {
     } else {
       this.closeAllPopover()
     }
-    this.setState({ menuOpened: !this.state.menuOpened, kibanaMenuBlocked, hover: this.state.currentMenuTab }, async () => {
+    this.setState({ menuOpened: !this.state.menuOpened, kibanaMenuBlockedOrOpened, hover: this.state.currentMenuTab }, async () => {
       if (this.state.menuOpened) await this.loadApiList();
     });
   };
@@ -758,7 +757,7 @@ class WzMenu extends Component {
           <Fragment>
             <EuiPopover
               panelClassName={
-                this.state.kibanaMenuBlocked ?
+                this.state.kibanaMenuBlockedOrOpened ?
                   "wz-menu-popover wz-menu-popover-over" :
                   "wz-menu-popover wz-menu-popover-under"
               }
@@ -766,6 +765,8 @@ class WzMenu extends Component {
               isOpen={this.state.menuOpened}
               closePopover={() => this.setState({ menuOpened: false })}
               anchorPosition="downLeft"
+              panelPaddingSize='none'
+              hasArrow={false}
             >
               <Fragment>{menu}</Fragment>
             </EuiPopover>

--- a/public/components/wz-menu/wz-menu.scss
+++ b/public/components/wz-menu/wz-menu.scss
@@ -34,9 +34,6 @@ wz-menu {
 }
 
 .wz-menu-wrapper{
-    margin-top: 1.6rem;
-    margin-left: -1.6rem;
-    margin-bottom: -1.1rem;
     display: flex;
 }
 
@@ -90,11 +87,17 @@ wz-menu {
 
 .wz-menu-popover{
     position: fixed;
-    top: 56px !important;
+    top: 105px !important;
     left: 96px !important;
     border-radius: 0px 0px 4px 0px;
     max-height: unset!important;
     border-right: none!important;
+}
+
+@media only screen and (min-width: 1068px){
+    .wz-menu-popover{
+        top: 97px !important;
+    }
 }
 
 .wz-menu-popover-over .euiPopover__panelArrow.euiPopover__panelArrow--bottom:after {


### PR DESCRIPTION
Hi team, this PR resolves:
- Overlay the Wazuh menu to the Kibana menu when it is opened or docked.

Closes: https://github.com/wazuh/wazuh-kibana-app/issues/2994