### PR TITLE
Fixed RBAC issue with agent group permissions

### DIFF
--- a/public/components/agents/fim/main.tsx
+++ b/public/components/agents/fim/main.tsx
@@ -30,8 +30,14 @@ export const MainFim = compose(
     const agentData =
       props.currentAgentData && props.currentAgentData.id ? props.currentAgentData : props.agent;
     return [
-      { action: 'agent:read', resource: `agent:id:${agentData.id}` },
-      { action: 'syscheck:read', resource: `agent:id:${agentData.id}` },
+      [
+        { action: 'agent:read', resource: `agent:id:${agentData.id}` },
+        ...(agentData.group || {}).map(group => ({ action: 'agent:read', resource: `agent:group:${group}` }))
+      ],
+      [
+        { action: 'syscheck:read', resource: `agent:id:${agentData.id}` },
+        ...(agentData.group || []).map(group => ({ action: 'syscheck:read', resource: `agent:group:${group}` }))
+      ]
     ];
   })
 )(function MainFim({ currentAgentData, agent, ...rest }) {

--- a/public/components/agents/fim/main.tsx
+++ b/public/components/agents/fim/main.tsx
@@ -32,7 +32,7 @@ export const MainFim = compose(
     return [
       [
         { action: 'agent:read', resource: `agent:id:${agentData.id}` },
-        ...(agentData.group || {}).map(group => ({ action: 'agent:read', resource: `agent:group:${group}` }))
+        ...(agentData.group || []).map(group => ({ action: 'agent:read', resource: `agent:group:${group}` }))
       ],
       [
         { action: 'syscheck:read', resource: `agent:id:${agentData.id}` },

--- a/public/components/agents/sca/main.tsx
+++ b/public/components/agents/sca/main.tsx
@@ -10,7 +10,16 @@ const mapStateToProps = (state) => ({
 });
 
 export const MainSca = compose(
-  withUserAuthorizationPrompt([{action: 'agent:read', resource: 'agent:id:*'}, {action: 'sca:read', resource: 'agent:id:*'}]),
+  withUserAuthorizationPrompt([
+    [
+      {action: 'agent:read', resource: 'agent:id:*'},
+      {action: 'agent:read', resource: 'agent:group:*'}
+    ],
+    [
+      {action: 'sca:read', resource: 'agent:id:*'},
+      {action: 'sca:read', resource: 'agent:group:*'}
+    ]
+  ]),
   connect(mapStateToProps),
   withGuard(
     (props) => !(props.currentAgentData && props.currentAgentData.id && props.agent),

--- a/public/components/agents/sca/main.tsx
+++ b/public/components/agents/sca/main.tsx
@@ -39,9 +39,16 @@ export const MainSca = compose(
   withUserAuthorizationPrompt((props) => {
     const agentData =
       props.currentAgentData && props.currentAgentData.id ? props.currentAgentData : props.agent;
+    console.log(agentData)
     return [
-      { action: 'agent:read', resource: `agent:id:${agentData.id}` },
-      { action: 'sca:read', resource: `agent:id:${agentData.id}` },
+      [
+        { action: 'agent:read', resource: `agent:id:${agentData.id}` },
+        ...(agentData.group || []).map(group => ({ action: 'agent:read', resource: `agent:group:${group}` }))
+      ],
+      [
+        { action: 'sca:read', resource: `agent:id:${agentData.id}` },
+        ...(agentData.group || []).map(group => ({ action: 'sca:read', resource: `agent:group:${group}` }))
+      ]
     ];
   })
 )(function MainSca({ selectView, currentAgentData, agent, ...rest }) {

--- a/public/components/agents/sca/main.tsx
+++ b/public/components/agents/sca/main.tsx
@@ -39,7 +39,6 @@ export const MainSca = compose(
   withUserAuthorizationPrompt((props) => {
     const agentData =
       props.currentAgentData && props.currentAgentData.id ? props.currentAgentData : props.agent;
-    console.log(agentData)
     return [
       [
         { action: 'agent:read', resource: `agent:id:${agentData.id}` },

--- a/public/components/agents/stats/agent-stats.tsx
+++ b/public/components/agents/stats/agent-stats.tsx
@@ -94,7 +94,10 @@ export const MainAgentStats = compose(
       text: 'Stats'
     },
   ]),
-  withUserAuthorizationPrompt(({agent}) => [{action: 'agent:read', resource: `agent:id:${agent.id}`}]),
+  withUserAuthorizationPrompt(({agent}) => [[
+    {action: 'agent:read', resource: `agent:id:${agent.id}`}, 
+    ...(agent.group || []).map(group => ({ action: 'agent:read', resource: `agent:group:${group}` }))
+  ]]),
   withGuard(({agent}) => agent.status !== 'active', PromptNoActiveAgentWithoutSelect),
   withGuard(({agent}) => {
     const [major, minor, patch] = agent.version.replace('Wazuh v','').split('.').map(value => parseInt(value));

--- a/public/components/agents/vuls/main.tsx
+++ b/public/components/agents/vuls/main.tsx
@@ -30,8 +30,14 @@ export const MainVuls = compose(
     const agentData =
       props.currentAgentData && props.currentAgentData.id ? props.currentAgentData : props.agent;
     return [
-      { action: 'agent:read', resource: `agent:id:${agentData.id}` },
-      { action: 'vulnerability:read', resource: `agent:id:${agentData.id}` },
+      [
+        { action: 'agent:read', resource: `agent:id:${agentData.id}` },
+        ...(agentData.group || []).map(group => ({ action: 'agent:read', resource: `agent:group:${group}` }))
+      ],
+      [
+        { action: 'vulnerability:read', resource: `agent:id:${agentData.id}` },
+        ...(agentData.group || []).map(group => ({ action: 'vulnerability:read', resource: `agent:group:${group}` }))
+      ]
     ];
   })
 )(function MainVuls({ currentAgentData, agent, ...rest }) {

--- a/public/components/common/welcome/components/sca_scan/sca_scan.tsx
+++ b/public/components/common/welcome/components/sca_scan/sca_scan.tsx
@@ -39,7 +39,16 @@ import { compose } from 'redux';
 
 export const ScaScan = compose(
   withReduxProvider,
-  withUserAuthorizationPrompt([{action: 'agent:read', resource: 'agent:id:*'}, {action: 'sca:read', resource: 'agent:id:*'}])
+  withUserAuthorizationPrompt([
+    [
+      {action: 'agent:read', resource: 'agent:id:*'},
+      {action: 'agent:read', resource: 'agent:group:*'}
+    ],
+    [
+      {action: 'sca:read', resource: 'agent:id:*'},
+      {action: 'sca:read', resource: 'agent:group:*'}
+    ]
+  ])
 )(class ScaScan extends Component {
   _isMount = false;
   props!: {

--- a/public/controllers/management/components/management/configuration/configuration-switch.js
+++ b/public/controllers/management/components/management/configuration/configuration-switch.js
@@ -415,7 +415,12 @@ const mapDispatchToProps = dispatch => ({
 });
 
 export default compose(
-  withUserAuthorizationPrompt((props) => [props.agent.id === '000' ? {action: 'manager:read', resource: '*:*:*'} : {action: 'agent:read', resource: `agent:id:${props.agent.id}`}]), //TODO: this need cluster:read permission but manager/cluster is managed in WzConfigurationSwitch component
+  withUserAuthorizationPrompt((props) => [props.agent.id === '000' ? 
+  {action: 'manager:read', resource: '*:*:*'} : 
+  [
+    {action: 'agent:read', resource: `agent:id:${props.agent.id}`},
+    ...(props.agent.group || []).map(group => ({ action: 'agent:read', resource: `agent:group:${group}` }))
+  ]]), //TODO: this need cluster:read permission but manager/cluster is managed in WzConfigurationSwitch component
   withRenderIfOrWrapped((props) => props.agent.status === 'never_connected', WzAgentNeverConnectedPrompt),
   connect(
     mapStateToProps,

--- a/public/controllers/management/components/management/groups/group-agents-table.js
+++ b/public/controllers/management/components/management/groups/group-agents-table.js
@@ -106,7 +106,7 @@ class WzGroupAgentsTable extends Component {
             <div>
               <WzButtonPermissions
                 buttonType='icon'
-                permissions={[{action: 'agent:read', resource: `agent:id:${item.id}`}]}
+                permissions={[[{action: 'agent:read', resource: `agent:id:${item.id}`}, ...(item.group || []).map(group => ({ action: 'agent:read', resource: `agent:group:${group}` }))]]}
                 tooltip={{position: 'top', content: 'Go to the agent'}}
                 aria-label="Go to the agent"
                 iconType="eye"
@@ -117,7 +117,7 @@ class WzGroupAgentsTable extends Component {
               />
               <WzButtonPermissionsModalConfirm
                 buttonType='icon'
-                permissions={[{action: 'agent:modify_group', resource: `agent:id:${item.id}`}]}
+                permissions={[[{action: 'agent:modify_group', resource: `agent:id:${item.id}`}, ...(item.group || []).map(group => ({ action: 'agent:modify_group', resource: `agent:group:${group}` }))]]}
                 tooltip={{position: 'top', content: 'Remove agent from this group'}}
                 aria-label="Remove agent from this group"
                 iconType="trash"

--- a/public/controllers/management/components/management/status/status-overview.js
+++ b/public/controllers/management/components/management/status/status-overview.js
@@ -253,7 +253,14 @@ export default compose(
     { text: 'Management', href: '/app/wazuh#/manager' },
     { text: 'Status' }
   ]),
-  withUserAuthorizationPrompt([{ action: 'agent:read', resource: 'agent:id:*' }, { action: 'manager:read', resource: '*:*:*' }, { action: 'cluster:read', resource: 'node:id:*' }]),
+  withUserAuthorizationPrompt([
+    [
+      { action: 'agent:read', resource: 'agent:id:*' },
+      { action: 'agent:read', resource: 'agent:group:*' }
+    ],
+    { action: 'manager:read', resource: '*:*:*' },
+    { action: 'cluster:read', resource: 'node:id:*' }
+  ]),
   connect(
     mapStateToProps,
     mapDispatchToProps


### PR DESCRIPTION
Hi team, this resolves

- A user with agent groups permission can't see some sections
 - SCA
 - Integrity Monitoring
 - Agent configuration

Closes #3180 

Testing:

With a user with permissions for `agent:read`, `sca:read`, `syscheck:read`  only allowed for `agent:group:xxxx`  
Open the sections: 
- SCA
- Integrity Monitoring
- Agent configuration
