### PR TITLE
Add validation form creating new rule/decoder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Configuration to disable Wazuh App access from X-Pack/ODFE role [#3222](https://github.com/wazuh/wazuh-kibana-app/pull/3222)
 - Added confirmation message when closing a form [#3221](https://github.com/wazuh/wazuh-kibana-app/pull/3221)
 - Improvement to hide navbar Wazuh label. [#3240](https://github.com/wazuh/wazuh-kibana-app/pull/3240)
+- Add modal creating new rule/decoder [#3274](https://github.com/wazuh/wazuh-kibana-app/pull/3274)
 
 ### Changed
 

--- a/public/components/security/policies/create-policy.tsx
+++ b/public/components/security/policies/create-policy.tsx
@@ -286,21 +286,13 @@ export const CreatePolicyFlyout = ({ closeFlyout }) => {
       <WzOverlayMask
         headerZindexLocation="below"
         onClick={() => {
-          if (hasChanges) {
-            setIsModalVisible(true);
-          } else {
-            closeFlyout(false);
-          }
+          hasChanges ? setIsModalVisible(true) : closeFlyout(false);
         }}
       >
         <EuiFlyout
           className="wzApp"
           onClose={() => {
-            if (hasChanges) {
-              setIsModalVisible(true);
-            } else {
-              closeFlyout(false);
-            }
+            hasChanges ? setIsModalVisible(true) : closeFlyout(false);
           }}
         >
           <EuiFlyoutHeader hasBorder={false}>

--- a/public/components/security/policies/create-policy.tsx
+++ b/public/components/security/policies/create-policy.tsx
@@ -243,7 +243,7 @@ export const CreatePolicyFlyout = ({ closeFlyout }) => {
     modal = (
       <EuiOverlayMask>
         <EuiConfirmModal
-          title="Close flyout"
+          title="Unsubmitted changes"
           onConfirm={() => {
             setIsModalVisible(false);
             closeFlyout(false);

--- a/public/components/security/policies/edit-policy.tsx
+++ b/public/components/security/policies/edit-policy.tsx
@@ -259,7 +259,7 @@ export const EditPolicyFlyout = ({ policy, closeFlyout }) => {
     modal = (
       <EuiOverlayMask>
         <EuiConfirmModal
-          title="Close flyout"
+          title="Unsubmitted changes"
           onConfirm={() => {
             setIsModalVisible(false);
             closeFlyout(false);

--- a/public/components/security/policies/edit-policy.tsx
+++ b/public/components/security/policies/edit-policy.tsx
@@ -290,19 +290,11 @@ export const EditPolicyFlyout = ({ policy, closeFlyout }) => {
       <WzOverlayMask
         headerZindexLocation="below"
         onClick={() => {
-          if (hasChanges) {
-            setIsModalVisible(true);
-          } else {
-            closeFlyout(false);
-          }
+          hasChanges ? setIsModalVisible(true) : closeFlyout(false);
         }}
       >
         <EuiFlyout className="wzApp" onClose={() => {
-          if (hasChanges) {
-            setIsModalVisible(true);
-          } else {
-            closeFlyout(false);
-          }
+          hasChanges ? setIsModalVisible(true) : closeFlyout(false);
         }}>
           <EuiFlyoutHeader hasBorder={false}>
             <EuiTitle size="m">

--- a/public/components/security/roles-mapping/components/roles-mapping-create.tsx
+++ b/public/components/security/roles-mapping/components/roles-mapping-create.tsx
@@ -69,7 +69,7 @@ export const RolesMappingCreate = ({
     modal = (
       <EuiOverlayMask>
         <EuiConfirmModal
-          title="Close flyout"
+          title="Unsubmitted changes"
           onConfirm={() => {
             setIsModalVisible(false);
             closeFlyout(false);

--- a/public/components/security/roles-mapping/components/roles-mapping-create.tsx
+++ b/public/components/security/roles-mapping/components/roles-mapping-create.tsx
@@ -100,19 +100,13 @@ export const RolesMappingCreate = ({
       <WzOverlayMask
         headerZindexLocation="below"
         onClick={() => {
-          if (hasChanges) {
-            setIsModalVisible(true);
-          } else {
-            closeFlyout(false);
-          }
+          hasChanges ? setIsModalVisible(true) : closeFlyout(false);
         }}
       >
-        <EuiFlyout className="wzApp" onClose={() => {
-          if (hasChanges) {
-            setIsModalVisible(true);
-          } else {
-            closeFlyout(false);
-          }
+        <EuiFlyout 
+        className="wzApp" 
+        onClose={() => {
+          hasChanges ? setIsModalVisible(true) : closeFlyout(false);
         }}>
           <EuiFlyoutHeader hasBorder={false}>
             <EuiTitle size="m">

--- a/public/components/security/roles-mapping/components/roles-mapping-edit.tsx
+++ b/public/components/security/roles-mapping/components/roles-mapping-edit.tsx
@@ -126,20 +126,15 @@ export const RolesMappingEdit = ({
       <WzOverlayMask
         headerZindexLocation="below"
         onClick={() => {
-          if (hasChanges) {
-            setIsModalVisible(true);
-          } else {
-            closeFlyout(false);
-          }
+          hasChanges ? setIsModalVisible(true) : closeFlyout(false);
         }}
       >
-        <EuiFlyout className="wzApp" onClose={() => {
-          if (hasChanges) {
-            setIsModalVisible(true);
-          } else {
-            closeFlyout(false);
-          }
-        }}>
+        <EuiFlyout
+          className="wzApp"
+          onClose={() => {
+            hasChanges ? setIsModalVisible(true) : closeFlyout(false);
+          }}
+        >
           <EuiFlyoutHeader hasBorder={false}>
             <EuiTitle size="m">
               <h2>

--- a/public/components/security/roles-mapping/components/roles-mapping-edit.tsx
+++ b/public/components/security/roles-mapping/components/roles-mapping-edit.tsx
@@ -93,7 +93,7 @@ export const RolesMappingEdit = ({
     modal = (
       <EuiOverlayMask>
         <EuiConfirmModal
-          title="Close flyout"
+          title="Unsubmitted changes"
           onConfirm={() => {
             setIsModalVisible(false);
             closeFlyout(false);

--- a/public/components/security/roles/create-role.tsx
+++ b/public/components/security/roles/create-role.tsx
@@ -104,7 +104,7 @@ export const CreateRole = ({ closeFlyout }) => {
     modal = (
       <EuiOverlayMask>
         <EuiConfirmModal
-          title="Close flyout"
+          title="Unsubmitted changes"
           onConfirm={() => {
             setIsModalVisible(false);
             closeFlyout(false);

--- a/public/components/security/roles/create-role.tsx
+++ b/public/components/security/roles/create-role.tsx
@@ -135,19 +135,11 @@ export const CreateRole = ({ closeFlyout }) => {
       <WzOverlayMask
         headerZindexLocation="below"
         onClick={() => {
-          if (hasChanges) {
-            setIsModalVisible(true);
-          } else {
-            closeFlyout(false);
-          }
+          hasChanges ? setIsModalVisible(true) : closeFlyout(false);
         }}
       >
         <EuiFlyout className="wzApp" onClose={() => {
-          if (hasChanges) {
-            setIsModalVisible(true);
-          } else {
-            closeFlyout(false);
-          }
+          hasChanges ? setIsModalVisible(true) : closeFlyout(false);
         }}>
           <EuiFlyoutHeader hasBorder={false}>
             <EuiTitle size="m">

--- a/public/components/security/roles/edit-role.tsx
+++ b/public/components/security/roles/edit-role.tsx
@@ -117,7 +117,7 @@ export const EditRole = ({ role, closeFlyout }) => {
     modal = (
       <EuiOverlayMask>
         <EuiConfirmModal
-          title="Close flyout"
+          title="Unsubmitted changes"
           onConfirm={() => {
             setIsModalVisible(false);
             closeFlyout(false);

--- a/public/components/security/users/components/create-user.tsx
+++ b/public/components/security/users/components/create-user.tsx
@@ -195,7 +195,7 @@ export const CreateUser = ({ closeFlyout }) => {
     modal = (
       <EuiOverlayMask>
         <EuiConfirmModal
-          title="Close flyout"
+          title="Unsubmitted changes"
           onConfirm={() => {
             setIsModalVisible(false);
             closeFlyout(false);

--- a/public/components/security/users/components/create-user.tsx
+++ b/public/components/security/users/components/create-user.tsx
@@ -229,19 +229,11 @@ export const CreateUser = ({ closeFlyout }) => {
       <WzOverlayMask
         headerZindexLocation="below"
         onClick={() => {
-          if (hasChanges) {
-            setIsModalVisible(true);
-          } else {
-            closeFlyout(false);
-          }
+          hasChanges ? setIsModalVisible(true) : closeFlyout(false);
         }}
       >
         <EuiFlyout className="wzApp" onClose={() => {
-          if (hasChanges) {
-            setIsModalVisible(true);
-          } else {
-            closeFlyout(false);
-          }
+          hasChanges ? setIsModalVisible(true) : closeFlyout(false);
         }}>
           <EuiFlyoutHeader hasBorder={false}>
             <EuiTitle size="m">

--- a/public/components/security/users/components/edit-user.tsx
+++ b/public/components/security/users/components/edit-user.tsx
@@ -222,19 +222,11 @@ export const EditUser = ({ currentUser, closeFlyout, rolesObject }) => {
       <WzOverlayMask
         headerZindexLocation="below"
         onClick={() => {
-          if (hasChanges) {
-            setIsModalVisible(true);
-          } else {
-            closeFlyout(false);
-          }
+          hasChanges ? setIsModalVisible(true) : closeFlyout(false);
         }}
       >
         <EuiFlyout className="wzApp" onClose={() => {
-          if (hasChanges) {
-            setIsModalVisible(true);
-          } else {
-            closeFlyout(false);
-          }
+          hasChanges ? setIsModalVisible(true) : closeFlyout(false);
         }}>
           <EuiFlyoutHeader hasBorder={false}>
             <EuiTitle size="m">

--- a/public/components/security/users/components/edit-user.tsx
+++ b/public/components/security/users/components/edit-user.tsx
@@ -188,7 +188,7 @@ export const EditUser = ({ currentUser, closeFlyout, rolesObject }) => {
     modal = (
       <EuiOverlayMask>
         <EuiConfirmModal
-          title="Close flyout"
+          title="Unsubmitted changes"
           onConfirm={() => {
             setIsModalVisible(false);
             closeFlyout(false);

--- a/public/controllers/management/components/management/configuration/util-components/configuration-path.js
+++ b/public/controllers/management/components/management/configuration/util-components/configuration-path.js
@@ -56,7 +56,7 @@ class WzConfigurationPath extends Component {
       modal = (
         <WzOverlayMask>
           <EuiConfirmModal
-            title="Close flyout"
+            title="Unsubmitted changes"
             onConfirm={() => {
               closeModal;
               updateConfigurationSection('');

--- a/public/controllers/management/components/management/groups/groups-editor.js
+++ b/public/controllers/management/components/management/groups/groups-editor.js
@@ -163,7 +163,7 @@ class WzGroupsEditor extends Component {
       modal = (
         <WzOverlayMask>
           <EuiConfirmModal
-            title="Close flyout"
+            title="Unsubmitted changes"
             onConfirm={() => {
               closeModal;
               this.props.cleanFileContent();

--- a/public/controllers/management/components/management/ruleset/ruleset-editor.js
+++ b/public/controllers/management/components/management/ruleset/ruleset-editor.js
@@ -282,11 +282,7 @@ class WzRulesetEditor extends Component {
                               iconSize="l"
                               iconType="arrowLeft"
                               onClick={() => {
-                                if (this.state.hasChanges) {
-                                  showModal();
-                                } else {
-                                  this.props.cleanInfo();
-                                }
+                                this.state.hasChanges ? showModal() : this.props.cleanInfo();
                               }}
                             />
                           </EuiToolTip>
@@ -311,11 +307,7 @@ class WzRulesetEditor extends Component {
                               iconSize="l"
                               iconType="arrowLeft"
                               onClick={() => {
-                                if (this.state.hasChanges) {
-                                  showModal();
-                                } else {
-                                  this.props.cleanInfo();
-                                }
+                                this.state.hasChanges ? showModal() : this.props.cleanInfo();
                               }}
                             />
                           </EuiToolTip>

--- a/public/controllers/management/components/management/ruleset/ruleset-editor.js
+++ b/public/controllers/management/components/management/ruleset/ruleset-editor.js
@@ -73,6 +73,7 @@ class WzRulesetEditor extends Component {
       isSaving: false,
       error: false,
       inputValue: '',
+      initialInputValue: '',
       showWarningRestart: false,
       isModalVisible: false,
       hasChanges: false,
@@ -96,6 +97,9 @@ class WzRulesetEditor extends Component {
   componentDidUpdate(prevProps, prevState) {
     if (prevState.content !== this.state.content) {
       this.setState({ hasChanges: this.state.content !== this.state.initContent });
+    }
+    if (prevState.inputValue !== this.state.inputValue){
+      this.setState({ hasChanges: this.state.inputValue !== this.state.initialInputValue });
     }
   }
 
@@ -277,7 +281,13 @@ class WzRulesetEditor extends Component {
                               color="primary"
                               iconSize="l"
                               iconType="arrowLeft"
-                              onClick={() => this.props.cleanInfo()}
+                              onClick={() => {
+                                if (this.state.hasChanges) {
+                                  showModal();
+                                } else {
+                                  this.props.cleanInfo();
+                                }
+                              }}
                             />
                           </EuiToolTip>
                         </EuiFlexItem>

--- a/public/controllers/management/components/management/ruleset/ruleset-editor.js
+++ b/public/controllers/management/components/management/ruleset/ruleset-editor.js
@@ -247,7 +247,7 @@ class WzRulesetEditor extends Component {
       modal = (
         <WzOverlayMask>
           <EuiConfirmModal
-            title="Close flyout"
+            title="Unsubmitted changes"
             onConfirm={() => {
               closeModal;
               this.props.cleanInfo();

--- a/public/controllers/management/components/management/ruleset/ruleset-editor.js
+++ b/public/controllers/management/components/management/ruleset/ruleset-editor.js
@@ -76,7 +76,6 @@ class WzRulesetEditor extends Component {
       initialInputValue: '',
       showWarningRestart: false,
       isModalVisible: false,
-      hasChanges: false,
       initContent: content,
       content,
       name,
@@ -94,14 +93,6 @@ class WzRulesetEditor extends Component {
     this._isMounted = true;
   }
 
-  componentDidUpdate(prevProps, prevState) {
-    if (prevState.content !== this.state.content) {
-      this.setState({ hasChanges: this.state.content !== this.state.initContent });
-    }
-    if (prevState.inputValue !== this.state.inputValue){
-      this.setState({ hasChanges: this.state.inputValue !== this.state.initialInputValue });
-    }
-  }
 
   /**
    * Save the new content
@@ -151,7 +142,11 @@ class WzRulesetEditor extends Component {
       if (overwrite) {
         textSuccess = 'File successfully edited';
       }
-      this.setState({ showWarningRestart: true });
+      this.setState({
+        showWarningRestart: true,
+        initialInputValue: this.state.inputValue,
+        initContent: content,
+      });
       this.showToast('success', 'Success', textSuccess, 3000);
     } catch (error) {
       this.setState({ error, isSaving: false });
@@ -282,7 +277,14 @@ class WzRulesetEditor extends Component {
                               iconSize="l"
                               iconType="arrowLeft"
                               onClick={() => {
-                                this.state.hasChanges ? showModal() : this.props.cleanInfo();
+                                if (
+                                  this.state.content !== this.state.initContent ||
+                                  this.state.inputValue !== this.state.initialInputValue
+                                ) {
+                                  showModal();
+                                } else {
+                                  this.props.cleanInfo();
+                                }
                               }}
                             />
                           </EuiToolTip>
@@ -307,7 +309,14 @@ class WzRulesetEditor extends Component {
                               iconSize="l"
                               iconType="arrowLeft"
                               onClick={() => {
-                                this.state.hasChanges ? showModal() : this.props.cleanInfo();
+                                if (
+                                  this.state.content !== this.state.initContent ||
+                                  this.state.inputValue !== this.state.initialInputValue
+                                ) {
+                                  showModal();
+                                } else {
+                                  this.props.cleanInfo();
+                                }
                               }}
                             />
                           </EuiToolTip>


### PR DESCRIPTION
Hi team this PR solves: 

- Form validation on going back doesnt work on new Rules/Decoders files.

Closes #3253 

### How to test
1. Go to 'Management / Rules' and 'Management / Decoders'
2. Click on create a new file
3. Edit the form/name and go back or navigate from the menu.
4. The message should be displayed.