### PR TITLE
Add tab to manage outdated agents and upgrade

### DIFF
--- a/public/controllers/agent/components/agents-table.js
+++ b/public/controllers/agent/components/agents-table.js
@@ -335,7 +335,6 @@ export class AgentsTable extends Component {
   };
 
   addUpgradeStatus(agent) {
-  //console.log("Entramos en addUpgradeStatus con", agent);
     const { managerVersion } = this.state;
     return (
       <CheckUpgrade
@@ -375,9 +374,7 @@ export class AgentsTable extends Component {
 
   /* MULTISELECT TABLE */
   onSelectionChange = selectedItems => {
-    console.log("En onSelectionChange obtenemos: ", selectedItems.length);
     const { managerVersion, pageSize } = this.state;
-   // console.log("Entro en onSelectionChange", selectedItems);
     selectedItems.forEach(item => {
       if (item.version && item.version !== '-' && !ActionAgents.compareVersions('v'+managerVersion, item.version)) {
         item.outdated = true;
@@ -393,7 +390,6 @@ export class AgentsTable extends Component {
 
   renderUpgradeButton() {
     const { selectedItems } = this.state;
-  //  console.log("Upgrading es: ", selectedItems);
 
     if (
       selectedItems.length === 0 ||
@@ -434,7 +430,6 @@ export class AgentsTable extends Component {
 
   renderUpgradeButtonAll() {
     const { selectedItems, avaibleAgents, managerVersion } = this.state;
-  //  console.log("En renderUpgradeButtonAll: ", selectedItems, avaibleAgents);
     if (
       selectedItems.length > 0 &&
       avaibleAgents &&
@@ -463,7 +458,6 @@ export class AgentsTable extends Component {
   renderRestartButton() {
     const { selectedItems } = this.state;
 
-    // console.log("Al entrar en renderRestartButton, state es:  ", selectedItems.length, "y :", selectedItems);
     if (
       selectedItems.length === 0 ||
       selectedItems.filter(item => item.status === 'active').length === 0

--- a/public/controllers/agent/components/checkUpgrade.tsx
+++ b/public/controllers/agent/components/checkUpgrade.tsx
@@ -45,7 +45,7 @@ export class CheckUpgrade extends Component {
 	}
 
 	checkUpgrade(agentId) {
-		WzRequest.apiReq('GET', `/agents/${agentId}/upgrade_result`, {}).then(value => {
+		WzRequest.apiReq('GET', `/agents/upgrade_result?agents_list${agentId}`, {}).then(value => {
 			if (value.status === 200) {
 				this.props.changeStatusUpdate(agentId);
 				this.props.reloadAgent();

--- a/public/react-services/action-agents.js
+++ b/public/react-services/action-agents.js
@@ -22,41 +22,40 @@ export class ActionAgents {
     });
   };
 
-     /**
+  /**
    * Make the action (upgrade, restart or delete) to a specific group of agents
    * @param {Object} filters
    */
-   static async getAllAgents(filters){
+  static async getAllAgents(filters){
     try{
-
       const params = filters.q ? {q: filters.q, limit: 500} : { limit: 500 };
-       const output = await WzRequest.apiReq('GET', `/agents`, {params: params});
-       const totalItems = (((output || {}).data || {}).data || {}).total_affected_items;
-       let itemsArray = [];
-       if (totalItems && output.data && output.data.data && totalItems > 500) {
-         params.offset = 0;
-         itemsArray.push(...output.data.data.affected_items);
-         while (itemsArray.length < totalItems && params.offset < totalItems) {
-           params.offset += params.limit;
-           const tmpData = await WzRequest.apiReq(
-             'GET',
-             `/agents`,
-             { params: params },
-           );
-           itemsArray.push(...tmpData.data.data.affected_items);
-         }
-         const allowedAgents = itemsArray;
-         return allowedAgents;
-       }
-       else{
-         const allowedAgents = output.data.data.affected_items;
-         return allowedAgents;
-       }
-     }catch(error) {   
-       getToasts().addError(error, {title: `Error getting user authorized agents`});
-       return Promise.reject();
-     }
-   }
+      const output = await WzRequest.apiReq('GET', `/agents`, {params: params});
+      const totalItems = (((output || {}).data || {}).data || {}).total_affected_items;
+      let itemsArray = [];
+      if (totalItems && output.data && output.data.data && totalItems > 500) {
+        params.offset = 0;
+        itemsArray.push(...output.data.data.affected_items);
+        while (itemsArray.length < totalItems && params.offset < totalItems) {
+          params.offset += params.limit;
+          const tmpData = await WzRequest.apiReq(
+            'GET',
+            `/agents`,
+            { params: params },
+          );
+          itemsArray.push(...tmpData.data.data.affected_items);
+        }
+        const allowedAgents = itemsArray;
+        return allowedAgents;
+      }
+      else{
+        const allowedAgents = output.data.data.affected_items;
+        return allowedAgents;
+      }
+    }catch(error) {   
+      getToasts().addError(error, {title: `Error getting user authorized agents`});
+      return Promise.reject();
+    }
+  }
 
   /**
    * Make a string of all agents, and do some calls according to the maximum agents permitted in this call

--- a/public/react-services/action-agents.js
+++ b/public/react-services/action-agents.js
@@ -22,164 +22,111 @@ export class ActionAgents {
     });
   };
 
-  /**
-   * Upgrade unique agent to the latest version avaible.
-   * @param {Number} agentId
+     /**
+   * Make the action (upgrade, restart or delete) to a specific group of agents
+   * @param {Object} filters
    */
-  static upgradeAgent(agentId) {
-    WzRequest.apiReq('PUT', `/agents/${agentId}/upgrade`, {
-      force: 1
-    })
-      .then(() => {
-        console.log('Upgrading');
-      })
-      .catch(error => {
-        error !== 'Wazuh API error: 3021 - Timeout executing API request'
-          ? this.showToast('danger', 'Error upgrading agent', error, 5000)
-          : false;
-      });
-    this.showToast('success', 'Upgrading agent...', '', 5000);
-  }
+   static async getAllAgents(filters){
+    try{
+
+      const params = filters.q ? {q: filters.q, limit: 500} : { limit: 500 };
+       const output = await WzRequest.apiReq('GET', `/agents`, {params: params});
+       const totalItems = (((output || {}).data || {}).data || {}).total_affected_items;
+       let itemsArray = [];
+       if (totalItems && output.data && output.data.data && totalItems > 500) {
+         params.offset = 0;
+         itemsArray.push(...output.data.data.affected_items);
+         while (itemsArray.length < totalItems && params.offset < totalItems) {
+           params.offset += params.limit;
+           const tmpData = await WzRequest.apiReq(
+             'GET',
+             `/agents`,
+             { params: params },
+           );
+           itemsArray.push(...tmpData.data.data.affected_items);
+         }
+         const allowedAgents = itemsArray;
+         return allowedAgents;
+       }
+       else{
+         const allowedAgents = output.data.data.affected_items;
+         return allowedAgents;
+       }
+     }catch(error) {   
+       getToasts().addError(error, {title: `Error getting user authorized agents`});
+       return Promise.reject();
+     }
+   }
 
   /**
-   * Upgrade list of agents to the latest version avaible.
-   * @param {Array} selectedItems
+   * Make a string of all agents, and do some calls according to the maximum agents permitted in this call
+   * @param {String} action
+   * @param {String} type
+   * @param {Array} agents
    */
-  static upgradeAgents(selectedItems) {
-    for (let item of selectedItems.filter(
-      item => item.outdated && item.status !== 'Disconnected'
-    )) {
-      WzRequest.apiReq('PUT', `/agents/${item.id}/upgrade`, '1')
-        .then(() => {})
-        .catch(error => {});
+  static async redirectActionAgents(action, type, agents){
+    if(type === 'one' && agents.id !== '000')
+        this.actionAgentCall(action, agents);
+    else{
+      agents = agents.filter(function(item){ if(item.id !== '000'){ return item; }})
+      if(action === 'upgrade' && agents.length > 100){
+        for (let i = 0; i < agents.length; i=i+100) {
+          let activeAgents = [];
+          agents.slice(i, i+100).map(item => {
+            if(item.status === 'active' && item.outdated && item.id != '000')
+              activeAgents.push(item.id);
+            });
+          if(activeAgents.length !== 0)
+            this.actionAgentCall(action, activeAgents);
+        }
+      }
+      else if(action === 'upgrade' || action === 'restart'){
+        this.actionAgentCall(action, agents.filter(function(item){
+          if(item.status === 'active' && action === 'upgrade' && item.outdated){
+            return item;
+          }
+          else if(item.status === 'active' && action === 'restart'){
+            return item;
+          }
+          }).map(item => item.id));
+      }
+      else{
+        for (let i = 0; i < agents.length; i=i+100) {
+          this.actionAgentCall(action, agents.map(item => item.id));
+        }
+      }
     }
-    this.showToast('success', 'Upgrading selected agents...', '', 5000);
   }
 
-  /**
-   * Upgrade a list of agents to the latest version avaible.
-   * @param {Array} selectedItems
-   * @param {String} managerVersion
+   /**
+   * Make the action (upgrade, restart or delete) to a specific group of agents
+   * @param {String} action
+   * @param {Array} agents
    */
-  static upgradeAllAgents(selectedItems, managerVersion) {
-    selectedItems.forEach(agent => {
-      if (
-        agent.id !== '000' &&
-        this.compareVersions(agent.version, managerVersion) === true &&
-        agent.status === 'active'
-      ) {
-        WzRequest.apiReq('PUT', `/agents/${agent.id}/upgrade`, '1')
-          .then(() => {})
-          .catch(error => {});
+  static async actionAgentCall(action, agents){
+    const agentsFormatted = (typeof agents !== 'string') ? agents.toString() : agents;
+    const commandType = (action === 'delete') ? 'DELETE' : 'PUT';
+    const firstCommand = (action === 'delete') ? `` : `/${action}`
+    const statusDelete = (action === 'delete') ? '&status=all' : ''
+    try {
+      const result = await WzRequest.apiReq(
+        `${commandType}`,
+        `/agents${firstCommand}?agents_list=${agentsFormatted}${statusDelete}&pretty=true`,
+        {}
+      );
+      const messageShowed = action.charAt(0).toUpperCase() + (action === 'delete' ? action.slice(1, action.length-1) : action.slice(1)) + 'ing agents ...';
+      if(result.data.data.affected_items.length > 0){
+        this.showToast('success', messageShowed, '', 5000);
       }
-    });
-    this.showToast('success', 'Upgrading all agents...', '', 5000);
-  }
-
-  /**
-   * Restart an agent
-   * @param {Number} agentId
-   */
-  static restartAgent(agentId) {
-    WzRequest.apiReq('PUT', `/agents/restart`, { ids: agentId })
-      .then(value => {
-        value.status === 200
-          ? this.showToast('success', 'Restarting agent...', '', 5000)
-          : this.showToast('warning', 'Error restarting agent', '', 5000);
-      })
-      .catch(error => {
-        this.showToast('danger', 'Error restarting agent', error, 5000);
-      });
-  }
-
-  /**
-   * Restart a list of agents
-   * @param {Array} selectedItems
-   */
-  static restartAgents(selectedItems) {
-    const agentsId = selectedItems.map(item => item.id);
-
-    WzRequest.apiReq('PUT', `/agents/restart`, { ids: [...agentsId] })
-      .then(value => {
-        value.status === 200
-          ? this.showToast('success', 'Restarting selected agents...', '', 5000)
-          : this.showToast(
-              'warning',
-              'Error restarting selected agents',
-              '',
-              5000
-            );
-      })
-      .catch(error => {
-        this.showToast(
-          'danger',
-          'Error restarting selected agents',
-          error,
-          5000
-        );
-      });
-  }
-
-  /**
-   * Restart a list of agents
-   * @param {Array} selectedItems
-   */
-  static restartAllAgents(selectedItems) {
-    let idAvaibleAgents = [];
-    selectedItems.forEach(agent => {
-      if (agent.id !== '000' && agent.status === 'active') {
-        idAvaibleAgents.push(agent.id);
+      if(result.data.data.failed_items.length > 0){
+        messageShowed = 'Error' + messageShowed.charAt(0).toLowerCase() + messageShowed.slice(1, messageShowed.length); 
+        this.showToast('warning', messageShowed, result.data.data.failed_items.toString(), 5000);
       }
-    });
-    WzRequest.apiReq('PUT', `/agents/restart`, { ids: [...idAvaibleAgents] })
-      .then(value => {
-        value.status === 200
-          ? this.showToast('success', 'Restarting all agents...', '', 5000)
-          : this.showToast('warning', 'Error restarting all agents.', '', 5000);
-      })
-      .catch(error => {
-        this.showToast('danger', 'Error restarting all agents.', error, 5000);
-      });
-  }
-
-  /**
-   * Delete an agent
-   * @param {Number} selectedItems
-   */
-  static deleteAgents(selectedItems) {
-    const auxAgents = selectedItems
-      .map(agent => {
-        return agent.id !== '000' ? agent.id : null;
-      })
-      .filter(agent => agent !== null);
-    WzRequest.apiReq('DELETE', `/agents`, {
-      purge: true,
-      ids: auxAgents,
-      older_than: '1s'
-    })
-      .then(value => {
-        value.status === 200
-          ? this.showToast(
-              'success',
-              `Selected agents were successfully deleted`,
-              '',
-              5000
-            )
-          : this.showToast(
-              'warning',
-              `Failed to delete selected agents`,
-              '',
-              5000
-            );
-      })
-      .catch(error => {
-        this.showToast(
-          'danger',
-          `Failed to delete selected agents`,
-          error,
-          5000
-        );
-      });
+    } catch (error) {
+      const messageShowed = 'Error' + (action === 'delete' ? action.slice(0, action.length-1) : action.slice(0)) + 'ing agents ...';
+      this.showToast('warning', messageShowed, error , 5000);
+      return Promise.reject(error);
+    }
   }
 
   /**


### PR DESCRIPTION
Hi team, this PR adds the functionality to update, restart or delete the desired agents, both from the agents table and from the overview of each agent.

In order to test it, you will need:
- Install an environment with old agents and going to the / Agents sections and clicking on the agents, you will get the options, to be able to select all the agents, you will have to click on the white button at the top left of the table you select all the agents on that page and then it will let you choose them all.

Closes #3107 