### PR TITLE
UseValueSuggestions hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Added try catch strategy with ErrorOrchestrator service on FIM & SCA sections [#3417](https://github.com/wazuh/wazuh-kibana-app/pull/3417)
 - Added sample data for office365 events [#3424](https://github.com/wazuh/wazuh-kibana-app/pull/3424)
 - Created a separate component to check for sample data [#3475](https://github.com/wazuh/wazuh-kibana-app/pull/3475)
+- Added a new hook for getting value suggestions [#3506](https://github.com/wazuh/wazuh-kibana-app/pull/3506)
 
 ### Changed
 

--- a/public/components/common/hooks/index.ts
+++ b/public/components/common/hooks/index.ts
@@ -24,4 +24,4 @@ export * from './useApiRequest';
 export * from './use-app-config';
 export * from './useRootScope';
 export * from './use_async_action';
-export { useValueSuggestions } from './use-value-suggestions';
+export { useValueSuggestions, IValueSuggestiions } from './use-value-suggestions';

--- a/public/components/common/hooks/index.ts
+++ b/public/components/common/hooks/index.ts
@@ -24,3 +24,4 @@ export * from './useApiRequest';
 export * from './use-app-config';
 export * from './useRootScope';
 export * from './use_async_action';
+export { useValueSuggestions } from './use-value-suggestions';

--- a/public/components/common/hooks/use-value-suggestions.ts
+++ b/public/components/common/hooks/use-value-suggestions.ts
@@ -24,13 +24,13 @@ import { UI_LOGGER_LEVELS } from '../../../../common/constants';
 import { getErrorOrchestrator } from '../../../react-services/common-services';
 
 export interface IValueSuggestiions {
-  filterOptions: string[] | boolean[];
+  suggestedValues: string[] | boolean[];
   isLoading: boolean;
   setQuery: React.Dispatch<React.SetStateAction<string>>;
 }
 
 export const useValueSuggestions = (filterField: string, type: 'string' | 'boolean' = 'string') => {
-  const [filterOptions, setFilterOptions] = useState<string[] | boolean[]>([]);
+  const [suggestedValues, setSuggestedValues] = useState<string[] | boolean[]>([]);
   const [query, setQuery] = useState<string>('');
   const [isLoading, setIsLoading] = useState(true);
   const data = getDataPlugin();
@@ -46,7 +46,7 @@ export const useValueSuggestions = (filterField: string, type: 'string' | 'boole
           aggregatable: true,
         } as IFieldType;
         try {
-          setFilterOptions(
+          setSuggestedValues(
             await data.autocomplete.getValueSuggestions({
               query,
               indexPattern: indexPattern as IIndexPattern,
@@ -72,5 +72,5 @@ export const useValueSuggestions = (filterField: string, type: 'string' | 'boole
     }
   }, [indexPattern, query, filterField, type]);
 
-  return { filterOptions, isLoading, setQuery };
+  return { suggestedValues, isLoading, setQuery };
 };

--- a/public/components/common/hooks/use-value-suggestions.ts
+++ b/public/components/common/hooks/use-value-suggestions.ts
@@ -1,3 +1,14 @@
+/*
+ * Wazuh app - React hook for getting value suggestions
+ * Copyright (C) 2015-2021 Wazuh, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Find more information about this on the LICENSE file.
+ */
 import { useState, useEffect } from 'react';
 import { getDataPlugin } from '../../../kibana-services';
 import { useIndexPattern } from '.';

--- a/public/components/common/hooks/use-value-suggestions.ts
+++ b/public/components/common/hooks/use-value-suggestions.ts
@@ -29,7 +29,7 @@ export interface IValueSuggestiions {
   setQuery: React.Dispatch<React.SetStateAction<string>>;
 }
 
-export const useValueSuggestions = (filterField: string, type: 'string' | 'boolean' = 'string') => {
+export const useValueSuggestions = (filterField: string, type: 'string' | 'boolean' = 'string') : IValueSuggestiions => {
   const [suggestedValues, setSuggestedValues] = useState<string[] | boolean[]>([]);
   const [query, setQuery] = useState<string>('');
   const [isLoading, setIsLoading] = useState(true);

--- a/public/components/common/hooks/use-value-suggestions.ts
+++ b/public/components/common/hooks/use-value-suggestions.ts
@@ -1,0 +1,45 @@
+import { useState, useEffect } from 'react';
+import { getDataPlugin } from '../../../kibana-services';
+import { useIndexPattern } from '.';
+import { IFieldType, IIndexPattern } from 'src/plugins/data/public';
+import React from 'react'
+
+
+export interface IValueSuggestiions {
+  filterOptions: string[] | boolean[];
+  isLoading: boolean;
+  setQuery: React.Dispatch<React.SetStateAction<string>>
+}
+
+export const useValueSuggestions = (filterField: string, type: 'string' | 'boolean' = 'string') => {
+  const [filterOptions, setFilterOptions] = useState<string[] | boolean[]>([]);
+  const [query, setQuery] = useState<string>('');
+  const [isLoading, setIsLoading] = useState(true);
+  const data = getDataPlugin();
+  const indexPattern = useIndexPattern();
+
+  useEffect(() => {
+    if (indexPattern) {
+      setIsLoading(true);
+      const field = {
+        type: type,
+        name: filterField,
+        aggregatable: true,
+      } as IFieldType;
+      data.autocomplete
+        .getValueSuggestions({
+          query,
+          indexPattern: indexPattern as IIndexPattern,
+          field,
+        })
+        .then((result) => {
+          setFilterOptions(result);
+        })
+        .finally(() => {
+          setIsLoading(false);
+        });
+    }
+  }, [indexPattern, query, filterField, type]);
+
+  return { filterOptions, isLoading, setQuery };
+};


### PR DESCRIPTION
closes https://github.com/wazuh/wazuh-kibana-app/issues/3500

This hook gets value suggestions for the provided field.
It uses

- `filterField` : The name of the field to get values for
- `type` : either `'string'` or `'boolean'`, the kind of field requested.

It returns:

- `suggestedValues` : array of possible values
- `isLoading` : updates on the loading state
- `setQuery` : Setting the query string will update the `suggestedValues` to match
