### PR TITLE
Fixed fields overlap in the agent summary screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,9 @@ All notable changes to the Wazuh app project will be documented in this file.
 ## Wazuh v4.2.0 - Kibana 7.10.0 , 7.10.2 - Revision 4202
 
 ### Fixed
-
+Hola
 - Fixed screen flickers in Cluster visualization [#3159](https://github.com/wazuh/wazuh-kibana-app/pull/3159)
+- Fixed fields overlap in the agent summary screen [#3217](https://github.com/wazuh/wazuh-kibana-app/pull/3217)
 
 ## Wazuh v4.2.0 - Kibana 7.10.2 , 7.11.2 - Revision 4202
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 ## Wazuh v4.2.0 - Kibana 7.10.0 , 7.10.2 - Revision 4202
 
 ### Fixed
-Hola
+
 - Fixed screen flickers in Cluster visualization [#3159](https://github.com/wazuh/wazuh-kibana-app/pull/3159)
 - Fixed fields overlap in the agent summary screen [#3217](https://github.com/wazuh/wazuh-kibana-app/pull/3217)
 

--- a/public/components/common/welcome/agents-info.js
+++ b/public/components/common/welcome/agents-info.js
@@ -73,7 +73,7 @@ export class AgentInfo extends Component {
     const osName = os_name === '- -' ? '-' : os_name;
 
     return (
-      <WzTextWithTooltipIfTruncated position='bottom' elementStyle={{ maxWidth: style.maxWidth, fontSize: 12 }}>
+      <WzTextWithTooltipIfTruncated position='bottom' tooltipProps={{ anchorClassName: 'wz-width-100'}} elementStyle={{ maxWidth: style.maxWidth, fontSize: 12 }}>
         {this.getPlatformIcon(this.props.agent)}
         {' '}{osName}
       </WzTextWithTooltipIfTruncated>
@@ -125,6 +125,8 @@ export class AgentInfo extends Component {
       return field !== undefined || field ? field : '-';
     };
     const stats = items.map(item => {
+      // We add tooltipProps, so that the ClusterNode and Operating System fields occupy their space and do not exceed this, overlapping with the one on the right
+      const tooltipProps = item.description === 'Cluster node' ? { anchorClassName: 'wz-width-100'} : {};
       return (
         <EuiFlexItem key={item.description} style={item.style || null}>
           <WzStat
@@ -143,7 +145,7 @@ export class AgentInfo extends Component {
               ) : item.description === 'Status' ? (
                 this.addHealthRender(this.props.agent, item.style)
               ) : (
-                <WzTextWithTooltipIfTruncated position='bottom' elementStyle={{ maxWidth: item.style.maxWidth, fontSize: 12 }}>
+                <WzTextWithTooltipIfTruncated position='bottom' tooltipProps={tooltipProps} elementStyle={{ maxWidth: item.style.maxWidth, fontSize: 12 }}>
                   {checkField(item.title)}
                 </WzTextWithTooltipIfTruncated>
               )

--- a/public/styles/common.scss
+++ b/public/styles/common.scss
@@ -1697,3 +1697,7 @@ iframe.width-changed {
 .custom-charts-bar span.euiLoadingChart__bar{
   width: 15px;
 }
+
+.wz-width-100{
+  width: 100%;
+}


### PR DESCRIPTION
Hi team, 
We have fixed that when we have a very large operating system or cluster name, these overlap with the rest of the fields, within the overview of an agent
Closes #3204 

**Steps to test it:**
In `agents-info.js` we modify in line 177, after the if, the variable `agent.node_name`, and we put a long node name and then in line 78 we change `osName` to another super long name, which will change the name of the operating system to display.
Then we go to `/Agents`, we select an agent and the names of both should not overlap.