### PR TITLE
Created new Mitre flyout

### DIFF
--- a/public/components/overview/mitre_attack_intelligence/mitre_attack_resources.ts
+++ b/public/components/overview/mitre_attack_intelligence/mitre_attack_resources.ts
@@ -13,6 +13,7 @@
 
 import { WzRequest } from '../../../react-services';
 import { Markdown } from '../../common/util';
+import { formatUIDate } from '../../../react-services';
 
 const getMitreAttackIntelligenceSuggestions = (endpoint: string, field: string) => async (input: string) => {
   try{
@@ -83,7 +84,35 @@ function buildResource(label: string, labelResource: string){
         ) : '',
         truncateText: true
       }
-    ]
+    ],
+    mitreFlyoutHeaderProperties: [
+      {
+        label: 'ID',
+        id: 'references.external_id',
+      },
+      {
+        label: 'Name',
+        id: 'name'
+      },
+      {
+        label: 'Created Time',
+        id: 'created_time',
+        render: (value) => value ? (
+          formatUIDate(value)
+        ) : ''
+      },
+      {
+        label: 'Modified Time',
+        id: 'modified_time',
+        render: (value) => value ? (
+          formatUIDate(value)
+        ) : ''
+      },
+      {
+        label: 'Version',
+        id: 'mitre_version'
+      },
+    ],
   }
 };
 

--- a/public/components/overview/mitre_attack_intelligence/module_mitre_attack_intelligence_all_resources.tsx
+++ b/public/components/overview/mitre_attack_intelligence/module_mitre_attack_intelligence_all_resources.tsx
@@ -11,7 +11,7 @@
  * Find more information about this on the LICENSE file.
  */
 
-import React from 'react';
+import React, {useCallback, useState} from 'react';
 import { 
   EuiTitle,
   EuiSpacer
@@ -19,13 +19,45 @@ import {
 import { withGuard } from'../../../components/common/hocs';
 import { ModuleMitreAttackIntelligenceAllResourcesWelcome } from './module_mitre_attack_intelligence_all_resources_welcome';
 import { ModuleMitreAttackIntelligenceAllResourcesSearchResults } from './module_mitre_attack_intelligence_all_resources_search_results';
+import { ModuleMitreAttackIntelligenceFlyout } from './module_mitre_attack_intelligence_resource_flyout';
 
 export const ModuleMitreAttackIntelligenceAllResources = withGuard(({didSearch}) => !didSearch, ModuleMitreAttackIntelligenceAllResourcesWelcome)(({ results, loading }) => {
+  const [isDetailsOpen, setIsDetailsOpen] = useState(false);
+  const [details, setDetails] = useState(null);
+
+  const  mapResponseItem = (item) => ({...item, ['references.external_id']: item.references.find(reference => reference.source === 'mitre-attack')?.external_id});
+
+  const rowProps = useCallback((item) => {
+    setDetails(mapResponseItem(item));
+    setIsDetailsOpen(true);
+  },[]);
+
+  const rowPropsFlyout = useCallback((item) => ({
+    // 'data-test-subj': `row-${file}`,
+    onClick: () => {
+      setDetails(item);
+      setIsDetailsOpen(true);
+    },
+  }), []);
+
+  const closeFlyout = useCallback(() => {
+    setDetails(null);
+    setIsDetailsOpen(false);
+  },[]);
+
   return (
     <>
       <EuiTitle><h1>Search results</h1></EuiTitle>
       <EuiSpacer />
-      <ModuleMitreAttackIntelligenceAllResourcesSearchResults results={results} loading={loading}/> 
+      <ModuleMitreAttackIntelligenceAllResourcesSearchResults results={results} loading={loading} rowProps={rowProps}/> 
+
+      {details && isDetailsOpen && (
+        <ModuleMitreAttackIntelligenceFlyout
+        details={details}
+        closeFlyout={() => closeFlyout()}
+        tableProps={rowPropsFlyout}
+        />
+      )}
     </>
   )
 });

--- a/public/components/overview/mitre_attack_intelligence/module_mitre_attack_intelligence_all_resources_search_results.tsx
+++ b/public/components/overview/mitre_attack_intelligence/module_mitre_attack_intelligence_all_resources_search_results.tsx
@@ -28,7 +28,7 @@ const LoadingProgress = () => (
   <EuiProgress color='primary' size='s'/>
 );
 
-export const ModuleMitreAttackIntelligenceAllResourcesSearchResults = withGuard(({loading}) => loading, LoadingProgress)(({ results, setResourceFilters }) => {
+export const ModuleMitreAttackIntelligenceAllResourcesSearchResults = withGuard(({loading}) => loading, LoadingProgress)(({ results, setResourceFilters, rowProps }) => {
   const thereAreResults = results && results.length > 0;
   return thereAreResults
   ? results.map(item => (
@@ -49,6 +49,7 @@ export const ModuleMitreAttackIntelligenceAllResourcesSearchResults = withGuard(
       {item.results.map((result, resultIndex) => (
         <EuiButtonEmpty
           key={`module_mitre_attack_intelligence_all_resources_search_results_${item.name}_${resultIndex}`}
+          onClick={() => rowProps(result)}
         >
           {result[item.fieldName]}
         </EuiButtonEmpty>

--- a/public/components/overview/mitre_attack_intelligence/module_mitre_attack_intelligence_resource.tsx
+++ b/public/components/overview/mitre_attack_intelligence/module_mitre_attack_intelligence_resource.tsx
@@ -13,8 +13,9 @@
 
 import React, { useCallback, useState } from 'react';
 import { TableWzAPI } from '../../../components/common/tables';
+import { ModuleMitreAttackIntelligenceFlyout } from './module_mitre_attack_intelligence_resource_flyout';
 
-export const ModuleMitreAttackIntelligenceResource = ({ label, searchBarSuggestions, apiEndpoint, tableColumns, detailsProperties, initialSortingField = 'name', resourceFilters }) => {
+export const ModuleMitreAttackIntelligenceResource = ({ label, searchBarSuggestions, apiEndpoint, tableColumns, initialSortingField = 'name', resourceFilters }) => {
   const [isDetailsOpen, setIsDetailsOpen] = useState(false);
   const [details, setDetails] = useState(null);
 
@@ -46,59 +47,13 @@ export const ModuleMitreAttackIntelligenceResource = ({ label, searchBarSuggesti
         mapResponseItem={(item) => ({...item, ['references.external_id']: item.references.find(reference => reference.source === 'mitre-attack')?.external_id})}
         filters={resourceFilters}
       />
-      {/* {details && isDetailsOpen && (
-        <EuiOverlayMask
-          headerZindexLocation="below"
-          onClick={closeFlyout} >
-          <EuiFlyout
-            onClose={closeFlyout}
-            size="l"
-            aria-labelledby={``}
-            // maxWidth="70%"
-            // className=""
-          >
-            <EuiFlyoutHeader hasBorder>
-              <EuiTitle size="m">
-                <h2 id="flyoutTitle">Details</h2>
-              </EuiTitle>
-            </EuiFlyoutHeader>
-            <EuiFlyoutBody>
-              <EuiFlexGroup>
-                {detailsProperties.map(detailProperty => (
-                  <EuiFlexItem grow={false} key={`module_mitre_ingelligense_resource_detail_property_${detailProperty.id}`}>
-                    <div><strong>{detailProperty.label}</strong></div>
-                    <EuiText color='subdued'>{details[detailProperty.id]}</EuiText>
-                  </EuiFlexItem>
-                ))}
-              </EuiFlexGroup>
-              <EuiFlexGroup>
-                <EuiFlexItem>
-                  <div><strong>Description</strong></div>
-                  <EuiText color='subdued'>{details.description}</EuiText>
-                </EuiFlexItem>
-              </EuiFlexGroup>
-              <EuiFlexGroup>
-                <EuiFlexItem>
-                  <EuiAccordion
-                    style={{ textDecoration: 'none' }}
-                    id=''
-                    className='events-accordion'
-                    // extraAction={<div style={{ marginBottom: 5 }}><strong>{this.state.totalHits || 0}</strong> hits</div>}
-                    buttonContent='Techniques'
-                    paddingSize='none'
-                    initialIsOpen={true}>
-                      <EuiBasicTable 
-                        items={details.techniques.map(technique => ({technique}))}
-                        columns={[{field: 'technique', name: 'Technique'}]}
-                      />
-                  </EuiAccordion>
-                </EuiFlexItem>
-              </EuiFlexGroup>
-            </EuiFlyoutBody>
-          </EuiFlyout>
-        </EuiOverlayMask>
-      )
-      } */}
+      {details && isDetailsOpen && (
+        <ModuleMitreAttackIntelligenceFlyout
+        details={details}
+        closeFlyout={() => closeFlyout()}
+        tableProps={rowProps}
+        />
+      )}
     </> 
   )
 }

--- a/public/components/overview/mitre_attack_intelligence/module_mitre_attack_intelligence_resource_flyout.tsx
+++ b/public/components/overview/mitre_attack_intelligence/module_mitre_attack_intelligence_resource_flyout.tsx
@@ -1,0 +1,169 @@
+/*
+ * Wazuh app - React component for showing the Mitre Att&ck intelligence flyout.
+ *
+ * Copyright (C) 2015-2021 Wazuh, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Find more information about this on the LICENSE file.
+ */
+
+import React , {useState, useEffect, useRef} from 'react';
+import { WzRequest } from '../../../react-services';
+import { MitreAttackResources } from './mitre_attack_resources';
+
+import {
+  EuiBasicTableColumn,
+  EuiButtonIcon,
+    EuiFlyout,
+    EuiFlyoutHeader,
+    EuiOverlayMask,
+    EuiTitle,
+    EuiText,
+    EuiFlexGroup,
+    EuiFlyoutBody,
+    EuiFlexItem,
+    EuiAccordion,
+    SortDirection,
+    EuiInMemoryTable,
+  } from '@elastic/eui';
+  import { Markdown } from '../../common/util/markdown'
+import { EuiButton } from '@elastic/eui/src/components/button/button';
+
+  const GetFlyoutSubtable = ({name, array, props}) => {
+    const [isLoading, setIsLoading] = useState(true);
+    const [data, setData] = useState<any[]>([]);
+
+    useEffect(() => {
+      getValues();
+    }, []);
+    useEffect(() => {
+      getValues();
+    }, [array]);
+
+    const getValues = async () => {
+      setIsLoading(true);
+      // We extract the ids from the subtable and count them in a string for the call that will extract the info
+      let namesContatenated = [''];
+      let contador = 0;
+      array.forEach((element) => {
+        //The character limit of a request is 8190, if the characters of our request exceed 8100, we divide said call into several to avoid errors
+        if(namesContatenated[contador].length + element.length >= 8100)
+          contador++;
+        namesContatenated[contador] += element;
+        namesContatenated[contador] += ',';
+      });
+      // We make the call to extract the necessary information from the subtable
+      try{
+        namesContatenated.forEach(async (nameConcatenated) => {
+          const data = await WzRequest.apiReq('GET', `/mitre/${name}?${name.slice(-1) === 's' ? name.substring(0, name.length-1) : name}_ids=${nameConcatenated}`, {});
+          setData(((((data || {}).data || {}).data || {}).affected_items || []).map((item) => ({...item, ['references.external_id']: item.references.find(reference => reference.source === 'mitre-attack')?.external_id})));  
+        });
+      }
+      catch (error){
+        console.log("Error in Mitre Flyout due to: ", error);
+      }
+      setIsLoading(false);
+    }
+
+    const columns: EuiBasicTableColumn<any>[] = [
+      {
+        field: 'references.external_id',
+        name: 'ID',
+        sortable: true,
+      },
+      {
+        field: 'name',
+        name: 'Name',
+        sortable: true,
+      },
+      {
+        field: 'description',
+        name: 'Description',
+        sortable: true,
+        render: (item) => item ? <Markdown markdown={item} /> : '',
+        truncateText: true
+
+      },
+    ];
+
+    return (
+      <EuiAccordion
+        style={{ textDecoration: 'none' }}
+        id=''
+        className='events-accordion'
+        // extraAction={<div style={{ marginBottom: 5 }}><strong>{this.state.totalHits || 0}</strong> hits</div>}
+        buttonContent={name.charAt(0).toUpperCase() + name.slice(1)}
+        paddingSize='none'
+        initialIsOpen={true}>
+        <EuiInMemoryTable
+          columns={columns}
+          items={data}
+          loading={isLoading}
+          pagination={{ pageSizeOptions: [5, 10, 20] }}
+          sorting={{ sort: { field: 'name', direction: SortDirection.DESC } }}
+          rowProps={props}
+        />
+      </EuiAccordion>
+    );
+  }
+
+    // run this function from an event handler or an effect to execute scroll 
+
+  export const ModuleMitreAttackIntelligenceFlyout = ({details, closeFlyout, tableProps}) => {
+    const startReference = useRef(null);
+    startReference.current?.scrollIntoView();
+
+    return (
+      <EuiOverlayMask
+              headerZindexLocation="below"
+              onClick= {closeFlyout} >
+              <EuiFlyout
+                onClose={closeFlyout}
+                size="l"
+                aria-labelledby={``}
+                // maxWidth="70%"
+                // className=""
+              >
+                <EuiFlyoutHeader hasBorder>
+                  <EuiTitle size="m">
+                    <h2 id="flyoutTitle">Details</h2>
+                  </EuiTitle>
+                </EuiFlyoutHeader>
+                <EuiFlyoutBody>
+                  <div ref={startReference}>
+                    <EuiFlexGroup>
+                      {MitreAttackResources[0].mitreFlyoutHeaderProperties.map(detailProperty => (
+                        <EuiFlexItem>
+                          <div><strong>{detailProperty.label}</strong></div>
+                          <EuiText color='subdued'>{detailProperty.render ? detailProperty.render(details[detailProperty.id]) : details[detailProperty.id]}</EuiText>
+                        </EuiFlexItem>
+                      ))}
+                    </EuiFlexGroup>
+                  </div>
+                  <EuiFlexGroup>
+                    <EuiFlexItem>
+                        <div><strong>Description</strong></div>
+                        <EuiText color='subdued'>{ details.description ? <Markdown markdown={details.description}/> : ''}</EuiText>
+                      </EuiFlexItem>
+                  </EuiFlexGroup>
+                  <EuiFlexGroup>
+                    <EuiFlexItem>
+                        {MitreAttackResources.filter((item) => details[item.id]).map((item) => 
+                          <GetFlyoutSubtable
+                            name={item.id}
+                            array={details[item.id]}
+                            props={tableProps}
+                          />
+                        )}
+                    </EuiFlexItem>
+                  </EuiFlexGroup>
+                </EuiFlyoutBody>
+              </EuiFlyout>
+            </EuiOverlayMask>
+    )
+  };
+


### PR DESCRIPTION
With this PR we created the flyout for the new Miter section. We can also navigate through it by selecting a row in a subtable.
We close issue #3293 

To test it, we will have to enter `/Mitre Att&ack` -> `/Intelligence`, select one of the fields (such as Groups, Tactics ...) click on it and try to navigate through the subtables, clicking on them.
We also have to prove that when doing a search in the left search bar, when clicking on a result it has to work the same as the previous case