### PR TITLE
Use the longest value in column to get column width in PDF report tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fixed dark mode visualization background in pdf reports [#3315](https://github.com/wazuh/wazuh-kibana-app/pull/3315)
 - Adapt Kibana integrations to Kibana 7.11 and 7.12  [#3309](https://github.com/wazuh/wazuh-kibana-app/pull/3309)
 - Fixed error agent view does not render correctly  [#3306](https://github.com/wazuh/wazuh-kibana-app/pull/3306)
+- Fixed miscalculation in table column width in PDF reports  [#3326](https://github.com/wazuh/wazuh-kibana-app/pull/3326)
 
 ## Wazuh v4.2.0 - Kibana 7.10.2 , 7.11.2 - Revision 4201
 

--- a/server/lib/reporting/printer.ts
+++ b/server/lib/reporting/printer.ts
@@ -496,22 +496,12 @@ export class ReportPrinter{
     let totalLength = columns.length - 1;
     const widthColumn = 385/totalLength;
     let totalWidth = totalLength * widthColumn;
-    const widthCharacter = 5; //min width per character
-    const widths = [];
+    
+    const widths:(number)[] = [];
     
     for (let step = 0; step < columns.length - 1; step++) {
 
-      //Get the longest row value
-      const maxRowLength = tableRows.reduce((maxLength, row)=>{
-        return (row[step].text.length > maxLength ? row[step].text.length : maxLength);
-      },0);
-
-      //Get column name length
-      const headerLength = columns[step].label.length;
-
-      //Use the longest to get the column width
-      const maxLength = maxRowLength > headerLength ? maxRowLength : headerLength;
-      let columnLength = maxLength * widthCharacter;
+      let columnLength = this.getColumnWidth(columns[step], tableRows, step);
       
       if (columnLength <= Math.round(totalWidth / totalLength)) {
         widths.push(columnLength);
@@ -627,4 +617,28 @@ export class ReportPrinter{
     document.end();
   }
 
+  /**
+   * Returns the width of a given column
+   * 
+   * @param column 
+   * @param tableRows 
+   * @param step 
+   * @returns {number}
+   */
+  getColumnWidth(column, tableRows, index){
+    const widthCharacter = 5; //min width per character
+
+    //Get the longest row value
+    const maxRowLength = tableRows.reduce((maxLength, row)=>{
+      return (row[index].text.length > maxLength ? row[index].text.length : maxLength);
+    },0);
+
+    //Get column name length
+    const headerLength = column.label.length;
+
+    //Use the longest to get the column width
+    const maxLength = maxRowLength > headerLength ? maxRowLength : headerLength;
+
+    return maxLength * widthCharacter;
+  }
 }

--- a/server/lib/reporting/printer.ts
+++ b/server/lib/reporting/printer.ts
@@ -500,7 +500,19 @@ export class ReportPrinter{
     const widths = [];
     
     for (let step = 0; step < columns.length - 1; step++) {
-      let columnLength = tableRows[0][step].text.length * widthCharacter;
+
+      //Get the longest row value
+      const maxRowLength = tableRows.reduce((maxLength, row)=>{
+        return (row[step].text.length > maxLength ? row[step].text.length : maxLength);
+      },0);
+
+      //Get column name length
+      const headerLength = columns[step].label.length;
+
+      //Use the longest to get the column width
+      const maxLength = maxRowLength > headerLength ? maxRowLength : headerLength;
+      let columnLength = maxLength * widthCharacter;
+      
       if (columnLength <= Math.round(totalWidth / totalLength)) {
         widths.push(columnLength);
         totalWidth -= columnLength;


### PR DESCRIPTION
Hi team,

this fixes the _get column width algorithm_ in PDF report tables. 

Closes #3322 

To test it try to reproduce the issue linked