### PR TITLE
Changed all context value of all try-catch implementations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Adapted the Mitre tactics and techniques resources to use the API endpoints [#3346](https://github.com/wazuh/wazuh-kibana-app/pull/3346)
 - Refactored all try catch strategy on Settings section [#3392](https://github.com/wazuh/wazuh-kibana-app/pull/3392)
 - Refactored all try catch strategy on Controller/Agent section [#3398](https://github.com/wazuh/wazuh-kibana-app/issues/3398)
+- Refactored all try catch value of context for ErrorOrchestrator service. [#3432](https://github.com/wazuh/wazuh-kibana-app/issues/3432)
 
 ### Fixed
 

--- a/public/components/security/policies/create-policy.tsx
+++ b/public/components/security/policies/create-policy.tsx
@@ -24,8 +24,6 @@ import { UI_LOGGER_LEVELS } from '../../../../common/constants';
 import { UI_ERROR_SEVERITIES } from '../../../react-services/error-orchestrator/types';
 import { getErrorOrchestrator } from '../../../react-services/common-services';
 
-const errorContext = 'CreatePolicyFlyout';
-
 export const CreatePolicyFlyout = ({ closeFlyout }) => {
   const [isModalVisible, setIsModalVisible] = useState(false);
   const [resources, setResources] = useState([]);
@@ -188,7 +186,7 @@ export const CreatePolicyFlyout = ({ closeFlyout }) => {
       setEffectValue(null);
     } catch (error) {
       const options = {
-        context: errorContext,
+        context: `${CreatePolicyFlyout.name}.createPolicy`,
         level: UI_LOGGER_LEVELS.ERROR,
         severity: UI_ERROR_SEVERITIES.BUSINESS,
         store: true,

--- a/public/components/security/policies/edit-policy.tsx
+++ b/public/components/security/policies/edit-policy.tsx
@@ -27,8 +27,6 @@ import { UI_ERROR_SEVERITIES } from '../../../react-services/error-orchestrator/
 import { getErrorOrchestrator } from '../../../react-services/common-services';
 import _ from 'lodash';
 
-const errorContext = 'EditPolicyFlyout';
-
 export const EditPolicyFlyout = ({ policy, closeFlyout }) => {
   const isReserved = WzAPIUtils.isReservedID(policy.id);
   const [actionValue, setActionValue] = useState('');
@@ -78,7 +76,7 @@ export const EditPolicyFlyout = ({ policy, closeFlyout }) => {
       closeFlyout();
     } catch (error) {
       const options = {
-        context: errorContext,
+        context: `${EditPolicyFlyout.name}.updatePolicy`,
         level: UI_LOGGER_LEVELS.ERROR,
         severity: UI_ERROR_SEVERITIES.BUSINESS,
         store: true,
@@ -291,8 +289,8 @@ export const EditPolicyFlyout = ({ policy, closeFlyout }) => {
     );
   }
   useEffect(() => {
-    if (initialActionValue != actionValue ||  !_.isEqual(addedResources, initialAddedResources) ||  
-        !_.isEqual(addedActions, initialAddedActions) || initialResourceValue != resourceValue || 
+    if (initialActionValue != actionValue ||  !_.isEqual(addedResources, initialAddedResources) ||
+        !_.isEqual(addedActions, initialAddedActions) || initialResourceValue != resourceValue ||
         initialEffectValue != effectValue) {
       setHasChanges(true);
     } else {

--- a/public/components/security/policies/policies-table.tsx
+++ b/public/components/security/policies/policies-table.tsx
@@ -8,8 +8,6 @@ import { UI_LOGGER_LEVELS } from '../../../../common/constants';
 import { UI_ERROR_SEVERITIES } from '../../../react-services/error-orchestrator/types';
 import { getErrorOrchestrator } from '../../../react-services/common-services';
 
-const errorContext = 'PoliciesTable';
-
 export const PoliciesTable = ({ policies, loading, editPolicy, createPolicy, updatePolicies }) => {
   const getRowProps = (item) => {
     const { id } = item;
@@ -21,6 +19,37 @@ export const PoliciesTable = ({ policies, loading, editPolicy, createPolicy, upd
       },
     };
   };
+
+  const confirmDeletePolicy = (item) => {
+    return async () => {
+      try {
+        const response = await WzRequest.apiReq('DELETE', `/security/policies/`, {
+          params: {
+            policy_ids: item.id,
+          },
+        });
+        const data = (response.data || {}).data;
+        if (data.failed_items && data.failed_items.length) {
+          return;
+        }
+        ErrorHandler.info('Policy was successfully deleted');
+        await updatePolicies();
+      } catch (error) {
+        const options = {
+          context: `${PoliciesTable.name}.confirmDeletePolicy`,
+          level: UI_LOGGER_LEVELS.ERROR,
+          severity: UI_ERROR_SEVERITIES.BUSINESS,
+          store: true,
+          error: {
+            error: error,
+            message: error.message || error,
+            title: error.name || error,
+          },
+        };
+        getErrorOrchestrator().handleError(options);
+      }
+    };
+  }
 
   const columns = [
     {
@@ -82,34 +111,7 @@ export const PoliciesTable = ({ policies, loading, editPolicy, createPolicy, upd
             }}
             isDisabled={WzAPIUtils.isReservedID(item.id)}
             modalTitle={`Do you want to delete the ${item.name} policy?`}
-            onConfirm={async () => {
-              try {
-                const response = await WzRequest.apiReq('DELETE', `/security/policies/`, {
-                  params: {
-                    policy_ids: item.id,
-                  },
-                });
-                const data = (response.data || {}).data;
-                if (data.failed_items && data.failed_items.length) {
-                  return;
-                }
-                ErrorHandler.info('Policy was successfully deleted');
-                await updatePolicies();
-              } catch (error) {
-                const options = {
-                  context: errorContext,
-                  level: UI_LOGGER_LEVELS.ERROR,
-                  severity: UI_ERROR_SEVERITIES.BUSINESS,
-                  store: true,
-                  error: {
-                    error: error,
-                    message: error.message || error,
-                    title: error.name || error,
-                  },
-                };
-                getErrorOrchestrator().handleError(options);
-              }
-            }}
+            onConfirm={confirmDeletePolicy(item)}
             modalProps={{ buttonColor: 'danger' }}
             iconType="trash"
             color="danger"

--- a/public/components/security/roles-mapping/components/roles-mapping-create.tsx
+++ b/public/components/security/roles-mapping/components/roles-mapping-create.tsx
@@ -23,8 +23,6 @@ import { UI_LOGGER_LEVELS } from '../../../../../common/constants';
 import { UI_ERROR_SEVERITIES } from '../../../../react-services/error-orchestrator/types';
 import { getErrorOrchestrator } from '../../../../react-services/common-services';
 
-const errorContext = 'RolesMappingCreate';
-
 export const RolesMappingCreate = ({
   closeFlyout,
   rolesEquivalences,
@@ -64,7 +62,7 @@ export const RolesMappingCreate = ({
       ErrorHandler.info('Role mapping was successfully created');
     } catch (error) {
       const options = {
-        context: errorContext,
+        context: `${RolesMappingCreate.name}.createRule`,
         level: UI_LOGGER_LEVELS.ERROR,
         severity: UI_ERROR_SEVERITIES.BUSINESS,
         store: true,

--- a/public/components/security/roles-mapping/components/roles-mapping-edit.tsx
+++ b/public/components/security/roles-mapping/components/roles-mapping-edit.tsx
@@ -26,8 +26,6 @@ import { UI_LOGGER_LEVELS } from '../../../../../common/constants';
 import { UI_ERROR_SEVERITIES } from '../../../../react-services/error-orchestrator/types';
 import { getErrorOrchestrator } from '../../../../react-services/common-services';
 
-const errorContext = 'RolesMappingEdit';
-
 export const RolesMappingEdit = ({
   rule,
   closeFlyout,
@@ -87,7 +85,7 @@ export const RolesMappingEdit = ({
       ErrorHandler.info('Role mapping was successfully updated');
     } catch (error) {
       const options = {
-        context: errorContext,
+        context: `${RolesMappingEdit.name}.editRule`,
         level: UI_LOGGER_LEVELS.ERROR,
         severity: UI_ERROR_SEVERITIES.BUSINESS,
         store: true,

--- a/public/components/security/roles-mapping/components/roles-mapping-table.tsx
+++ b/public/components/security/roles-mapping/components/roles-mapping-table.tsx
@@ -17,8 +17,6 @@ import { UI_LOGGER_LEVELS } from '../../../../../common/constants';
 import { UI_ERROR_SEVERITIES } from '../../../../react-services/error-orchestrator/types';
 import { getErrorOrchestrator } from '../../../../react-services/common-services';
 
-const errorContext = 'RolesMappingTable';
-
 export const RolesMappingTable = ({ rolesEquivalences, rules, loading, editRule, updateRules }) => {
   const getRowProps = item => {
     const { id } = item;
@@ -27,6 +25,29 @@ export const RolesMappingTable = ({ rolesEquivalences, rules, loading, editRule,
       onClick: () => editRule(item),
     };
   };
+
+  const onDeleteRoleMapping = (item) => {
+    return async () => {
+      try {
+        await RulesServices.DeleteRules([item.id]);
+        ErrorHandler.info('Role mapping was successfully deleted');
+        updateRules();
+      } catch (error) {
+        const options = {
+          context: `${RolesMappingTable.name}.onDeleteRoleMapping`,
+          level: UI_LOGGER_LEVELS.ERROR,
+          severity: UI_ERROR_SEVERITIES.BUSINESS,
+          store: true,
+          error: {
+            error: error,
+            message: error.message || error,
+            title: error.name || error,
+          },
+        };
+        getErrorOrchestrator().handleError(options);
+      }
+    };
+  }
 
   const columns: EuiBasicTableColumn<any>[] = [
     {
@@ -99,26 +120,7 @@ export const RolesMappingTable = ({ rolesEquivalences, rules, loading, editRule,
             }}
             isDisabled={WzAPIUtils.isReservedID(item.id)}
             modalTitle={`Do you want to delete the ${item.name} role mapping?`}
-            onConfirm={async () => {
-              try {
-                await RulesServices.DeleteRules([item.id]);
-                ErrorHandler.info('Role mapping was successfully deleted');
-                updateRules();
-              } catch (error) {
-                const options = {
-                  context: errorContext,
-                  level: UI_LOGGER_LEVELS.ERROR,
-                  severity: UI_ERROR_SEVERITIES.BUSINESS,
-                  store: true,
-                  error: {
-                    error: error,
-                    message: error.message || error,
-                    title: error.name || error,
-                  },
-                };
-                getErrorOrchestrator().handleError(options);
-              }
-            }}
+            onConfirm={onDeleteRoleMapping(item)}
             modalProps={{ buttonColor: 'danger' }}
             iconType="trash"
             color="danger"

--- a/public/components/security/roles-mapping/helpers/rule-editor.helper.ts
+++ b/public/components/security/roles-mapping/helpers/rule-editor.helper.ts
@@ -123,7 +123,6 @@ const getFormatedRules = (rulesArray, internalUsers) => {
 };
 
 export const decodeJsonRule = (jsonRule, internalUsers) => {
-  const errorContext = 'decodeJsonRule';
   try {
     var wrongFormat = false;
     const ruleObject = JSON.parse(jsonRule);
@@ -150,7 +149,7 @@ export const decodeJsonRule = (jsonRule, internalUsers) => {
     };
   } catch (error) {
     const options = {
-      context: errorContext,
+      context: decodeJsonRule.name,
       level: UI_LOGGER_LEVELS.ERROR,
       severity: UI_ERROR_SEVERITIES.BUSINESS,
       store: true,

--- a/public/components/security/roles-mapping/roles-mapping.tsx
+++ b/public/components/security/roles-mapping/roles-mapping.tsx
@@ -30,8 +30,6 @@ import { UI_LOGGER_LEVELS } from '../../../../common/constants';
 import { UI_ERROR_SEVERITIES } from '../../../react-services/error-orchestrator/types';
 import { getErrorOrchestrator } from '../../../react-services/common-services';
 
-const errorContext = 'RolesMapping';
-
 export const RolesMapping = () => {
   const [isEditingRule, setIsEditingRule] = useState(false);
   const [isCreatingRule, setIsCreatingRule] = useState(false);
@@ -44,7 +42,7 @@ export const RolesMapping = () => {
   const currentPlatform = useSelector((state: any) => state.appStateReducers.currentPlatform);
 
   useEffect(() => {
-    initData();    
+    initData();
   }, []);
 
   useEffect(() => {
@@ -59,24 +57,26 @@ export const RolesMapping = () => {
       ErrorHandler.handle('There was an error loading roles');
     }
   }, [rolesLoading]);
-  
+
   const getInternalUsers = async () => {
     try {
       const wazuhSecurity = new WazuhSecurity();
       const users = await wazuhSecurity.security.getUsers();
-      const _users = users.map((item, idx) => {
-        return {
-          id: idx,
-          user: item.username,
-          roles: [],
-          full_name: item.full_name,
-          email: item.email,
-        };
-      }).sort((a, b) => (a.user > b.user) ? 1 : (a.user < b.user) ? -1 : 0);      
+      const _users = users
+        .map((item, idx) => {
+          return {
+            id: idx,
+            user: item.username,
+            roles: [],
+            full_name: item.full_name,
+            email: item.email,
+          };
+        })
+        .sort((a, b) => (a.user > b.user ? 1 : a.user < b.user ? -1 : 0));
       setInternalUsers(_users);
     } catch (error) {
       const options = {
-        context: errorContext,
+        context: `${RolesMapping.name}.getInternalUsers`,
         level: UI_LOGGER_LEVELS.ERROR,
         severity: UI_ERROR_SEVERITIES.BUSINESS,
         store: true,
@@ -96,7 +96,7 @@ export const RolesMapping = () => {
       setRules(_rules);
     } catch (error) {
       const options = {
-        context: errorContext,
+        context: `${RolesMapping.name}.getRules`,
         level: UI_LOGGER_LEVELS.ERROR,
         severity: UI_ERROR_SEVERITIES.BUSINESS,
         store: true,
@@ -122,7 +122,7 @@ export const RolesMapping = () => {
   const updateRoles = async () => {
     await getRules();
   };
-  
+
   let editFlyout;
   if (isEditingRule) {
     editFlyout = (

--- a/public/components/security/roles/edit-role.tsx
+++ b/public/components/security/roles/edit-role.tsx
@@ -25,10 +25,7 @@ import { UI_LOGGER_LEVELS } from '../../../../common/constants';
 import { UI_ERROR_SEVERITIES } from '../../../react-services/error-orchestrator/types';
 import { getErrorOrchestrator } from '../../../react-services/common-services';
 
-const errorContext = 'EditRole';
-
 const reservedRoles = ['administrator', 'readonly', 'users_admin', 'agents_readonly', 'agents_admin', 'cluster_readonly', 'cluster_admin'];
-
 
 export const EditRole = ({ role, closeFlyout }) => {
   const [isLoading, setIsLoading] = useState(true);
@@ -106,7 +103,7 @@ export const EditRole = ({ role, closeFlyout }) => {
       await update();
     } catch (error) {
       const options = {
-        context: errorContext,
+        context: `${EditRole.name}.addPolicy`,
         level: UI_LOGGER_LEVELS.ERROR,
         severity: UI_ERROR_SEVERITIES.BUSINESS,
         store: true,

--- a/public/components/settings/api/add-api.js
+++ b/public/components/settings/api/add-api.js
@@ -30,7 +30,6 @@ import { UI_LOGGER_LEVELS } from '../../../../common/constants';
 import { UI_ERROR_SEVERITIES } from '../../../react-services/error-orchestrator/types';
 import { getErrorOrchestrator } from '../../../react-services/common-services';
 
-const errorContext = 'AddApi';
 export const AddApi = withErrorBoundary (class AddApi extends Component {
   constructor(props) {
     super(props);
@@ -99,7 +98,7 @@ export const AddApi = withErrorBoundary (class AddApi extends Component {
       });
 
       const options = {
-        context: errorContext,
+        context: `${AddApi.name}.checkConnection`,
         level: UI_LOGGER_LEVELS.ERROR,
         severity: UI_ERROR_SEVERITIES.UI,
         store: true,

--- a/public/components/settings/api/api-is-down.js
+++ b/public/components/settings/api/api-is-down.js
@@ -37,7 +37,6 @@ import {
 import { UI_LOGGER_LEVELS } from '../../../../common/constants';
 import { getErrorOrchestrator } from '../../../react-services/common-services';
 
-const errorContext = 'ApiIsDown'
 export const ApiIsDown = withErrorBoundary (class ApiIsDown extends Component {
   constructor(props) {
     super(props);
@@ -110,7 +109,7 @@ export const ApiIsDown = withErrorBoundary (class ApiIsDown extends Component {
       }
 
       const options = {
-        context: errorContext,
+        context: `${ApiIsDown.name}.checkConnection`,
         level: UI_LOGGER_LEVELS.ERROR,
         severity: UI_ERROR_SEVERITIES.UI,
         store: true,

--- a/public/components/settings/api/api-table.js
+++ b/public/components/settings/api/api-table.js
@@ -40,7 +40,6 @@ import {
 import { UI_LOGGER_LEVELS } from '../../../../common/constants';
 import { getErrorOrchestrator } from '../../../react-services/common-services';
 
-const errorContext = 'ApiTable';
 export const ApiTable = compose(withErrorBoundary, withReduxProvider)(class ApiTable extends Component {
   constructor(props) {
     super(props);
@@ -143,7 +142,7 @@ export const ApiTable = compose(withErrorBoundary, withReduxProvider)(class ApiT
       }
     } catch (error) {
       const options = {
-        context: errorContext,
+        context: `${ApiTable.name}.checkApi`,
         level: UI_LOGGER_LEVELS.ERROR,
         severity: UI_ERROR_SEVERITIES.BUSINESS,
         store: true,

--- a/public/components/settings/configuration/components/bottom-bar.tsx
+++ b/public/components/settings/configuration/components/bottom-bar.tsx
@@ -34,7 +34,6 @@ import {
 } from '../../../../react-services/error-orchestrator/types';
 import { getErrorOrchestrator } from '../../../../react-services/common-services';
 
-const errorContext = 'BottomBar'
 interface IBottomBarProps {
   updatedConfig: { [setting: string]: string | number | boolean | object }
   setUpdateConfig(setting: {}): void
@@ -105,7 +104,7 @@ const saveSettings = async (updatedConfig: {}, setUpdateConfig: Function, setLoa
     setUpdateConfig({});
   } catch (error) {
     const options: UIErrorLog = {
-      context: errorContext,
+      context: `${BottomBar.name}.saveSettings`,
       level: UI_LOGGER_LEVELS.ERROR as UILogLevel,
       severity: UI_ERROR_SEVERITIES.BUSINESS as UIErrorSeverity,
       store: true,

--- a/public/components/settings/configuration/components/categories/components/category/components/field-form.tsx
+++ b/public/components/settings/configuration/components/categories/components/category/components/field-form.tsx
@@ -33,7 +33,6 @@ import {
 import { UI_LOGGER_LEVELS } from '../../../../../../../../../common/constants';
 import { getErrorOrchestrator } from '../../../../../../../../react-services/common-services';
 
-const errorContext = 'FieldForm';
 interface IFieldForm {
   item: ISetting
   updatedConfig: { [field: string]: string | number | boolean | [] }
@@ -110,16 +109,18 @@ const IntervalForm: React.FunctionComponent<IFieldForm> = (props) => {
 
 const ArrayForm: React.FunctionComponent<IFieldForm> = (props) => {
   const [list, setList] = useState(JSON.stringify(getValue(props)));
+
   useEffect(() => {
     setList(JSON.stringify(getValue(props)))
   }, [props.updatedConfig])
+
   const checkErrors = () => {
     try {
       const parsed = JSON.parse(list);
       onChange(parsed, props);
     } catch (error) {
       const options: UIErrorLog = {
-        context: errorContext,
+        context: `${FieldForm.name}.checkErrors`,
         level: UI_LOGGER_LEVELS.ERROR as UILogLevel,
         severity: UI_ERROR_SEVERITIES.UI as UIErrorSeverity,
         error: {

--- a/public/components/settings/modules/modules.js
+++ b/public/components/settings/modules/modules.js
@@ -25,8 +25,6 @@ import { compose } from 'redux';
 import { UI_ERROR_SEVERITIES } from '../../../react-services/error-orchestrator/types';
 import { getErrorOrchestrator } from '../../../react-services/common-services';
 
-const errorContext = 'EnableModulesWrapper';
-
 export class EnableModulesWrapper extends Component {
   constructor(props) {
     try {
@@ -78,7 +76,7 @@ export class EnableModulesWrapper extends Component {
       };
     } catch (error) {
       const options = {
-        context: errorContext,
+        context: `${EnableModulesWrapper.name}.constructor`,
         level: UI_LOGGER_LEVELS.ERROR,
         severity: UI_ERROR_SEVERITIES.CRITICAL,
         store: true,
@@ -100,7 +98,7 @@ export class EnableModulesWrapper extends Component {
       this.setState({ extensions });
     } catch (error) {
       const options = {
-        context: errorContext,
+        context: `${EnableModulesWrapper.name}.componentDidMount`,
         level: UI_LOGGER_LEVELS.ERROR,
         severity: UI_ERROR_SEVERITIES.BUSINESS,
         error: {

--- a/public/components/visualize/wz-visualize.js
+++ b/public/components/visualize/wz-visualize.js
@@ -45,7 +45,6 @@ import { getErrorOrchestrator } from '../../react-services/common-services';
 
 const visHandler = new VisHandlers();
 
-const errorContext = 'WzVisualize';
 export const WzVisualize = compose (withErrorBoundary,withReduxProvider) (class WzVisualize extends Component {
   _isMount = false;
   constructor(props) {
@@ -110,7 +109,7 @@ export const WzVisualize = compose (withErrorBoundary,withReduxProvider) (class 
       this._isMount && this.setState({ thereAreSampleAlerts });
     } catch (error) {
       const options = {
-        context: errorContext,
+        context: `${WzVisualize.name}.componentDidMount`,
         level: UI_LOGGER_LEVELS.ERROR,
         severity: UI_ERROR_SEVERITIES.UI,
         error: {
@@ -119,7 +118,6 @@ export const WzVisualize = compose (withErrorBoundary,withReduxProvider) (class 
           title: error.name || error,
         },
       };
-
       getErrorOrchestrator().handleError(options);
     }
   }
@@ -154,7 +152,7 @@ export const WzVisualize = compose (withErrorBoundary,withReduxProvider) (class 
       } catch (error) {
         this.setState({ isRefreshing: false });
         const options = {
-          context: errorContext,
+          context: `${WzVisualize.name}.refreshKnownFields`,
           level: UI_LOGGER_LEVELS.ERROR,
           severity: UI_ERROR_SEVERITIES.BUSINESS,
           error: {

--- a/public/controllers/agent/agents-preview.js
+++ b/public/controllers/agent/agents-preview.js
@@ -26,8 +26,6 @@ import { UI_LOGGER_LEVELS } from '../../../common/constants';
 import { UI_ERROR_SEVERITIES } from '../../react-services/error-orchestrator/types';
 import { getErrorOrchestrator } from '../../react-services/common-services';
 
-const errorContext = 'AgentsPreviewController';
-
 export class AgentsPreviewController {
   /**
    * Class constructor
@@ -168,7 +166,7 @@ export class AgentsPreviewController {
       return;
     } catch (error) {
       const options = {
-        context: errorContext,
+        context: `${AgentsPreviewController.name}.downloadCsv`,
         level: UI_LOGGER_LEVELS.ERROR,
         severity: UI_ERROR_SEVERITIES.BUSINESS,
         error: {
@@ -179,7 +177,6 @@ export class AgentsPreviewController {
       };
       getErrorOrchestrator().handleError(options);
     }
-    return;
   }
 
   async getMostActive() {
@@ -205,7 +202,7 @@ export class AgentsPreviewController {
       return this.mostActiveAgent;
     } catch (error) {
       const options = {
-        context: errorContext,
+        context: `${AgentsPreviewController.name}.getMostActive`,
         level: UI_LOGGER_LEVELS.ERROR,
         severity: UI_ERROR_SEVERITIES.BUSINESS,
         store: true,
@@ -233,7 +230,7 @@ export class AgentsPreviewController {
       this.pattern = (await getDataPlugin().indexPatterns.get(AppState.getCurrentPattern())).title;
     } catch (error) {
       const options = {
-        context: errorContext,
+        context: `${AgentsPreviewController.name}.load`,
         level: UI_LOGGER_LEVELS.ERROR,
         severity: UI_ERROR_SEVERITIES.CRITICAL,
         store: true,
@@ -275,7 +272,7 @@ export class AgentsPreviewController {
       return url.substr(numToClean);
     } catch (error) {
       const options = {
-        context: errorContext,
+        context: `${AgentsPreviewController.name}.getCurrentApiAddress`,
         level: UI_LOGGER_LEVELS.ERROR,
         severity: UI_ERROR_SEVERITIES.UI,
         error: {
@@ -298,7 +295,7 @@ export class AgentsPreviewController {
       return result.api_version;
     } catch (error) {
       const options = {
-        context: errorContext,
+        context: `${AgentsPreviewController.name}.getWazuhVersion`,
         level: UI_LOGGER_LEVELS.ERROR,
         severity: UI_ERROR_SEVERITIES.BUSINESS,
         error: {

--- a/public/controllers/agent/agents.js
+++ b/public/controllers/agent/agents.js
@@ -35,7 +35,6 @@ import { UI_LOGGER_LEVELS } from '../../../common/constants';
 import { UI_ERROR_SEVERITIES } from '../../react-services/error-orchestrator/types';
 import { getErrorOrchestrator } from '../../react-services/common-services';
 
-const errorContext = 'AgentsController';
 export class AgentsController {
   /**
    * Class constructor
@@ -230,7 +229,7 @@ export class AgentsController {
         this.$scope.restartingAgent = false;
       } catch (error) {
         const options = {
-          context: errorContext,
+          context: `${AgentsController.name}.restartAgent`,
           level: UI_LOGGER_LEVELS.ERROR,
           severity: UI_ERROR_SEVERITIES.BUSINESS,
           store: true,
@@ -251,7 +250,7 @@ export class AgentsController {
       this.$scope.getAgent();
     } catch (error) {
       const options = {
-        context: errorContext,
+        context: `${AgentsController.name}.$onInit`,
         level: UI_LOGGER_LEVELS.ERROR,
         severity: UI_ERROR_SEVERITIES.BUSINESS,
         store: true,
@@ -283,7 +282,7 @@ export class AgentsController {
         }
       } catch (error) {
         const options = {
-          context: errorContext,
+          context: `${AgentsController.name}.switchConfigTab`,
           level: UI_LOGGER_LEVELS.ERROR,
           severity: UI_ERROR_SEVERITIES.BUSINESS,
           store: true,
@@ -412,7 +411,7 @@ export class AgentsController {
         this.$scope.$applyAsync();
       } catch (error) {
         const options = {
-          context: errorContext,
+          context: `${AgentsController.name}.confirmAddGroup`,
           level: UI_LOGGER_LEVELS.ERROR,
           severity: UI_ERROR_SEVERITIES.BUSINESS,
           store: true,
@@ -577,7 +576,7 @@ export class AgentsController {
       this.$scope.$applyAsync();
     } catch (error) {
       const options = {
-        context: errorContext,
+        context: `${AgentsController.name}.switchTab`,
         level: UI_LOGGER_LEVELS.ERROR,
         severity: UI_ERROR_SEVERITIES.CRITICAL,
         store: true,
@@ -694,7 +693,7 @@ export class AgentsController {
       this.showToast('success', 'The agent is being upgrade.', '', 5000);
     } catch (error) {
       const options = {
-        context: errorContext,
+        context: `${AgentsController.name}.onClickUpgrade`,
         level: UI_LOGGER_LEVELS.ERROR,
         severity: UI_ERROR_SEVERITIES.BUSINESS,
         store: true,
@@ -714,7 +713,7 @@ export class AgentsController {
       this.showToast('success', 'Agent restarted.', '', 5000);
     } catch (error) {
       const options = {
-        context: errorContext,
+        context: `${AgentsController.name}.onClickRestart`,
         level: UI_LOGGER_LEVELS.ERROR,
         severity: UI_ERROR_SEVERITIES.BUSINESS,
         store: true,
@@ -892,7 +891,7 @@ export class AgentsController {
       return text + formatUIDate(time);
     } catch (error) {
       const options = {
-        context: errorContext,
+        context: `${AgentsController.name}.offsetTimestamp`,
         level: UI_LOGGER_LEVELS.ERROR,
         severity: UI_ERROR_SEVERITIES.BUSINESS,
         store: false,
@@ -974,7 +973,7 @@ export class AgentsController {
       );
     } catch (error) {
       const options = {
-        context: errorContext,
+        context: `${AgentsController.name}.launchRootcheckScan`,
         level: UI_LOGGER_LEVELS.ERROR,
         severity: UI_ERROR_SEVERITIES.BUSINESS,
         store: true,
@@ -986,7 +985,6 @@ export class AgentsController {
       };
       getErrorOrchestrator().handleError(options);
     }
-    return;
   }
 
   async launchSyscheckScan() {
@@ -1003,7 +1001,7 @@ export class AgentsController {
       ErrorHandler.info(`FIM scan launched successfully on agent ${this.$scope.agent.id}`, '');
     } catch (error) {
       const options = {
-        context: errorContext,
+        context: `${AgentsController.name}.launchSyscheckScan`,
         level: UI_LOGGER_LEVELS.ERROR,
         severity: UI_ERROR_SEVERITIES.BUSINESS,
         store: true,
@@ -1015,7 +1013,6 @@ export class AgentsController {
       };
       getErrorOrchestrator().handleError(options);
     }
-    return;
   }
 
   falseAllExpand() {

--- a/public/controllers/agent/components/agents-preview.js
+++ b/public/controllers/agent/components/agents-preview.js
@@ -48,8 +48,6 @@ import { UI_LOGGER_LEVELS } from '../../../../common/constants';
 import { UI_ERROR_SEVERITIES } from '../../../react-services/error-orchestrator/types';
 import { getErrorOrchestrator } from '../../../react-services/common-services';
 
-const errorContext = 'AgentsPreview';
-
 const FILTER_ACTIVE = 'active';
 const FILTER_DISCONNECTED = 'disconnected';
 const FILTER_NEVER_CONNECTED = 'never_connected';
@@ -148,7 +146,7 @@ export const AgentsPreview = compose(
         this._isMount && this.setState({ platforms: platformsModel, loading: false });
       } catch (error) {
         const options = {
-          context: errorContext,
+          context: `${AgentsPreview.name}.getSummary`,
           level: UI_LOGGER_LEVELS.ERROR,
           severity: UI_ERROR_SEVERITIES.BUSINESS,
           store: true,

--- a/public/controllers/agent/components/agents-table.js
+++ b/public/controllers/agent/components/agents-table.js
@@ -45,8 +45,6 @@ import { UI_LOGGER_LEVELS } from '../../../../common/constants';
 import { UI_ERROR_SEVERITIES } from '../../../react-services/error-orchestrator/types';
 import { getErrorOrchestrator } from '../../../react-services/common-services';
 
-const errorContext = 'AgentsTable';
-
 export const AgentsTable = withErrorBoundary(
   class AgentsTable extends Component {
     _isMount = false;
@@ -244,7 +242,7 @@ export const AgentsTable = withErrorBoundary(
           });
       } catch (error) {
         const options = {
-          context: errorContext,
+          context: `${AgentsTable.name}.getItems`,
           level: UI_LOGGER_LEVELS.ERROR,
           severity: UI_ERROR_SEVERITIES.BUSINESS,
           store: true,
@@ -714,7 +712,7 @@ export const AgentsTable = withErrorBoundary(
           : this.showToast('warning', `Failed to delete selected agents`, '', 5000);
       } catch (error) {
         const options = {
-          context: errorContext,
+          context: `${AgentsTable.name}.onClickPurge`,
           level: UI_LOGGER_LEVELS.ERROR,
           severity: UI_ERROR_SEVERITIES.BUSINESS,
           store: true,
@@ -749,7 +747,7 @@ export const AgentsTable = withErrorBoundary(
           : this.showToast('warning', `Failed to delete all agents`, '', 5000);
       } catch (error) {
         const options = {
-          context: errorContext,
+          context: `${AgentsTable.name}.onClickPurgeAll`,
           level: UI_LOGGER_LEVELS.ERROR,
           severity: UI_ERROR_SEVERITIES.BUSINESS,
           store: true,

--- a/public/controllers/agent/components/checkUpgrade.tsx
+++ b/public/controllers/agent/components/checkUpgrade.tsx
@@ -17,8 +17,6 @@ import { UI_LOGGER_LEVELS } from '../../../../common/constants';
 import { UI_ERROR_SEVERITIES } from '../../../react-services/error-orchestrator/types';
 import { getErrorOrchestrator } from '../../../react-services/common-services';
 
-const errorContext = 'CheckUpgrade';
-
 export class CheckUpgrade extends Component {
   props!: {
     id: String;
@@ -57,7 +55,7 @@ export class CheckUpgrade extends Component {
       }
     } catch (error) {
       const options = {
-        context: errorContext,
+        context: `${CheckUpgrade.name}.checkUpgrade`,
         level: UI_LOGGER_LEVELS.ERROR,
         severity: UI_ERROR_SEVERITIES.BUSINESS,
         error: {

--- a/public/controllers/agent/components/register-agent.js
+++ b/public/controllers/agent/components/register-agent.js
@@ -41,8 +41,6 @@ import { UI_LOGGER_LEVELS } from '../../../../common/constants';
 import { UI_ERROR_SEVERITIES } from '../../../react-services/error-orchestrator/types';
 import { getErrorOrchestrator } from '../../../react-services/common-services';
 
-const errorContext = 'RegisterAgent';
-
 const architectureButtons = [
   {
     id: 'i386',
@@ -186,7 +184,7 @@ export const RegisterAgent = withErrorBoundary(
           loading: false,
         });
         const options = {
-          context: errorContext,
+          context: `${RegisterAgent.name}.componentDidMount`,
           level: UI_LOGGER_LEVELS.ERROR,
           severity: UI_ERROR_SEVERITIES.BUSINESS,
           display: false,

--- a/public/controllers/management/components/management/mg-logs/logs.js
+++ b/public/controllers/management/components/management/mg-logs/logs.js
@@ -42,8 +42,6 @@ import { UI_LOGGER_LEVELS } from '../../../../../../common/constants';
 import { UI_ERROR_SEVERITIES } from '../../../../../react-services/error-orchestrator/types';
 import { getErrorOrchestrator } from '../../../../../react-services/common-services';
 
-const errorContext = 'WzLogs';
-
 export default compose(
   withGlobalBreadcrumb([
     { text: '' },
@@ -120,7 +118,7 @@ export default compose(
         });
 
         const options = {
-          context: errorContext,
+          context: `${WzLogs.name}.componentDidMount`,
           level: UI_LOGGER_LEVELS.ERROR,
           severity: UI_ERROR_SEVERITIES.CRITICAL,
           store: true,
@@ -211,7 +209,7 @@ export default compose(
         this.setState({ logsList: result, offset: 0 });
       } catch (error) {
         const options = {
-          context: errorContext,
+          context: `${WzLogs.name}.setFullLogs`,
           level: UI_LOGGER_LEVELS.ERROR,
           severity: UI_ERROR_SEVERITIES.BUSINESS,
           store: true,
@@ -290,7 +288,7 @@ export default compose(
         }
       } catch (error) {
         const options = {
-          context: errorContext,
+          context: `${WzLogs.name}.getNodeList`,
           level: UI_LOGGER_LEVELS.ERROR,
           severity: UI_ERROR_SEVERITIES.BUSINESS,
           store: true,
@@ -389,7 +387,7 @@ export default compose(
         );
       } catch (error) {
         const options = {
-          context: errorContext,
+          context: `${WzLogs.name}.exportFormatted`,
           level: UI_LOGGER_LEVELS.ERROR,
           severity: UI_ERROR_SEVERITIES.BUSINESS,
           store: true,

--- a/public/controllers/management/management.js
+++ b/public/controllers/management/management.js
@@ -48,7 +48,6 @@ export class ManagementController {
     this.logtestOpened = false;
     this.uploadOpened = false;
     this.rulesetTab = RulesetResources.RULES;
-    this.context = 'ManagementController';
 
 
     this.$scope.$on('setCurrentGroup', (ev, params) => {
@@ -232,7 +231,7 @@ export class ManagementController {
       const errorOptions = {
         level: UI_LOGGER_LEVELS.ERROR,
         severity: UI_ERROR_SEVERITIES.BUSINESS,
-        context: this.context,
+        context: `${ManagementController.name}.$onInit`,
         error: {
           error: error,
           message: error?.message || '',
@@ -268,7 +267,7 @@ export class ManagementController {
       const errorOptions = {
         level: UI_LOGGER_LEVELS.ERROR,
         severity: UI_ERROR_SEVERITIES.BUSINESS,
-        context: this.context,
+        context: `${ManagementController.name}.restartManager`,
         error: {
           error: error,
           message: error?.message || '',
@@ -294,7 +293,7 @@ export class ManagementController {
       const errorOptions = {
         level: UI_LOGGER_LEVELS.ERROR,
         severity: UI_ERROR_SEVERITIES.BUSINESS,
-        context: this.context,
+        context: `${ManagementController.name}.restartCluster`,
         error: {
           error: error,
           message: error?.message || '',
@@ -446,7 +445,7 @@ export class ManagementController {
       const errorOptions = {
         level: UI_LOGGER_LEVELS.ERROR,
         severity: UI_ERROR_SEVERITIES.BUSINESS,
-        context: this.context,
+        context: `${ManagementController.name}.loadNodeList`,
         error: {
           error: error,
           message: error?.message || '',
@@ -519,14 +518,13 @@ export class ManagementController {
       }
       if (this.errors) throw this.results;
       ErrorHandler.info('Upload successful');
-      return;
     } catch (error) {
       if (Array.isArray(error) && error.length) throw error;
 
       const errorOptions = {
         level: UI_LOGGER_LEVELS.ERROR,
         severity: UI_ERROR_SEVERITIES.BUSINESS,
-        context: this.context,
+        context: `${ManagementController.name}.uploadFiles`,
         error: {
           error: error,
           message: error?.message || '',

--- a/public/react-services/error-orchestrator/README.md
+++ b/public/react-services/error-orchestrator/README.md
@@ -5,7 +5,7 @@ This is a client side orchestrator error service.
 ## Example import
 
 ```tsx
-import { createGetterSetter } from '../utils/create-getter-setter';
+import { getErrorOrchestrator } from '../react-services/common-services';
 ```
 
 ## Example usage
@@ -18,7 +18,7 @@ try {
   throw new Error('Some error here...');
 } catch (error) {
   const options: UIErrorLog = {
-    context: 'contextError',
+    context: `${MyClass.name}.myMethodName`,
     level: UI_LOGGER_LEVELS.WARNING,
     severity: UI_ERROR_SEVERITIES.BUSINESS,
     display: true,


### PR DESCRIPTION
Hi team,
This PR modifies in all try catch implementations, the way to obtain the context for our orchestrator, adding the name of the class + the name of the method in which the error was caught.