### PR TITLE
fix index typo settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fixed screen flickers in Cluster visualization [#3159](https://github.com/wazuh/wazuh-kibana-app/pull/3159)
 - Fix the broken links when using `server.basePath` Kibana setting [#3161](https://github.com/wazuh/wazuh-kibana-app/pull/3161)
 - Fixing filter in reports [#3173](https://github.com/wazuh/wazuh-kibana-app/pull/3173)
+- Fix typo error in Settings/Configuration [#3234](https://github.com/wazuh/wazuh-kibana-app/pull/3234)
 
 
 ## Wazuh v4.2.0 - Kibana 7.10.2 , 7.11.2 - Revision 4201

--- a/public/utils/config-equivalences.js
+++ b/public/utils/config-equivalences.js
@@ -90,7 +90,7 @@ export const nameEquivalence = {
   'wazuh.monitoring.frequency': 'Frequency',
   'wazuh.monitoring.shards': 'Index shards',
   'wazuh.monitoring.replicas': 'Index replicas',
-  'wazuh.monitoring.creation': 'Interval creation',
+  'wazuh.monitoring.creation': 'Index creation',
   'wazuh.monitoring.pattern': 'Index pattern',
   hideManagerAlerts: 'Hide manager alerts',
   'logs.level': 'Log level',


### PR DESCRIPTION
Hi team, this PR fixed a typo error in /Settings/Configuration replacing `Interval creation` for `Index creation`.
Closes #3216 

