### PR TITLE
Normalize visData table property for 7.12 retro-compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fixed dark mode visualization background in pdf reports [#3315](https://github.com/wazuh/wazuh-kibana-app/pull/3315)
 - Adapt Kibana integrations to Kibana 7.11 and 7.12  [#3309](https://github.com/wazuh/wazuh-kibana-app/pull/3309)
 - Fixed error agent view does not render correctly  [#3306](https://github.com/wazuh/wazuh-kibana-app/pull/3306)
+- Normalized visData table property for 7.12 retro-compatibility  [#3323](https://github.com/wazuh/wazuh-kibana-app/pull/3323)
 
 ## Wazuh v4.2.0 - Kibana 7.10.2 , 7.11.2 - Revision 4201
 

--- a/public/factories/vis-handlers.js
+++ b/public/factories/vis-handlers.js
@@ -66,20 +66,29 @@ export class VisHandlers {
       item => (((item || {}).vis || {}).type || {}).name === 'table'
     );
     for (let i = 0; i < tables.length; i++) {
+      let tablesData = [];
       const columns = [];
       const title =
         tables[i].vis.title ||
         'Table';
       const item = await tables[i].handler.execution.getData();
-      for (const table of item.value.visData.tables) {
+
+      //Normalize visData tables structure for 7.12 retro-compatibility
+      if(item.value.visData.tables?.length)
+        tablesData = item.value.visData.tables;
+      else if(item.value.visData.table)
+        tablesData.push(item.value.visData.table);
+
+      for (const table of tablesData) {
         columns.push(...table.columns.map(t => t.name));
       }
 
+
       tables[i] = !!(
-        ((((item || {}).value || {}).visData || {}).tables || [])[0] || {}
+        tablesData[0] || {}
       ).rows
         ? {
-            rows: item.value.visData.tables[0].rows.map(x => {
+            rows: tablesData[0].rows.map(x => {
               return Object.values(x);
             }),
             title,


### PR DESCRIPTION
Hi team,

this fixes the property name change in vizdata table in 7.12 with retro-compatibility.

Closes #3319 

To test the PR:
- Go to Security Events (or any other module with alerts summary in the PDF report)
- Generate a PDF report
- Verify the Alerts Summary table is present