### PR TITLE
fix render size elements in agents preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fixed Elastic UI breaking changes in 7.12 [#3345](https://github.com/wazuh/wazuh-kibana-app/pull/3345)
 - Fixed Wazuh main menu and breadcrumb render issues [#3347](https://github.com/wazuh/wazuh-kibana-app/pull/3347)
 - Fixed generation of huge logs from backend errors [#3397](https://github.com/wazuh/wazuh-kibana-app/pull/3397)
+- Fixed render size elements in agents preview [#3452](https://github.com/wazuh/wazuh-kibana-app/pull/3452)
 
 ## Wazuh v4.2.0 - Kibana 7.10.2 , 7.11.2 - Revision 4201
 

--- a/public/controllers/agent/components/agents-preview.js
+++ b/public/controllers/agent/components/agents-preview.js
@@ -191,7 +191,7 @@ export const AgentsPreview = compose(
                 </EuiFlexItem>
               )) || (
                 <Fragment>
-                  <EuiFlexItem className="agents-status-pie" grow={false}>
+                  <EuiFlexItem className="agents-status-pie" grow={2}>
                     <EuiPanel betaBadgeLabel="Status" className="eui-panel">
                       <EuiFlexGroup>
                         {this.totalAgents > 0 && (
@@ -219,7 +219,7 @@ export const AgentsPreview = compose(
                     </EuiPanel>
                   </EuiFlexItem>
                   {this.totalAgents > 0 && (
-                    <EuiFlexItem>
+                    <EuiFlexItem grow={4}>
                       <EuiPanel betaBadgeLabel="Details">
                         <EuiFlexGroup>
                           <EuiFlexItem>
@@ -340,7 +340,7 @@ export const AgentsPreview = compose(
               )}
               {this.state.showAgentsEvolutionVisualization && (
                 <EuiFlexItem
-                  grow={false}
+                  grow={6}
                   className="agents-evolution-visualization"
                   style={{
                     display: !this.state.loading ? 'block' : 'none',


### PR DESCRIPTION
Hi team, this resolves:

- elements on the agent preview page not render correctly in lows widths

How to Test:

- go to the agents preview
- lower the page width
- check if elements render correctly

Closes [#3354](https://github.com/wazuh/wazuh-kibana-app/issues/3354)