### PR TITLE
Fixed Vulnerability Detail error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fixed Elastic UI breaking changes in 7.12 [#3345](https://github.com/wazuh/wazuh-kibana-app/pull/3345)
 - Fixed Wazuh main menu and breadcrumb render issues [#3347](https://github.com/wazuh/wazuh-kibana-app/pull/3347)
 - Fixed generation of huge logs from backend errors [#3397](https://github.com/wazuh/wazuh-kibana-app/pull/3397)
+- Fixed Vulnerability Detail error [#3520](https://github.com/wazuh/wazuh-kibana-app/pull/3520)
 
 ## Wazuh v4.2.0 - Kibana 7.10.2 , 7.11.2 - Revision 4201
 

--- a/public/components/agents/vuls/inventory/flyout.tsx
+++ b/public/components/agents/vuls/inventory/flyout.tsx
@@ -121,7 +121,6 @@ export class FlyoutDetail extends Component {
                 { 'rule.groups': 'vulnerability-detector' },
                 { 'data.vulnerability.package.name': currentItem.name },
                 { 'data.vulnerability.cve': currentItem.cve },
-                { 'data.vulnerability.type': currentItem.type },
                 { 'data.vulnerability.package.architecture': currentItem.architecture },
                 { 'data.vulnerability.package.version': currentItem.version },
                 { 'agent.id': this.props.agentId },


### PR DESCRIPTION
Hi Team,
This PR resolves an error when is opening the Vulnerability Flyout Detail. 
`Type` filter has been removed.

To test it:

Go to Vulnerabilities/Inventory

- **Given** the browser is in wazuh app
- **When** the user navigates to modules/vulnerabilities/inventory with an agent selected
- **Then** the Inventory section will be shown

Open a Vulnerabilies/Inventory flyout

- **Given** Vulnerabilites sections showed
- **When** the user click in a row of the table
- **Then** the flyout of this row will be opened and it doesn't close itself or show any errors

Closes #3519 