### PR TITLE
[Feature]: Add Wazuh help links as extension in Kibana help menu

### DIFF
--- a/common/constants.ts
+++ b/common/constants.ts
@@ -219,3 +219,9 @@ export enum WAZUH_MODULES_ID{
 }
 
 export const AUTHORIZED_AGENTS = 'authorized-agents';
+
+// Wazuh links
+export const WAZUH_LINK_DOCUMENTATION = 'https://documentation.wazuh.com';
+export const WAZUH_LINK_GITHUB = 'https://github.com/wazuh';
+export const WAZUH_LINK_GOOGLE_GROUPS = 'https://groups.google.com/forum/#!forum/wazuh';
+export const WAZUH_LINK_SLACK = 'https://wazuh.com/community/join-us-on-slack';

--- a/public/app.js
+++ b/public/app.js
@@ -55,7 +55,9 @@ import store from './redux/store';
 import { updateCurrentPlatform } from './redux/actions/appStateActions';
 import { WzAuthentication } from './react-services/wz-authentication';
 
-import { getAngularModule } from './kibana-services';
+import { getAngularModule} from './kibana-services';
+import { addHelpMenuToAppChrome } from './utils';
+
 const app = getAngularModule();
 
 app.config([
@@ -100,6 +102,9 @@ app.run(function ($rootElement) {
       <react-component name="WzAgentSelectorWrapper" props=""></react-component>
       <react-component name="ToastNotificationsModal" props=""></react-component>
     </div>`);
+
+  // Add plugin help links as extension to Kibana help menu
+  addHelpMenuToAppChrome();
 
   // Bind deleteExistentToken on Log out component.
   $('.euiHeaderSectionItem__button').on('mouseleave', function () {

--- a/public/assets/icon_google_groups.svg
+++ b/public/assets/icon_google_groups.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 15.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1"  xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="48px" height="48px" viewBox="0 0 48 48" enable-background="new 0 0 48 48" xml:space="preserve">
+<path fill="#CFD8DC" d="M39,6H9C7.343,6,6,7.343,6,9v33l8.556-7H39c1.656,0,3-1.344,3-3V9C42,7.343,40.656,6,39,6z"/>
+<path fill="#42A5F5" d="M12,9h24c1.656,0,3,1.343,3,3v30L27,32H12c-1.657,0-3-1.344-3-3V12C9,10.343,10.343,9,12,9z"/>
+<g>
+	<path fill="#BBDEFB" d="M31,19c0,1.104-0.896,2-2,2s-2-0.896-2-2s0.896-2,2-2S31,17.896,31,19"/>
+	<path fill="#BBDEFB" d="M33,24.667c0,0-1.107-2.667-4-2.667s-4,2.667-4,2.667V26h8V24.667z"/>
+</g>
+<g>
+	<path fill="#E3F2FD" d="M24,17c0,1.656-1.343,3-3,3s-3-1.344-3-3s1.343-3,3-3S24,15.344,24,17"/>
+	<path fill="#E3F2FD" d="M27,24.334c0,0-1.66-3.334-6-3.334s-6,3.334-6,3.334V26h12V24.334z"/>
+</g>
+</svg>

--- a/public/services/routes.js
+++ b/public/services/routes.js
@@ -137,68 +137,84 @@ app.config(($routeProvider) => {
   $routeProvider
   .when('/health-check', {
     template: healthCheckTemplate,
-    resolve: { apiCount, wzConfig, ip }
+    resolve: { apiCount, wzConfig, ip },
+    outerAngularWrapperRoute: true
   })
   .when('/agents/:agent?/:tab?/:tabView?', {
     template: agentsTemplate,
     resolve: { enableWzMenu, nestedResolve, ip, savedSearch },
     reloadOnSearch: false,
+    outerAngularWrapperRoute: true
   })
   .when('/agents-preview/', {
     template: agentsPrevTemplate,
     resolve: { enableWzMenu, nestedResolve, ip, savedSearch },
     reloadOnSearch: false,
+    outerAngularWrapperRoute: true
   })
   .when('/manager/', {
     template: managementTemplate,
     resolve: { enableWzMenu, nestedResolve, ip, savedSearch, clearRuleId },
     reloadOnSearch: false,
+    outerAngularWrapperRoute: true
   })
   .when('/manager/:tab?', {
     template: managementTemplate,
-    resolve: { enableWzMenu, nestedResolve, ip, savedSearch, clearRuleId }
+    resolve: { enableWzMenu, nestedResolve, ip, savedSearch, clearRuleId },
+    outerAngularWrapperRoute: true
   })
   .when('/overview/', {
     template: overviewTemplate,
     resolve: { enableWzMenu, nestedResolve, ip, savedSearch },
     reloadOnSearch: false,
+    outerAngularWrapperRoute: true
   })
   .when('/settings', {
     template: settingsTemplate,
     resolve: { enableWzMenu, nestedResolve, ip, savedSearch },
-    reloadOnSearch: false
+    reloadOnSearch: false,
+    outerAngularWrapperRoute: true
   })
   .when('/security', {
     template: securityTemplate,
-    resolve: { enableWzMenu, nestedResolve, ip, savedSearch }
+    resolve: { enableWzMenu, nestedResolve, ip, savedSearch },
+    outerAngularWrapperRoute: true
   })
   .when('/visualize/create?', {
     redirectTo: function () { },
-    resolve: { wzConfig, wzKibana }
+    resolve: { wzConfig, wzKibana },
+    outerAngularWrapperRoute: true
   })
   .when('/context/:pattern?/:type?/:id?', {
     redirectTo: function () { },
-    resolve: { wzKibana }
+    resolve: { wzKibana },
+    outerAngularWrapperRoute: true
   })
   .when('/doc/:pattern?/:index?/:type?/:id?', {
     redirectTo: function () { },
-    resolve: { wzKibana }
+    resolve: { wzKibana },
+    outerAngularWrapperRoute: true
   })
   .when('/wazuh-dev', {
     template: toolsTemplate,
-    resolve: { enableWzMenu, nestedResolve, ip, savedSearch }
+    resolve: { enableWzMenu, nestedResolve, ip, savedSearch },
+    outerAngularWrapperRoute: true
   })
   .when('/blank-screen', {
     template: blankScreenTemplate,
-    resolve: { enableWzMenu, wzConfig }
+    resolve: { enableWzMenu, wzConfig },
+    outerAngularWrapperRoute: true
   })
   .when('/', {
-    redirectTo: '/overview/'
+    redirectTo: '/overview/',
+    outerAngularWrapperRoute: true
   })
   .when('', {
-    redirectTo: '/overview/'
+    redirectTo: '/overview/',
+    outerAngularWrapperRoute: true
   })
   .otherwise({
-    redirectTo: '/overview'
+    redirectTo: '/overview',
+    outerAngularWrapperRoute: true
   });
 });

--- a/public/utils/add_help_menu_to_app.tsx
+++ b/public/utils/add_help_menu_to_app.tsx
@@ -1,0 +1,54 @@
+/*
+ * Wazuh app - Add the plugin help links as extension in Kibana help menu
+ * Copyright (C) 2015-2021 Wazuh, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Find more information about this on the LICENSE file.
+ */
+
+import React from 'react';
+import {
+  EuiButtonEmpty,
+} from '@elastic/eui';
+import { version } from '../../package.json';
+import { getChrome, getHttp} from '../kibana-services';
+import { 
+  WAZUH_LINK_DOCUMENTATION,
+  WAZUH_LINK_GITHUB,
+  WAZUH_LINK_GOOGLE_GROUPS,
+  WAZUH_LINK_SLACK
+} from '../../common/constants';
+
+const appVersionMajorDotMinor = version.split('.').slice(0, 2).join('.');
+
+export function addHelpMenuToAppChrome(){
+  getChrome().setHelpExtension({
+    appName: 'Wazuh support',
+    links: [
+      {
+        linkType: 'custom',
+        href: `${WAZUH_LINK_DOCUMENTATION}/${appVersionMajorDotMinor}`,
+        content: <EuiButtonEmpty iconType={getHttp().basePath.prepend('/plugins/wazuh/assets/icon_blue.svg')} style={{color:'black'}}>Documentation</EuiButtonEmpty>
+      },
+      {
+        linkType: 'custom',
+        href: WAZUH_LINK_SLACK,
+        content: <EuiButtonEmpty iconType='logoSlack' style={{color:'black'}}>Slack channel</EuiButtonEmpty>
+      },
+      {
+        linkType: 'custom',
+        href: WAZUH_LINK_GITHUB,
+        content: <EuiButtonEmpty iconType='logoGithub' style={{color:'black'}}>Projects on Github</EuiButtonEmpty>
+      },
+      {
+        linkType: 'custom',
+        href: WAZUH_LINK_GOOGLE_GROUPS,
+        content: <EuiButtonEmpty iconType={getHttp().basePath.prepend('/plugins/wazuh/assets/icon_google_groups.svg')} style={{color:'black'}}>Google Group</EuiButtonEmpty>
+      }
+    ]
+  });
+}

--- a/public/utils/index.ts
+++ b/public/utils/index.ts
@@ -1,3 +1,5 @@
 export * as OdfeUtils from './odfe-utils';
 
 export { checkPluginVersion } from './check-plugin-version';
+
+export { addHelpMenuToAppChrome } from './add_help_menu_to_app';


### PR DESCRIPTION
### Description
This PR resolves:
- Add the Wazuh help links as an extension to the Kibana help menu

### Screenshots
![image](https://user-images.githubusercontent.com/34042064/114909396-645d2c00-9e1d-11eb-91ac-22cd9c8c7f22.png)

### Checks
- Check the Wazuh help links are added in the Kibana help menu. Try to navigate to another section and review the help links that are there.

Closes #3119 