### PR TITLE
Fix/default pattern error

### DIFF
--- a/public/services/resolves/get-ip.js
+++ b/public/services/resolves/get-ip.js
@@ -33,8 +33,8 @@ export function getIp(
     if(!indexPatternFound){
       AppState.removeCurrentPattern()
     }
-    getDataPlugin().indexPatterns.setDefault(configuration.pattern, true);
-    AppState.setCurrentPattern(configuration.pattern)
+    getDataPlugin().indexPatterns.setDefault(indexPatternFound.id, true);
+    AppState.setCurrentPattern(indexPatternFound.id)
 
     return indexPatternFound;
   }


### PR DESCRIPTION
Hi team this PR solve:
- Error when selecting pattern as default in the  `wazuh.yml` with different id and title

### How to test:
To test this PR first you need to create a new index pattern in Stack Management > Index pattern without changing it's id (if it is not created it will be created in the health check). Then you have to add this configuration to your wazuh.yml pattern: '<INDEX_PATTERN_NAME>'. After this you should clean the cookies and the caché before entering to the app. Finally click on Wazuh and the default index pattern should be the same that you had created.

