### PR TITLE
[SCA] Fix the render of the checks in a SCA check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fix improving and removing WUI error logs [#3260](https://github.com/wazuh/wazuh-kibana-app/pull/3260)
 - Fix some errors of PDF reports [#3272](https://github.com/wazuh/wazuh-kibana-app/pull/3272)
 - Fix TypeError when selecting macOS agent deployment in a Safari Browser [#3289](https://github.com/wazuh/wazuh-kibana-app/pull/3289)
+- Fix error in how the SCA check's checks are displayed [#](https://github.com/wazuh/wazuh-kibana-app/pull/3297)
 
 ## Wazuh v4.2.0 - Kibana 7.10.2 , 7.11.2 - Revision 4201
 

--- a/public/components/agents/sca/components/rule-text.tsx
+++ b/public/components/agents/sca/components/rule-text.tsx
@@ -2,16 +2,15 @@
 import React from 'react'
 import { EuiText } from '@elastic/eui';
 
-interface IRuleText {
-  rulesText: string
+interface RuleTextProps {
+  rules: {type: string, rule: string}[]
 }
 
-export const RuleText: React.FunctionComponent<IRuleText> = ({ rulesText }) => {
-  const splitRulesText = rulesText.split(' -> ');
+export const RuleText: React.FunctionComponent<RuleTextProps> = ({ rules }) => {
   return (
     <EuiText size="s">
       <ul>
-        {splitRulesText.map((text, idx) => <li key={idx}>{text}</li>)}
+        {rules.map((rule, idx) => <li key={`check-rule-${idx}`}>{rule.rule}</li>)}
       </ul>
     </EuiText>
   )

--- a/public/components/agents/sca/inventory.tsx
+++ b/public/components/agents/sca/inventory.tsx
@@ -355,7 +355,7 @@ export class Inventory extends Component {
         },
         {
           title: checks,
-          description: <RuleText rulesText={rulesText} />,
+          description: <RuleText rules={item.rules.length ? item.rules : []} />,
         },
         {
           title: 'Compliance',


### PR DESCRIPTION
### Description
This PR resolves the render of each check in an SCA check. before the checks are split by ` -> ` character

![image](https://user-images.githubusercontent.com/34042064/119496301-a4d88f80-bd63-11eb-85d1-77502e025110.png)

### Test
- Review the `Checks` within an SCA check

Closes #3261 