### PR TITLE
Fix redirect to settings after the health check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 
 ### Fixed
 
+- Filter only authorized agents in Agents stats and Visualizations [#3088](https://github.com/wazuh/wazuh-kibana-app/pull/3088)
 - Fixed missing `pending` status suggestion for agents [#3095](https://github.com/wazuh/wazuh-kibana-app/pull/3095)
 - Index pattern setting not used for choosing from existing patterns [#3097](https://github.com/wazuh/wazuh-kibana-app/pull/3097)
 - Fix space character missing on deployment command if UDP is configured [#3108](https://github.com/wazuh/wazuh-kibana-app/pull/3108)
@@ -27,19 +28,6 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fixed name for "TCP sessions" visualization and average metric is now a sum [#3118](https://github.com/wazuh/wazuh-kibana-app/pull/3118)
 - Fixed Last keep alive label is outside the panel [#3122](https://github.com/wazuh/wazuh-kibana-app/pull/3122)
 - Fixed app redirect to Settings section after the health check [#3128](https://github.com/wazuh/wazuh-kibana-app/pull/3128)
-
-## Wazuh v4.1.4 - Kibana 7.10.0 , 7.10.2 - Revision 4105
-
-- Adapt for Wazuh 4.1.4
-
-
-## Wazuh v4.1.4 - Kibana 7.10.0 , 7.10.2 - Revision 4105
-
-- Adapt for Wazuh 4.1.4
-
-### Fixed 
-
-- Filter only authorized agents in Agents stats and Visualizations [#3088](https://github.com/wazuh/wazuh-kibana-app/pull/3088)
 
 ## Wazuh v4.1.4 - Kibana 7.10.0 , 7.10.2 - Revision 4105
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Flyout date filter also changes main date filter [#3114](https://github.com/wazuh/wazuh-kibana-app/pull/3114)
 - Fixed name for "TCP sessions" visualization and average metric is now a sum [#3118](https://github.com/wazuh/wazuh-kibana-app/pull/3118)
 - Fixed Last keep alive label is outside the panel [#3122](https://github.com/wazuh/wazuh-kibana-app/pull/3122)
+- Fixed app redirect to Settings section after the health check [#3128](https://github.com/wazuh/wazuh-kibana-app/pull/3128)
 
 ## Wazuh v4.1.4 - Kibana 7.10.0 , 7.10.2 - Revision 4105
 

--- a/common/constants.ts
+++ b/common/constants.ts
@@ -176,7 +176,7 @@ export const WAZUH_DEFAULT_APP_CONFIG = {
 };
 
 // Wazuh errors
-export const WAZUH_ERROR_DAEMONS_NOT_READY = 'ERROR3099 - Some Wazuh daemons are not ready yet in node';
+export const WAZUH_ERROR_DAEMONS_NOT_READY = 'ERROR3099';
 
 // Agents
 export enum WAZUH_AGENTS_OS_TYPE{

--- a/public/components/health-check/health-check.tsx
+++ b/public/components/health-check/health-check.tsx
@@ -183,21 +183,21 @@ export class HealthCheck extends Component {
     let errors = this.state.errors;
     let apiChanged = false;
     const buttonRestartApi = <div> <span><EuiIcon type="alert" color="danger" ></EuiIcon> Error</span>
-            {<EuiToolTip
-              position='top'
-              content='Try to reconnect to the API'
-            >
-              <EuiButtonIcon
-                display="base"
-                iconType="refresh"
-                isLoading
-                iconSize="l"
-                onClick={() => this.reconnectWithAPI()}
-                size="m"
-                aria-label="Next"
-              />
-            </EuiToolTip>}
-          </div>;
+      {<EuiToolTip
+        position='top'
+        content='Try to reconnect to the API'
+      >
+        <EuiButtonIcon
+          display="base"
+          iconType="refresh"
+          isLoading
+          iconSize="l"
+          onClick={() => this.reconnectWithAPI()}
+          size="m"
+          aria-label="Next"
+        />
+      </EuiToolTip>}
+    </div>;
 
     try {
       const currentApi = JSON.parse(AppState.getCurrentAPI() || '{}');
@@ -284,16 +284,15 @@ export class HealthCheck extends Component {
                 permissionToGoToTheApp = false;
               }
               results[i].description = <span><EuiIcon type="check" color="secondary" ></EuiIcon> Ready</span>;
-              for (let element of results) {
-                if (results[i].description.props.children[1].includes('Error')) {
-                  permissionToGoToTheApp = false;
-                }
+              if (results[i].description.props.children[1].includes('Error')) {
+                permissionToGoToTheApp = false;
               }
               this.setState({ results, errors });
-              if (permissionToGoToTheApp)
+              if (permissionToGoToTheApp) {
                 this.goAppOverview();
                 const updateNotReadyYet = updateWazuhNotReadyYet(false);
                 store.dispatch(updateNotReadyYet);
+              }
             }
           }
         }

--- a/public/components/health-check/health-check.tsx
+++ b/public/components/health-check/health-check.tsx
@@ -158,20 +158,20 @@ export class HealthCheck extends Component {
   /**
    * This attempts to reconnect with API
    */
-  reconnectWithAPI(){
+  reconnectWithAPI() {
     let results = this.state.results;
     results[0].description = <span><EuiLoadingSpinner size="m" /> Checking...</span>;
     results[1].description = <span><EuiLoadingSpinner size="m" /> Checking...</span>;
     getToasts().toasts$._value.forEach(toast => {
-      if(toast.text.includes('3000'))
+      if (toast.text.includes('3000'))
         getToasts().remove(toast.id);
     });
     let errors = this.state.errors;
     this.state.errors.forEach(error => {
-      if(error.includes('API'))
+      if (error.includes('API'))
         errors.pop(error);
     });
-    this.setState({results, errors});
+    this.setState({ results, errors });
     this.checkApiConnection();
   }
 
@@ -182,6 +182,23 @@ export class HealthCheck extends Component {
     let results = this.state.results;
     let errors = this.state.errors;
     let apiChanged = false;
+    const buttonRestartApi = <div> <span><EuiIcon type="alert" color="danger" ></EuiIcon> Error</span>
+            {<EuiToolTip
+              position='top'
+              content='Try to reconnect to the API'
+            >
+              <EuiButtonIcon
+                display="base"
+                iconType="refresh"
+                isLoading
+                iconSize="l"
+                onClick={() => this.reconnectWithAPI()}
+                size="m"
+                aria-label="Next"
+              />
+            </EuiToolTip>}
+          </div>;
+
     try {
       const currentApi = JSON.parse(AppState.getCurrentAPI() || '{}');
       if (this.state.checks.api && currentApi && currentApi.id) {
@@ -219,7 +236,7 @@ export class HealthCheck extends Component {
         const i = results.map(item => item.id).indexOf(0);
         if (data === 3099) {
           errors.push('Wazuh not ready yet.');
-          results[i].description = <span><EuiIcon type="alert" color="danger" ></EuiIcon> Error</span>;
+          results[i].description = <span><EuiIcon type="alert" color="danger" ></EuiIcon> Error</span>;;
           if (this.checks.setup) {
             const i = results.map(item => item.id).indexOf(1);
             results[i].description = <span><EuiIcon type="alert" color="danger" ></EuiIcon> Error</span>;
@@ -227,23 +244,8 @@ export class HealthCheck extends Component {
           this.setState({ results, errors });
         } else if (data.data.error || data.data.data.apiIsDown) {
           errors.push(data.data.data.apiIsDown ? 'Wazuh API is down.' : `Error connecting to the API.${data.data.error && data.data.error.message ? ` ${data.data.error.message}` : ''}`);
-          results[i].description =    <div> <span><EuiIcon type="alert" color="danger" ></EuiIcon> Error</span> 
-          { <EuiToolTip
-                  position='top'
-                  content='Try to reconnect to the API'
-          >
-             <EuiButtonIcon
-                display="base"
-                iconType="refresh"
-                isLoading
-                iconSize="l"
-                onClick={() => this.reconnectWithAPI()}
-                size="m"
-                aria-label="Next"
-              />
-          </EuiToolTip> }
-          </div>;
-          results[i + 1].description = <span><EuiIcon type="alert" color="danger" ></EuiIcon> Error</span> 
+          results[i].description = buttonRestartApi;
+          results[i + 1].description = <span><EuiIcon type="alert" color="danger" ></EuiIcon> Error</span>
           this.setState({ results, errors });
         } else {
           results[i].description = <span><EuiIcon type="check" color="secondary" ></EuiIcon> Ready</span>;
@@ -277,27 +279,28 @@ export class HealthCheck extends Component {
               results[i].description = <span><EuiIcon type="alert" color="danger" ></EuiIcon> Error</span>;
               this.setState({ results, errors });
             } else {
-               let permissionToGoToTheApp = true;
-               if(!results[i].description.props.children[1].includes('Checking')){
-                 permissionToGoToTheApp = false;
-               }
-               results[i].description = <span><EuiIcon type="check" color="secondary" ></EuiIcon> Ready</span>;
-               for (let element of results){
-                 if(results[i].description.props.children[1].includes('Error')){
-                   permissionToGoToTheApp = false;
-                 }
-               }
-
-               this.setState({ results, errors });
-               if(permissionToGoToTheApp)
-                 this.goApp();
+              let permissionToGoToTheApp = true;
+              if (!results[i].description.props.children[1].includes('Checking')) {
+                permissionToGoToTheApp = false;
+              }
+              results[i].description = <span><EuiIcon type="check" color="secondary" ></EuiIcon> Ready</span>;
+              for (let element of results) {
+                if (results[i].description.props.children[1].includes('Error')) {
+                  permissionToGoToTheApp = false;
+                }
+              }
+              this.setState({ results, errors });
+              if (permissionToGoToTheApp)
+                this.goAppOverview();
+                const updateNotReadyYet = updateWazuhNotReadyYet(false);
+                store.dispatch(updateNotReadyYet);
             }
           }
         }
       }
       return;
     } catch (error) {
-      results[0].description = <span><EuiIcon type="alert" color="danger" ></EuiIcon> Error</span>;
+      results[0].description = buttonRestartApi;
       results[1].description = <span><EuiIcon type="alert" color="danger" ></EuiIcon> Error</span>;
       this.setState({ results });
       AppState.removeNavigation();
@@ -442,8 +445,12 @@ export class HealthCheck extends Component {
     }
   }
 
-  goApp() {
+  goAppSettings() {
     window.location.href = '/app/wazuh#/settings';
+  }
+
+  goAppOverview() {
+    window.location.href = '/app/wazuh#/overview';
   }
 
   render() {
@@ -478,7 +485,7 @@ export class HealthCheck extends Component {
         {!!this.state.errors.length && (
           <EuiButton
             fill
-            onClick={() => this.goApp()}>
+            onClick={() => this.goAppSettings()}>
             Go to App
           </EuiButton>
         )}

--- a/public/components/health-check/health-check.tsx
+++ b/public/components/health-check/health-check.tsx
@@ -119,10 +119,10 @@ export class HealthCheck extends Component {
       const hosts = response.data;
       const errors = [];
       const results = this.state.results;
+      const maxTries = 5;
 
       if (hosts.length) {
         for (let i = 0; i < hosts.length; i++) {
-          const maxTries = 5;
           let tries = maxTries;
           while (tries--) {
             await this.delay(3000);


### PR DESCRIPTION
Hi team this PR solves:
- The app redirect to Settings section after the health check 
- If the wazuh-manager service was stopped the button did not appeared.
- Remove some unused code.

### How to test
To test this PR you have to `stop the manager service` and then try to pass the health check. After that the button should appeared and then you need to `start the manager service` again before clicking on the button. Finally after the health check is passed you should be redirected to `overview` section