### PR TITLE
Identity components with hocs

### DIFF
--- a/public/components/common/hocs/error-boundary/with-error-boundary.tsx
+++ b/public/components/common/hocs/error-boundary/with-error-boundary.tsx
@@ -12,9 +12,13 @@
 
 import React from 'react';
 import ErrorBoundary from '../../error-boundary/error-boundary';
+import { getDisplayName } from '../utils/utils';
 
-export const withErrorBoundary = (WrappedComponent) => (props) => (
-  <ErrorBoundary>
-    <WrappedComponent {...props} />
-  </ErrorBoundary>
-);
+export const withErrorBoundary = (WrappedComponent) => (props) => {
+  WrappedComponent.displayName = `withErrorBoundary(${getDisplayName(WrappedComponent)})`;
+  return (
+    <ErrorBoundary>
+      <WrappedComponent {...props} />
+    </ErrorBoundary>
+  );
+};

--- a/public/components/common/hocs/utils/utils.tsx
+++ b/public/components/common/hocs/utils/utils.tsx
@@ -1,3 +1,15 @@
+/*
+ * Wazuh app - React Higher Order Components Utils
+ * Copyright (C) 2015-2021 Wazuh, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Find more information about this on the LICENSE file.
+ */
+
 export const getDisplayName = (WrappedComponent) => {
   return WrappedComponent.displayName || WrappedComponent.name || 'UnknownComponent';
 };

--- a/public/components/common/hocs/utils/utils.tsx
+++ b/public/components/common/hocs/utils/utils.tsx
@@ -1,0 +1,3 @@
+export const getDisplayName = (WrappedComponent) => {
+  return WrappedComponent.displayName || WrappedComponent.name || 'UnknownComponent';
+};

--- a/public/controllers/management/index.js
+++ b/public/controllers/management/index.js
@@ -20,6 +20,10 @@ import { getAngularModule } from '../../kibana-services';
 
 const app = getAngularModule();
 
+WzManagement.displayName = 'WzManagement';
+ManagementWelcomeWrapper.displayName = 'ManagementWelcomeWrapper';
+WzManagementConfiguration.displayName = 'WzManagementConfiguration';
+
 app
   .controller('managementController', ManagementController)
   .controller('groupsPreviewController', GroupsController)


### PR DESCRIPTION
Hi team,
In order to improve the identity of each component and for ErrorBoundary to provide us with more precise information, I suggest the following change (which we should implement in all our hocs) following [Convention: Wrap the Display Name for Easy Debugging](https://reactjs.org/docs/higher-order-components.html#convention-wrap-the-display-name-for-easy-debugging).
At the moment since the parent components are rendered from Angular we have to give identity explicitly, as I apply it for Management:

```
WzManagement.displayName = 'WzManagement';
ManagementWelcomeWrapper.displayName = 'ManagementWelcomeWrapper';
WzManagementConfiguration.displayName = 'WzManagementConfiguration';
```

After:
![image](https://user-images.githubusercontent.com/11060558/122977730-1f4cfd00-d36c-11eb-821d-a47960d26545.png)

Before:
![image](https://user-images.githubusercontent.com/11060558/122977632-05131f00-d36c-11eb-8e0b-06a3910dbc8a.png)

All hocs with displayName:
![image](https://user-images.githubusercontent.com/11060558/122977382-b6658500-d36b-11eb-98ff-d8ec424dce97.png)
