### PR TITLE
Fix not retrying the API connection in the healthcheck

### DIFF
--- a/public/components/health-check/health-check.tsx
+++ b/public/components/health-check/health-check.tsx
@@ -209,6 +209,10 @@ export class HealthCheck extends Component {
         let data;
         try {
           data = await ApiCheck.checkStored(currentApi.id);
+          // Fix when the app endpoint replies with a valid response but the API is really down
+          if(data.data.data.apiIsDown){
+            throw 'API is down'
+          };
         } catch (err) {
           try {
             const newApi = await this.trySetDefault();


### PR DESCRIPTION
### Description
Hi team, this PR resolves:
- Fix when the API is down not retrying the connection.

Note: this has a temporal fix

### Checks
- Stop the Wazuh manager service/binary
```
service wazuh-manager stop
```
- Stop the container/down the machine with the Wazuh manager of the used Wazuh API

In both cases, it should allow to retry the connection and it should appear the `Retrying` in the API connection and API version checks