### PR TITLE
Fix the plugin logo path in Kibana menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Filter only authorized agents in Events and Security Alerts table [#3120](https://github.com/wazuh/wazuh-kibana-app/pull/3120)
 - Fixed Last keep alive label is outside the panel [#3122](https://github.com/wazuh/wazuh-kibana-app/pull/3122)
 - Fixed app redirect to Settings section after the health check [#3128](https://github.com/wazuh/wazuh-kibana-app/pull/3128)
+- Fix the plugin logo path in Kibana menu when use `server.basePath` setting [#3144](https://github.com/wazuh/wazuh-kibana-app/pull/3144)
 
 ## Wazuh v4.1.4 - Kibana 7.10.0 , 7.10.2 - Revision 4105
 

--- a/public/plugin.ts
+++ b/public/plugin.ts
@@ -36,7 +36,7 @@ export class WazuhPlugin implements Plugin<WazuhSetup, WazuhStart, WazuhSetupPlu
     core.application.register({
       id: `wazuh`,
       title: 'Wazuh',
-      icon: '/plugins/wazuh/assets/icon_blue.png',
+      icon: core.http.basePath.prepend('/plugins/wazuh/assets/icon_blue.png'),
       mount: async (params: AppMountParameters) => {
         if (!this.initializeInnerAngular) {
           throw Error('Wazuh plugin method initializeInnerAngular is undefined');
@@ -65,7 +65,7 @@ export class WazuhPlugin implements Plugin<WazuhSetup, WazuhStart, WazuhSetupPlu
         id: 'wazuh',
         label: 'Wazuh',
         order: 0,
-        euiIconType: '/plugins/wazuh/assets/icon_blue.png',      
+        euiIconType: core.http.basePath.prepend('/plugins/wazuh/assets/icon_blue.png'),      
       },
     });
     return {};


### PR DESCRIPTION
### Description
Hi team, this PR resolves:
- Fix the path of the plugin logo in the Kibana menu

### Checks

- Add the `server.basePath` setting in `kibana.yml`, for example:
```
server.basePath: /wazuh
```
This changes the path to Kibana to `<KIBANA_HOST_IP>:<KIBANA_PORT>:<SERVER_BASE_PATH>`

Check the plugin logo is visible in the Kibana menu.

![image](https://user-images.githubusercontent.com/34042064/114529625-7175f180-9c4a-11eb-8052-89af0ef4e261.png)

Closes #3142