### PR TITLE
Fix typerror deploy new agent Safari 12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fixed the `Visualize` button is not displaying when expanding a field in the Events sidebar [#3237](https://github.com/wazuh/wazuh-kibana-app/pull/3237)
 - Add error when add sample data fails [#3241] (https://github.com/wazuh/wazuh-kibana-app/pull/3241)
 - Fix modules are missing in the agent menu [#3244] (https://github.com/wazuh/wazuh-kibana-app/pull/3244)
+- Fix TypeError when selecting macOS agent deployment in a Safari Browser [#3289](https://github.com/wazuh/wazuh-kibana-app/pull/3289)
 
 ## Wazuh v4.2.0 - Kibana 7.10.2 , 7.11.2 - Revision 4201
 

--- a/public/controllers/agent/components/register-agent.js
+++ b/public/controllers/agent/components/register-agent.js
@@ -291,7 +291,7 @@ export class RegisterAgent extends Component {
 
     // macos doesnt need = param
     if (this.state.selectedOS === 'macos') {
-      return deployment.replaceAll('=', ' ');
+      return deployment.replace(/=/g, ' ');
     }
 
     return deployment;


### PR DESCRIPTION
Hi team this PR resolves: 
- TypeError when selecting macOS agent deployment in a Safari Browser.

Closes #3255 

### How to test
Check if the deploy new agent command for macOS is correct, if you can try it also with Safari 12.