### PR TITLE
Modify the default settings related to monitoring indices creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 ### Changed
 
 - Changed default `wazuh.monitoring.creation` app setting from `d` to `w` [#3174](https://github.com/wazuh/wazuh-kibana-app/pull/3174)
+- Changed default `wazuh.monitoring.shards` app setting from `2` to `1` [#3174](https://github.com/wazuh/wazuh-kibana-app/pull/3174)
 
 ## Wazuh v4.2.0 - Kibana 7.10.2 , 7.11.2 - Revision 4201
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to the Wazuh app project will be documented in this file.
 
-## Wazuh v4.2.0 - Kibana 7.10.2 , 7.11.2 - Revision 4201
+## Wazuh v4.2.0 - Kibana 7.10.2 , 7.11.2 - Revision 4202
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to the Wazuh app project will be documented in this file.
 
 ## Wazuh v4.2.0 - Kibana 7.10.2 , 7.11.2 - Revision 4201
 
+### Changed
+
+- Changed default `wazuh.monitoring.creation` app setting from `d` to `w` [#3174](https://github.com/wazuh/wazuh-kibana-app/pull/3174)
+
+## Wazuh v4.2.0 - Kibana 7.10.2 , 7.11.2 - Revision 4201
+
 ### Added
 
 - Added `Ruleset Test` section under Tools menu, and on Edit Rules/Decoders as a tool. [#1434](https://github.com/wazuh/wazuh-kibana-app/pull/1434)

--- a/common/constants.ts
+++ b/common/constants.ts
@@ -21,19 +21,17 @@ export const WAZUH_INDEX_SHARDS = 2;
 export const WAZUH_INDEX_REPLICAS = 0;
 
 // Job - Wazuh monitoring
-
 export const WAZUH_INDEX_TYPE_MONITORING = "monitoring";
 export const WAZUH_MONITORING_PREFIX = "wazuh-monitoring-";
 export const WAZUH_MONITORING_PATTERN = "wazuh-monitoring-*";
 export const WAZUH_MONITORING_TEMPLATE_NAME = "wazuh-agent";
 export const WAZUH_MONITORING_DEFAULT_INDICES_SHARDS = WAZUH_INDEX_SHARDS;
-export const WAZUH_MONITORING_DEFAULT_CREATION = 'd';
+export const WAZUH_MONITORING_DEFAULT_CREATION = 'w';
 export const WAZUH_MONITORING_DEFAULT_ENABLED = true;
 export const WAZUH_MONITORING_DEFAULT_FREQUENCY = 900;
 export const WAZUH_MONITORING_DEFAULT_CRON_FREQ = '0 * * * * *';
 
 // Job - Wazuh statistics
-
 export const WAZUH_INDEX_TYPE_STATISTICS = "statistics";
 export const WAZUH_STATISTICS_DEFAULT_PREFIX = "wazuh";
 export const WAZUH_STATISTICS_DEFAULT_NAME = "statistics";

--- a/common/constants.ts
+++ b/common/constants.ts
@@ -25,7 +25,7 @@ export const WAZUH_INDEX_TYPE_MONITORING = "monitoring";
 export const WAZUH_MONITORING_PREFIX = "wazuh-monitoring-";
 export const WAZUH_MONITORING_PATTERN = "wazuh-monitoring-*";
 export const WAZUH_MONITORING_TEMPLATE_NAME = "wazuh-agent";
-export const WAZUH_MONITORING_DEFAULT_INDICES_SHARDS = WAZUH_INDEX_SHARDS;
+export const WAZUH_MONITORING_DEFAULT_INDICES_SHARDS = 1;
 export const WAZUH_MONITORING_DEFAULT_CREATION = 'w';
 export const WAZUH_MONITORING_DEFAULT_ENABLED = true;
 export const WAZUH_MONITORING_DEFAULT_FREQUENCY = 900;
@@ -164,7 +164,7 @@ export const WAZUH_DEFAULT_APP_CONFIG = {
   'xpack.rbac.enabled': true,
   'wazuh.monitoring.enabled': WAZUH_MONITORING_DEFAULT_ENABLED,
   'wazuh.monitoring.frequency': WAZUH_MONITORING_DEFAULT_FREQUENCY,
-  'wazuh.monitoring.shards': WAZUH_INDEX_SHARDS,
+  'wazuh.monitoring.shards': WAZUH_MONITORING_DEFAULT_INDICES_SHARDS,
   'wazuh.monitoring.replicas': WAZUH_INDEX_REPLICAS,
   'wazuh.monitoring.creation': WAZUH_MONITORING_DEFAULT_CREATION,
   'wazuh.monitoring.pattern': WAZUH_MONITORING_PATTERN,

--- a/public/services/resolves/get-config.js
+++ b/public/services/resolves/get-config.js
@@ -14,6 +14,7 @@ import {
   WAZUH_ALERTS_PATTERN,
   WAZUH_INDEX_REPLICAS,
   WAZUH_INDEX_SHARDS,
+  WAZUH_MONITORING_DEFAULT_INDICES_SHARDS,
   WAZUH_MONITORING_PATTERN,
   WAZUH_SAMPLE_ALERT_PREFIX
 } from "../../../common/constants";
@@ -50,9 +51,9 @@ export async function getWzConfig($q, genericReq, wazuhConfig) {
     'xpack.rbac.enabled': true,
     'wazuh.monitoring.enabled': true,
     'wazuh.monitoring.frequency': 900,
-    'wazuh.monitoring.shards': WAZUH_INDEX_SHARDS,
+    'wazuh.monitoring.shards': WAZUH_MONITORING_DEFAULT_INDICES_SHARDS,
     'wazuh.monitoring.replicas': WAZUH_INDEX_REPLICAS,
-    'wazuh.monitoring.creation': 'd',
+    'wazuh.monitoring.creation': 'w',
     'wazuh.monitoring.pattern': WAZUH_MONITORING_PATTERN,
     'cron.prefix': 'wazuh',
     'cron.statistics.status': true,

--- a/server/lib/initial-wazuh-config.ts
+++ b/server/lib/initial-wazuh-config.ts
@@ -111,7 +111,7 @@ export const initialWazuhConfig: string = `---
 #wazuh.monitoring.frequency: 900
 #
 # Configure wazuh-monitoring-* indices shards and replicas.
-#wazuh.monitoring.shards: 2
+#wazuh.monitoring.shards: 1
 #wazuh.monitoring.replicas: 0
 #
 # Configure wazuh-monitoring-* indices custom creation interval.

--- a/server/lib/initial-wazuh-config.ts
+++ b/server/lib/initial-wazuh-config.ts
@@ -116,8 +116,8 @@ export const initialWazuhConfig: string = `---
 #
 # Configure wazuh-monitoring-* indices custom creation interval.
 # Values: h (hourly), d (daily), w (weekly), m (monthly)
-# Default: d
-#wazuh.monitoring.creation: d
+# Default: w
+#wazuh.monitoring.creation: w
 #
 # Default index pattern to use for Wazuh monitoring
 #wazuh.monitoring.pattern: wazuh-monitoring-*
@@ -126,7 +126,7 @@ export const initialWazuhConfig: string = `---
 #
 # Customize the index prefix of predefined jobs
 # This change is not retroactive, if you change it new indexes will be created
-# cron.prefix: test
+# cron.prefix: wazuh
 #
 # --------------------------------- wazuh-sample-alerts -------------------------
 #

--- a/server/start/monitoring/index.ts
+++ b/server/start/monitoring/index.ts
@@ -19,7 +19,6 @@ import { buildIndexSettings } from '../../lib/build-index-settings';
 import { WazuhHostsCtrl } from '../../controllers/wazuh-hosts';
 import { 
   WAZUH_MONITORING_PATTERN,
-  WAZUH_INDEX_SHARDS,
   WAZUH_INDEX_REPLICAS,
   WAZUH_MONITORING_TEMPLATE_NAME,
   WAZUH_MONITORING_DEFAULT_INDICES_SHARDS,
@@ -280,7 +279,7 @@ async function createIndex(context, indexName: string) {
     const IndexConfiguration = {
       settings: {
         index: {
-          number_of_shards: getAppConfigurationSetting('wazuh.monitoring.shards', appConfig, WAZUH_INDEX_SHARDS),
+          number_of_shards: getAppConfigurationSetting('wazuh.monitoring.shards', appConfig, WAZUH_MONITORING_DEFAULT_INDICES_SHARDS),
           number_of_replicas: getAppConfigurationSetting('wazuh.monitoring.replicas', appConfig, WAZUH_INDEX_REPLICAS)
         }
       }
@@ -513,8 +512,10 @@ export async function jobMonitoringRun(context) {
   // Check Kibana index and if it is prepared, start the initialization of Wazuh App.
   await checkKibanaStatus(context);
   // // Run the cron job only it it's enabled
+  console.log('MONITORING_ENABLED', MONITORING_ENABLED)
   if (MONITORING_ENABLED) {
     cronTask(context);
+    console.log('MONITORING_CRON_FREQ', MONITORING_CRON_FREQ)
     cron.schedule(MONITORING_CRON_FREQ, () => cronTask(context));
   }
 }

--- a/server/start/monitoring/index.ts
+++ b/server/start/monitoring/index.ts
@@ -514,7 +514,6 @@ export async function jobMonitoringRun(context) {
   // // Run the cron job only it it's enabled
   if (MONITORING_ENABLED) {
     cronTask(context);
-    console.log('MONITORING_CRON_FREQ', MONITORING_CRON_FREQ)
     cron.schedule(MONITORING_CRON_FREQ, () => cronTask(context));
   }
 }

--- a/server/start/monitoring/index.ts
+++ b/server/start/monitoring/index.ts
@@ -512,7 +512,6 @@ export async function jobMonitoringRun(context) {
   // Check Kibana index and if it is prepared, start the initialization of Wazuh App.
   await checkKibanaStatus(context);
   // // Run the cron job only it it's enabled
-  console.log('MONITORING_ENABLED', MONITORING_ENABLED)
   if (MONITORING_ENABLED) {
     cronTask(context);
     console.log('MONITORING_CRON_FREQ', MONITORING_CRON_FREQ)


### PR DESCRIPTION
### Description
This PR resolves:
- Modify in the default app settings the frequency of creation for `monitoring` indices from `daily` to `weekly`.
- Modify in the default app settings the shards for `monitoring` indices from `2` to `1`.

### Checks
Using a new installation (remove the `wazuh` data directory if needed)
- `wazuh.yml` app configuration file should contain:
```
# Configure wazuh-monitoring-* indices shards and replicas.
#wazuh.monitoring.shards: 1
#wazuh.monitoring.replicas: 0

# Configure wazuh-monitoring-* indices custom creation interval.
# Values: h (hourly), d (daily), w (weekly), m (monthly)
# Default: w
#wazuh.monitoring.creation: w
```
- By default `monitoring` indices should be created weekly instead of daily.


Note: the issue suggests changing the indices `shards` from `2` to `1`. Should we do that change too? I only changed the creation setting to match with the `statistics` indices too.

Closes #3147 
