### PR TITLE
Unable to change selected index pattern from the Wazuh menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the Wazuh app project will be documented in this file.
 
+## Wazuh v4.1.5 - Kibana 7.10.0 , 7.10.2, 7.11.2 - Revision 4108
+
+### Fixed
+
+- Unable to change selected index pattern from the Wazuh menu [#3330](https://github.com/wazuh/wazuh-kibana-app/pull/3330)
+
 ## Wazuh v4.1.5 - Kibana 7.10.0 , 7.10.2, 7.11.2 - Revision 4107
 
 ### Added

--- a/public/services/resolves/get-ip.js
+++ b/public/services/resolves/get-ip.js
@@ -34,7 +34,6 @@ export function getIp(
       AppState.removeCurrentPattern()
     }
     getDataPlugin().indexPatterns.setDefault(configuration.pattern, true);
-    AppState.setCurrentPattern(configuration.pattern)
 
     return indexPatternFound;
   }


### PR DESCRIPTION
Hi team, this resolves:

- The default index pattern always is set as the selected pattern

Testing:
- Create a new index pattern
- Select it from Menu 
- It should stay selected after the refresh

Related to [#wazuh/wazuh/8776](https://github.com/wazuh/wazuh/issues/8776)