### PR TITLE
Fix/elastic UI upgrade breaking changes in 7.11 and 7.12 3318

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fixed dark mode visualization background in pdf reports [#3315](https://github.com/wazuh/wazuh-kibana-app/pull/3315)
 - Adapt Kibana integrations to Kibana 7.11 and 7.12  [#3309](https://github.com/wazuh/wazuh-kibana-app/pull/3309)
 - Fixed error agent view does not render correctly  [#3306](https://github.com/wazuh/wazuh-kibana-app/pull/3306)
+- Normalized visData table property for 7.12 retro-compatibility  [#3323](https://github.com/wazuh/wazuh-kibana-app/pull/3323)
 
 ## Wazuh v4.2.0 - Kibana 7.10.2 , 7.11.2 - Revision 4201
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Adapt Kibana integrations to Kibana 7.11 and 7.12  [#3309](https://github.com/wazuh/wazuh-kibana-app/pull/3309)
 - Fixed error agent view does not render correctly  [#3306](https://github.com/wazuh/wazuh-kibana-app/pull/3306)
 - Normalized visData table property for 7.12 retro-compatibility  [#3323](https://github.com/wazuh/wazuh-kibana-app/pull/3323)
+- Fixed Elastic UI breaking changes in 7.12 [#3345](https://github.com/wazuh/wazuh-kibana-app/pull/3345)
 
 ## Wazuh v4.2.0 - Kibana 7.10.2 , 7.11.2 - Revision 4201
 

--- a/public/components/add-modules-data/module-guide.js
+++ b/public/components/add-modules-data/module-guide.js
@@ -758,6 +758,7 @@ class WzModuleGuide extends Component {
             <EuiFlexItem grow={false}>
               <EuiButtonGroup
                 color='primary'
+                legend='Agent type'
                 options={agentTypeButtons}
                 idSelected={this.state.agentTypeSelected}
                 onChange={this.onChangeAgentTypeSelected}

--- a/public/components/overview/compliance-table/components/requirements/requirements.tsx
+++ b/public/components/overview/compliance-table/components/requirements/requirements.tsx
@@ -182,7 +182,6 @@ export class ComplianceRequirements extends Component {
               button={(<EuiButtonIcon iconType="gear" onClick={() => this.onGearButtonClick()}></EuiButtonIcon>)}
               isOpen={this.state.isPopoverOpen}
               panelPaddingSize="none"
-              withTitle
               closePopover={() => this.closePopover()}>
                 <EuiContextMenu initialPanelId={0} panels={panels} />
            </EuiPopover>

--- a/public/components/overview/compliance-table/components/subrequirements/subrequirements.tsx
+++ b/public/components/overview/compliance-table/components/subrequirements/subrequirements.tsx
@@ -195,7 +195,6 @@ export class ComplianceSubrequirements extends Component {
             closePopover={() => { }}
             panelPaddingSize="none"
             style={{ width: "100%" }}
-            withTitle
             anchorPosition="downLeft">xxx
           </EuiPopover>
         </EuiFlexItem>

--- a/public/components/overview/mitre/components/tactics/tactics.tsx
+++ b/public/components/overview/mitre/components/tactics/tactics.tsx
@@ -290,7 +290,6 @@ export class Tactics extends Component {
               button={(<EuiButtonIcon iconType="gear" onClick={() => this.onGearButtonClick()} aria-label={'tactics options'}></EuiButtonIcon>)}
               isOpen={this.state.isPopoverOpen}
               panelPaddingSize="none"
-              withTitle
               closePopover={() => this.closePopover()}>
                 <EuiContextMenu initialPanelId={0} panels={panels} />
             </EuiPopover>

--- a/public/components/overview/mitre/components/techniques/techniques.tsx
+++ b/public/components/overview/mitre/components/techniques/techniques.tsx
@@ -244,7 +244,6 @@ export const Techniques = withWindowSize(class Techniques extends Component {
             closePopover={() => this.closeActionsMenu()}
             panelPaddingSize="none"
             style={{width: "100%"}}
-            withTitle
             anchorPosition="downLeft">
             <EuiContextMenu initialPanelId={0} panels={this.buildPanel(item.id)} />
           </EuiPopover>

--- a/public/components/wz-search-bar/components/wz-search-badges/context-menu.tsx
+++ b/public/components/wz-search-bar/components/wz-search-badges/context-menu.tsx
@@ -192,22 +192,26 @@ async function updateSuggestsValues(suggest: any, value: any, setSuggetsValues: 
 }
 
 function EditFilterOperator(operator, setOperator) {
+  const operatorSelectOptions = [
+    { value: '=', inputDisplay: 'is' },
+    { value: '!=', inputDisplay: 'is not' },
+    { value: '<', inputDisplay: 'less than' },
+    { value: '>', inputDisplay: 'greater than' },
+    { value: '~', inputDisplay: 'like' },
+  ];
+
   return <EuiFormRow label="Operator">
-    <EuiSuperSelect options={[
-      { value: '=', inputDisplay: 'is' },
-      { value: '!=', inputDisplay: 'is not' },
-      { value: '<', inputDisplay: 'less than' },
-      { value: '>', inputDisplay: 'greater than' },
-      { value: '~', inputDisplay: 'like' },
-    ]} valueOfSelected={operator} onChange={setOperator} />
+    <EuiSuperSelect options={operatorSelectOptions} valueOfSelected={operator} onChange={setOperator} />
   </EuiFormRow>;
 }
 
 function EditFilterConjuntion(conjuntion: string, setConjuntion): React.ReactNode {
+  const conjuntionOptions = [
+    { id: `conjuntion-AND`, label: "AND" },
+    { id: `conjuntion-OR`, label: "OR" },
+  ];
+
   return <EuiFormRow label="Conjuntion">
-    <EuiButtonGroup legend="Conjunction" options={[
-      { id: `conjuntion-AND`, label: "AND" },
-      { id: `conjuntion-OR`, label: "OR" },
-    ]} idSelected={`conjuntion-${conjuntion.trim()}`} onChange={() => setConjuntion(/and/gi.test(conjuntion) ? ' OR ' : ' AND ')} />
+    <EuiButtonGroup legend="Conjunction" options={conjuntionOptions} idSelected={`conjuntion-${conjuntion.trim()}`} onChange={() => setConjuntion(/and/gi.test(conjuntion) ? ' OR ' : ' AND ')} />
   </EuiFormRow>;
 }

--- a/public/components/wz-search-bar/components/wz-search-badges/context-menu.tsx
+++ b/public/components/wz-search-bar/components/wz-search-badges/context-menu.tsx
@@ -205,7 +205,7 @@ function EditFilterOperator(operator, setOperator) {
 
 function EditFilterConjuntion(conjuntion: string, setConjuntion): React.ReactNode {
   return <EuiFormRow label="Conjuntion">
-    <EuiButtonGroup options={[
+    <EuiButtonGroup legend="Conjunction" options={[
       { id: `conjuntion-AND`, label: "AND" },
       { id: `conjuntion-OR`, label: "OR" },
     ]} idSelected={`conjuntion-${conjuntion.trim()}`} onChange={() => setConjuntion(/and/gi.test(conjuntion) ? ' OR ' : ' AND ')} />

--- a/public/controllers/agent/components/register-agent.js
+++ b/public/controllers/agent/components/register-agent.js
@@ -524,6 +524,7 @@ export class RegisterAgent extends Component {
         children: (
           <EuiButtonGroup
             color="primary"
+            legend="Choose the Operating system"
             options={osButtons}
             idSelected={this.state.selectedOS}
             onChange={(os) => this.selectOS(os)}
@@ -537,6 +538,7 @@ export class RegisterAgent extends Component {
               children: (
                 <EuiButtonGroup
                   color="primary"
+                  legend="Choose the version"
                   options={versionButtonsCentos}
                   idSelected={this.state.selectedVersion}
                   onChange={(version) => this.setVersion(version)}
@@ -552,6 +554,7 @@ export class RegisterAgent extends Component {
               children: (
                 <EuiButtonGroup
                   color="primary"
+                  legend="Choose the architecture"
                   options={this.state.architectureCentos5}
                   idSelected={this.state.selectedArchitecture}
                   onChange={(architecture) => this.setArchitecture(architecture)}
@@ -568,6 +571,7 @@ export class RegisterAgent extends Component {
               children: (
                 <EuiButtonGroup
                   color="primary"
+                  legend="Choose the architecture"
                   options={this.state.architectureButtons}
                   idSelected={this.state.selectedArchitecture}
                   onChange={(architecture) => this.setArchitecture(architecture)}

--- a/public/factories/vis-handlers.js
+++ b/public/factories/vis-handlers.js
@@ -66,20 +66,29 @@ export class VisHandlers {
       item => (((item || {}).vis || {}).type || {}).name === 'table'
     );
     for (let i = 0; i < tables.length; i++) {
+      let tablesData = [];
       const columns = [];
       const title =
         tables[i].vis.title ||
         'Table';
       const item = await tables[i].handler.execution.getData();
-      for (const table of item.value.visData.tables) {
+
+      //Normalize visData tables structure for 7.12 retro-compatibility
+      if(item.value.visData.tables?.length)
+        tablesData = item.value.visData.tables;
+      else if(item.value.visData.table)
+        tablesData.push(item.value.visData.table);
+
+      for (const table of tablesData) {
         columns.push(...table.columns.map(t => t.name));
       }
 
+
       tables[i] = !!(
-        ((((item || {}).value || {}).visData || {}).tables || [])[0] || {}
+        tablesData[0] || {}
       ).rows
         ? {
-            rows: item.value.visData.tables[0].rows.map(x => {
+            rows: tablesData[0].rows.map(x => {
               return Object.values(x);
             }),
             title,


### PR DESCRIPTION
Hi team!

this fixes breaking changes in Elastic UI 7.12 upgrade:

- Updated legend and idSelected props of EuiButtonGroup to be required
- Removed EuiPopover's withTitle prop

Closes #3318 

To test:

- Go to Security Events
- Open Browser Dev Tools
- Check there's no EuiButtonGroup's error 

- Go to GDPR -> Controls
- Open Browser Dev Tools
- Check there's no EuiPopover's error 