### PR TITLE
[FEATURE] Add redirect to group details using the URL

### DIFF
--- a/public/controllers/management/components/management/groups/groups-main.js
+++ b/public/controllers/management/components/management/groups/groups-main.js
@@ -24,6 +24,7 @@ import {
 } from '../../../../../redux/actions/groupsActions';
 import { connect } from 'react-redux';
 import { updateGlobalBreadcrumb } from '../../../../../redux/actions/globalBreadcrumbActions';
+import { WzRequest } from '../../../../../react-services/wz-request';
 
 class WzGroups extends Component {
   constructor(props) {
@@ -39,8 +40,20 @@ class WzGroups extends Component {
     store.dispatch(updateGlobalBreadcrumb(breadcrumb));
   }
 
-  componentDidMount() {
+  async componentDidMount() {
     this.setGlobalBreadcrumb();
+    console.log(window.location.href)
+    // Check if there is a group in the URL
+    const [_, group] = window.location.href.match(new RegExp('group=' + '([^&]*)')) || [];
+    window.location.href = window.location.href.replace(new RegExp('group=' + '[^&]*'), '');
+    if(group){
+      try{
+        // Try if the group can be accesed
+        const responseGroup = await WzRequest.apiReq('GET', '/groups', {params: {groups_list: group}});
+        const dataGroup = responseGroup?.data?.data?.affected_items?.[0];
+        this.props.updateGroupDetail(dataGroup);
+      }catch(error){};
+    };
   }
 
   UNSAFE_componentWillReceiveProps(nextProps) {
@@ -87,7 +100,8 @@ const mapDispatchToProps = dispatch => {
   return {
     resetGroup: () => dispatch(resetGroup()),
     updateShowAddAgents: showAddAgents =>
-      dispatch(updateShowAddAgents(showAddAgents))
+      dispatch(updateShowAddAgents(showAddAgents)),
+    updateGroupDetail: groupDetail => dispatch(updateGroupDetail(groupDetail))
   };
 };
 export default connect(


### PR DESCRIPTION
### Description

Redirect to group detail using the `group` parameter in the URL when the `Management > Groups` is accesed.

  - Redirect to group details when the URL contains group query param
  
### Checks
In a new tab, use the next URL to access to group details directly:
```
KIBANA_HOST_ADDRESS/app/wazuh#/manager/?tab=groups&group=GROUP_NAME
```
- If the group:
  - exists and the user can get information about the group, it should display information about the group.
  - not exists: it should display the main groups section.
  - without permission to that group: it should display the main groups section.

Replace `KIBANA_HOST_ADDRESS` and `GROUP_NAME` for your case