### PR TITLE
Fix 3209/improving and removing WUI error logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fixed the `Visualize` button is not displaying when expanding a field in the Events sidebar [#3237](https://github.com/wazuh/wazuh-kibana-app/pull/3237)
 - Add error when add sample data fails [#3241] (https://github.com/wazuh/wazuh-kibana-app/pull/3241)
 - Fix modules are missing in the agent menu [#3244] (https://github.com/wazuh/wazuh-kibana-app/pull/3244)
+- Fix improving and removing WUI error logs [#3260] (https://github.com/wazuh/wazuh-kibana-app/pull/3260)
 
 ## Wazuh v4.2.0 - Kibana 7.10.2 , 7.11.2 - Revision 4201
 

--- a/server/controllers/wazuh-api.ts
+++ b/server/controllers/wazuh-api.ts
@@ -53,10 +53,10 @@ export class WazuhApiCtrl {
               });
             }
           } catch (error) {
-            log('wazuh-api:getToken', error.message || error);
+              log('wazuh-api:getToken', error.message || error);
+            }
           }
         }
-      }
       let token;
       if (await APIUserAllowRunAs.canUse(idHost) == API_USER_STATUS_RUN_AS.ENABLED) {
         token = await context.wazuh.api.client.asCurrentUser.authenticate(idHost);
@@ -81,7 +81,7 @@ export class WazuhApiCtrl {
       });
     } catch (error) {
       const errorMessage = ((error.response || {}).data || {}).detail || error.message || error;
-      log('wazuh-api:getToken', errorMessage);
+        log('wazuh-api:getToken', errorMessage);
       return ErrorResponse(
         `Error getting the authorization token: ${errorMessage}`,
         3000,
@@ -207,7 +207,10 @@ export class WazuhApiCtrl {
       // If we have an invalid response from the Wazuh API
       throw new Error(responseManagerInfo.data.detail || `${api.url}:${api.port} is unreachable`);
     } catch (error) {
-      log('wazuh-api:checkStoredAPI', error.message || error);
+      const isDown = (error || {}).code === 'ECONNREFUSED';
+      if (!isDown) {
+        log('wazuh-api:checkStoredAPI', error.message || error);
+      }
       if (error.code === 'EPROTO') {
         return response.ok({
           body: {

--- a/server/controllers/wazuh-api.ts
+++ b/server/controllers/wazuh-api.ts
@@ -53,10 +53,10 @@ export class WazuhApiCtrl {
               });
             }
           } catch (error) {
-              log('wazuh-api:getToken', error.message || error);
-            }
+            log('wazuh-api:getToken', error.message || error);
           }
         }
+      }
       let token;
       if (await APIUserAllowRunAs.canUse(idHost) == API_USER_STATUS_RUN_AS.ENABLED) {
         token = await context.wazuh.api.client.asCurrentUser.authenticate(idHost);

--- a/server/controllers/wazuh-api.ts
+++ b/server/controllers/wazuh-api.ts
@@ -207,10 +207,6 @@ export class WazuhApiCtrl {
       // If we have an invalid response from the Wazuh API
       throw new Error(responseManagerInfo.data.detail || `${api.url}:${api.port} is unreachable`);
     } catch (error) {
-      const isDown = (error || {}).code === 'ECONNREFUSED';
-      if (!isDown) {
-        log('wazuh-api:checkStoredAPI', error.message || error);
-      }
       if (error.code === 'EPROTO') {
         return response.ok({
           body: {
@@ -255,8 +251,10 @@ export class WazuhApiCtrl {
             } catch (error) { } // eslint-disable-line
           }
         } catch (error) {
+          log('wazuh-api:checkStoredAPI', error.message || error);
           return ErrorResponse(error.message || error, 3020, 500, response);
         }
+        log('wazuh-api:checkStoredAPI', error.message || error);
         return ErrorResponse(error.message || error, 3002, 500, response);
       }
     }

--- a/server/controllers/wazuh-api.ts
+++ b/server/controllers/wazuh-api.ts
@@ -81,7 +81,7 @@ export class WazuhApiCtrl {
       });
     } catch (error) {
       const errorMessage = ((error.response || {}).data || {}).detail || error.message || error;
-        log('wazuh-api:getToken', errorMessage);
+      log('wazuh-api:getToken', errorMessage);
       return ErrorResponse(
         `Error getting the authorization token: ${errorMessage}`,
         3000,

--- a/server/lib/update-registry.ts
+++ b/server/lib/update-registry.ts
@@ -148,7 +148,7 @@ export class UpdateRegistry {
   async updateAPIExtensions(id, extensions) {
     try {
       const content = await this.readContent();
-      content.hosts[id].extensions = extensions;
+      if(content.hosts[id]) content.hosts[id].extensions = extensions;
       await this.writeContent(content);
       log(
         'update-registry:updateAPIExtensions',

--- a/server/start/cron-scheduler/save-document.ts
+++ b/server/start/cron-scheduler/save-document.ts
@@ -3,6 +3,7 @@ import { getConfiguration } from '../../lib/get-configuration';
 import { log } from '../../lib/logger';
 import { indexDate } from '../../lib/index-date';
 import { WAZUH_INDEX_SHARDS, WAZUH_INDEX_REPLICAS } from '../../../common/constants'
+import { tryCatchForIndexPermissionError } from '../tryCatchForIndexPermissionError'
 
 export interface IIndexConfiguration {
   name: string
@@ -43,7 +44,7 @@ export class SaveDocument {
 
   private async checkIndexAndCreateIfNotExists(index, shards, replicas) {
     try {
-      try {
+      tryCatchForIndexPermissionError(index, this.logPath) (async() => {
         const exists = await this.esClientInternalUser.indices.exists({ index });
         log(this.logPath, `Index '${index}' exists? ${exists.body}`, 'debug');
         if (!exists.body) {
@@ -60,9 +61,7 @@ export class SaveDocument {
           });
           log(this.logPath, `Status of create a new index: ${JSON.stringify(response)}`, 'debug');
         }
-      } catch (error) {
-        log(this.logPath ,`Error searching or creating '${index}' due to '${error.message || error}'`);
-      }
+      });
     } catch (error) {
       this.checkDuplicateIndexError(error);
     }

--- a/server/start/cron-scheduler/save-document.ts
+++ b/server/start/cron-scheduler/save-document.ts
@@ -44,7 +44,7 @@ export class SaveDocument {
 
   private async checkIndexAndCreateIfNotExists(index, shards, replicas) {
     try {
-      tryCatchForIndexPermissionError(index, this.logPath) (async() => {
+      await tryCatchForIndexPermissionError(index) (async() => {
         const exists = await this.esClientInternalUser.indices.exists({ index });
         log(this.logPath, `Index '${index}' exists? ${exists.body}`, 'debug');
         if (!exists.body) {
@@ -61,8 +61,9 @@ export class SaveDocument {
           });
           log(this.logPath, `Status of create a new index: ${JSON.stringify(response)}`, 'debug');
         }
-      });
+      })();
     } catch (error) {
+      log(this.logPath, error.message || error);
       this.checkDuplicateIndexError(error);
     }
   }

--- a/server/start/index.ts
+++ b/server/start/index.ts
@@ -2,3 +2,4 @@ export * from './cron-scheduler';
 export * from './initialize';
 export * from './monitoring';
 export * from './queue';
+export * from './tryCatchForIndexPermissionError'

--- a/server/start/index.ts
+++ b/server/start/index.ts
@@ -2,4 +2,4 @@ export * from './cron-scheduler';
 export * from './initialize';
 export * from './monitoring';
 export * from './queue';
-export * from './tryCatchForIndexPermissionError'
+export * from './tryCatchForIndexPermissionError';

--- a/server/start/initialize/index.ts
+++ b/server/start/initialize/index.ts
@@ -18,6 +18,7 @@ import fs from 'fs';
 import { ManageHosts } from '../../lib/manage-hosts';
 import { WAZUH_ALERTS_PATTERN, WAZUH_DATA_CONFIG_REGISTRY_PATH, WAZUH_INDEX, WAZUH_VERSION_INDEX, WAZUH_KIBANA_TEMPLATE_NAME, WAZUH_DATA_KIBANA_BASE_ABSOLUTE_PATH } from '../../../common/constants';
 import { createDataDirectoryIfNotExists } from '../../lib/filesystem';
+import { tryCatchForIndexPermissionError } from '../tryCatchForIndexPermissionError'
 
 const manageHosts = new ManageHosts();
 
@@ -98,39 +99,30 @@ export function jobInitializeRun(context) {
   /**
    * Checks if the .wazuh index exist in order to migrate to wazuh.yml
    */
-  const checkWazuhIndex = async () => {
-    try {
-      log('initialize:checkWazuhIndex', `Checking ${WAZUH_INDEX} index.`, 'debug');
-
-      const result = await context.core.elasticsearch.client.asInternalUser.indices.exists({
+  const checkWazuhIndex = tryCatchForIndexPermissionError(WAZUH_INDEX)( async () => {
+    log('initialize:checkWazuhIndex', `Checking ${WAZUH_INDEX} index.`, 'debug');
+    const result = await context.core.elasticsearch.client.asInternalUser.indices.exists({
+      index: WAZUH_INDEX
+    });
+    if (result.body) {
+      const data = await context.core.elasticsearch.client.asInternalUser.search({
+        index: WAZUH_INDEX,
+        size: 100
+      });
+      const apiEntries = (((data || {}).body || {}).hits || {}).hits || [];
+      await manageHosts.migrateFromIndex(apiEntries);
+      log(
+        'initialize:checkWazuhIndex',
+        `Index ${WAZUH_INDEX} will be removed and its content will be migrated to wazuh.yml`,
+        'debug'
+      );
+      // Check if all APIs entries were migrated properly and delete it from the .wazuh index
+      await checkProperlyMigrate();
+      await context.core.elasticsearch.client.asInternalUser.indices.delete({
         index: WAZUH_INDEX
       });
-      if (result.body) {
-        try {
-          const data = await context.core.elasticsearch.client.asInternalUser.search({
-            index: WAZUH_INDEX,
-            size: 100
-          });
-          const apiEntries = (((data || {}).body || {}).hits || {}).hits || [];
-          await manageHosts.migrateFromIndex(apiEntries);
-          log(
-            'initialize:checkWazuhIndex',
-            `Index ${WAZUH_INDEX} will be removed and its content will be migrated to wazuh.yml`,
-            'debug'
-          );
-          // Check if all APIs entries were migrated properly and delete it from the .wazuh index
-          await checkProperlyMigrate();
-          await context.core.elasticsearch.client.asInternalUser.indices.delete({
-            index: WAZUH_INDEX
-          });
-        } catch (error) {
-          throw new Error(error);
-        }
-      }
-    } catch (error) {
-      return Promise.reject(error);
     }
-  };
+  });
 
   /**
    * Checks if the API entries were properly migrated
@@ -365,7 +357,8 @@ export function jobInitializeRun(context) {
         await getTemplateByName();
       }
     } catch (error) {
-      log('initialize:checkKibanaStatus', error.message || error);
+      if(error.name !== 'ResponseError')
+        log('initialize:checkKibanaStatus', error.message || error);
       context.wazuh.logger.error(error.message || error);
     }
   };

--- a/server/start/initialize/index.ts
+++ b/server/start/initialize/index.ts
@@ -18,7 +18,7 @@ import fs from 'fs';
 import { ManageHosts } from '../../lib/manage-hosts';
 import { WAZUH_ALERTS_PATTERN, WAZUH_DATA_CONFIG_REGISTRY_PATH, WAZUH_INDEX, WAZUH_VERSION_INDEX, WAZUH_KIBANA_TEMPLATE_NAME, WAZUH_DATA_KIBANA_BASE_ABSOLUTE_PATH } from '../../../common/constants';
 import { createDataDirectoryIfNotExists } from '../../lib/filesystem';
-import { tryCatchForIndexPermissionError } from '../tryCatchForIndexPermissionError'
+import { tryCatchForIndexPermissionError } from '../tryCatchForIndexPermissionError';
 
 const manageHosts = new ManageHosts();
 
@@ -357,9 +357,10 @@ export function jobInitializeRun(context) {
         await getTemplateByName();
       }
     } catch (error) {
-      if(error.name !== 'ResponseError')
+      if(error.name !== 'ResponseError'){
         log('initialize:checkKibanaStatus', error.message || error);
-      context.wazuh.logger.error(error.message || error);
+        context.wazuh.logger.error(error.message || error);
+      }
     }
   };
 

--- a/server/start/initialize/index.ts
+++ b/server/start/initialize/index.ts
@@ -235,16 +235,10 @@ export function jobInitializeRun(context) {
 
   // Init function. Check for "wazuh-version" document existance.
   const init = async () => {
-    try {
-      await Promise.all([
-        checkWazuhIndex(),
-        checkWazuhRegistry()
-      ]);
-    } catch (error) {
-      log('initialize:init', error.message || error);
-      context.wazuh.logger.error(error.message || error);
-      return Promise.reject(error);
-    }
+    await Promise.all([
+      checkWazuhIndex(),
+      checkWazuhRegistry()
+    ]);
   };
 
   const createKibanaTemplate = () => {
@@ -357,10 +351,8 @@ export function jobInitializeRun(context) {
         await getTemplateByName();
       }
     } catch (error) {
-      if(error.name !== 'ResponseError'){
-        log('initialize:checkKibanaStatus', error.message || error);
-        context.wazuh.logger.error(error.message || error);
-      }
+      log('initialize:checkKibanaStatus', error.message || error);
+      context.wazuh.logger.error(error.message || error);
     }
   };
 

--- a/server/start/monitoring/index.ts
+++ b/server/start/monitoring/index.ts
@@ -177,7 +177,7 @@ async function checkTemplate(context) {
  */
 async function insertMonitoringDataElasticsearch(context, data) {
   const monitoringIndexName = MONITORING_INDEX_PREFIX + indexDate(MONITORING_CREATION);
-  const indexLocation = 'monitoring:insertMonitoringDataElasticsearch';
+  const logLocation = 'monitoring:insertMonitoringDataElasticsearch';
     if (!MONITORING_ENABLED){
       return;
     };
@@ -189,7 +189,7 @@ async function insertMonitoringDataElasticsearch(context, data) {
         }
       })();
     }catch(error){
-      log(indexLocation, error.message || error);
+      log(logLocation, error.message || error);
     }
     try{
       await tryCatchForIndexPermissionError(monitoringIndexName) (async() => {
@@ -211,7 +211,7 @@ async function insertMonitoringDataElasticsearch(context, data) {
 
       })(); 
     }catch(error){
-      log(indexLocation, error.message || error);
+      log(logLocation, error.message || error);
     }
     try {
       await tryCatchForIndexPermissionError(monitoringIndexName) (async() => {
@@ -219,7 +219,7 @@ async function insertMonitoringDataElasticsearch(context, data) {
       await insertDataToIndex(context, monitoringIndexName, data);
       })();
     } catch (error) {
-      log(indexLocation, errorMessage);
+      log(logLocation, errorMessage);
       context.wazuh.logger.error(error.message);
     }
 }

--- a/server/start/monitoring/index.ts
+++ b/server/start/monitoring/index.ts
@@ -26,6 +26,7 @@ import {
   WAZUH_MONITORING_DEFAULT_ENABLED,
   WAZUH_MONITORING_DEFAULT_FREQUENCY,
 } from '../../../common/constants';
+import { tryCatchForIndexPermissionError } from '../tryCatchForIndexPermissionError'
 
 const blueWazuh = '\u001b[34mwazuh\u001b[39m';
 const monitoringErrorLogColors = [blueWazuh, 'monitoring', 'error'];
@@ -176,19 +177,16 @@ async function checkTemplate(context) {
  */
 async function insertMonitoringDataElasticsearch(context, data) {
   const monitoringIndexName = MONITORING_INDEX_PREFIX + indexDate(MONITORING_CREATION);
-  try {
     if (!MONITORING_ENABLED){
       return;
     };
-    try{
+    tryCatchForIndexPermissionError(monitoringIndexName, 'monitoring:insertMonitoringDataElasticsearch') (async() => {
       const exists = await context.core.elasticsearch.client.asInternalUser.indices.exists({index: monitoringIndexName});
       if(!exists.body){
         await createIndex(context, monitoringIndexName);
       }
-    }catch(error){
-      log('monitoring:insertMonitoringDataElasticsearch', error.message || error);
-    }
-    try{
+    });
+    tryCatchForIndexPermissionError(monitoringIndexName, 'monitoring:insertMonitoringDataElasticsearch') (async() => {
       // Update the index configuration
       const appConfig = getConfiguration();
       const indexConfiguration = buildIndexSettings(
@@ -205,22 +203,12 @@ async function insertMonitoringDataElasticsearch(context, data) {
         body: indexConfiguration
       });
 
-    }catch(error){
-      log('monitoring:insertMonitoringDataElasticsearch', error.message || error);
-    }
+    });    
 
+    tryCatchForIndexPermissionError(monitoringIndexName, 'monitoring:insertMonitoringDataElasticsearch', context) (async() => {
     // Insert data to the monitoring index
     await insertDataToIndex(context, monitoringIndexName, data);
-  } catch (error) {
-    const errorMessage = `Could not check if the index ${
-      monitoringIndexName
-    } exists due to ${error.message || error}`;
-    log(
-      'monitoring:insertMonitoringDataElasticsearch',
-      errorMessage
-    );
-    context.wazuh.logger.error(errorMessage);
-  }
+    });
 }
 
 /**

--- a/server/start/monitoring/index.ts
+++ b/server/start/monitoring/index.ts
@@ -177,16 +177,17 @@ async function checkTemplate(context) {
  */
 async function insertMonitoringDataElasticsearch(context, data) {
   const monitoringIndexName = MONITORING_INDEX_PREFIX + indexDate(MONITORING_CREATION);
+  const indexLocation = 'monitoring:insertMonitoringDataElasticsearch';
     if (!MONITORING_ENABLED){
       return;
     };
-    tryCatchForIndexPermissionError(monitoringIndexName, 'monitoring:insertMonitoringDataElasticsearch') (async() => {
+    tryCatchForIndexPermissionError(monitoringIndexName, indexLocation) (async() => {
       const exists = await context.core.elasticsearch.client.asInternalUser.indices.exists({index: monitoringIndexName});
       if(!exists.body){
         await createIndex(context, monitoringIndexName);
       }
     });
-    tryCatchForIndexPermissionError(monitoringIndexName, 'monitoring:insertMonitoringDataElasticsearch') (async() => {
+    tryCatchForIndexPermissionError(monitoringIndexName, indexLocation) (async() => {
       // Update the index configuration
       const appConfig = getConfiguration();
       const indexConfiguration = buildIndexSettings(
@@ -205,7 +206,7 @@ async function insertMonitoringDataElasticsearch(context, data) {
 
     });    
 
-    tryCatchForIndexPermissionError(monitoringIndexName, 'monitoring:insertMonitoringDataElasticsearch', context) (async() => {
+    tryCatchForIndexPermissionError(monitoringIndexName, indexLocation, context) (async() => {
     // Insert data to the monitoring index
     await insertDataToIndex(context, monitoringIndexName, data);
     });

--- a/server/start/monitoring/index.ts
+++ b/server/start/monitoring/index.ts
@@ -26,7 +26,7 @@ import {
   WAZUH_MONITORING_DEFAULT_ENABLED,
   WAZUH_MONITORING_DEFAULT_FREQUENCY,
 } from '../../../common/constants';
-import { tryCatchForIndexPermissionError } from '../tryCatchForIndexPermissionError'
+import { tryCatchForIndexPermissionError } from '../tryCatchForIndexPermissionError';
 
 const blueWazuh = '\u001b[34mwazuh\u001b[39m';
 const monitoringErrorLogColors = [blueWazuh, 'monitoring', 'error'];

--- a/server/start/monitoring/index.ts
+++ b/server/start/monitoring/index.ts
@@ -181,35 +181,47 @@ async function insertMonitoringDataElasticsearch(context, data) {
     if (!MONITORING_ENABLED){
       return;
     };
-    tryCatchForIndexPermissionError(monitoringIndexName, indexLocation) (async() => {
-      const exists = await context.core.elasticsearch.client.asInternalUser.indices.exists({index: monitoringIndexName});
-      if(!exists.body){
-        await createIndex(context, monitoringIndexName);
-      }
-    });
-    tryCatchForIndexPermissionError(monitoringIndexName, indexLocation) (async() => {
-      // Update the index configuration
-      const appConfig = getConfiguration();
-      const indexConfiguration = buildIndexSettings(
-        appConfig,
-        'wazuh.monitoring',
-        WAZUH_MONITORING_DEFAULT_INDICES_SHARDS
-      );
+    try {
+      await tryCatchForIndexPermissionError(monitoringIndexName) (async() => {
+        const exists = await context.core.elasticsearch.client.asInternalUser.indices.exists({index: monitoringIndexName});
+        if(!exists.body){
+          await createIndex(context, monitoringIndexName);
+        }
+      })();
+    }catch(error){
+      log(indexLocation, error.message || error);
+    }
+    try{
+      await tryCatchForIndexPermissionError(monitoringIndexName) (async() => {
+        // Update the index configuration
+        const appConfig = getConfiguration();
+        const indexConfiguration = buildIndexSettings(
+          appConfig,
+          'wazuh.monitoring',
+          WAZUH_MONITORING_DEFAULT_INDICES_SHARDS
+        );
 
-      // To update the index settings with this client is required close the index, update the settings and open it
-      // Number of shards is not dynamic so delete that setting if it's given
-      delete indexConfiguration.settings.index.number_of_shards;
-      await context.core.elasticsearch.client.asInternalUser.indices.putSettings({
-        index: monitoringIndexName,
-        body: indexConfiguration
-      });
+        // To update the index settings with this client is required close the index, update the settings and open it
+        // Number of shards is not dynamic so delete that setting if it's given
+        delete indexConfiguration.settings.index.number_of_shards;
+        await context.core.elasticsearch.client.asInternalUser.indices.putSettings({
+          index: monitoringIndexName,
+          body: indexConfiguration
+        });
 
-    });    
-
-    tryCatchForIndexPermissionError(monitoringIndexName, indexLocation, context) (async() => {
-    // Insert data to the monitoring index
-    await insertDataToIndex(context, monitoringIndexName, data);
-    });
+      })(); 
+    }catch(error){
+      log(indexLocation, error.message || error);
+    }
+    try {
+      await tryCatchForIndexPermissionError(monitoringIndexName) (async() => {
+      // Insert data to the monitoring index
+      await insertDataToIndex(context, monitoringIndexName, data);
+      })();
+    } catch (error) {
+      log(indexLocation, errorMessage);
+      context.wazuh.logger.error(error.message);
+    }
 }
 
 /**

--- a/server/start/monitoring/index.ts
+++ b/server/start/monitoring/index.ts
@@ -177,7 +177,6 @@ async function checkTemplate(context) {
  */
 async function insertMonitoringDataElasticsearch(context, data) {
   const monitoringIndexName = MONITORING_INDEX_PREFIX + indexDate(MONITORING_CREATION);
-  const logLocation = 'monitoring:insertMonitoringDataElasticsearch';
     if (!MONITORING_ENABLED){
       return;
     };
@@ -186,13 +185,8 @@ async function insertMonitoringDataElasticsearch(context, data) {
         const exists = await context.core.elasticsearch.client.asInternalUser.indices.exists({index: monitoringIndexName});
         if(!exists.body){
           await createIndex(context, monitoringIndexName);
-        }
-      })();
-    }catch(error){
-      log(logLocation, error.message || error);
-    }
-    try{
-      await tryCatchForIndexPermissionError(monitoringIndexName) (async() => {
+        };
+
         // Update the index configuration
         const appConfig = getConfiguration();
         const indexConfiguration = buildIndexSettings(
@@ -209,17 +203,11 @@ async function insertMonitoringDataElasticsearch(context, data) {
           body: indexConfiguration
         });
 
-      })(); 
-    }catch(error){
-      log(logLocation, error.message || error);
-    }
-    try {
-      await tryCatchForIndexPermissionError(monitoringIndexName) (async() => {
-      // Insert data to the monitoring index
-      await insertDataToIndex(context, monitoringIndexName, data);
+        // Insert data to the monitoring index
+        await insertDataToIndex(context, monitoringIndexName, data);
       })();
-    } catch (error) {
-      log(logLocation, errorMessage);
+    }catch(error){
+      log('monitoring:insertMonitoringDataElasticsearch', error.message || error);
       context.wazuh.logger.error(error.message);
     }
 }

--- a/server/start/tryCatchForIndexPermissionError.ts
+++ b/server/start/tryCatchForIndexPermissionError.ts
@@ -1,0 +1,41 @@
+/*
+ * Wazuh app - React HOCs to manage the message when elastic show a Response error
+ * Copyright (C) 2015-2021 Wazuh, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Find more information about this on the LICENSE file.
+ */
+import { log } from '../lib/logger';
+
+export const tryCatchForIndexPermissionError = (wazuhIndex: string, logLocation?: string, context?) => (functionToTryCatch) => async () => {
+    console.log("HOAL QUE PASA NENE", logLocation);
+    try {
+        await functionToTryCatch();
+    }
+    catch (error) {
+        switch(error.message){
+            case 'security_exception':
+              error.message = (((((error.meta || error.message).body || error.message).error || error.message).root_cause[0] || error.message).reason || error.message);
+              break;
+            case 'Response Error':
+              error.message = `Could not check if the index ${
+                wazuhIndex
+              } exists due to no permissions for create, delete or check`;
+              break;
+        }
+        if(context){
+            context.wazuh.logger.error(error); 
+        }
+        if(logLocation){
+            log(logLocation, error.message || error);
+        }
+        else{
+            return Promise.reject(error);
+        }
+
+    }
+}

--- a/server/start/tryCatchForIndexPermissionError.ts
+++ b/server/start/tryCatchForIndexPermissionError.ts
@@ -16,11 +16,15 @@ export const tryCatchForIndexPermissionError = (wazuhIndex: string, logLocation?
         await functionToTryCatch();
     }
     catch (error) {
+        enum error_types{
+            SECURITY_EXCEPTION = 'security_exception',
+            RESPONSE_ERROR = 'Response Error',
+        }
         switch(error.message){
-            case 'security_exception':
+            case error_types.SECURITY_EXCEPTION:
               error.message = (((((error.meta || error.message).body || error.message).error || error.message).root_cause[0] || error.message).reason || error.message);
               break;
-            case 'Response Error':
+            case error_types.RESPONSE_ERROR:
               error.message = `Could not check if the index ${
                 wazuhIndex
               } exists due to no permissions for create, delete or check`;

--- a/server/start/tryCatchForIndexPermissionError.ts
+++ b/server/start/tryCatchForIndexPermissionError.ts
@@ -11,7 +11,7 @@
  */
 import { log } from '../lib/logger';
 
-export const tryCatchForIndexPermissionError = (wazuhIndex: string, logLocation?: string, context?) => (functionToTryCatch) => async () => {
+export const tryCatchForIndexPermissionError = (wazuhIndex: string) => (functionToTryCatch) => async () => {
     try {
         await functionToTryCatch();
     }
@@ -30,15 +30,6 @@ export const tryCatchForIndexPermissionError = (wazuhIndex: string, logLocation?
               } exists due to no permissions for create, delete or check`;
               break;
         }
-        if(context){
-            context.wazuh.logger.error(error); 
-        }
-        if(logLocation){
-            log(logLocation, error.message || error);
-        }
-        else{
-            return Promise.reject(error);
-        }
-
+        return Promise.reject(error);
     }
 }

--- a/server/start/tryCatchForIndexPermissionError.ts
+++ b/server/start/tryCatchForIndexPermissionError.ts
@@ -12,7 +12,6 @@
 import { log } from '../lib/logger';
 
 export const tryCatchForIndexPermissionError = (wazuhIndex: string, logLocation?: string, context?) => (functionToTryCatch) => async () => {
-    console.log("HOAL QUE PASA NENE", logLocation);
     try {
         await functionToTryCatch();
     }

--- a/server/start/tryCatchForIndexPermissionError.ts
+++ b/server/start/tryCatchForIndexPermissionError.ts
@@ -1,5 +1,5 @@
 /*
- * Wazuh app - React HOCs to manage the message when elastic show a Response error
+ * Wazuh app - HOF to manage the message when elastic show a Response error / security_exception
  * Copyright (C) 2015-2021 Wazuh, Inc.
  *
  * This program is free software; you can redistribute it and/or modify
@@ -16,15 +16,15 @@ export const tryCatchForIndexPermissionError = (wazuhIndex: string, logLocation?
         await functionToTryCatch();
     }
     catch (error) {
-        enum error_types{
+        enum errorTypes{
             SECURITY_EXCEPTION = 'security_exception',
             RESPONSE_ERROR = 'Response Error',
         }
         switch(error.message){
-            case error_types.SECURITY_EXCEPTION:
+            case errorTypes.SECURITY_EXCEPTION:
               error.message = (((((error.meta || error.message).body || error.message).error || error.message).root_cause[0] || error.message).reason || error.message);
               break;
-            case error_types.RESPONSE_ERROR:
+            case errorTypes.RESPONSE_ERROR:
               error.message = `Could not check if the index ${
                 wazuhIndex
               } exists due to no permissions for create, delete or check`;


### PR DESCRIPTION
Hi guys,
In this PR we solve the problem that several records of the same type are shown when starting the app, we improve the message that is shown for the errors of the `Response Error` and `security_exception `type.

To test it, you will have to create an environment, delete the wazuh folder from / kibana / data and see the logs that appear in the app `/Configuration/Logs` section.

The tests must be done with ODFE, X-Pack and without security.

Closes #3209 