### PR TITLE
Fix error due short graphs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Added version in package downloaded name in agent deploy command [#3210](https://github.com/wazuh/wazuh-kibana-app/issues/3210)
 - Removed restriction to allow only current active agents from vulnerability inventory [#3243](https://github.com/wazuh/wazuh-kibana-app/pull/3243)
 - Health check actions notifications refactored and added debug mode [#3258](https://github.com/wazuh/wazuh-kibana-app/pull/3258)
-- Changed the way kibana-vis hides the visualization while loading, this should prevent errors caused by having a 0 height visualization (#3349)[https://github.com/wazuh/wazuh-kibana-app/pull/3349]
+- Changed the way kibana-vis hides the visualization while loading, this should prevent errors caused by having a 0 height visualization [#3349](https://github.com/wazuh/wazuh-kibana-app/pull/3349)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Added version in package downloaded name in agent deploy command [#3210](https://github.com/wazuh/wazuh-kibana-app/issues/3210)
 - Removed restriction to allow only current active agents from vulnerability inventory [#3243](https://github.com/wazuh/wazuh-kibana-app/pull/3243)
 - Health check actions notifications refactored and added debug mode [#3258](https://github.com/wazuh/wazuh-kibana-app/pull/3258)
+- Changed the way kibana-vis hides the visualization while loading, this should prevent errors caused by having a 0 height visualization (#3349)[https://github.com/wazuh/wazuh-kibana-app/pull/3349]
 
 ### Fixed
 

--- a/public/kibana-integrations/kibana-vis.js
+++ b/public/kibana-integrations/kibana-vis.js
@@ -226,9 +226,14 @@ class KibanaVis extends Component {
               },
               query: {
                 bool: {
-                  should: [{ term: AppState.getClusterInfo().status === 'enabled'
-                  ? {'cluster.name': AppState.getClusterInfo().cluster}
-                  : {'manager.keyword': AppState.getClusterInfo().manager} }],
+                  should: [
+                    {
+                      term:
+                        AppState.getClusterInfo().status === 'enabled'
+                          ? { 'cluster.name': AppState.getClusterInfo().cluster }
+                          : { 'manager.keyword': AppState.getClusterInfo().manager },
+                    },
+                  ],
                 },
               },
               $state: {
@@ -381,6 +386,7 @@ class KibanaVis extends Component {
   };
 
   render() {
+    const isLoading = this.props.resultState === 'loading';
     return (
       this.visID && (
         <span>
@@ -403,10 +409,7 @@ class KibanaVis extends Component {
           </div>
           <div
             style={{
-              display:
-                this.props.resultState === 'loading' && !this.state.visRefreshingIndex
-                  ? 'block'
-                  : 'none',
+              display: isLoading && !this.state.visRefreshingIndex ? 'block' : 'none',
               textAlign: 'center',
               paddingTop: 100,
             }}
@@ -416,11 +419,7 @@ class KibanaVis extends Component {
           <div
             style={{
               display:
-                this.deadField &&
-                this.props.resultState !== 'loading' &&
-                !this.state.visRefreshingIndex
-                  ? 'block'
-                  : 'none',
+                this.deadField && !isLoading && !this.state.visRefreshingIndex ? 'block' : 'none',
               textAlign: 'center',
               paddingTop: 100,
             }}
@@ -437,7 +436,11 @@ class KibanaVis extends Component {
               <EuiIcon type="iInCircle" />
             </EuiToolTip>
           </div>
-          <div id={this.visID} vis-id={this.visID} style={{ display: this.props.resultState === 'loading' ? 'none' : 'block', height:"100%" }}></div>
+          <div
+            id={this.visID}
+            vis-id={this.visID}
+            style={{ display: isLoading ? 'none' : 'block', height: '100%' }}
+          ></div>
         </span>
       )
     );

--- a/public/kibana-integrations/kibana-vis.js
+++ b/public/kibana-integrations/kibana-vis.js
@@ -381,7 +381,6 @@ class KibanaVis extends Component {
   };
 
   render() {
-    const height = this.props.resultState === 'loading' ? 0 : '100%';
     return (
       this.visID && (
         <span>
@@ -438,7 +437,7 @@ class KibanaVis extends Component {
               <EuiIcon type="iInCircle" />
             </EuiToolTip>
           </div>
-          <div id={this.visID} vis-id={this.visID} style={{ height }}></div>
+          <div id={this.visID} vis-id={this.visID} style={{ display: this.props.resultState === 'loading' ? 'none' : 'block', height:"100%" }}></div>
         </span>
       )
     );


### PR DESCRIPTION
| Wazuh Version | Kibana Version |
| - | - |
| 4.2 | 7.12 |

closes #3219 

**Description**
The error message in the issue was caused due short graphs. The Visualization plugin subtracts internally a certain height from certain elements without checking that the result is positive. This means that there is an unspecified minimum when this error starts appearing.

**The fix**
The way the `KibanaVis` component used to hide elements for loading, while still having them present in the `DOM` to inject the graph into them, was to set the height to 0, leading to this error. Simply replacing the hiding condition to display:none avoids the error message.

**Testing**
Visit pages with graphs that use the `KibanaVis` component and check that they still load correctly and without errors.