### PR TITLE
[FIX] [Module] [Mitre Att&ck] [Framework] Double fetching alerts count on pin/unpin agent

### DIFF
--- a/public/components/overview/mitre/components/techniques/techniques.tsx
+++ b/public/components/overview/mitre/components/techniques/techniques.tsx
@@ -100,7 +100,8 @@ export const Techniques = withWindowSize(
       const { isLoading, tacticsObject, filters } = this.props;
       if (
         JSON.stringify(prevProps.tacticsObject) !== JSON.stringify(tacticsObject) ||
-        isLoading !== prevProps.isLoading
+        isLoading !== prevProps.isLoading ||
+        JSON.stringify(prevProps.filterParams) !== JSON.stringify(this.props.filterParams)
       )
         this.getTechniquesCount();
     }

--- a/public/controllers/overview/overview.js
+++ b/public/controllers/overview/overview.js
@@ -180,7 +180,7 @@ export class OverviewController {
           this.tab,
           this.tabView,
           agentList[0],
-          (this.tabView === 'discover' || this.oldFilteredTab === this.tab)
+          (this.tabView === 'discover' || this.oldFilteredTab === this.tab || this.tabView === 'inventory')
         );
         this.oldFilteredTab = this.tab;
     } else if (!agentList && this.tab !== 'welcome') {
@@ -189,7 +189,7 @@ export class OverviewController {
           this.filterHandler,
           this.tab,
           this.tabView,
-          (this.tabView === 'discover' || this.oldFilteredTab === this.tab)
+          (this.tabView === 'discover' || this.oldFilteredTab === this.tab || this.tabView === 'inventory')
         );
         this.oldFilteredTab = this.tab;
       }


### PR DESCRIPTION
### Description

This PR solves a problem with double fetching alerts count in Mitre Att&ck/Framework.

### Changes
- Fix double fetching the alerts count in `Modules/Mitre Att&ck/Framework` when pin/unpin agent using the `Explore agent` button.

### Tests
- Go to `Modules/Mitre Att&ck/Framework` and review that only fetch one time the alerts count when pinning/unpinning the agent

Closes #3363