### PR TITLE
Added lowercase levels in storeError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Added retry button to check api again in health check [#3109](https://github.com/wazuh/wazuh-kibana-app/pull/3109)
 - Added `wazuh-statistics` template and a new mapping for these indices [#3111](https://github.com/wazuh/wazuh-kibana-app/pull/3111)
 - Added link to documentation "Checking connection with Manager" in deploy new agent [#3126](https://github.com/wazuh/wazuh-kibana-app/pull/3126
+- Added lowercase levels in storeError [#3377](https://github.com/wazuh/wazuh-kibana-app/pull/3377)
 
 ### Changed
 

--- a/public/react-services/error-orchestrator/error-orchestrator-base.ts
+++ b/public/react-services/error-orchestrator/error-orchestrator-base.ts
@@ -26,9 +26,14 @@ export class ErrorOrchestratorBase implements ErrorOrchestrator {
 
   private async storeError(errorLog: UIErrorLog) {
     try {
+      let winstonLevel =  errorLog.level.toLowerCase();
+      if(errorLog.level === 'WARNING'){
+          winstonLevel = 'warn';
+      }
+
       await GenericRequest.request('POST', `/utils/logs/ui`, {
         message: errorLog.error.message,
-        level: errorLog.level,
+        level: winstonLevel,
         location: errorLog.location,
       });
     } catch (error) {


### PR DESCRIPTION
Hi team,
This PR changes de log level to lowercase before storing logs in the backend. This prevents the error that happens when passing a wrong level to Winston js library.
