### PR TITLE
Bugfix/ruleset test not handle multiline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,6 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Changed position of Top users on Integrity Monitoring Top 5 user. [#2892](https://github.com/wazuh/wazuh-kibana-app/pull/2892)
 - Changed user allow_run_as way of editing. [#3080](https://github.com/wazuh/wazuh-kibana-app/pull/3080)
 - Rename some ossec references to Wazuh [#3046](https://github.com/wazuh/wazuh-kibana-app/pull/3046)
-- Fixed ruleset test not handle multiline [#3149] (https://github.com/wazuh/wazuh-kibana-app/issues/3149)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Changed position of Top users on Integrity Monitoring Top 5 user. [#2892](https://github.com/wazuh/wazuh-kibana-app/pull/2892)
 - Changed user allow_run_as way of editing. [#3080](https://github.com/wazuh/wazuh-kibana-app/pull/3080)
 - Rename some ossec references to Wazuh [#3046](https://github.com/wazuh/wazuh-kibana-app/pull/3046)
+- Fixed ruleset test not handle multiline [#3149] (https://github.com/wazuh/wazuh-kibana-app/issues/3149)
 
 ### Fixed
 

--- a/public/directives/wz-logtest/components/logtest.tsx
+++ b/public/directives/wz-logtest/components/logtest.tsx
@@ -57,7 +57,7 @@ export const Logtest = compose(
       `hostname: ${(result.predecoder || '').hostname || '-'} \n    ` +
       `program_name: ${(result.predecoder || '').program_name || '-'} \n\n` +
       `**Phase 2: Completed decoding. \n    ` +
-      `name: ${(result.decoder || '').name || '-'} \n   ` +
+      `name: ${(result.decoder || '').name || '-'} \n    ` +
       `parent: ${(result.decoder || '').parent || '-'} \n    ` +
       `srcip: ${(result.data || '').srcip || '-'}  \n    ` +
       `srcport: ${(result.data || '').srcport || '-'} \n    ` +

--- a/public/directives/wz-logtest/components/logtest.tsx
+++ b/public/directives/wz-logtest/components/logtest.tsx
@@ -47,7 +47,7 @@ export const Logtest = compose(
   const [testResult, setTestResult] = useState('');
 
   const onChange = (e) => {
-    setValue((e.target.value).split("\n"));
+    setValue((e.target.value).split("\n").filter(item => item));
   };
 
   const formatResult = (result) => {
@@ -106,7 +106,6 @@ export const Logtest = compose(
   };
 
   const buildLogtest = () => {
-    console.log(value)
     return (
       <Fragment>
         <EuiTextArea
@@ -121,7 +120,7 @@ export const Logtest = compose(
           <EuiButton
             style={{ maxWidth: '100px' }}
             isLoading={testing}
-            isDisabled={testing || !value}
+            isDisabled={testing || value.length === 0}
             iconType="play"
             fill
             onClick={() => {

--- a/public/directives/wz-logtest/components/logtest.tsx
+++ b/public/directives/wz-logtest/components/logtest.tsx
@@ -9,7 +9,7 @@
  *
  * Find more information about this on the LICENSE file.
  */
-import React, { Fragment, useState, prevState } from 'react';
+import React, { Fragment, useState } from 'react';
 import { DynamicHeight } from '../../../utils/dynamic-height';
 import {
   EuiButton,
@@ -19,23 +19,22 @@ import {
   EuiFlyout,
   EuiFlyoutBody,
   EuiFlyoutHeader,
+  EuiOverlayMask,
   EuiPage,
   EuiPanel,
   EuiSpacer,
   EuiTextArea,
   EuiTitle,
-  EuiOverlayMask,
 } from '@elastic/eui';
 import { WzRequest } from '../../../react-services';
 import { withReduxProvider, withUserAuthorizationPrompt } from '../../../components/common/hocs';
 import { compose } from 'redux';
 
-
 type LogstestProps = {
-  openCloseFlyout: () => {},
-  showClose: boolean,
-  onFlyout: boolean,
-  isRuleset: string,
+  openCloseFlyout: () => {};
+  showClose: boolean;
+  onFlyout: boolean;
+  isRuleset: string;
 };
 
 export const Logtest = compose(
@@ -47,7 +46,7 @@ export const Logtest = compose(
   const [testResult, setTestResult] = useState('');
 
   const onChange = (e) => {
-    setValue((e.target.value).split("\n").filter(item => item));
+    setValue(e.target.value.split('\n').filter((item) => item));
   };
 
   const formatResult = (result) => {
@@ -85,12 +84,12 @@ export const Logtest = compose(
   };
 
   const runAllTest = () => {
-    setTestResult('')
+    setTestResult('');
     value.map((event) => {
-      test(event)
-    })
+      test(event);
+    });
     setTesting(false);
-  }
+  };
 
   const test = async (event) => {
     setTesting(true);
@@ -101,8 +100,13 @@ export const Logtest = compose(
     };
 
     const result = await WzRequest.apiReq('PUT', '/logtest', body);
-    
-    setTestResult(prevState => [...prevState, formatResult(result.data.data.output)]);
+
+    result.data.data.alert
+      ? setTestResult((prevState) => [...prevState, formatResult(result.data.data.output)])
+      : setTestResult((prevState) => [
+          ...prevState,
+          `No result found for:  ${result.data.data.output.full_log} \n\n\n`,
+        ]);
   };
 
   const buildLogtest = () => {

--- a/public/redux/reducers/toolsReducers.js
+++ b/public/redux/reducers/toolsReducers.js
@@ -13,10 +13,10 @@
 const initialState = { selected_tools_section: '' };
 
 const toolsReducers = (state = initialState, action) => {
-  if (action.type === 'UPDATE_TOOLS_SECTION') {
+  if (action.type === 'UPDATE_SELECTED_TOOLS_SECTION') {
     return {
       ...state,
-      selected_tools_section: action.section
+      selected_tools_section: action.selected_tools_section
     };
   }
 


### PR DESCRIPTION
Hi team, this resolve:

- Test multiple lines in ruleset tests (each line as a log test)

![Captura de pantalla de 2021-04-16 15-16-20](https://user-images.githubusercontent.com/36004787/115067048-bdcd6580-9ec6-11eb-8c6f-4b3b5e7cb80e.png)

### Checks
Add multiple logs in new lines and click on the `Test` button. It should:
- display multiple outputs
- be in the same order as the logs.

Try with valid logs and invalid. Check the output for the invalid logs.

#### Side check
- Check the menu item is selected correctly in the Wazuh menu when you are in `API Console` o `Ruleset Test` section. 