### PR TITLE
Fixed error creating a new group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fixed Last keep alive label is outside the panel [#3122](https://github.com/wazuh/wazuh-kibana-app/pull/3122)
 - Fixed app redirect to Settings section after the health check [#3128](https://github.com/wazuh/wazuh-kibana-app/pull/3128)
 - Fix the plugin logo path in Kibana menu when use `server.basePath` setting [#3144](https://github.com/wazuh/wazuh-kibana-app/pull/3144)
-- Fixed deprecated endpoint for creat agent groups [3152](https://github.com/wazuh/wazuh-kibana-app/pull/3152)
+- Fixed deprecated endpoint for create agent groups [3152](https://github.com/wazuh/wazuh-kibana-app/pull/3152)
 
 ## Wazuh v4.1.4 - Kibana 7.10.0 , 7.10.2 - Revision 4105
 

--- a/public/controllers/management/components/management/groups/utils/groups-handler.js
+++ b/public/controllers/management/components/management/groups/utils/groups-handler.js
@@ -22,9 +22,7 @@ export default class GroupsHandler {
   static async saveGroup(name) {
     try {
       const result = await WzRequest.apiReq('POST', `/groups`, {
-        params: {
-          group_id: name
-        }
+        group_id: name
       });
       return result;
     } catch (error) {


### PR DESCRIPTION
Hi team, this resolves
- Error creating a new agent group.

![image](https://user-images.githubusercontent.com/26828184/114736224-4c51b380-9d1c-11eb-8856-f0840d42750c.png)

Testing:
- Go to `Management/Groups`
- Then create a new group