### PR TITLE
fix tcp sessions visualizations

### DIFF
--- a/server/integration-files/visualizations/cluster/statistics.ts
+++ b/server/integration-files/visualizations/cluster/statistics.ts
@@ -64,7 +64,7 @@ export default [
     _source: {
       title: 'Wazuh App Statistics remoted tcp sessions',
       visState:
-        `{"title":"Wazuh App Statistics remoted tcp sessions","type":"timelion","params":{"expression":".es(timefield=timestamp,metric=avg:remoted.tcp_sessions, q='*').label(tcp_sessions)","interval":"5m"},"aggs":[]}`,
+        `{"title":"Wazuh App Statistics remoted tcp sessions","type":"timelion","params":{"expression":".es(timefield=timestamp,metric=sum:remoted.tcp_sessions, q='*').label(tcp_sessions),.es(timefield=timestamp,metric=avg:remoted.tcp_sessions, q='*').label(tcp_sessions_avg)","interval":"5m"},"aggs":[]}`,
       uiStateJSON: '{}',
       description: '',
       version: 1,

--- a/server/integration-files/visualizations/cluster/statistics.ts
+++ b/server/integration-files/visualizations/cluster/statistics.ts
@@ -64,7 +64,7 @@ export default [
     _source: {
       title: 'Wazuh App Statistics remoted tcp sessions',
       visState:
-        `{"title":"Wazuh App Statistics remoted tcp sessions","type":"timelion","params":{"expression":".es(timefield=timestamp,metric=sum:remoted.tcp_sessions, q='*').label(tcp_sessions),.es(timefield=timestamp,metric=avg:remoted.tcp_sessions, q='*').label(tcp_sessions_avg)","interval":"5m"},"aggs":[]}`,
+        `{"title":"Wazuh App Statistics remoted tcp sessions","type":"timelion","params":{"expression":".es(timefield=timestamp,metric=sum:remoted.tcp_sessions, q='*').label(tcp_sessions)","interval":"5m"},"aggs":[]}`,
       uiStateJSON: '{}',
       description: '',
       version: 1,


### PR DESCRIPTION
Hi team, this resolve:

- Wrong name in TCP sessions visualization when showing TCP sessions average.
- Fix metric Avg TCP sessions to total TCP sessions

![Captura de pantalla de 2021-03-26 12-41-58](https://user-images.githubusercontent.com/36004787/112656978-b4edf480-8e30-11eb-9ff7-d6ae693392d9.png)
