### PR TITLE
Added 2 new aggtables to office365 with their drilldowns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,8 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Added sample data for office365 events [#3424](https://github.com/wazuh/wazuh-kibana-app/pull/3424)
 - Created a separate component to check for sample data [#3475](https://github.com/wazuh/wazuh-kibana-app/pull/3475)
 - Added a new hook for getting value suggestions [#3506](https://github.com/wazuh/wazuh-kibana-app/pull/3506)
-- Added base Module Panel view with Office365 setup [3518](https://github.com/wazuh/wazuh-kibana-app/pull/3518)
+- Added base Module Panel view with Office365 setup [#3518](https://github.com/wazuh/wazuh-kibana-app/pull/3518)
+- Two new aggregations tables, for rules and operations, to office365 module [#3511] https://github.com/wazuh/wazuh-kibana-app/pull/3526
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,6 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Created a separate component to check for sample data [#3475](https://github.com/wazuh/wazuh-kibana-app/pull/3475)
 - Added a new hook for getting value suggestions [#3506](https://github.com/wazuh/wazuh-kibana-app/pull/3506)
 - Added base Module Panel view with Office365 setup [#3518](https://github.com/wazuh/wazuh-kibana-app/pull/3518)
-- Two new aggregations tables, for rules and operations, to office365 module [#3511] https://github.com/wazuh/wazuh-kibana-app/pull/3526
 
 ### Changed
 

--- a/public/components/overview/office-panel/config/drilldown-ip-config.tsx
+++ b/public/components/overview/office-panel/config/drilldown-ip-config.tsx
@@ -62,7 +62,6 @@ export const drilldownIPConfig = {
       ],
     },
     {
-      height: 300,
       columns: [
         {
           width: 100,

--- a/public/components/overview/office-panel/config/drilldown-ip-config.tsx
+++ b/public/components/overview/office-panel/config/drilldown-ip-config.tsx
@@ -69,7 +69,15 @@ export const drilldownIPConfig = {
           component: () => (
             <EuiFlexItem>
               <EuiPanel paddingSize={'s'}>
-                <SecurityAlerts />
+                <SecurityAlerts
+                  initialColumns={[
+                    'icon',
+                    'timestamp',
+                    'data.office365.UserId',
+                    'rule.description',
+                    'data.office365.Operation',
+                  ]}
+                />
               </EuiPanel>
             </EuiFlexItem>
           ),

--- a/public/components/overview/office-panel/config/drilldown-operations-config.tsx
+++ b/public/components/overview/office-panel/config/drilldown-operations-config.tsx
@@ -21,7 +21,7 @@ export const drilldownOperationsConfig = {
     {
       height: 400,
       columns: [
-                {
+        {
           width: 40,
           component: (props) => (
             <VisCard id="Wazuh-App-Overview-Office-Top-Users" tab="office" {...props} />

--- a/public/components/overview/office-panel/config/drilldown-operations-config.tsx
+++ b/public/components/overview/office-panel/config/drilldown-operations-config.tsx
@@ -21,20 +21,14 @@ export const drilldownOperationsConfig = {
     {
       height: 400,
       columns: [
-        {
-          width: 30,
-          component: (props) => (
-            <VisCard id="Wazuh-App-Overview-Office-Metric-Stats" tab="office" {...props} />
-          ),
-        },
-        {
-          width: 30,
+                {
+          width: 40,
           component: (props) => (
             <VisCard id="Wazuh-App-Overview-Office-Top-Users" tab="office" {...props} />
           ),
         },
         {
-          width: 40,
+          width: 60,
           component: (props) => (
             <VisCard id="Wazuh-App-Overview-Office-Country-Tag-Cloud" tab="office" {...props} />
           ),

--- a/public/components/overview/office-panel/config/drilldown-operations-config.tsx
+++ b/public/components/overview/office-panel/config/drilldown-operations-config.tsx
@@ -1,0 +1,82 @@
+/*
+ * Wazuh app - Office 365 Drilldown Operations field Config.
+ *
+ * Copyright (C) 2015-2021 Wazuh, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Find more information about this on the LICENSE file.
+ */
+
+import React from 'react';
+import { VisCard } from '../../../common/modules/panel';
+import { EuiFlexItem, EuiPanel } from '@elastic/eui';
+import { SecurityAlerts } from '../../../visualize/components';
+
+export const drilldownOperationsConfig = {
+  rows: [
+    {
+      height: 400,
+      columns: [
+        {
+          width: 30,
+          component: (props) => (
+            <VisCard id="Wazuh-App-Overview-Office-Metric-Stats" tab="office" {...props} />
+          ),
+        },
+        {
+          width: 30,
+          component: (props) => (
+            <VisCard id="Wazuh-App-Overview-Office-Top-Users" tab="office" {...props} />
+          ),
+        },
+        {
+          width: 40,
+          component: (props) => (
+            <VisCard id="Wazuh-App-Overview-Office-Country-Tag-Cloud" tab="office" {...props} />
+          ),
+        },
+      ],
+    },
+    {
+      height: 300,
+      columns: [
+        {
+          width: 100,
+          component: (props) => (
+            <VisCard
+              id="Wazuh-App-Overview-Office-Alerts-Evolution-By-UserID"
+              tab="office"
+              {...props}
+            />
+          ),
+        },
+      ],
+    },
+    {
+      columns: [
+        {
+          width: 100,
+          component: () => (
+            <EuiFlexItem>
+              <EuiPanel paddingSize={'s'}>
+                <SecurityAlerts
+                  initialColumns={[
+                    'icon',
+                    'timestamp',
+                    'data.office365.UserId',
+                    'data.office365.ClientIP',
+                    'rule.description',
+                  ]}
+                />
+              </EuiPanel>
+            </EuiFlexItem>
+          ),
+        },
+      ],
+    },
+  ],
+};

--- a/public/components/overview/office-panel/config/drilldown-rules-config.tsx
+++ b/public/components/overview/office-panel/config/drilldown-rules-config.tsx
@@ -69,7 +69,7 @@ export const drilldownRulesConfig = {
                     'timestamp',
                     'data.office365.UserId',
                     'data.office365.ClientIP',
-                    'data.office365.Operation'
+                    'data.office365.Operation',
                   ]}
                 />
               </EuiPanel>

--- a/public/components/overview/office-panel/config/drilldown-rules-config.tsx
+++ b/public/components/overview/office-panel/config/drilldown-rules-config.tsx
@@ -1,0 +1,82 @@
+/*
+ * Wazuh app - Office 365 Drilldown Rules field Config.
+ *
+ * Copyright (C) 2015-2021 Wazuh, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Find more information about this on the LICENSE file.
+ */
+
+import React from 'react';
+import { VisCard } from '../../../common/modules/panel';
+import { EuiFlexItem, EuiPanel } from '@elastic/eui';
+import { SecurityAlerts } from '../../../visualize/components';
+
+export const drilldownRulesConfig = {
+  rows: [
+    {
+      height: 400,
+      columns: [
+        {
+          width: 30,
+          component: (props) => (
+            <VisCard id="Wazuh-App-Overview-Office-Top-Operations" tab="office" {...props} />
+          ),
+        },
+        {
+          width: 30,
+          component: (props) => (
+            <VisCard id="Wazuh-App-Overview-Office-Top-Users" tab="office" {...props} />
+          ),
+        },
+        {
+          width: 40,
+          component: (props) => (
+            <VisCard id="Wazuh-App-Overview-Office-Country-Tag-Cloud" tab="office" {...props} />
+          ),
+        },
+      ],
+    },
+    {
+      height: 300,
+      columns: [
+        {
+          width: 100,
+          component: (props) => (
+            <VisCard
+              id="Wazuh-App-Overview-Office-Alerts-Evolution-By-UserID"
+              tab="office"
+              {...props}
+            />
+          ),
+        },
+      ],
+    },
+    {
+      columns: [
+        {
+          width: 100,
+          component: () => (
+            <EuiFlexItem>
+              <EuiPanel paddingSize={'s'}>
+                <SecurityAlerts
+                  initialColumns={[
+                    'icon',
+                    'timestamp',
+                    'data.office365.UserId',
+                    'data.office365.ClientIP',
+                    'data.office365.Operation'
+                  ]}
+                />
+              </EuiPanel>
+            </EuiFlexItem>
+          ),
+        },
+      ],
+    },
+  ],
+};

--- a/public/components/overview/office-panel/config/drilldown-user-config.tsx
+++ b/public/components/overview/office-panel/config/drilldown-user-config.tsx
@@ -69,14 +69,14 @@ export const drilldownUserConfig = {
           component: () => (
             <EuiFlexItem>
               <EuiPanel paddingSize={'s'}>
-                <SecurityAlerts 
-                initialColumns={[
-                  'icon',
-                  'timestamp',
-                  'data.office365.ClientIP',
-                  'rule.description',
-                  'data.office365.Operation',
-                ]}
+                <SecurityAlerts
+                  initialColumns={[
+                    'icon',
+                    'timestamp',
+                    'data.office365.ClientIP',
+                    'rule.description',
+                    'data.office365.Operation',
+                  ]}
                 />
               </EuiPanel>
             </EuiFlexItem>

--- a/public/components/overview/office-panel/config/drilldown-user-config.tsx
+++ b/public/components/overview/office-panel/config/drilldown-user-config.tsx
@@ -69,7 +69,15 @@ export const drilldownUserConfig = {
           component: () => (
             <EuiFlexItem>
               <EuiPanel paddingSize={'s'}>
-                <SecurityAlerts />
+                <SecurityAlerts 
+                initialColumns={[
+                  'icon',
+                  'timestamp',
+                  'data.office365.ClientIP',
+                  'rule.description',
+                  'data.office365.Operation',
+                ]}
+                />
               </EuiPanel>
             </EuiFlexItem>
           ),

--- a/public/components/overview/office-panel/config/drilldown-user-config.tsx
+++ b/public/components/overview/office-panel/config/drilldown-user-config.tsx
@@ -62,7 +62,6 @@ export const drilldownUserConfig = {
       ],
     },
     {
-      height: 300,
       columns: [
         {
           width: 100,

--- a/public/components/overview/office-panel/config/index.ts
+++ b/public/components/overview/office-panel/config/index.ts
@@ -13,6 +13,8 @@
 
 export { drilldownIPConfig } from './drilldown-ip-config';
 export { drilldownUserConfig } from './drilldown-user-config';
+export { drilldownOperationsConfig } from './drilldown-operations-config'
+export { drilldownRulesConfig } from './drilldown-rules-config'
 export { MainViewConfig } from './main-view-config';
 export { ModuleConfig } from './module-config';
 export { filtersValues } from './search-bar-config';

--- a/public/components/overview/office-panel/config/index.ts
+++ b/public/components/overview/office-panel/config/index.ts
@@ -13,8 +13,8 @@
 
 export { drilldownIPConfig } from './drilldown-ip-config';
 export { drilldownUserConfig } from './drilldown-user-config';
-export { drilldownOperationsConfig } from './drilldown-operations-config'
-export { drilldownRulesConfig } from './drilldown-rules-config'
+export { drilldownOperationsConfig } from './drilldown-operations-config';
+export { drilldownRulesConfig } from './drilldown-rules-config';
 export { MainViewConfig } from './main-view-config';
 export { ModuleConfig } from './module-config';
 export { filtersValues } from './search-bar-config';

--- a/public/components/overview/office-panel/config/main-view-config.tsx
+++ b/public/components/overview/office-panel/config/main-view-config.tsx
@@ -14,6 +14,7 @@
 import React from 'react';
 import { AggTable } from '../../../common/modules/panel/';
 import { EuiFlexItem } from '@elastic/eui';
+import { SecurityAlerts } from '../../../visualize/components';
 
 export const MainViewConfig = {
   rows: [
@@ -24,7 +25,7 @@ export const MainViewConfig = {
           component: (props) => (
             <EuiFlexItem grow={props.grow}>
               <AggTable
-                tableTitle={'Users'}
+                tableTitle={'Top users'}
                 aggTerm={'data.office365.UserId'}
                 aggLabel={'User'}
                 maxRows={'5'}
@@ -38,7 +39,7 @@ export const MainViewConfig = {
           component: (props) => (
             <EuiFlexItem grow={props.grow}>
               <AggTable
-                tableTitle={'Client IP'}
+                tableTitle={'Top client IP'}
                 aggTerm={'data.office365.ClientIP'}
                 aggLabel={'Client IP'}
                 maxRows={'5'}
@@ -48,6 +49,38 @@ export const MainViewConfig = {
           ),
         },
       ],
+    },
+    {
+      columns: [
+        {
+          width: 50,
+          component: (props) => (
+            <EuiFlexItem grow={props.grow}>
+              <AggTable
+                tableTitle={'Top rules'}
+                aggTerm={'rule.description'}
+                aggLabel={'Rule'}
+                maxRows={'5'}
+                onRowClick={(field, value) => props.onRowClick(field, value)}
+              />
+            </EuiFlexItem>
+          ),
+        },
+        {
+          width: 50,
+          component: (props) => (
+            <EuiFlexItem grow={props.grow}>
+              <AggTable
+                tableTitle={'Top operations'}
+                aggTerm={'data.office365.Operation'}
+                aggLabel={'Operation'}
+                maxRows={'5'}
+                onRowClick={(field, value) => props.onRowClick(field, value)}
+              />
+            </EuiFlexItem>
+          ),
+        },
+      ]
     },
   ],
 };

--- a/public/components/overview/office-panel/config/main-view-config.tsx
+++ b/public/components/overview/office-panel/config/main-view-config.tsx
@@ -25,10 +25,10 @@ export const MainViewConfig = {
           component: (props) => (
             <EuiFlexItem grow={props.grow}>
               <AggTable
-                tableTitle={'Top users'}
-                aggTerm={'data.office365.UserId'}
-                aggLabel={'User'}
-                maxRows={'5'}
+                tableTitle="Top users"
+                aggTerm="data.office365.UserId"
+                aggLabel="User"
+                maxRows={5}
                 onRowClick={(field, value) => props.onRowClick(field, value)}
               />
             </EuiFlexItem>
@@ -39,10 +39,10 @@ export const MainViewConfig = {
           component: (props) => (
             <EuiFlexItem grow={props.grow}>
               <AggTable
-                tableTitle={'Top client IP'}
-                aggTerm={'data.office365.ClientIP'}
-                aggLabel={'Client IP'}
-                maxRows={'5'}
+                tableTitle="Top client IP"
+                aggTerm="data.office365.ClientIP"
+                aggLabel="Client IP"
+                maxRows={5}
                 onRowClick={(field, value) => props.onRowClick(field, value)}
               />
             </EuiFlexItem>
@@ -57,10 +57,10 @@ export const MainViewConfig = {
           component: (props) => (
             <EuiFlexItem grow={props.grow}>
               <AggTable
-                tableTitle={'Top rules'}
-                aggTerm={'rule.description'}
-                aggLabel={'Rule'}
-                maxRows={'5'}
+                tableTitle="Top rules"
+                aggTerm="rule.description"
+                aggLabel="Rule"
+                maxRows={5}
                 onRowClick={(field, value) => props.onRowClick(field, value)}
               />
             </EuiFlexItem>
@@ -71,10 +71,10 @@ export const MainViewConfig = {
           component: (props) => (
             <EuiFlexItem grow={props.grow}>
               <AggTable
-                tableTitle={'Top operations'}
-                aggTerm={'data.office365.Operation'}
-                aggLabel={'Operation'}
-                maxRows={'5'}
+                tableTitle="Top operations"
+                aggTerm="data.office365.Operation"
+                aggLabel="Operation"
+                maxRows={5}
                 onRowClick={(field, value) => props.onRowClick(field, value)}
               />
             </EuiFlexItem>

--- a/public/components/overview/office-panel/config/main-view-config.tsx
+++ b/public/components/overview/office-panel/config/main-view-config.tsx
@@ -80,7 +80,7 @@ export const MainViewConfig = {
             </EuiFlexItem>
           ),
         },
-      ]
+      ],
     },
   ],
 };

--- a/public/components/overview/office-panel/config/module-config.tsx
+++ b/public/components/overview/office-panel/config/module-config.tsx
@@ -13,7 +13,13 @@
 
 import React from 'react';
 import { OfficeBody, OfficeDrilldown } from '../views';
-import { MainViewConfig, drilldownIPConfig, drilldownUserConfig, drilldownOperationsConfig, drilldownRulesConfig } from './';
+import {
+  MainViewConfig,
+  drilldownIPConfig,
+  drilldownUserConfig,
+  drilldownOperationsConfig,
+  drilldownRulesConfig,
+} from './';
 
 /**
  * The length method has to count Kibana Visualizations for TabVisualizations class
@@ -36,16 +42,17 @@ export const ModuleConfig = {
     ),
   },
   'data.office365.Operation': {
-    length: () => drilldownOperationsConfig.rows.reduce((total, row) => total + row.columns.length, 0),
+    length: () =>
+      drilldownOperationsConfig.rows.reduce((total, row) => total + row.columns.length, 0),
     component: (props) => (
       <OfficeDrilldown title={'Operation'} {...{ ...drilldownOperationsConfig, ...props }} />
     ),
   },
   'rule.description': {
-    length: () => drilldownOperationsConfig.rows.reduce((total, row) => total + row.columns.length, 0),
+    length: () =>
+      drilldownRulesConfig.rows.reduce((total, row) => total + row.columns.length, 0),
     component: (props) => (
       <OfficeDrilldown title={'Rule'} {...{ ...drilldownRulesConfig, ...props }} />
     ),
-  }
-  
+  },
 };

--- a/public/components/overview/office-panel/config/module-config.tsx
+++ b/public/components/overview/office-panel/config/module-config.tsx
@@ -13,7 +13,7 @@
 
 import React from 'react';
 import { OfficeBody, OfficeDrilldown } from '../views';
-import { MainViewConfig, drilldownIPConfig, drilldownUserConfig } from './';
+import { MainViewConfig, drilldownIPConfig, drilldownUserConfig, drilldownOperationsConfig, drilldownRulesConfig } from './';
 
 /**
  * The length method has to count Kibana Visualizations for TabVisualizations class
@@ -35,5 +35,17 @@ export const ModuleConfig = {
       <OfficeDrilldown title={'Client IP'} {...{ ...drilldownIPConfig, ...props }} />
     ),
   },
+  'data.office365.Operation': {
+    length: () => drilldownOperationsConfig.rows.reduce((total, row) => total + row.columns.length, 0),
+    component: (props) => (
+      <OfficeDrilldown title={'Operation'} {...{ ...drilldownOperationsConfig, ...props }} />
+    ),
+  },
+  'rule.description': {
+    length: () => drilldownOperationsConfig.rows.reduce((total, row) => total + row.columns.length, 0),
+    component: (props) => (
+      <OfficeDrilldown title={'Rule'} {...{ ...drilldownRulesConfig, ...props }} />
+    ),
+  }
   
 };

--- a/server/integration-files/visualizations/overview/overview-office.ts
+++ b/server/integration-files/visualizations/overview/overview-office.ts
@@ -165,56 +165,56 @@ export default [
     _source: {
       title: 'Max Rule Level',
       visState: JSON.stringify({
-        "title": "Max Rule Level",
-        "type": "metric",
-        "aggs": [
+        title: 'Max Rule Level',
+        type: 'metric',
+        aggs: [
           {
-            "id": "1",
-            "enabled": true,
-            "type": "max",
-            "params": {
-              "field": "rule.level",
-              "customLabel": "Max Rule Level"
+            id: '1',
+            enabled: true,
+            type: 'max',
+            params: {
+              field: 'rule.level',
+              customLabel: 'Max Rule Level',
             },
-            "schema": "metric"
-          }
+            schema: 'metric',
+          },
         ],
-        "params": {
-          "addTooltip": true,
-          "addLegend": false,
-          "type": "metric",
-          "metric": {
-            "percentageMode": false,
-            "useRanges": false,
-            "colorSchema": "Green to Red",
-            "metricColorMode": "Labels",
-            "colorsRange": [
+        params: {
+          addTooltip: true,
+          addLegend: false,
+          type: 'metric',
+          metric: {
+            percentageMode: false,
+            useRanges: false,
+            colorSchema: 'Green to Red',
+            metricColorMode: 'Labels',
+            colorsRange: [
               {
-                "from": 0,
-                "to": 7
+                from: 0,
+                to: 7,
               },
               {
-                "from": 7,
-                "to": 10
+                from: 7,
+                to: 10,
               },
               {
-                "from": 10,
-                "to": 20
-              }
+                from: 10,
+                to: 20,
+              },
             ],
-            "labels": {
-              "show": true
+            labels: {
+              show: true,
             },
-            "invertColors": false,
-            "style": {
-              "bgFill": "#000",
-              "bgColor": false,
-              "labelColor": false,
-              "subText": "",
-              "fontSize": 26
-            }
-          }
-        }
+            invertColors: false,
+            style: {
+              bgFill: '#000',
+              bgColor: false,
+              labelColor: false,
+              subText: '',
+              fontSize: 26,
+            },
+          },
+        },
       }),
       uiStateJSON: JSON.stringify({ vis: { defaultColors: { '0 - 100': 'rgb(0,104,55)' } } }),
       description: '',
@@ -231,62 +231,62 @@ export default [
     _source: {
       title: 'Suspicious Downloads',
       visState: JSON.stringify({
-        "title": "Suspicious Downloads Count",
-        "type": "metric",
-        "aggs": [
+        title: 'Suspicious Downloads Count',
+        type: 'metric',
+        aggs: [
           {
-            "id": "1",
-            "enabled": true,
-            "type": "count",
-            "params": {},
-            "schema": "metric"
+            id: '1',
+            enabled: true,
+            type: 'count',
+            params: {},
+            schema: 'metric',
           },
           {
-            "id": "2",
-            "enabled": true,
-            "type": "filters",
-            "params": {
-              "filters": [
+            id: '2',
+            enabled: true,
+            type: 'filters',
+            params: {
+              filters: [
                 {
-                  "input": {
-                    "query": "rule.id: \"91724\"",
-                    "language": "kuery"
+                  input: {
+                    query: 'rule.id: "91724"',
+                    language: 'kuery',
                   },
-                  "label": "Suspicious Downloads"
-                }
-              ]
+                  label: 'Suspicious Downloads',
+                },
+              ],
             },
-            "schema": "group"
-          }
+            schema: 'group',
+          },
         ],
-        "params": {
-          "addTooltip": true,
-          "addLegend": false,
-          "type": "metric",
-          "metric": {
-            "percentageMode": false,
-            "useRanges": false,
-            "colorSchema": "Green to Red",
-            "metricColorMode": "Labels",
-            "colorsRange": [
+        params: {
+          addTooltip: true,
+          addLegend: false,
+          type: 'metric',
+          metric: {
+            percentageMode: false,
+            useRanges: false,
+            colorSchema: 'Green to Red',
+            metricColorMode: 'Labels',
+            colorsRange: [
               {
-                "from": 0,
-                "to": 1
-              }
+                from: 0,
+                to: 1,
+              },
             ],
-            "labels": {
-              "show": true
+            labels: {
+              show: true,
             },
-            "invertColors": false,
-            "style": {
-              "bgFill": "#000",
-              "bgColor": false,
-              "labelColor": false,
-              "subText": "",
-              "fontSize": 26
-            }
-          }
-        }
+            invertColors: false,
+            style: {
+              bgFill: '#000',
+              bgColor: false,
+              labelColor: false,
+              subText: '',
+              fontSize: 26,
+            },
+          },
+        },
       }),
       uiStateJSON: JSON.stringify({ vis: { defaultColors: { '0 - 100': 'rgb(0,104,55)' } } }),
       description: '',
@@ -303,62 +303,62 @@ export default [
     _source: {
       title: 'Malware Alerts',
       visState: JSON.stringify({
-        "title": "Malware Alerts Count",
-        "type": "metric",
-        "aggs": [
+        title: 'Malware Alerts Count',
+        type: 'metric',
+        aggs: [
           {
-            "id": "1",
-            "enabled": true,
-            "type": "count",
-            "params": {},
-            "schema": "metric"
+            id: '1',
+            enabled: true,
+            type: 'count',
+            params: {},
+            schema: 'metric',
           },
           {
-            "id": "2",
-            "enabled": true,
-            "type": "filters",
-            "params": {
-              "filters": [
+            id: '2',
+            enabled: true,
+            type: 'filters',
+            params: {
+              filters: [
                 {
-                  "input": {
-                    "query": "rule.id: \"91556\" or rule.id: \"91575\" or rule.id: \"91700\" ",
-                    "language": "kuery"
+                  input: {
+                    query: 'rule.id: "91556" or rule.id: "91575" or rule.id: "91700" ',
+                    language: 'kuery',
                   },
-                  "label": "Malware Alerts"
-                }
-              ]
+                  label: 'Malware Alerts',
+                },
+              ],
             },
-            "schema": "group"
-          }
+            schema: 'group',
+          },
         ],
-        "params": {
-          "addTooltip": true,
-          "addLegend": false,
-          "type": "metric",
-          "metric": {
-            "percentageMode": false,
-            "useRanges": false,
-            "colorSchema": "Green to Red",
-            "metricColorMode": "None",
-            "colorsRange": [
+        params: {
+          addTooltip: true,
+          addLegend: false,
+          type: 'metric',
+          metric: {
+            percentageMode: false,
+            useRanges: false,
+            colorSchema: 'Green to Red',
+            metricColorMode: 'None',
+            colorsRange: [
               {
-                "from": 0,
-                "to": 10000
-              }
+                from: 0,
+                to: 10000,
+              },
             ],
-            "labels": {
-              "show": true
+            labels: {
+              show: true,
             },
-            "invertColors": false,
-            "style": {
-              "bgFill": "#000",
-              "bgColor": false,
-              "labelColor": false,
-              "subText": "",
-              "fontSize": 26
-            }
-          }
-        }
+            invertColors: false,
+            style: {
+              bgFill: '#000',
+              bgColor: false,
+              labelColor: false,
+              subText: '',
+              fontSize: 26,
+            },
+          },
+        },
       }),
       uiStateJSON: JSON.stringify({ vis: { defaultColors: { '0 - 100': 'rgb(0,104,55)' } } }),
       description: '',
@@ -375,62 +375,62 @@ export default [
     _source: {
       title: 'Full Access Permissions',
       visState: JSON.stringify({
-        "title": "Full Access Permission Count",
-        "type": "metric",
-        "aggs": [
+        title: 'Full Access Permission Count',
+        type: 'metric',
+        aggs: [
           {
-            "id": "1",
-            "enabled": true,
-            "type": "count",
-            "params": {},
-            "schema": "metric"
+            id: '1',
+            enabled: true,
+            type: 'count',
+            params: {},
+            schema: 'metric',
           },
           {
-            "id": "2",
-            "enabled": true,
-            "type": "filters",
-            "params": {
-              "filters": [
+            id: '2',
+            enabled: true,
+            type: 'filters',
+            params: {
+              filters: [
                 {
-                  "input": {
-                    "query": "rule.id: \"91725\"",
-                    "language": "kuery"
+                  input: {
+                    query: 'rule.id: "91725"',
+                    language: 'kuery',
                   },
-                  "label": "Full Access Permissions"
-                }
-              ]
+                  label: 'Full Access Permissions',
+                },
+              ],
             },
-            "schema": "group"
-          }
+            schema: 'group',
+          },
         ],
-        "params": {
-          "addTooltip": true,
-          "addLegend": false,
-          "type": "metric",
-          "metric": {
-            "percentageMode": false,
-            "useRanges": false,
-            "colorSchema": "Green to Red",
-            "metricColorMode": "None",
-            "colorsRange": [
+        params: {
+          addTooltip: true,
+          addLegend: false,
+          type: 'metric',
+          metric: {
+            percentageMode: false,
+            useRanges: false,
+            colorSchema: 'Green to Red',
+            metricColorMode: 'None',
+            colorsRange: [
               {
-                "from": 0,
-                "to": 10000
-              }
+                from: 0,
+                to: 10000,
+              },
             ],
-            "labels": {
-              "show": true
+            labels: {
+              show: true,
             },
-            "invertColors": false,
-            "style": {
-              "bgFill": "#000",
-              "bgColor": false,
-              "labelColor": false,
-              "subText": "",
-              "fontSize": 26
-            }
-          }
-        }
+            invertColors: false,
+            style: {
+              bgFill: '#000',
+              bgColor: false,
+              labelColor: false,
+              subText: '',
+              fontSize: 26,
+            },
+          },
+        },
       }),
       uiStateJSON: JSON.stringify({ vis: { defaultColors: { '0 - 100': 'rgb(0,104,55)' } } }),
       description: '',
@@ -1057,80 +1057,80 @@ export default [
     _source: {
       title: 'User Operations',
       visState: JSON.stringify({
-        "title": "User Operation Level",
-        "type": "table",
-        "aggs": [
+        title: 'User Operation Level',
+        type: 'table',
+        aggs: [
           {
-            "id": "1",
-            "enabled": true,
-            "type": "count",
-            "params": {},
-            "schema": "metric"
+            id: '1',
+            enabled: true,
+            type: 'count',
+            params: {},
+            schema: 'metric',
           },
           {
-            "id": "2",
-            "enabled": true,
-            "type": "terms",
-            "params": {
-              "field": "data.office365.UserId",
-              "orderBy": "1",
-              "order": "desc",
-              "size": 500,
-              "otherBucket": true,
-              "otherBucketLabel": "Others",
-              "missingBucket": false,
-              "missingBucketLabel": "Missing",
-              "customLabel": "Users"
+            id: '2',
+            enabled: true,
+            type: 'terms',
+            params: {
+              field: 'data.office365.UserId',
+              orderBy: '1',
+              order: 'desc',
+              size: 500,
+              otherBucket: true,
+              otherBucketLabel: 'Others',
+              missingBucket: false,
+              missingBucketLabel: 'Missing',
+              customLabel: 'Users',
             },
-            "schema": "bucket"
+            schema: 'bucket',
           },
           {
-            "id": "3",
-            "enabled": true,
-            "type": "terms",
-            "params": {
-              "field": "data.office365.Operation",
-              "orderBy": "1",
-              "order": "desc",
-              "size": 100,
-              "otherBucket": false,
-              "otherBucketLabel": "Other",
-              "missingBucket": false,
-              "missingBucketLabel": "Missing",
-              "customLabel": "Operation"
+            id: '3',
+            enabled: true,
+            type: 'terms',
+            params: {
+              field: 'data.office365.Operation',
+              orderBy: '1',
+              order: 'desc',
+              size: 100,
+              otherBucket: false,
+              otherBucketLabel: 'Other',
+              missingBucket: false,
+              missingBucketLabel: 'Missing',
+              customLabel: 'Operation',
             },
-            "schema": "bucket"
+            schema: 'bucket',
           },
           {
-            "id": "4",
-            "enabled": true,
-            "type": "terms",
-            "params": {
-              "field": "rule.level",
-              "orderBy": "1",
-              "order": "desc",
-              "size": 20,
-              "otherBucket": false,
-              "otherBucketLabel": "Other",
-              "missingBucket": false,
-              "missingBucketLabel": "Missing",
-              "customLabel": "Rule level"
+            id: '4',
+            enabled: true,
+            type: 'terms',
+            params: {
+              field: 'rule.level',
+              orderBy: '1',
+              order: 'desc',
+              size: 20,
+              otherBucket: false,
+              otherBucketLabel: 'Other',
+              missingBucket: false,
+              missingBucketLabel: 'Missing',
+              customLabel: 'Rule level',
             },
-            "schema": "bucket"
-          }
+            schema: 'bucket',
+          },
         ],
-        "params": {
-          "perPage": 5,
-          "showPartialRows": false,
-          "showMetricsAtAllLevels": false,
-          "sort": {
-            "columnIndex": null,
-            "direction": null
+        params: {
+          perPage: 5,
+          showPartialRows: false,
+          showMetricsAtAllLevels: false,
+          sort: {
+            columnIndex: null,
+            direction: null,
           },
-          "showTotal": false,
-          "totalFunc": "sum",
-          "percentageCol": ""
-        }
+          showTotal: false,
+          totalFunc: 'sum',
+          percentageCol: '',
+        },
       }),
       uiStateJSON: '{}',
       description: '',
@@ -1150,80 +1150,80 @@ export default [
     _source: {
       title: 'Client IP Operations',
       visState: JSON.stringify({
-        "title": "Client IP Operation Level",
-        "type": "table",
-        "aggs": [
+        title: 'Client IP Operation Level',
+        type: 'table',
+        aggs: [
           {
-            "id": "1",
-            "enabled": true,
-            "type": "count",
-            "params": {},
-            "schema": "metric"
+            id: '1',
+            enabled: true,
+            type: 'count',
+            params: {},
+            schema: 'metric',
           },
           {
-            "id": "2",
-            "enabled": true,
-            "type": "terms",
-            "params": {
-              "field": "data.office365.ClientIP",
-              "orderBy": "1",
-              "order": "desc",
-              "size": 500,
-              "otherBucket": true,
-              "otherBucketLabel": "Others",
-              "missingBucket": false,
-              "missingBucketLabel": "Missing",
-              "customLabel": "Client IP"
+            id: '2',
+            enabled: true,
+            type: 'terms',
+            params: {
+              field: 'data.office365.ClientIP',
+              orderBy: '1',
+              order: 'desc',
+              size: 500,
+              otherBucket: true,
+              otherBucketLabel: 'Others',
+              missingBucket: false,
+              missingBucketLabel: 'Missing',
+              customLabel: 'Client IP',
             },
-            "schema": "bucket"
+            schema: 'bucket',
           },
           {
-            "id": "3",
-            "enabled": true,
-            "type": "terms",
-            "params": {
-              "field": "data.office365.Operation",
-              "orderBy": "1",
-              "order": "desc",
-              "size": 100,
-              "otherBucket": false,
-              "otherBucketLabel": "Other",
-              "missingBucket": false,
-              "missingBucketLabel": "Missing",
-              "customLabel": "Operation"
+            id: '3',
+            enabled: true,
+            type: 'terms',
+            params: {
+              field: 'data.office365.Operation',
+              orderBy: '1',
+              order: 'desc',
+              size: 100,
+              otherBucket: false,
+              otherBucketLabel: 'Other',
+              missingBucket: false,
+              missingBucketLabel: 'Missing',
+              customLabel: 'Operation',
             },
-            "schema": "bucket"
+            schema: 'bucket',
           },
           {
-            "id": "4",
-            "enabled": true,
-            "type": "terms",
-            "params": {
-              "field": "rule.level",
-              "orderBy": "1",
-              "order": "desc",
-              "size": 20,
-              "otherBucket": false,
-              "otherBucketLabel": "Other",
-              "missingBucket": false,
-              "missingBucketLabel": "Missing",
-              "customLabel": "Rule level"
+            id: '4',
+            enabled: true,
+            type: 'terms',
+            params: {
+              field: 'rule.level',
+              orderBy: '1',
+              order: 'desc',
+              size: 20,
+              otherBucket: false,
+              otherBucketLabel: 'Other',
+              missingBucket: false,
+              missingBucketLabel: 'Missing',
+              customLabel: 'Rule level',
             },
-            "schema": "bucket"
-          }
+            schema: 'bucket',
+          },
         ],
-        "params": {
-          "perPage": 5,
-          "showPartialRows": false,
-          "showMetricsAtAllLevels": false,
-          "sort": {
-            "columnIndex": null,
-            "direction": null
+        params: {
+          perPage: 5,
+          showPartialRows: false,
+          showMetricsAtAllLevels: false,
+          sort: {
+            columnIndex: null,
+            direction: null,
           },
-          "showTotal": false,
-          "totalFunc": "sum",
-          "percentageCol": ""
-        }
+          showTotal: false,
+          totalFunc: 'sum',
+          percentageCol: '',
+        },
       }),
       uiStateJSON: '{}',
       description: '',
@@ -1553,63 +1553,63 @@ export default [
     _source: {
       title: 'Rule Description by Level',
       visState: JSON.stringify({
-        "title": "Rule Description Level Table",
-        "type": "table",
-        "aggs": [
+        title: 'Rule Description Level Table',
+        type: 'table',
+        aggs: [
           {
-            "id": "1",
-            "enabled": true,
-            "type": "count",
-            "params": {},
-            "schema": "metric"
+            id: '1',
+            enabled: true,
+            type: 'count',
+            params: {},
+            schema: 'metric',
           },
           {
-            "id": "2",
-            "enabled": true,
-            "type": "terms",
-            "params": {
-              "field": "rule.description",
-              "orderBy": "1",
-              "order": "desc",
-              "size": 500,
-              "otherBucket": false,
-              "otherBucketLabel": "Other",
-              "missingBucket": false,
-              "missingBucketLabel": "Missing",
-              "customLabel": "Rule Description"
+            id: '2',
+            enabled: true,
+            type: 'terms',
+            params: {
+              field: 'rule.description',
+              orderBy: '1',
+              order: 'desc',
+              size: 500,
+              otherBucket: false,
+              otherBucketLabel: 'Other',
+              missingBucket: false,
+              missingBucketLabel: 'Missing',
+              customLabel: 'Rule Description',
             },
-            "schema": "bucket"
+            schema: 'bucket',
           },
           {
-            "id": "3",
-            "enabled": true,
-            "type": "terms",
-            "params": {
-              "field": "rule.level",
-              "orderBy": "1",
-              "order": "desc",
-              "size": 20,
-              "otherBucket": false,
-              "otherBucketLabel": "Other",
-              "missingBucket": false,
-              "missingBucketLabel": "Missing",
-              "customLabel": "Rule Level"
+            id: '3',
+            enabled: true,
+            type: 'terms',
+            params: {
+              field: 'rule.level',
+              orderBy: '1',
+              order: 'desc',
+              size: 20,
+              otherBucket: false,
+              otherBucketLabel: 'Other',
+              missingBucket: false,
+              missingBucketLabel: 'Missing',
+              customLabel: 'Rule Level',
             },
-            "schema": "bucket"
-          }
+            schema: 'bucket',
+          },
         ],
-        "params": {
-          "perPage": 5,
-          "showPartialRows": false,
-          "showMetricsAtAllLevels": false,
-          "sort": {
-            "columnIndex": null,
-            "direction": null
+        params: {
+          perPage: 5,
+          showPartialRows: false,
+          showMetricsAtAllLevels: false,
+          sort: {
+            columnIndex: null,
+            direction: null,
           },
-          "showTotal": false,
-          "totalFunc": "sum",
-          "percentageCol": ""
-        }
+          showTotal: false,
+          totalFunc: 'sum',
+          percentageCol: '',
+        },
       }),
       uiStateJSON: '{}',
       description: '',
@@ -2034,126 +2034,126 @@ export default [
     _source: {
       title: 'Severity by user',
       visState: JSON.stringify({
-        "title": "Severity By User Barchart",
-        "type": "histogram",
-        "aggs": [
+        title: 'Severity By User Barchart',
+        type: 'histogram',
+        aggs: [
           {
-            "id": "1",
-            "enabled": true,
-            "type": "count",
-            "params": {},
-            "schema": "metric"
+            id: '1',
+            enabled: true,
+            type: 'count',
+            params: {},
+            schema: 'metric',
           },
           {
-            "id": "2",
-            "enabled": true,
-            "type": "terms",
-            "params": {
-              "field": "rule.level",
-              "orderBy": "1",
-              "order": "desc",
-              "size": 5,
-              "otherBucket": true,
-              "otherBucketLabel": "Other",
-              "missingBucket": false,
-              "missingBucketLabel": "Missing"
+            id: '2',
+            enabled: true,
+            type: 'terms',
+            params: {
+              field: 'rule.level',
+              orderBy: '1',
+              order: 'desc',
+              size: 5,
+              otherBucket: true,
+              otherBucketLabel: 'Other',
+              missingBucket: false,
+              missingBucketLabel: 'Missing',
             },
-            "schema": "segment"
+            schema: 'segment',
           },
           {
-            "id": "3",
-            "enabled": true,
-            "type": "terms",
-            "params": {
-              "field": "data.office365.UserId",
-              "orderBy": "1",
-              "order": "desc",
-              "size": 20,
-              "otherBucket": false,
-              "otherBucketLabel": "Other",
-              "missingBucket": false,
-              "missingBucketLabel": "Missing"
+            id: '3',
+            enabled: true,
+            type: 'terms',
+            params: {
+              field: 'data.office365.UserId',
+              orderBy: '1',
+              order: 'desc',
+              size: 20,
+              otherBucket: false,
+              otherBucketLabel: 'Other',
+              missingBucket: false,
+              missingBucketLabel: 'Missing',
             },
-            "schema": "group"
-          }
+            schema: 'group',
+          },
         ],
-        "params": {
-          "type": "histogram",
-          "grid": {
-            "categoryLines": false
+        params: {
+          type: 'histogram',
+          grid: {
+            categoryLines: false,
           },
-          "categoryAxes": [
+          categoryAxes: [
             {
-              "id": "CategoryAxis-1",
-              "type": "category",
-              "position": "bottom",
-              "show": true,
-              "style": {},
-              "scale": {
-                "type": "linear"
+              id: 'CategoryAxis-1',
+              type: 'category',
+              position: 'bottom',
+              show: true,
+              style: {},
+              scale: {
+                type: 'linear',
               },
-              "labels": {
-                "show": true,
-                "filter": true,
-                "truncate": 100
+              labels: {
+                show: true,
+                filter: true,
+                truncate: 100,
               },
-              "title": {}
-            }
+              title: {},
+            },
           ],
-          "valueAxes": [
+          valueAxes: [
             {
-              "id": "ValueAxis-1",
-              "name": "LeftAxis-1",
-              "type": "value",
-              "position": "left",
-              "show": true,
-              "style": {},
-              "scale": {
-                "type": "linear",
-                "mode": "normal"
+              id: 'ValueAxis-1',
+              name: 'LeftAxis-1',
+              type: 'value',
+              position: 'left',
+              show: true,
+              style: {},
+              scale: {
+                type: 'linear',
+                mode: 'normal',
               },
-              "labels": {
-                "show": true,
-                "rotate": 0,
-                "filter": false,
-                "truncate": 100
+              labels: {
+                show: true,
+                rotate: 0,
+                filter: false,
+                truncate: 100,
               },
-              "title": {
-                "text": "Count"
-              }
-            }
+              title: {
+                text: 'Count',
+              },
+            },
           ],
-          "seriesParams": [
+          seriesParams: [
             {
-              "show": true,
-              "type": "histogram",
-              "mode": "stacked",
-              "data": {
-                "label": "Count",
-                "id": "1"
+              show: true,
+              type: 'histogram',
+              mode: 'stacked',
+              data: {
+                label: 'Count',
+                id: '1',
               },
-              "valueAxis": "ValueAxis-1",
-              "drawLinesBetweenPoints": true,
-              "lineWidth": 2,
-              "showCircles": true
-            }
+              valueAxis: 'ValueAxis-1',
+              drawLinesBetweenPoints: true,
+              lineWidth: 2,
+              showCircles: true,
+            },
           ],
-          "addTooltip": true,
-          "addLegend": true,
-          "legendPosition": "right",
-          "times": [],
-          "addTimeMarker": false,
-          "labels": {
-            "show": false
+          addTooltip: true,
+          addLegend: true,
+          legendPosition: 'right',
+          times: [],
+          addTimeMarker: false,
+          labels: {
+            show: false,
           },
-          "thresholdLine": {
-            "show": false,
-            "value": 10,
-            "width": 1,
-            "style": "full",
-            "color": "#E7664C"
-          }
-        }
+          thresholdLine: {
+            show: false,
+            value: 10,
+            width: 1,
+            style: 'full',
+            color: '#E7664C',
+          },
+        },
       }),
       uiStateJSON: '{}',
       description: '',
@@ -2173,127 +2173,127 @@ export default [
     _source: {
       title: 'Top User By Subscription',
       visState: JSON.stringify({
-        "title": "Top User By Subscription",
-        "type": "histogram",
-        "aggs": [
+        title: 'Top User By Subscription',
+        type: 'histogram',
+        aggs: [
           {
-            "id": "1",
-            "enabled": true,
-            "type": "count",
-            "params": {},
-            "schema": "metric"
+            id: '1',
+            enabled: true,
+            type: 'count',
+            params: {},
+            schema: 'metric',
           },
           {
-            "id": "2",
-            "enabled": true,
-            "type": "terms",
-            "params": {
-              "field": "data.office365.UserId",
-              "orderBy": "1",
-              "order": "desc",
-              "size": 5,
-              "otherBucket": false,
-              "otherBucketLabel": "Other",
-              "missingBucket": false,
-              "missingBucketLabel": "Missing"
+            id: '2',
+            enabled: true,
+            type: 'terms',
+            params: {
+              field: 'data.office365.UserId',
+              orderBy: '1',
+              order: 'desc',
+              size: 5,
+              otherBucket: false,
+              otherBucketLabel: 'Other',
+              missingBucket: false,
+              missingBucketLabel: 'Missing',
             },
-            "schema": "segment"
+            schema: 'segment',
           },
           {
-            "id": "3",
-            "enabled": true,
-            "type": "terms",
-            "params": {
-              "field": "data.office365.Subscription",
-              "orderBy": "1",
-              "order": "desc",
-              "size": 5,
-              "otherBucket": false,
-              "otherBucketLabel": "Other",
-              "missingBucket": false,
-              "missingBucketLabel": "Missing"
+            id: '3',
+            enabled: true,
+            type: 'terms',
+            params: {
+              field: 'data.office365.Subscription',
+              orderBy: '1',
+              order: 'desc',
+              size: 5,
+              otherBucket: false,
+              otherBucketLabel: 'Other',
+              missingBucket: false,
+              missingBucketLabel: 'Missing',
             },
-            "schema": "group"
-          }
+            schema: 'group',
+          },
         ],
-        "params": {
-          "type": "histogram",
-          "grid": {
-            "categoryLines": false
+        params: {
+          type: 'histogram',
+          grid: {
+            categoryLines: false,
           },
-          "categoryAxes": [
+          categoryAxes: [
             {
-              "id": "CategoryAxis-1",
-              "type": "category",
-              "position": "bottom",
-              "show": true,
-              "style": {},
-              "scale": {
-                "type": "linear"
+              id: 'CategoryAxis-1',
+              type: 'category',
+              position: 'bottom',
+              show: true,
+              style: {},
+              scale: {
+                type: 'linear',
               },
-              "labels": {
-                "show": true,
-                "filter": true,
-                "truncate": 100,
-                "rotate": 0
+              labels: {
+                show: true,
+                filter: true,
+                truncate: 100,
+                rotate: 0,
               },
-              "title": {}
-            }
+              title: {},
+            },
           ],
-          "valueAxes": [
+          valueAxes: [
             {
-              "id": "ValueAxis-1",
-              "name": "LeftAxis-1",
-              "type": "value",
-              "position": "left",
-              "show": true,
-              "style": {},
-              "scale": {
-                "type": "linear",
-                "mode": "normal"
+              id: 'ValueAxis-1',
+              name: 'LeftAxis-1',
+              type: 'value',
+              position: 'left',
+              show: true,
+              style: {},
+              scale: {
+                type: 'linear',
+                mode: 'normal',
               },
-              "labels": {
-                "show": true,
-                "rotate": 0,
-                "filter": false,
-                "truncate": 100
+              labels: {
+                show: true,
+                rotate: 0,
+                filter: false,
+                truncate: 100,
               },
-              "title": {
-                "text": "Count"
-              }
-            }
+              title: {
+                text: 'Count',
+              },
+            },
           ],
-          "seriesParams": [
+          seriesParams: [
             {
-              "show": true,
-              "type": "histogram",
-              "mode": "stacked",
-              "data": {
-                "label": "Count",
-                "id": "1"
+              show: true,
+              type: 'histogram',
+              mode: 'stacked',
+              data: {
+                label: 'Count',
+                id: '1',
               },
-              "valueAxis": "ValueAxis-1",
-              "drawLinesBetweenPoints": true,
-              "lineWidth": 2,
-              "showCircles": true
-            }
+              valueAxis: 'ValueAxis-1',
+              drawLinesBetweenPoints: true,
+              lineWidth: 2,
+              showCircles: true,
+            },
           ],
-          "addTooltip": true,
-          "addLegend": true,
-          "legendPosition": "right",
-          "times": [],
-          "addTimeMarker": false,
-          "labels": {
-            "show": false
+          addTooltip: true,
+          addLegend: true,
+          legendPosition: 'right',
+          times: [],
+          addTimeMarker: false,
+          labels: {
+            show: false,
           },
-          "thresholdLine": {
-            "show": false,
-            "value": 10,
-            "width": 1,
-            "style": "full",
-            "color": "#E7664C"
-          }
-        }
+          thresholdLine: {
+            show: false,
+            value: 10,
+            width: 1,
+            style: 'full',
+            color: '#E7664C',
+          },
+        },
       }),
       uiStateJSON: '{}',
       description: '',
@@ -2371,6 +2371,323 @@ export default [
           index: 'wazuh-alerts',
           query: { query: '', language: 'lucene' },
           filter: [],
+        }),
+      },
+    },
+  },
+  {
+    _id: 'Wazuh-App-Overview-Office-Country-Tag-Cloud',
+    _type: 'visualization',
+    _source: {
+      title: 'Country of origin',
+      visState: JSON.stringify({
+        title: 'Country tag cloud',
+        type: 'tagcloud',
+        aggs: [
+          {
+            id: '1',
+            enabled: true,
+            type: 'count',
+            params: {},
+            schema: 'metric',
+          },
+          {
+            id: '2',
+            enabled: true,
+            type: 'terms',
+            params: {
+              field: 'GeoLocation.country_name',
+              orderBy: '1',
+              order: 'desc',
+              size: 5,
+              otherBucket: false,
+              otherBucketLabel: 'Other',
+              missingBucket: false,
+              missingBucketLabel: 'Missing',
+            },
+            schema: 'segment',
+          },
+        ],
+        params: {
+          scale: 'linear',
+          orientation: 'right angled',
+          minFontSize: 18,
+          maxFontSize: 72,
+          showLabel: false,
+        },
+      }),
+      uiStateJSON: '{}',
+      description: '',
+      version: 1,
+      kibanaSavedObjectMeta: {
+        searchSourceJSON: JSON.stringify({
+          index: 'wazuh-alerts',
+          filter: [],
+          query: { query: '', language: 'lucene' },
+        }),
+      },
+    },
+  },
+  {
+    _id: 'Wazuh-App-Overview-Office-Alerts-Evolution-By-UserID',
+    _type: 'visualization',
+    _source: {
+      title: 'Alerts by user',
+      visState: JSON.stringify({
+        title: 'Alerts evolution over time',
+        type: 'line',
+        aggs: [
+          {
+            id: '1',
+            enabled: true,
+            type: 'count',
+            params: {
+              customLabel: 'Alerts',
+            },
+            schema: 'metric',
+          },
+          {
+            id: '2',
+            enabled: true,
+            type: 'date_histogram',
+            params: {
+              field: 'timestamp',
+              timeRange: {
+                from: 'now-1w',
+                to: 'now',
+              },
+              useNormalizedEsInterval: true,
+              scaleMetricValues: false,
+              interval: 'auto',
+              drop_partials: false,
+              min_doc_count: 1,
+              extended_bounds: {},
+            },
+            schema: 'segment',
+          },
+          {
+            id: '3',
+            enabled: true,
+            type: 'terms',
+            params: {
+              field: 'data.office365.UserId',
+              orderBy: '1',
+              order: 'desc',
+              size: 5,
+              otherBucket: false,
+              otherBucketLabel: 'Other',
+              missingBucket: false,
+              missingBucketLabel: 'Missing',
+              customLabel: 'User ID',
+            },
+            schema: 'group',
+          },
+        ],
+        params: {
+          type: 'line',
+          grid: {
+            categoryLines: false,
+          },
+          categoryAxes: [
+            {
+              id: 'CategoryAxis-1',
+              type: 'category',
+              position: 'bottom',
+              show: true,
+              style: {},
+              scale: {
+                type: 'linear',
+              },
+              labels: {
+                show: true,
+                filter: true,
+                truncate: 100,
+              },
+              title: {},
+            },
+          ],
+          valueAxes: [
+            {
+              id: 'ValueAxis-1',
+              name: 'LeftAxis-1',
+              type: 'value',
+              position: 'left',
+              show: true,
+              style: {},
+              scale: {
+                type: 'linear',
+                mode: 'normal',
+              },
+              labels: {
+                show: true,
+                rotate: 0,
+                filter: false,
+                truncate: 100,
+              },
+              title: {
+                text: 'Alerts',
+              },
+            },
+          ],
+          seriesParams: [
+            {
+              show: true,
+              type: 'line',
+              mode: 'normal',
+              data: {
+                label: 'Alerts',
+                id: '1',
+              },
+              valueAxis: 'ValueAxis-1',
+              drawLinesBetweenPoints: true,
+              lineWidth: 2,
+              interpolate: 'linear',
+              showCircles: true,
+            },
+          ],
+          addTooltip: true,
+          addLegend: true,
+          legendPosition: 'right',
+          times: [],
+          addTimeMarker: false,
+          labels: {},
+          thresholdLine: {
+            show: false,
+            value: 10,
+            width: 1,
+            style: 'full',
+            color: '#E7664C',
+          },
+          row: true,
+        },
+      }),
+      uiStateJSON: '{}',
+      description: '',
+      version: 1,
+      kibanaSavedObjectMeta: {
+        searchSourceJSON: JSON.stringify({
+          index: 'wazuh-alerts',
+          filter: [],
+          query: { query: '', language: 'lucene' },
+        }),
+      },
+    },
+  },
+  {
+    _id: 'Wazuh-App-Overview-Office-Top-Users',
+    _type: 'visualization',
+    _source: {
+      title: 'Top Office Users',
+      visState: JSON.stringify({
+        title: 'Alerts by user',
+        type: 'pie',
+        aggs: [
+          {
+            id: '1',
+            enabled: true,
+            type: 'count',
+            params: {},
+            schema: 'metric',
+          },
+          {
+            id: '2',
+            enabled: true,
+            type: 'terms',
+            params: {
+              field: 'data.office365.UserId',
+              orderBy: '1',
+              order: 'desc',
+              size: 5,
+              otherBucket: false,
+              otherBucketLabel: 'Other',
+              missingBucket: false,
+              missingBucketLabel: 'Missing',
+            },
+            schema: 'segment',
+          },
+        ],
+        params: {
+          type: 'pie',
+          addTooltip: true,
+          addLegend: true,
+          legendPosition: 'right',
+          isDonut: true,
+          labels: {
+            show: false,
+            values: true,
+            last_level: true,
+            truncate: 100,
+          },
+        },
+      }),
+      uiStateJSON: '{}',
+      description: '',
+      version: 1,
+      kibanaSavedObjectMeta: {
+        searchSourceJSON: JSON.stringify({
+          index: 'wazuh-alerts',
+          filter: [],
+          query: { query: '', language: 'lucene' },
+        }),
+      },
+    },
+  },
+  {
+    _id: 'Wazuh-App-Overview-Office-Top-Operations',
+    _type: 'visualization',
+    _source: {
+      title: 'Top Operations',
+      visState: JSON.stringify({
+        title: 'Top Operations',
+        type: 'pie',
+        aggs: [
+          {
+            id: '1',
+            enabled: true,
+            type: 'count',
+            params: {},
+            schema: 'metric',
+          },
+          {
+            id: '2',
+            enabled: true,
+            type: 'terms',
+            params: {
+              field: 'data.office365.Operation',
+              orderBy: '1',
+              order: 'desc',
+              size: 5,
+              otherBucket: false,
+              otherBucketLabel: 'Other',
+              missingBucket: false,
+              missingBucketLabel: 'Missing',
+              customLabel: 'Operation',
+            },
+            schema: 'segment',
+          },
+        ],
+        params: {
+          type: 'pie',
+          addTooltip: true,
+          addLegend: true,
+          legendPosition: 'right',
+          isDonut: true,
+          labels: {
+            show: false,
+            values: true,
+            last_level: true,
+            truncate: 100,
+          },
+        },
+      }),
+      uiStateJSON: '{}',
+      description: '',
+      version: 1,
+      kibanaSavedObjectMeta: {
+        searchSourceJSON: JSON.stringify({
+          index: 'wazuh-alerts',
+          filter: [],
+          query: { query: '', language: 'lucene' },
         }),
       },
     },


### PR DESCRIPTION
In this PR I am adding 2 new aggregation tables to the Office 365 module, bringing the total up to four.

These new table are:

- **Rules table:** Shows top 5 triggered rules, with a drilldown menu that shows what operations happened for each rule, which users triggered it and where it was triggered from.
- **Operations table:** Shows top 5 operations, with which users performed them, when and where from.

![image](https://user-images.githubusercontent.com/80431234/128018213-440ef128-1643-4cc0-a7f8-eb2c5b10a6e3.png)
![image](https://user-images.githubusercontent.com/80431234/128018356-dd7950d9-db7e-49b5-ad01-6b590aa23ea2.png)


Closes #3511 