### PR TITLE
fix size api selector and add basic test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 ### Fixed
 
 - Fixed creation of log files [#3384](https://github.com/wazuh/wazuh-kibana-app/pull/3384) 
+- Fix size api selector when name is too long [#3445](https://github.com/wazuh/wazuh-kibana-app/pull/3445)
 
 ## Wazuh v4.2.1 - Kibana 7.10.2 , 7.11.2 - Revision 4202
 

--- a/public/components/wz-menu/__snapshots__/wz-menu.test.tsx.snap
+++ b/public/components/wz-menu/__snapshots__/wz-menu.test.tsx.snap
@@ -1,0 +1,12 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`WzMenu tests should render a WzMenu 1`] = `
+<WzMenu
+  windowSize={
+    Object {
+      "height": 768,
+      "width": 1024,
+    }
+  }
+/>
+`;

--- a/public/components/wz-menu/wz-menu.js
+++ b/public/components/wz-menu/wz-menu.js
@@ -632,7 +632,7 @@ export const WzMenu = withWindowSize(class WzMenu extends Component {
   }
 
   getApiSelectorComponent() {
-    let style = { minWidth: 'max-content' };
+    let style = { minWidth: 100, textOverflow: 'ellipsis' };
     if (this.showSelectorsInPopover){
       style = { width: '100%', minWidth: 200 };
     }

--- a/public/components/wz-menu/wz-menu.js
+++ b/public/components/wz-menu/wz-menu.js
@@ -632,7 +632,7 @@ export const WzMenu = withWindowSize(class WzMenu extends Component {
   }
 
   getApiSelectorComponent() {
-    let style = { maxWidth: 100 };
+    let style = { minWidth: 'max-content' };
     if (this.showSelectorsInPopover){
       style = { width: '100%', minWidth: 200 };
     }

--- a/public/components/wz-menu/wz-menu.test.tsx
+++ b/public/components/wz-menu/wz-menu.test.tsx
@@ -1,0 +1,26 @@
+/*
+ * Wazuh app - Health Check Component - Test
+ *
+ * Copyright (C) 2015-2021 Wazuh, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Find more information about this on the LICENSE file.
+ *
+ */
+
+import React from 'react';
+import { shallow } from 'enzyme';
+import { WzMenu } from './wz-menu';
+
+
+describe('WzMenu tests', () => {
+  test('should render a WzMenu', () => {
+    const component = shallow(<WzMenu />);
+
+    expect(component).toMatchSnapshot();
+  });
+});


### PR DESCRIPTION
Hi team, this resolves:

- Adapt API selector when api name is too long

**How to Test:** 

- Register a second API in kibana/data/wazuh/config/wazuh.yml, it doesn't need to be active
- Set the name of the active API (default if no other is set) to a very long name
- The API selector should show full name

Closes [#3334](https://github.com/wazuh/wazuh-kibana-app/issues/3334)