### PR TITLE
Fixed problems with permissions in Rules, Decoders and Groups

### DIFF
--- a/common/api-info/security-actions.json
+++ b/common/api-info/security-actions.json
@@ -652,7 +652,7 @@
   "rules:update": {
     "description": "Update or upload custom rule files",
     "resources": [
-      "**"
+      "*:*"
     ],
     "example": {
       "actions": [

--- a/common/api-info/security-actions.json
+++ b/common/api-info/security-actions.json
@@ -203,7 +203,7 @@
   "group:read": {
     "description": "Access agent groups information (id, name, agents, etc)",
     "resources": [
-      "*:*"
+      "*:*","group:id"
     ],
     "example": {
       "actions": [
@@ -652,7 +652,7 @@
   "rules:update": {
     "description": "Update or upload custom rule files",
     "resources": [
-      "rule:file"
+      "**"
     ],
     "example": {
       "actions": [
@@ -790,7 +790,7 @@
   "decoders:update": {
     "description": "Update or upload custom decoder files",
     "resources": [
-      "decoder:file"
+      "*:*"
     ],
     "example": {
       "actions": [


### PR DESCRIPTION
Hi guys, we have fixed a problem that causes us to not be able to interact with the buttons of manage rules files / decoders and add new rules / decoders file together with the bug of not being able to enter groups having permissions.