### PR TITLE
feat(error-orchestrator): Improved on createGetterSetter

### DIFF
--- a/public/components/common/error-boundary/error-boundary.tsx
+++ b/public/components/common/error-boundary/error-boundary.tsx
@@ -13,7 +13,6 @@
  */
 
 import React, { Component } from 'react';
-import loglevel from 'loglevel';
 import { UI_LOGGER_LEVELS } from '../../../../common/constants';
 import {
   UI_ERROR_SEVERITIES,
@@ -21,16 +20,14 @@ import {
   UIErrorSeverity,
   UILogLevel,
 } from '../../../react-services/error-orchestrator/types';
-import { ErrorOrchestratorService } from '../../../react-services';
 import { ErrorComponentPrompt } from '../error-boundary-prompt/error-boundary-prompt';
+import { getErrorOrchestrator } from '../../../react-services';
 
 export default class ErrorBoundary extends Component {
-  private logger: ErrorOrchestratorService;
   constructor(props) {
     super(props);
     this.state = { errorTitle: null, errorInfo: null, style: null };
     this.context = this.constructor.displayName || this.constructor.name || undefined;
-    this.logger = new ErrorOrchestratorService();
   }
 
   componentDidCatch = (errorTitle, errorInfo) => catchFunc(errorTitle, errorInfo, this);
@@ -65,7 +62,7 @@ const catchFunc = (errorTitle, errorInfo, ctx) => {
       },
     };
 
-    ctx.logger.handleError(options);
+    getErrorOrchestrator().handleError(options);
   } catch (error) {
     const optionsCatch: UIErrorLog = {
       context: ctx.context,
@@ -80,6 +77,6 @@ const catchFunc = (errorTitle, errorInfo, ctx) => {
       },
     };
 
-    ctx.logger.handleError(optionsCatch);
+    getErrorOrchestrator().handleError(optionsCatch);
   }
 };

--- a/public/kibana-services.ts
+++ b/public/kibana-services.ts
@@ -1,22 +1,22 @@
-let angularModule: any = null;
-let discoverModule: any = null;
-
+import { ErrorOrchestratorService } from './react-services';
 import {
   ChromeStart,
+  CoreStart,
   HttpStart,
   IUiSettingsClient,
-  ToastsStart,
-  SavedObjectsStart,
   OverlayStart,
+  SavedObjectsStart,
   ScopedHistory,
-  CoreStart,
+  ToastsStart,
 } from 'kibana/public';
 import { createGetterSetter } from '../../../src/plugins/kibana_utils/common';
 import { DataPublicPluginStart } from '../../../src/plugins/data/public';
 import { VisualizationsStart } from '../../../src/plugins/visualizations/public';
 import { NavigationPublicPluginStart } from '../../../src/plugins/navigation/public';
 import { AppPluginStartDependencies } from './types';
-import { ErrorOrchestrator } from '../common/constants';
+
+let angularModule: any = null;
+let discoverModule: any = null;
 
 export const [getCore, setCore] = createGetterSetter<CoreStart>('Core');
 export const [getPlugins, setPlugins] = createGetterSetter<AppPluginStartDependencies>('Plugins');
@@ -40,9 +40,9 @@ export const [getVisualizationsPlugin, setVisualizationsPlugin] = createGetterSe
 export const [getNavigationPlugin, setNavigationPlugin] = createGetterSetter<
   NavigationPublicPluginStart
 >('NavigationPlugin');
-export const [getErrorOrchestrator, setErrorOrchestrator] = createGetterSetter<ErrorOrchestrator>(
-  'ErrorOrchestrator'
-);
+export const [getErrorOrchestrator, setErrorOrchestrator] = createGetterSetter<
+  ErrorOrchestratorService
+>('ErrorOrchestratorService');
 
 /**
  * set bootstrapped inner angular module

--- a/public/kibana-services.ts
+++ b/public/kibana-services.ts
@@ -1,4 +1,3 @@
-import { ErrorOrchestratorService } from './react-services';
 import {
   ChromeStart,
   CoreStart,
@@ -40,9 +39,6 @@ export const [getVisualizationsPlugin, setVisualizationsPlugin] = createGetterSe
 export const [getNavigationPlugin, setNavigationPlugin] = createGetterSetter<
   NavigationPublicPluginStart
 >('NavigationPlugin');
-export const [getErrorOrchestrator, setErrorOrchestrator] = createGetterSetter<
-  ErrorOrchestratorService
->('ErrorOrchestratorService');
 
 /**
  * set bootstrapped inner angular module

--- a/public/plugin.ts
+++ b/public/plugin.ts
@@ -14,6 +14,7 @@ import {
   setCore,
   setPlugins,
   setCookies,
+  setErrorOrchestrator,
 } from './kibana-services';
 import {
   AppPluginStartDependencies,
@@ -24,6 +25,7 @@ import {
 } from './types';
 import { Cookies } from 'react-cookie';
 import { AppState } from './react-services/app-state';
+import { ErrorOrchestratorService } from './react-services';
 
 const innerAngularName = 'app/wazuh';
 
@@ -64,7 +66,7 @@ export class WazuhPlugin implements Plugin<WazuhSetup, WazuhStart, WazuhSetupPlu
         id: 'wazuh',
         label: 'Wazuh',
         order: 0,
-        euiIconType: core.http.basePath.prepend('/plugins/wazuh/assets/icon_blue.png'),      
+        euiIconType: core.http.basePath.prepend('/plugins/wazuh/assets/icon_blue.png'),
       },
     });
     return {};
@@ -108,6 +110,7 @@ export class WazuhPlugin implements Plugin<WazuhSetup, WazuhStart, WazuhSetupPlu
     setVisualizationsPlugin(plugins.visualizations);
     setSavedObjects(core.savedObjects);
     setOverlays(core.overlays);
+    setErrorOrchestrator(ErrorOrchestratorService);
     return {};
   }
 }

--- a/public/plugin.ts
+++ b/public/plugin.ts
@@ -14,7 +14,6 @@ import {
   setCore,
   setPlugins,
   setCookies,
-  setErrorOrchestrator,
 } from './kibana-services';
 import {
   AppPluginStartDependencies,
@@ -25,7 +24,8 @@ import {
 } from './types';
 import { Cookies } from 'react-cookie';
 import { AppState } from './react-services/app-state';
-import { ErrorOrchestratorService } from './react-services';
+import { setErrorOrchestrator } from './react-services';
+import { ErrorOrchestratorService } from './react-services/error-orchestrator/error-orchestrator.service';
 
 const innerAngularName = 'app/wazuh';
 

--- a/public/react-services/error-orchestrator/error-orchestrator-business.ts
+++ b/public/react-services/error-orchestrator/error-orchestrator-business.ts
@@ -21,7 +21,6 @@ export class ErrorOrchestratorBusiness extends ErrorOrchestratorBase {
     const toast = {
       error: errorLog.error,
       title: errorLog.error.title,
-      toastMessage: errorLog.error.message,
       message: errorLog.error.message,
       toastLifeTimeMs: 3000,
     };
@@ -34,7 +33,8 @@ export class ErrorOrchestratorBusiness extends ErrorOrchestratorBase {
         getToasts().addWarning(errorLog.error.error, toast as ErrorToastOptions);
         break;
       case UI_LOGGER_LEVELS.ERROR:
-        getToasts().addError(errorLog.error.error, toast as ErrorToastOptions);
+        const toastError = { ...toast, toastMessage: errorLog.error.message };
+        getToasts().addError(errorLog.error.error, toastError as ErrorToastOptions);
         break;
       default:
         console.log('No error level', errorLog.error.message, errorLog.error.error);

--- a/public/react-services/error-orchestrator/error-orchestrator.service.ts
+++ b/public/react-services/error-orchestrator/error-orchestrator.service.ts
@@ -16,7 +16,15 @@ import { ErrorOrchestrator, UIErrorLog } from './types';
 export class ErrorOrchestratorService {
   public constructor() {}
 
-  static handleError(uiErrorLog: UIErrorLog) {
+  static handleError({
+    context,
+    level,
+    severity,
+    display = true,
+    store = false,
+    error,
+  }: UIErrorLog) {
+    const uiErrorLog = { context, level, severity, display, store, error };
     const errorOrchestrator: ErrorOrchestrator = errorOrchestratorFactory(uiErrorLog.severity);
     errorOrchestrator.loadErrorLog(uiErrorLog);
   }

--- a/public/react-services/error-orchestrator/error-orchestrator.service.ts
+++ b/public/react-services/error-orchestrator/error-orchestrator.service.ts
@@ -16,7 +16,7 @@ import { ErrorOrchestrator, UIErrorLog } from './types';
 export class ErrorOrchestratorService {
   public constructor() {}
 
-  public handleError(uiErrorLog: UIErrorLog) {
+  static handleError(uiErrorLog: UIErrorLog) {
     const errorOrchestrator: ErrorOrchestrator = errorOrchestratorFactory(uiErrorLog.severity);
     errorOrchestrator.loadErrorLog(uiErrorLog);
   }

--- a/public/react-services/error-orchestrator/types.ts
+++ b/public/react-services/error-orchestrator/types.ts
@@ -32,13 +32,12 @@ export type UIError = {
 };
 
 export type UIErrorLog = {
-  context: string;
+  context?: string;
   level: UILogLevel;
   severity: UIErrorSeverity;
   display?: boolean;
   store?: boolean;
   error: UIError;
-  location?: string;
 };
 
 export type ErrorOrchestrator = {

--- a/public/react-services/index.ts
+++ b/public/react-services/index.ts
@@ -1,5 +1,12 @@
+import { ErrorOrchestratorService } from './error-orchestrator/error-orchestrator.service';
+import { createGetterSetter } from '../utils/create-getter-setter';
+
 export { GenericRequest } from './generic-request';
 export { WzRequest } from './wz-request';
 export { ErrorHandler } from './error-handler';
 export { formatUIDate } from './time-service';
-export { ErrorOrchestratorService } from './error-orchestrator/error-orchestrator.service';
+
+export const [getErrorOrchestrator, setErrorOrchestrator] = createGetterSetter<
+  ErrorOrchestratorService
+>('ErrorOrchestratorService');
+

--- a/public/utils/create-getter-setter.ts
+++ b/public/utils/create-getter-setter.ts
@@ -1,0 +1,29 @@
+/*
+ * Wazuh app - Create Getter Setter
+ * Copyright (C) 2015-2021 Wazuh, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Find more information about this on the LICENSE file.
+ */
+
+export type Get<T> = () => T;
+export type Set<T> = (value: T) => void;
+
+export const createGetterSetter = <T extends object>(name: string): [Get<T>, Set<T>] => {
+  let value: T;
+
+  const get: Get<T> = () => {
+    if (!value) throw new Error(`${name} was not set.`);
+    return value;
+  };
+
+  const set: Set<T> = (newValue) => {
+    value = newValue;
+  };
+
+  return [get, set];
+};


### PR DESCRIPTION
Hi team,
This PR applies the ErrorOrchestratorService enhancement by applying createGetterSetter.
ex: 

```
try {
    ...........
} catch (error) {
    const options = {
      level: 'INFO',
      severity: 'CRITICAL',
      error: error;
    };

    getErrorOrchestrator().handleError(options);
}
```
