### PR TITLE
Pagination in Drilldown tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Created a separate component to check for sample data [#3475](https://github.com/wazuh/wazuh-kibana-app/pull/3475)
 - Added a new hook for getting value suggestions [#3506](https://github.com/wazuh/wazuh-kibana-app/pull/3506)
 - Added base Module Panel view with Office365 setup [3518](https://github.com/wazuh/wazuh-kibana-app/pull/3518)
+- Adding pagination in GitHub Drilldown tables [3534](https://github.com/wazuh/wazuh-kibana-app/pull/3534)
 
 ### Changed
 

--- a/public/components/common/modules/panel/components/agg-table.tsx
+++ b/public/components/common/modules/panel/components/agg-table.tsx
@@ -62,6 +62,10 @@ export const AggTable = ({
       direction: 'desc',
     },
   };
+  const pagination = {
+    hidePerPageOptions: true,
+    pageSize: 10,
+  };
   return (
     <EuiPanel data-test-subj={`${aggTerm}-aggTable`} {...panelProps}>
       <EuiTitle {...titleProps}>
@@ -73,7 +77,7 @@ export const AggTable = ({
         loading={isLoading}
         rowProps={getRowProps}
         error={error ? error.message : undefined}
-        pagination={{ pageSizeOptions: [5, 10, 20] }}
+        pagination={pagination}
         sorting={sorting}
       />
     </EuiPanel>

--- a/public/components/common/modules/panel/components/agg-table.tsx
+++ b/public/components/common/modules/panel/components/agg-table.tsx
@@ -11,7 +11,7 @@
  * Find more information about this on the LICENSE file.
  */
 
-import { EuiBasicTable, EuiPanel, EuiTitle, EuiBasicTableColumn } from '@elastic/eui';
+import { EuiPanel, EuiTitle, EuiBasicTableColumn, EuiInMemoryTable } from '@elastic/eui';
 import { useEsSearch } from '../../../hooks';
 import React from 'react';
 
@@ -56,18 +56,25 @@ export const AggTable = ({
       },
     };
   };
-
+  const sorting = {
+    sort: {
+      field: 'doc_count',
+      direction: 'desc',
+    },
+  };
   return (
     <EuiPanel data-test-subj={`${aggTerm}-aggTable`} {...panelProps}>
       <EuiTitle {...titleProps}>
         <h2>{tableTitle}</h2>
       </EuiTitle>
-      <EuiBasicTable
-        items={buckets}
+      <EuiInMemoryTable
         columns={columns}
-        rowProps={getRowProps}
+        items={buckets}
         loading={isLoading}
+        rowProps={getRowProps}
         error={error ? error.message : undefined}
+        pagination={{ pageSizeOptions: [5, 10, 20] }}
+        sorting={sorting}
       />
     </EuiPanel>
   );

--- a/public/components/overview/github-panel/config/main.tsx
+++ b/public/components/overview/github-panel/config/main.tsx
@@ -28,7 +28,7 @@ export const MainViewConfig = {
                 tableTitle='Actors'
                 aggTerm='data.github.actor'
                 aggLabel='Actor'
-                maxRows={5} 
+                maxRows={100} 
                 onRowClick={props.onRowClick} />
             </EuiFlexItem>)
         },

--- a/public/components/overview/github-panel/config/main.tsx
+++ b/public/components/overview/github-panel/config/main.tsx
@@ -16,6 +16,7 @@ import {
   EuiFlexItem 
 } from '@elastic/eui';
 
+const maxRows = 100;
 export const MainViewConfig = {
   rows: [
     {
@@ -28,7 +29,7 @@ export const MainViewConfig = {
                 tableTitle='Actors'
                 aggTerm='data.github.actor'
                 aggLabel='Actor'
-                maxRows={100} 
+                maxRows={maxRows} 
                 onRowClick={props.onRowClick} />
             </EuiFlexItem>)
         },
@@ -40,7 +41,7 @@ export const MainViewConfig = {
                 tableTitle='Organizations'
                 aggTerm='data.github.org'
                 aggLabel='Organization'
-                maxRows={5} 
+                maxRows={maxRows} 
                 onRowClick={props.onRowClick} />
             </EuiFlexItem>)
         }
@@ -56,7 +57,7 @@ export const MainViewConfig = {
                 tableTitle='Repositories'
                 aggTerm='data.github.repo'
                 aggLabel='Repository'
-                maxRows={5} 
+                maxRows={maxRows} 
                 onRowClick={props.onRowClick} />
             </EuiFlexItem>)
         },
@@ -68,7 +69,7 @@ export const MainViewConfig = {
                 tableTitle='Actions'
                 aggTerm='data.github.action'
                 aggLabel='Action'
-                maxRows={5} 
+                maxRows={maxRows} 
                 onRowClick={props.onRowClick} />
             </EuiFlexItem>)
         } 


### PR DESCRIPTION
Hi guys,

In this PR we switch from basic tables to memory tables to be able to show the paginated tables.

![image](https://user-images.githubusercontent.com/17100196/128167641-627504e8-5798-4b1b-8e4a-ba058f4731da.png)

To test it we will only have to get into the GitHub module and go to the Panel tab