### PR TITLE
Add permissions control to Logtest

### DIFF
--- a/public/controllers/management/components/management/ruleset/ruleset-editor.js
+++ b/public/controllers/management/components/management/ruleset/ruleset-editor.js
@@ -203,14 +203,16 @@ class WzRulesetEditor extends Component {
 
     const buildLogtestButton = () => {
       return (
-        <EuiButtonEmpty
+        <WzButtonPermissions
+          buttonType="empty"
+          permissions={[{ action: 'logtest:run', resource: `*:*:*` }]}
           color="primary"
           iconType="documentEdit"
           style={{ margin: '0px 8px', cursor: 'pointer' }}
           onClick={onClickOpenLogtest}
         >
           {isRules}
-        </EuiButtonEmpty>
+        </WzButtonPermissions>
       );
     };
 

--- a/public/directives/wz-logtest/components/logtest.tsx
+++ b/public/directives/wz-logtest/components/logtest.tsx
@@ -10,7 +10,6 @@
  * Find more information about this on the LICENSE file.
  */
 import React, { Fragment, useState } from 'react';
-import PropTypes from 'prop-types';
 import { DynamicHeight } from '../../../utils/dynamic-height';
 import {
   EuiButton,
@@ -28,8 +27,21 @@ import {
   EuiOverlayMask,
 } from '@elastic/eui';
 import { WzRequest } from '../../../react-services';
+import { withReduxProvider, withUserAuthorizationPrompt } from '../../../components/common/hocs';
+import { compose } from 'redux';
 
-export const Logtest = (props) => {
+
+type LogstestProps = {
+  openCloseFlyout: () => {},
+  showClose: boolean,
+  onFlyout: boolean,
+  isRuleset: string,
+};
+
+export const Logtest = compose(
+  withReduxProvider,
+  withUserAuthorizationPrompt([{ action: 'logtest:run', resource: `*:*:*` }])
+)((props: LogstestProps) => {
   const [value, setValue] = useState('');
   const [testing, setTesting] = useState(false);
   const [testResult, setTestResult] = useState(false);
@@ -181,11 +193,4 @@ export const Logtest = (props) => {
       )}
     </Fragment>
   );
-};
-
-Logtest.propTypes = {
-  openCloseFlyout: PropTypes.func,
-  showClose: PropTypes.bool,
-  onFlyout: PropTypes.bool,
-  isRuleset: PropTypes.string,
-};
+});


### PR DESCRIPTION
### Description
This PR resolves:
- Add a prompt with the required permissions (`logtest:run`) for `Tools > Ruleset Test`
- Replace the `Ruleset Test` and `Decoders Test` buttons to require the permissions related to Logtest (`logtest:run`)

### Screenshots
*Tools > Ruleset Test**
![image](https://user-images.githubusercontent.com/34042064/114679084-24f2ea80-9d0c-11eb-825b-a9a2fa99e046.png)
**Adding a rule**
![image](https://user-images.githubusercontent.com/34042064/114679140-320fd980-9d0c-11eb-93cb-c5fa04f188bc.png)
**Adding a decoder**
![image](https://user-images.githubusercontent.com/34042064/114679207-3fc55f00-9d0c-11eb-8901-e3b8282066a7.png)

### Checks

Create a user without or denying the `logtest:run` (`*:*:*`) permission and login into Kibana.
- Check the `Tools > Ruleset Test` shows a prompt.
- Check the `Ruleset Test` button,  when adding a rule file, which requires the permissions.
- Check the `Decoders Test` button,  when adding a rule file, which requires the permissions.

Using a user with the `logtest:run` (`*:*:*`) permission as allowed:
- Check the `Tools > Ruleset Test` can be accessed and usable.
- Check the `Ruleset Test` button,  when adding a rule file, opens a flyout to use Logtest.
- Check the `Decoders Test` button,  when adding a rule file, opens a flyout to use Logtest.