### PR TITLE
Avoid huge logs 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fixed export to csv button in dashboards tables [#3358](https://github.com/wazuh/wazuh-kibana-app/pull/3358)
 - Fixed Elastic UI breaking changes in 7.12 [#3345](https://github.com/wazuh/wazuh-kibana-app/pull/3345)
 - Fixed Wazuh main menu and breadcrumb render issues [#3347](https://github.com/wazuh/wazuh-kibana-app/pull/3347)
+- Fixed generation of huge logs from backend errors [#3397](https://github.com/wazuh/wazuh-kibana-app/pull/3397)
 
 ## Wazuh v4.2.0 - Kibana 7.10.2 , 7.11.2 - Revision 4201
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wazuh",
-  "version": "4.2.1",
+  "version": "4.3.0",
   "revision": "4202-1",
   "code": "4202-1",
   "kibana": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wazuh",
-  "version": "4.3.0",
+  "version": "4.2.1",
   "revision": "4202-1",
   "code": "4202-1",
   "kibana": {

--- a/public/components/settings/settings-logs/logs.js
+++ b/public/components/settings/settings-logs/logs.js
@@ -27,6 +27,7 @@ import {
 import { formatUIDate } from '../../../react-services/time-service';
 import store from '../../../redux/store';
 import { updateSelectedSettingsSection } from '../../../redux/actions/appStateActions';
+import { JsxEmit } from 'typescript';
 
 export default class SettingsLogs extends Component {
   constructor(props) {
@@ -75,6 +76,11 @@ export default class SettingsLogs extends Component {
       .split('.')[0];
   }
 
+  getMessage(log) {
+    const data = log.data || log.message;
+    return typeof data === 'object' ? JSON.stringify(data.message || data) : data.toString();
+  } 
+
   render() {
     let text = '';
     (this.state.logs || []).forEach(x => {
@@ -84,7 +90,7 @@ export default class SettingsLogs extends Component {
           '  ' +
           x.level.toUpperCase() +
           '  ' +
-          x.message +
+          this.getMessage(x) +
           '\n');
     });
     return (

--- a/public/components/settings/settings-logs/logs.js
+++ b/public/components/settings/settings-logs/logs.js
@@ -27,7 +27,6 @@ import {
 import { formatUIDate } from '../../../react-services/time-service';
 import store from '../../../redux/store';
 import { updateSelectedSettingsSection } from '../../../redux/actions/appStateActions';
-import { JsxEmit } from 'typescript';
 
 export default class SettingsLogs extends Component {
   constructor(props) {

--- a/public/components/settings/settings-logs/logs.js
+++ b/public/components/settings/settings-logs/logs.js
@@ -78,7 +78,7 @@ export default class SettingsLogs extends Component {
 
   getMessage(log) {
     const data = log.data || log.message;
-    return typeof data === 'object' ? JSON.stringify(data.message || data) : data.toString();
+    return typeof data === 'object' ? data.message || JSON.stringify(data) : data.toString();
   } 
 
   render() {

--- a/server/lib/logger.ts
+++ b/server/lib/logger.ts
@@ -144,7 +144,7 @@ const yyyymmdd = () => {
  * @returns the data parsed 
  */
 const parseData = (data: any) => {
-  let parsedData = data instanceof Error? { 
+  let parsedData = data instanceof Error ? { 
     message: data.message,
     stack: data.stack
   } : data;

--- a/server/lib/logger.ts
+++ b/server/lib/logger.ts
@@ -139,29 +139,65 @@ const yyyymmdd = () => {
 };
 
 /**
+ * This function filter some known interfaces to avoid log hug objects
+ * @param data string | object
+ * @returns the data parsed 
+ */
+const parseData = (data: any) => {
+  let parsedData = data instanceof Error? { 
+    message: data.message,
+    stack: data.stack
+  } : data;
+
+  // when error is AxiosError, it extends from Error
+  if (data.isAxiosError) {
+    const { config } = data;
+    parsedData = {
+      ...parsedData,
+      config: {
+        url: config.url,
+        method: config.method,
+        data: config.data,
+        params: config.data,
+      }
+    };
+  }
+
+  if (typeof parsedData === 'object')
+    parsedData.toString = () => JSON.stringify(parsedData);
+
+  return parsedData;
+}
+
+/**
  * Main function to add a new log
  * @param {*} location File where the log is being thrown
  * @param {*} message Message to show
  * @param {*} level Optional, default is 'error'
  */
-export function log(location, message, level) {
+export function log(location, data, level) {
+  const parsedData = parseData(data);  
   initDirectory()
     .then(() => {
       if (allowed) {
         checkFiles();
-        wazuhlogger.log({
+        const options: any = {
           date: new Date(),
           level: level || 'error',
           location: location || 'Unknown origin',
-          message: message || 'An error occurred'
+          data: parsedData
+        };
+        if (typeof data == 'string') {
+          options.message = parsedData;
+          delete options.data;
+        }
+        wazuhlogger.log(options);
+        
+        wazuhPlainLogger.log({
+          level: level || 'error',
+          message: `${yyyymmdd()}: ${location ||
+            'Unknown origin'}: ${parsedData.toString() || 'An error occurred'}`
         });
-        try {
-          wazuhPlainLogger.log({
-            level: level || 'error',
-            message: `${yyyymmdd()}: ${location ||
-              'Unknown origin'}: ${message || 'An error occurred'}`
-          });
-        } catch (error) {} // eslint-disable-line
       }
     })
     .catch(error =>

--- a/server/start/cron-scheduler/error-handler.ts
+++ b/server/start/cron-scheduler/error-handler.ts
@@ -4,7 +4,6 @@ import { getConfiguration } from '../../lib/get-configuration';
 const DEBUG = 'debug';
 const INFO = 'info';
 const ERROR = 'error';
-const COLOR = '\u001b[34mwazuh\u001b[39m';
 
 function logLevel(level: string){
   return level === DEBUG ? INFO : level;
@@ -16,7 +15,7 @@ export function ErrorHandler(error, serverLogger) {
   log('Cron-scheduler', error, errorLevel === ERROR ? INFO : errorLevel);
   try {
     if (errorLevel === DEBUG && logsLevel !== DEBUG) return;
-    serverLogger[logLevel(errorLevel)](`${JSON.stringify(error)}`);
+    serverLogger[logLevel(errorLevel)](`${error instanceof Error? error.toString() : JSON.stringify(error)}`);
   } catch (error) {
     serverLogger[logLevel(errorLevel)](`Message too long to show in console output, check the log file`)
   }

--- a/server/start/cron-scheduler/error-handler.ts
+++ b/server/start/cron-scheduler/error-handler.ts
@@ -15,7 +15,7 @@ export function ErrorHandler(error, serverLogger) {
   log('Cron-scheduler', error, errorLevel === ERROR ? INFO : errorLevel);
   try {
     if (errorLevel === DEBUG && logsLevel !== DEBUG) return;
-    serverLogger[logLevel(errorLevel)](`${error instanceof Error? error.toString() : JSON.stringify(error)}`);
+    serverLogger[logLevel(errorLevel)](`${error instanceof Error ? error.toString() : JSON.stringify(error)}`);
   } catch (error) {
     serverLogger[logLevel(errorLevel)](`Message too long to show in console output, check the log file`)
   }


### PR DESCRIPTION
Hi team, this resolves:
- Avoid huge logs when messages or objects are too long.

Testing:
Turn down the Wazuh API when the cron job for statistics is waiting for the response at  `server/start/cron-scheduler/scheduler-job,ts#run()`

Closes #3388 