### PR TITLE
Fixing mac os agents add command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to the Wazuh app project will be documented in this file.
 
+## Wazuh v4.1.5 - Kibana 7.10.0 , 7.10.2 - Revision 4107
+
+- Fixing mac os agents add command [#3207](https://github.com/wazuh/wazuh-kibana-app/pull/3207)
 
 ## Wazuh v4.1.4 - Kibana 7.10.0 , 7.10.2 - Revision 4105
 

--- a/public/controllers/agent/components/register-agent.js
+++ b/public/controllers/agent/components/register-agent.js
@@ -289,7 +289,7 @@ export class RegisterAgent extends Component {
       deployment += `WAZUH_REGISTRATION_SERVER='${this.state.serverAddress}' `;
     }
 
-    if (true) {
+    if (this.state.wazuhPassword) {
       deployment += `WAZUH_REGISTRATION_PASSWORD='${this.state.wazuhPassword}' `;
     }
 

--- a/public/controllers/agent/components/register-agent.js
+++ b/public/controllers/agent/components/register-agent.js
@@ -283,14 +283,29 @@ export class RegisterAgent extends Component {
   }
 
   optionalDeploymentVariables() {
-    const deployment = `WAZUH_MANAGER${this.state.selectedOS == 'macos' ? ' ' : '='}'${this.state.serverAddress}' ${this.state.selectedOS == 'win' ? `WAZUH_REGISTRATION_SERVER='${this.state.serverAddress}' ` : ''}${this.state.needsPassword
-      ? `WAZUH_REGISTRATION_PASSWORD='${this.state.wazuhPassword}' `
-      : ''
-      }${this.state.udpProtocol
-        ? " WAZUH_PROTOCOL='UDP'"
-        : ''
-      }${this.state.selectedGroup.length ? `WAZUH_AGENT_GROUP='${this.state.selectedGroup.map(item => item.label).join(',')}' ` : ''}`
-    return deployment;
+    let deployment = `WAZUH_MANAGER='${this.state.serverAddress}' `;
+  
+    if (this.state.selectedOS == 'win') {
+      deployment += `WAZUH_REGISTRATION_SERVER='${this.state.serverAddress}' `;
+    }
+
+    if (true) {
+      deployment += `WAZUH_REGISTRATION_PASSWORD='${this.state.wazuhPassword}' `;
+    }
+
+    if (this.state.udpProtocol) {
+      deployment += `WAZUH_PROTOCOL='UDP' `;
+    }
+
+    if (this.state.selectedGroup.length) {
+      deployment += `WAZUH_AGENT_GROUP='${this.state.selectedGroup.map((item) => item.label).join(',')}' `;
+    }
+
+    // macos doesnt need = param
+    if (this.state.selectedOS === 'macos') {
+      return deployment.replaceAll('=', ' ');
+    }
+
   }
 
   resolveRPMPackage() {

--- a/public/controllers/agent/components/register-agent.js
+++ b/public/controllers/agent/components/register-agent.js
@@ -306,6 +306,7 @@ export class RegisterAgent extends Component {
       return deployment.replaceAll('=', ' ');
     }
 
+    return deployment;
   }
 
   resolveRPMPackage() {


### PR DESCRIPTION
Hi team, we fix a bug that shows `=` in Wazuh Password instead of `' '` in the new agent command for mac os

closes #3211 