### PR TITLE
Changed props for Discover

### DIFF
--- a/public/components/agents/fim/inventory/fileDetail.tsx
+++ b/public/components/agents/fim/inventory/fileDetail.tsx
@@ -479,12 +479,22 @@ export class FileDetails extends Component {
                 kbnSearchBar
                 shareFilterManager={this.discoverFilterManager}
                 initialColumns={[
-                  'icon',
-                  'timestamp',
-                  'syscheck.event',
-                  'rule.description',
-                  'rule.level',
-                  'rule.id',
+                  { field: 'icon' },
+                  { field: 'timestamp' },
+                  { field: 'agent.id', label: 'Agent' },
+                  { field: 'agent.name', label: 'Agent name' },
+                  { field: 'syscheck.event', label: 'Action' },
+                  { field: 'rule.description', label: 'Description' },
+                  { field: 'rule.level', label: 'Level' },
+                  { field: 'rule.id', label: 'Rule ID' },
+                ]}
+                initialAgentColumns={[
+                  { field: 'icon' },
+                  { field: 'timestamp' },
+                  { field: 'syscheck.event', label: 'Action' },
+                  { field: 'rule.description', label: 'Description' },
+                  { field: 'rule.level', label: 'Level' },
+                  { field: 'rule.id', label: 'Rule ID' },
                 ]}
                 includeFilters="syscheck"
                 implicitFilters={implicitFilters}

--- a/public/components/agents/fim/inventory/fileDetail.tsx
+++ b/public/components/agents/fim/inventory/fileDetail.tsx
@@ -95,7 +95,7 @@ export class FileDetails extends Component {
         grow: 2,
         icon: 'clock',
         link: true,
-        transformValue: formatUIDate
+        transformValue: formatUIDate,
       },
       {
         field: 'mtime',
@@ -103,7 +103,7 @@ export class FileDetails extends Component {
         grow: 2,
         icon: 'clock',
         link: true,
-        transformValue: formatUIDate
+        transformValue: formatUIDate,
       },
       {
         field: 'uname',
@@ -183,15 +183,15 @@ export class FileDetails extends Component {
         name: 'Last analysis',
         grow: 2,
         icon: 'clock',
-        transformValue: formatUIDate
+        transformValue: formatUIDate,
       },
       {
         field: 'mtime',
         name: 'Last modified',
         grow: 2,
         icon: 'clock',
-        transformValue: formatUIDate
-      }
+        transformValue: formatUIDate,
+      },
     ];
   }
 
@@ -264,7 +264,10 @@ export class FileDetails extends Component {
 
   getDetails() {
     const { view } = this.props;
-    const columns = this.props.type === 'registry_key' || this.props.currentFile.type === 'registry_key' ? this.registryDetails() : this.details();
+    const columns =
+      this.props.type === 'registry_key' || this.props.currentFile.type === 'registry_key'
+        ? this.registryDetails()
+        : this.details();
     const generalDetails = columns.map((item, idx) => {
       var value = this.props.currentFile[item.field] || '-';
       if (item.transformValue) {
@@ -418,29 +421,27 @@ export class FileDetails extends Component {
         >
           <div className="flyout-row details-row">{this.getDetails()}</div>
         </EuiAccordion>
-        { (type === 'registry_key' || currentFile.type === 'registry_key') && <>
-        <EuiSpacer size="s" />
-        <EuiAccordion
-          id={fileName === undefined ? Math.random().toString() : `${fileName}_values`}
-          buttonContent={
-            <EuiTitle size="s">
-              <h3>
-                Registry values                
-              </h3>
-            </EuiTitle>
-          }
-          paddingSize="none"
-          initialIsOpen={true}
-        >
-          <EuiFlexGroup className="flyout-row">
-            <EuiFlexItem>
-              <RegistryValues 
-                currentFile={currentFile}
-                agent={agent}
-              />
-            </EuiFlexItem>
-          </EuiFlexGroup>
-        </EuiAccordion> </>}
+        {(type === 'registry_key' || currentFile.type === 'registry_key') && (
+          <>
+            <EuiSpacer size="s" />
+            <EuiAccordion
+              id={fileName === undefined ? Math.random().toString() : `${fileName}_values`}
+              buttonContent={
+                <EuiTitle size="s">
+                  <h3>Registry values</h3>
+                </EuiTitle>
+              }
+              paddingSize="none"
+              initialIsOpen={true}
+            >
+              <EuiFlexGroup className="flyout-row">
+                <EuiFlexItem>
+                  <RegistryValues currentFile={currentFile} agent={agent} />
+                </EuiFlexItem>
+              </EuiFlexGroup>
+            </EuiAccordion>{' '}
+          </>
+        )}
         <EuiSpacer />
         <EuiAccordion
           id={fileName === undefined ? Math.random().toString() : `${fileName}_events`}

--- a/public/components/agents/vuls/inventory/detail.tsx
+++ b/public/components/agents/vuls/inventory/detail.tsx
@@ -32,7 +32,7 @@ import { getIndexPattern } from '../../../overview/mitre/lib';
 import moment from 'moment-timezone';
 import { AppNavigate } from '../../../../react-services/app-navigate';
 import { TruncateHorizontalComponents } from '../../../common/util';
-import { getDataPlugin,getUiSettings } from '../../../../kibana-services';
+import { getDataPlugin, getUiSettings } from '../../../../kibana-services';
 import { FilterManager } from '../../../../../../../src/plugins/data/public/';
 
 export class Details extends Component {
@@ -112,7 +112,7 @@ export class Details extends Component {
         name: 'Architecture',
         icon: 'node',
         link: false,
-      }
+      },
     ];
   }
 
@@ -138,7 +138,11 @@ export class Details extends Component {
     const { cve } = this.props.currentItem;
     const filters = [
       {
-        ...buildPhraseFilter({ name: 'data.vulnerability.cve', type: 'text' }, cve, this.indexPattern),
+        ...buildPhraseFilter(
+          { name: 'data.vulnerability.cve', type: 'text' },
+          cve,
+          this.indexPattern
+        ),
         $state: { store: 'appState' },
       },
     ];
@@ -151,7 +155,6 @@ export class Details extends Component {
     const { filterManager } = getDataPlugin().query;
     const _filters = filterManager.getFilters();
     if (_filters && _filters.length) {
-     
       filterManager.addFilters([filters]);
       const scope = await ModulesHelper.getDiscoverScope();
       scope.updateQueryAndFetch && scope.updateQueryAndFetch({ query: null });
@@ -188,7 +191,7 @@ export class Details extends Component {
       }
       var link = (item.link && !['events', 'extern'].includes(view)) || false;
       const agentPlatform = ((this.props.agent || {}).os || {}).platform;
-      
+
       if (!item.onlyLinux || (item.onlyLinux && this.props.agent && agentPlatform !== 'windows')) {
         let className = item.checksum ? 'detail-value detail-value-checksum' : 'detail-value';
         className += item.field === 'perm' ? ' detail-value-perm' : '';
@@ -303,7 +306,6 @@ export class Details extends Component {
     return value;
   }
 
-
   render() {
     const { type, implicitFilters, view, currentItem, agent } = this.props;
     const id = `${currentItem.name}-${currentItem.cve}-${currentItem.architecture}-${currentItem.version}`;
@@ -358,13 +360,7 @@ export class Details extends Component {
               <Discover
                 kbnSearchBar
                 shareFilterManager={this.discoverFilterManager}
-                initialColumns={[
-                  'icon',
-                  'timestamp',
-                  'rule.description',
-                  'rule.level',
-                  'rule.id',
-                ]}
+                initialColumns={['icon', 'timestamp', 'rule.description', 'rule.level', 'rule.id']}
                 includeFilters="vulnerability"
                 implicitFilters={implicitFilters}
                 initialFilters={[]}

--- a/public/components/agents/vuls/inventory/detail.tsx
+++ b/public/components/agents/vuls/inventory/detail.tsx
@@ -360,7 +360,22 @@ export class Details extends Component {
               <Discover
                 kbnSearchBar
                 shareFilterManager={this.discoverFilterManager}
-                initialColumns={['icon', 'timestamp', 'rule.description', 'rule.level', 'rule.id']}
+                initialColumns={[
+                  { field: 'icon' },
+                  { field: 'timestamp' },
+                  { field: 'agent.id', label: 'Agent' },
+                  { field: 'agent.name', label: 'Agent name' },
+                  { field: 'rule.description', label: 'Description' },
+                  { field: 'rule.level', label: 'Level' },
+                  { field: 'rule.id', label: 'Rule ID' },
+                ]}
+                initialAgentColumns={[
+                  { field: 'icon' },
+                  { field: 'timestamp' },
+                  { field: 'rule.description', label: 'Description' },
+                  { field: 'rule.level', label: 'Level' },
+                  { field: 'rule.id', label: 'Rule ID' },
+                ]}
                 includeFilters="vulnerability"
                 implicitFilters={implicitFilters}
                 initialFilters={[]}

--- a/public/components/common/modules/discover/discover.tsx
+++ b/public/components/common/modules/discover/discover.tsx
@@ -30,20 +30,20 @@ import { UI_ERROR_SEVERITIES } from '../../../../react-services/error-orchestrat
 import { getErrorOrchestrator } from '../../../../react-services/common-services';
 
 import {
- EuiBasicTable,
- EuiLoadingContent,
- EuiTableSortingType,
- EuiFlexItem,
- EuiFlexGroup,
- Direction,
- EuiOverlayMask,
- EuiOutsideClickDetector,
- EuiSpacer,
- EuiCallOut,
- EuiIcon,
- EuiButtonIcon,
- EuiButtonEmpty,
- EuiToolTip
+  EuiBasicTable,
+  EuiLoadingContent,
+  EuiTableSortingType,
+  EuiFlexItem,
+  EuiFlexGroup,
+  Direction,
+  EuiOverlayMask,
+  EuiOutsideClickDetector,
+  EuiSpacer,
+  EuiCallOut,
+  EuiIcon,
+  EuiButtonIcon,
+  EuiButtonEmpty,
+  EuiToolTip,
 } from '@elastic/eui';
 import {
   IIndexPattern,
@@ -738,71 +738,83 @@ export const Discover = compose(
 
       const columns = this.columns();
 
-    const sorting: EuiTableSortingType<{}> = {
-      sort: {
-        //@ts-ignore
-        field: this.state.sortField,
-        direction: this.state.sortDirection,
-      }
-    };
-    const pagination = {
-      pageIndex: this.state.pageIndex,
-      pageSize: this.state.pageSize,
-      totalItemCount: this.state.total > 10000 ? 10000 : this.state.total,
-      pageSizeOptions: [10, 25, 50],
-    };
-    const noResultsText = `No results match for this search criteria`;
-    let flyout = this.state.showMitreFlyout ? <EuiOverlayMask headerZindexLocation="below">
-      <EuiOutsideClickDetector onOutsideClick={this.closeMitreFlyout}>
-        <div>{/* EuiOutsideClickDetector needs a static first child */}
-          <FlyoutTechnique
-            openDashboard={(e, itemId) => this.openDashboard(e, itemId)}
-            openDiscover={(e, itemId) => this.openDiscover(e, itemId)}
-            onChangeFlyout={this.onMitreChangeFlyout}
-            currentTechnique={this.state.selectedTechnique} />
+      const sorting: EuiTableSortingType<{}> = {
+        sort: {
+          //@ts-ignore
+          field: this.state.sortField,
+          direction: this.state.sortDirection,
+        },
+      };
+      const pagination = {
+        pageIndex: this.state.pageIndex,
+        pageSize: this.state.pageSize,
+        totalItemCount: this.state.total > 10000 ? 10000 : this.state.total,
+        pageSizeOptions: [10, 25, 50],
+      };
+      const noResultsText = `No results match for this search criteria`;
+      let flyout = this.state.showMitreFlyout ? (
+        <EuiOverlayMask headerZindexLocation="below">
+          <EuiOutsideClickDetector onOutsideClick={this.closeMitreFlyout}>
+            <div>
+              {/* EuiOutsideClickDetector needs a static first child */}
+              <FlyoutTechnique
+                openDashboard={(e, itemId) => this.openDashboard(e, itemId)}
+                openDiscover={(e, itemId) => this.openDiscover(e, itemId)}
+                onChangeFlyout={this.onMitreChangeFlyout}
+                currentTechnique={this.state.selectedTechnique}
+              />
+            </div>
+          </EuiOutsideClickDetector>
+        </EuiOverlayMask>
+      ) : (
+        <></>
+      );
+      return (
+        <div className="wz-discover hide-filter-control wz-inventory">
+          {this.props.kbnSearchBar && (
+            <KbnSearchBar
+              indexPattern={this.indexPattern}
+              filterManager={this.props.shareFilterManager}
+              timeFilter={{
+                timeFilter: this.state.dateRange,
+                timeHistory: this.state.dateRangeHistory,
+                setTimeFilter: (dateRange) => this.setState({ dateRange }),
+              }}
+              onQuerySubmit={this.onQuerySubmit}
+              onFiltersUpdated={this.onFiltersUpdated}
+              query={query}
+            />
+          )}
+          {total ? (
+            <EuiFlexGroup>
+              <EuiFlexItem>
+                {this.state.alerts.length && (
+                  <EuiBasicTable
+                    items={this.state.alerts.map((alert) => ({ ...alert._source, _id: alert._id }))}
+                    className="module-discover-table"
+                    itemId="_id"
+                    itemIdToExpandedRowMap={itemIdToExpandedRowMap}
+                    isExpandable={true}
+                    columns={columns}
+                    rowProps={getRowProps}
+                    pagination={pagination}
+                    sorting={sorting}
+                    onChange={this.onTableChange}
+                  />
+                )}
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          ) : (
+            <EuiFlexGroup>
+              <EuiFlexItem>
+                <EuiSpacer size="s" />
+                <EuiCallOut title={noResultsText} color="warning" iconType="alert" />
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          )}
+          {flyout}
         </div>
-      </EuiOutsideClickDetector>
-    </EuiOverlayMask> : <></>;
-    return (
-      <div
-        className='wz-discover hide-filter-control wz-inventory' >
-        {this.props.kbnSearchBar && <KbnSearchBar
-          indexPattern={this.indexPattern}
-          filterManager={this.props.shareFilterManager}
-          timeFilter={{timeFilter:this.state.dateRange,
-            timeHistory:this.state.dateRangeHistory,
-            setTimeFilter:(dateRange)=> this.setState({dateRange})}}
-          onQuerySubmit={this.onQuerySubmit}
-          onFiltersUpdated={this.onFiltersUpdated}
-          query={query} />
-        }
-        {total
-          ? <EuiFlexGroup>
-            <EuiFlexItem>
-              {this.state.alerts.length && (
-                <EuiBasicTable
-                  items={this.state.alerts.map(alert => ({...alert._source, _id: alert._id}))}
-                  className="module-discover-table"
-                  itemId="_id"
-                  itemIdToExpandedRowMap={itemIdToExpandedRowMap}
-                  isExpandable={true}
-                  columns={columns}
-                  rowProps={getRowProps}
-                  pagination={pagination}
-                  sorting={sorting}
-                  onChange={this.onTableChange}
-                />
-              )}
-            </EuiFlexItem>
-          </EuiFlexGroup>
-          : <EuiFlexGroup>
-            <EuiFlexItem>
-              <EuiSpacer size="s" />
-              <EuiCallOut title={noResultsText} color="warning" iconType="alert" />
-            </EuiFlexItem>
-          </EuiFlexGroup>
-        }
-        {flyout}
-      </div>);
+      );
+    }
   }
-});
+);

--- a/public/components/overview/compliance-table/components/requirement-flyout/requirement-flyout.tsx
+++ b/public/components/overview/compliance-table/components/requirement-flyout/requirement-flyout.tsx
@@ -11,21 +11,21 @@
  */
 import React, { Component } from 'react';
 import {
-    EuiFlyout,
-    EuiFlyoutHeader,
-    EuiLoadingContent,
-    EuiTitle,
-    EuiToolTip,
-    EuiIcon,
-    EuiFlyoutBody,
-    EuiAccordion,
-    EuiFlexGroup,
-    EuiText,
-    EuiFlexItem,
-    EuiLink,
-    EuiStat,
-    EuiDescriptionList,
-    EuiSpacer
+  EuiFlyout,
+  EuiFlyoutHeader,
+  EuiLoadingContent,
+  EuiTitle,
+  EuiToolTip,
+  EuiIcon,
+  EuiFlyoutBody,
+  EuiAccordion,
+  EuiFlexGroup,
+  EuiText,
+  EuiFlexItem,
+  EuiLink,
+  EuiStat,
+  EuiDescriptionList,
+  EuiSpacer,
 } from '@elastic/eui';
 import { Discover } from '../../../../common/modules/discover';
 import { AppState } from '../../../../../react-services/app-state';
@@ -33,185 +33,208 @@ import { requirementGoal } from '../../requirement-goal';
 import { getUiSettings } from '../../../../../kibana-services';
 import { FilterManager } from '../../../../../../../../src/plugins/data/public/';
 
-
-
 export class RequirementFlyout extends Component {
-    _isMount = false;
-    state: {
+  _isMount = false;
+  state: {};
+
+  props!: {};
+
+  filterManager: FilterManager;
+
+  constructor(props) {
+    super(props);
+    this.state = {};
+    this.filterManager = new FilterManager(getUiSettings());
+  }
+
+  componentDidMount() {
+    this._isMount = true;
+  }
+
+  renderHeader() {
+    const { currentRequirement } = this.props;
+    return (
+      <EuiFlyoutHeader hasBorder style={{ padding: '12px 16px' }}>
+        {(!currentRequirement && (
+          <div>
+            <EuiLoadingContent lines={1} />
+          </div>
+        )) || (
+          <EuiTitle size="m">
+            <h2 id="flyoutSmallTitle">Requirement {currentRequirement}</h2>
+          </EuiTitle>
+        )}
+      </EuiFlyoutHeader>
+    );
+  }
+
+  updateTotalHits = (total) => {
+    this.setState({ totalHits: total });
+  };
+
+  renderBody() {
+    const { currentRequirement } = this.props;
+    const requirementImplicitFilter = {};
+    const isCluster = (AppState.getClusterInfo() || {}).status === 'enabled';
+    const clusterFilter = isCluster
+      ? { 'cluster.name': AppState.getClusterInfo().cluster }
+      : { 'manager.name': AppState.getClusterInfo().manager };
+    this.clusterFilter = clusterFilter;
+    requirementImplicitFilter[this.props.getRequirementKey()] = currentRequirement;
+
+    const implicitFilters = [requirementImplicitFilter, this.clusterFilter];
+    if (this.props.implicitFilters) {
+      this.props.implicitFilters.forEach((item) => implicitFilters.push(item));
     }
+    //Goal for PCI
+    const currentReq = this.props.currentRequirement.split('.')[0];
 
-    props!: {
-    };
+    return (
+      <EuiFlyoutBody className="flyout-body">
+        <EuiAccordion
+          id={'details'}
+          buttonContent={
+            <EuiTitle size="s">
+              <h3>Details</h3>
+            </EuiTitle>
+          }
+          paddingSize="xs"
+          initialIsOpen={true}
+        >
+          <div className="flyout-row details-row">
+            <EuiSpacer size="xs" />
+            {requirementGoal[currentReq] && (
+              <EuiFlexGroup style={{ marginBottom: 10 }}>
+                <EuiFlexItem grow={false}>
+                  <EuiIcon size="l" type={'bullseye'} color="primary" style={{ marginTop: 8 }} />
+                </EuiFlexItem>
+                <EuiFlexItem style={{ marginLeft: 2 }} grow={true}>
+                  <EuiText style={{ marginLeft: 8, fontSize: 14 }}>
+                    <p style={{ fontWeight: 500, marginBottom: 2 }}>Goals</p>
 
-    filterManager: FilterManager;
+                    <p>{requirementGoal[currentReq]}</p>
+                  </EuiText>
+                </EuiFlexItem>
+              </EuiFlexGroup>
+            )}
 
-    constructor(props) {
-        super(props);
-        this.state = {
-        }
-        this.filterManager = new FilterManager(getUiSettings());
-    }
+            <EuiFlexGroup>
+              <EuiFlexItem grow={false}>
+                <EuiIcon size="l" type={'filebeatApp'} color="primary" style={{ marginTop: 8 }} />
+              </EuiFlexItem>
+              <EuiFlexItem style={{ marginLeft: 2 }} grow={true}>
+                <EuiText style={{ marginLeft: 8, fontSize: 14 }}>
+                  <p style={{ fontWeight: 500, marginBottom: 2 }}>Requirement description</p>
 
-    componentDidMount() {
-        this._isMount = true;
-    }
+                  <p>{this.props.description}</p>
+                </EuiText>
+              </EuiFlexItem>
+            </EuiFlexGroup>
+            <EuiSpacer size="xs" />
+          </div>
+        </EuiAccordion>
 
-    renderHeader() {
-        const { currentRequirement } = this.props;
-        return (
-            <EuiFlyoutHeader hasBorder style={{ padding: "12px 16px" }}>
-                {(!currentRequirement && (
-                    <div>
-                        <EuiLoadingContent lines={1} />
-                    </div>
-                )) || (
-                        <EuiTitle size="m">
-                            <h2 id="flyoutSmallTitle">
-                                Requirement  {currentRequirement}
-                            </h2>
-                        </EuiTitle>
-                    )}
-            </EuiFlyoutHeader>
-        )
-    }
+        <EuiSpacer size="s" />
+        <EuiAccordion
+          style={{ textDecoration: 'none' }}
+          id={'recent_events'}
+          className="events-accordion"
+          extraAction={
+            <div style={{ marginBottom: 5 }}>
+              <strong>{this.state.totalHits || 0}</strong> hits
+            </div>
+          }
+          buttonContent={
+            <EuiTitle size="s">
+              <h3>
+                Recent events
+                {this.props.view !== 'events' && (
+                  <span style={{ marginLeft: 16 }}>
+                    <span>
+                      <EuiToolTip
+                        position="top"
+                        content={'Show ' + currentRequirement + ' in Dashboard'}
+                      >
+                        <EuiIcon
+                          onMouseDown={(e) => {
+                            this.props.openDashboard(e, currentRequirement);
+                            e.stopPropagation();
+                          }}
+                          color="primary"
+                          type="visualizeApp"
+                          style={{ marginRight: '10px' }}
+                        ></EuiIcon>
+                      </EuiToolTip>
+                      <EuiToolTip
+                        position="top"
+                        content={'Inspect ' + currentRequirement + ' in Events'}
+                      >
+                        <EuiIcon
+                          onMouseDown={(e) => {
+                            this.props.openDiscover(e, currentRequirement);
+                            e.stopPropagation();
+                          }}
+                          color="primary"
+                          type="discoverApp"
+                        ></EuiIcon>
+                      </EuiToolTip>
+                    </span>
+                  </span>
+                )}
+              </h3>
+            </EuiTitle>
+          }
+          paddingSize="none"
+          initialIsOpen={true}
+        >
+          <EuiFlexGroup className="flyout-row">
+            <EuiFlexItem>
+              <Discover
+                kbnSearchBar
+                shareFilterManager={this.filterManager}
+                initialColumns={[
+                  'icon',
+                  'timestamp',
+                  this.props.getRequirementKey(),
+                  'rule.level',
+                  'rule.id',
+                  'rule.description',
+                ]}
+                implicitFilters={implicitFilters}
+                initialFilters={[]}
+                updateTotalHits={(total) => this.updateTotalHits(total)}
+              />
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        </EuiAccordion>
+      </EuiFlyoutBody>
+    );
+  }
 
-    updateTotalHits = (total) => {
-        this.setState({ totalHits: total });
-    }
+  renderLoading() {
+    return (
+      <EuiFlyoutBody>
+        <EuiLoadingContent lines={2} />
+        <EuiLoadingContent lines={3} />
+      </EuiFlyoutBody>
+    );
+  }
 
-
-    renderBody() {
-        const { currentRequirement } = this.props;
-        const requirementImplicitFilter = {};
-        const isCluster = (AppState.getClusterInfo() || {}).status === "enabled";
-        const clusterFilter = isCluster
-            ? { "cluster.name": AppState.getClusterInfo().cluster }
-            : { "manager.name": AppState.getClusterInfo().manager };
-        this.clusterFilter = clusterFilter;
-        requirementImplicitFilter[this.props.getRequirementKey()] = currentRequirement;
-
-        const implicitFilters = [requirementImplicitFilter, this.clusterFilter];
-        if (this.props.implicitFilters) {
-            this.props.implicitFilters.forEach(item =>
-                implicitFilters.push(item))
-        }
-        //Goal for PCI
-        const currentReq = this.props.currentRequirement.split(".")[0];
-
-        return (
-            <EuiFlyoutBody className="flyout-body" >
-                <EuiAccordion
-                    id={"details"}
-                    buttonContent={
-                        <EuiTitle size="s">
-                            <h3>Details</h3>
-                        </EuiTitle>
-                    }
-                    paddingSize="xs"
-                    initialIsOpen={true}>
-                    <div className='flyout-row details-row'>
-                        <EuiSpacer size="xs" />
-                        {requirementGoal[currentReq] && <EuiFlexGroup style={{marginBottom: 10}}>
-                            <EuiFlexItem grow={false}>
-                                <EuiIcon size="l" type={"bullseye"} color='primary' style={{marginTop: 8}} />
-                            </EuiFlexItem>
-                            <EuiFlexItem style={{marginLeft: 2}} grow={true}>
-                                <EuiText style={{marginLeft: 8, fontSize: 14}}>
-                                    <p style={{fontWeight: 500, marginBottom: 2}}>Goals</p>
-                                    
-                                    <p>{requirementGoal[currentReq]}</p>
-                                </EuiText>
-                            </EuiFlexItem>
-                        </EuiFlexGroup>}
-
-                        <EuiFlexGroup>
-                            <EuiFlexItem grow={false}>
-                                <EuiIcon size="l" type={"filebeatApp"} color='primary' style={{marginTop: 8}} />
-                            </EuiFlexItem>
-                            <EuiFlexItem style={{marginLeft: 2}} grow={true}>
-                                <EuiText style={{marginLeft: 8, fontSize: 14}}>
-                                    <p style={{fontWeight: 500, marginBottom: 2}}>Requirement description</p>
-                                    
-                                    <p>{this.props.description}</p>
-                                </EuiText>
-                            </EuiFlexItem>
-                        </EuiFlexGroup>
-                        <EuiSpacer size="xs" />
-                    </div>
-                </EuiAccordion>
-
-
-                <EuiSpacer size='s' />
-                <EuiAccordion
-                    style={{ textDecoration: 'none' }}
-                    id={"recent_events"}
-                    className='events-accordion'
-                    extraAction={<div style={{ marginBottom: 5 }}><strong>{this.state.totalHits || 0}</strong> hits</div>}
-                    buttonContent={
-                        <EuiTitle size="s">
-                            <h3>
-                                Recent events{this.props.view !== 'events' && (
-                                    <span style={{ marginLeft: 16 }}>
-                                        <span>
-                                            <EuiToolTip position="top" content={"Show " + currentRequirement + " in Dashboard"}>
-                                                <EuiIcon onMouseDown={(e) => { this.props.openDashboard(e, currentRequirement); e.stopPropagation() }} color="primary" type="visualizeApp" style={{ marginRight: '10px' }}></EuiIcon>
-                                            </EuiToolTip>
-                                            <EuiToolTip position="top" content={"Inspect " + currentRequirement + " in Events"} >
-                                                <EuiIcon onMouseDown={(e) => { this.props.openDiscover(e, currentRequirement); e.stopPropagation() }} color="primary" type="discoverApp"></EuiIcon>
-                                            </EuiToolTip>
-                                        </span>
-                                    </span>
-                                )}
-                            </h3>
-                        </EuiTitle>
-                    }
-                    paddingSize="none"
-                    initialIsOpen={true}>
-                    <EuiFlexGroup className="flyout-row">
-                        <EuiFlexItem>
-                            <Discover kbnSearchBar shareFilterManager={this.filterManager} initialColumns={["icon", "timestamp", this.props.getRequirementKey(), 'rule.level', 'rule.id', 'rule.description']} implicitFilters={implicitFilters} initialFilters={[]} updateTotalHits={(total) => this.updateTotalHits(total)} />
-                        </EuiFlexItem>
-                    </EuiFlexGroup>
-                </EuiAccordion>
-
-            </EuiFlyoutBody>
-        );
-    }
-
-
-    renderLoading() {
-        return (
-            <EuiFlyoutBody>
-                <EuiLoadingContent lines={2} />
-                <EuiLoadingContent lines={3} />
-            </EuiFlyoutBody>
-        )
-    }
-
-
-
-
-    render() {
-        const { currentRequirement } = this.props;
-        const { onChangeFlyout } = this.props;
-        return (
-            <EuiFlyout
-                onClose={() => onChangeFlyout(false)}
-                maxWidth="60%"
-                size="l"
-                className="flyout-no-overlap wz-inventory wzApp"
-                aria-labelledby="flyoutSmallTitle"
-            >
-                {currentRequirement &&
-                    this.renderHeader()
-                }
-                {
-                    this.renderBody()
-                }
-                {this.state.loading &&
-                    this.renderLoading()
-                }
-            </EuiFlyout>
-        );
-    }
+  render() {
+    const { currentRequirement } = this.props;
+    const { onChangeFlyout } = this.props;
+    return (
+      <EuiFlyout
+        onClose={() => onChangeFlyout(false)}
+        maxWidth="60%"
+        size="l"
+        className="flyout-no-overlap wz-inventory wzApp"
+        aria-labelledby="flyoutSmallTitle"
+      >
+        {currentRequirement && this.renderHeader()}
+        {this.renderBody()}
+        {this.state.loading && this.renderLoading()}
+      </EuiFlyout>
+    );
+  }
 }

--- a/public/components/overview/compliance-table/components/requirement-flyout/requirement-flyout.tsx
+++ b/public/components/overview/compliance-table/components/requirement-flyout/requirement-flyout.tsx
@@ -193,12 +193,22 @@ export class RequirementFlyout extends Component {
                 kbnSearchBar
                 shareFilterManager={this.filterManager}
                 initialColumns={[
-                  'icon',
-                  'timestamp',
-                  this.props.getRequirementKey(),
-                  'rule.level',
-                  'rule.id',
-                  'rule.description',
+                  { field: 'icon' },
+                  { field: 'timestamp' },
+                  { field: 'agent.id', label: 'Agent' },
+                  { field: 'agent.name', label: 'Agent name' },
+                  { field: this.props.getRequirementKey() },
+                  { field: 'rule.description', label: 'Description' },
+                  { field: 'rule.level', label: 'Level' },
+                  { field: 'rule.id', label: 'Rule ID' },
+                ]}
+                initialAgentColumns={[
+                  { field: 'icon' },
+                  { field: 'timestamp' },
+                  { field: this.props.getRequirementKey() },
+                  { field: 'rule.description', label: 'Description' },
+                  { field: 'rule.level', label: 'Level' },
+                  { field: 'rule.id', label: 'Rule ID' },
                 ]}
                 implicitFilters={implicitFilters}
                 initialFilters={[]}

--- a/public/components/overview/mitre/components/techniques/components/flyout-technique/flyout-technique.tsx
+++ b/public/components/overview/mitre/components/techniques/components/flyout-technique/flyout-technique.tsx
@@ -17,7 +17,7 @@ const md = new MarkdownIt({
   html: true,
   linkify: true,
   breaks: true,
-  typographer: true
+  typographer: true,
 });
 
 import {
@@ -33,7 +33,7 @@ import {
   EuiLink,
   EuiAccordion,
   EuiToolTip,
-  EuiIcon
+  EuiIcon,
 } from '@elastic/eui';
 import { WzRequest } from '../../../../../../../react-services/wz-request';
 import { AppState } from '../../../../../../../react-services/app-state';
@@ -51,16 +51,16 @@ export class FlyoutTechnique extends Component {
 
   state: {
     techniqueData: {
-      [key:string]: any,
-    }
-    loading: boolean
-  }
+      [key: string]: any;
+    };
+    loading: boolean;
+  };
 
   props!: {
-    currentTechniqueData: any
-    currentTechnique: string
-    tacticsObject: any
-  }
+    currentTechniqueData: any;
+    currentTechnique: string;
+    tacticsObject: any;
+  };
 
   filterManager: FilterManager;
 
@@ -70,66 +70,76 @@ export class FlyoutTechnique extends Component {
       techniqueData: {
         // description: ''
       },
-      loading: false
-    }
+      loading: false,
+    };
     this.filterManager = new FilterManager(getUiSettings());
   }
 
   async componentDidMount() {
     this._isMount = true;
-    const isCluster = (AppState.getClusterInfo() || {}).status === "enabled";
-      const clusterFilter = isCluster
-        ? { "cluster.name": AppState.getClusterInfo().cluster }
-        : { "manager.name": AppState.getClusterInfo().manager };
-    this.clusterFilter = clusterFilter ;
+    const isCluster = (AppState.getClusterInfo() || {}).status === 'enabled';
+    const clusterFilter = isCluster
+      ? { 'cluster.name': AppState.getClusterInfo().cluster }
+      : { 'manager.name': AppState.getClusterInfo().manager };
+    this.clusterFilter = clusterFilter;
     await this.getTechniqueData();
     this.addListenersToCitations();
   }
 
   async componentDidUpdate(prevProps) {
     const { currentTechnique } = this.props;
-    if (prevProps.currentTechnique !== currentTechnique ){
+    if (prevProps.currentTechnique !== currentTechnique) {
       await this.getTechniqueData();
     }
     this.addListenersToCitations();
   }
 
-  componentWillUnmount(){
+  componentWillUnmount() {
     // remove listeners of citations if these exist
-    if(this.state.techniqueData && this.state.techniqueData.replaced_external_references && this.state.techniqueData.replaced_external_references.length > 0){
-      this.state.techniqueData.replaced_external_references.forEach(reference => {
-        $(`.technique-reference-${reference.index}`).each(function(){
+    if (
+      this.state.techniqueData &&
+      this.state.techniqueData.replaced_external_references &&
+      this.state.techniqueData.replaced_external_references.length > 0
+    ) {
+      this.state.techniqueData.replaced_external_references.forEach((reference) => {
+        $(`.technique-reference-${reference.index}`).each(function () {
           $(this).off();
         });
-      })
+      });
     }
   }
 
-  addListenersToCitations(){
-    if(this.state.techniqueData && this.state.techniqueData.replaced_external_references && this.state.techniqueData.replaced_external_references.length > 0){
-      this.state.techniqueData.replaced_external_references.forEach(reference => {
-        $(`.technique-reference-citation-${reference.index}`).each(function(){
+  addListenersToCitations() {
+    if (
+      this.state.techniqueData &&
+      this.state.techniqueData.replaced_external_references &&
+      this.state.techniqueData.replaced_external_references.length > 0
+    ) {
+      this.state.techniqueData.replaced_external_references.forEach((reference) => {
+        $(`.technique-reference-citation-${reference.index}`).each(function () {
           $(this).off();
           $(this).click(() => {
-            $(`.euiFlyoutBody__overflow`).scrollTop($(`#technique-reference-${reference.index}`).position().top - 150);
+            $(`.euiFlyoutBody__overflow`).scrollTop(
+              $(`#technique-reference-${reference.index}`).position().top - 150
+            );
           });
-        })
-      })
+        });
+      });
     }
   }
 
   async getTechniqueData() {
-    try{
-      this.setState({loading: true, techniqueData: {}});
+    try {
+      this.setState({ loading: true, techniqueData: {} });
       const { currentTechnique } = this.props;
       const result = await WzRequest.apiReq('GET', '/mitre/techniques', {
         params: {
-          q: `references.external_id=${currentTechnique}`
-        }
+          q: `references.external_id=${currentTechnique}`,
+        },
       });
-      const rawData = (((result || {}).data || {}).data || {}).affected_items
+      const rawData = (((result || {}).data || {}).data || {}).affected_items;
       !!rawData && this.formatTechniqueData(rawData[0]);
-    }catch(error){
+    } catch (error) {
       const options = {
         context: `${FlyoutTechnique.name}.getTechniqueData`,
         level: UI_LOGGER_LEVELS.ERROR,
@@ -143,208 +153,241 @@ export class FlyoutTechnique extends Component {
         },
       };
       getErrorOrchestrator().handleError(options);
-      this.setState({loading: false});
+      this.setState({ loading: false });
     }
   }
 
-  findTacticName(tactics){
+  findTacticName(tactics) {
     const { tacticsObject } = this.props;
     return tactics.map((element) => {
-      const tactic = Object.values(tacticsObject).find(obj => obj.id === element);
-      return { id:tactic.references[0].external_id, name: tactic.name};
+      const tactic = Object.values(tacticsObject).find((obj) => obj.id === element);
+      return { id: tactic.references[0].external_id, name: tactic.name };
     });
   }
 
-  formatTechniqueData (rawData) {
+  formatTechniqueData(rawData) {
     const { tactics, name, mitre_version } = rawData;
-    const tacticsObj = this.findTacticName(tactics)
-    this.setState({techniqueData: { name, mitre_version, tacticsObj }, loading: false  });
+    const tacticsObj = this.findTacticName(tactics);
+    this.setState({ techniqueData: { name, mitre_version, tacticsObj }, loading: false });
   }
-  
+
   renderHeader() {
     const { techniqueData } = this.state;
-    return(
-      <EuiFlyoutHeader hasBorder style={{padding:"12px 16px"}}>
+    return (
+      <EuiFlyoutHeader hasBorder style={{ padding: '12px 16px' }}>
         {(Object.keys(techniqueData).length === 0 && (
           <div>
             <EuiLoadingContent lines={1} />
           </div>
         )) || (
           <EuiTitle size="m">
-            <h2 id="flyoutSmallTitle">
-              {techniqueData.name}
-            </h2>
+            <h2 id="flyoutSmallTitle">{techniqueData.name}</h2>
           </EuiTitle>
         )}
       </EuiFlyoutHeader>
-    )
+    );
   }
 
   renderBody() {
     const { currentTechnique } = this.props;
     const { techniqueData } = this.state;
-    const implicitFilters=[{ 'rule.mitre.id': currentTechnique}, this.clusterFilter ];
-    if(this.props.implicitFilters){
-      this.props.implicitFilters.forEach( item => 
-        implicitFilters.push(item))
+    const implicitFilters = [{ 'rule.mitre.id': currentTechnique }, this.clusterFilter];
+    if (this.props.implicitFilters) {
+      this.props.implicitFilters.forEach((item) => implicitFilters.push(item));
     }
 
     const link = `https://attack.mitre.org/techniques/${currentTechnique}/`;
-    const formattedDescription = techniqueData.description 
-      ? (
-        <div
-          className="wz-markdown-margin wz-markdown-wrapper"
-          dangerouslySetInnerHTML={{__html: md.render(techniqueData.description)}}>
-        </div>
-      )
-      : techniqueData.description;
+    const formattedDescription = techniqueData.description ? (
+      <div
+        className="wz-markdown-margin wz-markdown-wrapper"
+        dangerouslySetInnerHTML={{ __html: md.render(techniqueData.description) }}
+      ></div>
+    ) : (
+      techniqueData.description
+    );
     const data = [
       {
         title: 'ID',
-        description: ( <EuiToolTip
-          position="top"
-          content={`Open ${currentTechnique} details in the Intelligence section`}>
-          <EuiLink onClick={(e) => {this.props.openIntelligence(e,'techniques',currentTechnique);e.stopPropagation()}}>
-            {currentTechnique}
-          </EuiLink>
-        </EuiToolTip>)
+        description: (
+          <EuiToolTip
+            position="top"
+            content={`Open ${currentTechnique} details in the Intelligence section`}
+          >
+            <EuiLink
+              onClick={(e) => {
+                this.props.openIntelligence(e, 'techniques', currentTechnique);
+                e.stopPropagation();
+              }}
+            >
+              {currentTechnique}
+            </EuiLink>
+          </EuiToolTip>
+        ),
       },
       {
         title: 'Tactics',
         description: techniqueData.tacticsObj
-        ? techniqueData.tacticsObj.map((tactic) => {
-            return (
-              <>
-                <EuiToolTip
-                  position="top"
-                  content={`Open ${tactic.name} details in the Intelligence section`}
-                >
-                  <EuiLink
-                    onClick={(e) => {
-                      this.props.openIntelligence(e, "tactics", tactic.id);
-                      e.stopPropagation();
-                    }}
+          ? techniqueData.tacticsObj.map((tactic) => {
+              return (
+                <>
+                  <EuiToolTip
+                    position="top"
+                    content={`Open ${tactic.name} details in the Intelligence section`}
                   >
-                    {tactic.name}
-                  </EuiLink>
-                </EuiToolTip>
-                <br />
-              </>
-            );
-          })
-        : ""
+                    <EuiLink
+                      onClick={(e) => {
+                        this.props.openIntelligence(e, 'tactics', tactic.id);
+                        e.stopPropagation();
+                      }}
+                    >
+                      {tactic.name}
+                    </EuiLink>
+                  </EuiToolTip>
+                  <br />
+                </>
+              );
+            })
+          : '',
       },
       {
         title: 'Version',
-        description: techniqueData.mitre_version
-      }
-      
+        description: techniqueData.mitre_version,
+      },
     ];
     return (
-      <EuiFlyoutBody className="flyout-body" >
+      <EuiFlyoutBody className="flyout-body">
         <EuiAccordion
-        id={"details"}
-        buttonContent={
-          <EuiTitle size="s">
-            <h3>Technique details</h3>
-          </EuiTitle>
-        }
-        paddingSize="none"
-        initialIsOpen={true}>
-        <div className='flyout-row details-row'>
-
+          id={'details'}
+          buttonContent={
+            <EuiTitle size="s">
+              <h3>Technique details</h3>
+            </EuiTitle>
+          }
+          paddingSize="none"
+          initialIsOpen={true}
+        >
+          <div className="flyout-row details-row">
             {(Object.keys(techniqueData).length === 0 && (
-                <div>
-                  <EuiLoadingContent lines={2} />
-                  <EuiLoadingContent lines={3} />
-                </div>
-              )) || (
-                <div style={{marginBottom: 30}}>
-                  <EuiDescriptionList listItems={data} />
-                </div>
-              )}
-        </div>
+              <div>
+                <EuiLoadingContent lines={2} />
+                <EuiLoadingContent lines={3} />
+              </div>
+            )) || (
+              <div style={{ marginBottom: 30 }}>
+                <EuiDescriptionList listItems={data} />
+              </div>
+            )}
+          </div>
         </EuiAccordion>
 
-
-        <EuiSpacer size='s' />
-          <EuiAccordion
-            style={{textDecoration: 'none'}}
-            id={"recent_events"}
-            className='events-accordion'
-            extraAction={<div style={{marginBottom: 5}}><strong>{this.state.totalHits || 0}</strong> hits</div>}
-            buttonContent={
-              <EuiTitle size="s">
-                <h3>
-                  Recent events{this.props.view !== 'events' && (
-                    <span style={{ marginLeft: 16 }}> 
-                      <span>
-                        <EuiToolTip position="top" content={"Show " + currentTechnique+ " in Dashboard"}>
-                            <EuiIcon onMouseDown={(e) => {this.props.openDashboard(e,currentTechnique);e.stopPropagation()}} color="primary" type="visualizeApp" style={{marginRight: '10px'}}></EuiIcon>
-                        </EuiToolTip>
-                        <EuiToolTip position="top" content={"Inspect " + currentTechnique + " in Events"} >
-                          <EuiIcon onMouseDown={(e) => {this.props.openDiscover(e,currentTechnique);e.stopPropagation()}} color="primary" type="discoverApp"></EuiIcon>
-                        </EuiToolTip>
-                      </span> 
+        <EuiSpacer size="s" />
+        <EuiAccordion
+          style={{ textDecoration: 'none' }}
+          id={'recent_events'}
+          className="events-accordion"
+          extraAction={
+            <div style={{ marginBottom: 5 }}>
+              <strong>{this.state.totalHits || 0}</strong> hits
+            </div>
+          }
+          buttonContent={
+            <EuiTitle size="s">
+              <h3>
+                Recent events
+                {this.props.view !== 'events' && (
+                  <span style={{ marginLeft: 16 }}>
+                    <span>
+                      <EuiToolTip
+                        position="top"
+                        content={'Show ' + currentTechnique + ' in Dashboard'}
+                      >
+                        <EuiIcon
+                          onMouseDown={(e) => {
+                            this.props.openDashboard(e, currentTechnique);
+                            e.stopPropagation();
+                          }}
+                          color="primary"
+                          type="visualizeApp"
+                          style={{ marginRight: '10px' }}
+                        ></EuiIcon>
+                      </EuiToolTip>
+                      <EuiToolTip
+                        position="top"
+                        content={'Inspect ' + currentTechnique + ' in Events'}
+                      >
+                        <EuiIcon
+                          onMouseDown={(e) => {
+                            this.props.openDiscover(e, currentTechnique);
+                            e.stopPropagation();
+                          }}
+                          color="primary"
+                          type="discoverApp"
+                        ></EuiIcon>
+                      </EuiToolTip>
                     </span>
-                  )}
-                </h3>
-              </EuiTitle>
-            }
-            paddingSize="none"
-            initialIsOpen={true}>
+                  </span>
+                )}
+              </h3>
+            </EuiTitle>
+          }
+          paddingSize="none"
+          initialIsOpen={true}
+        >
           <EuiFlexGroup className="flyout-row">
             <EuiFlexItem>
               <Discover
                 kbnSearchBar
                 shareFilterManager={this.filterManager}
-                initialColumns={["icon", "timestamp", 'rule.mitre.id', 'rule.mitre.tactic', 'rule.level', 'rule.id', 'rule.description']}
+                initialColumns={[
+                  'icon',
+                  'timestamp',
+                  'rule.mitre.id',
+                  'rule.mitre.tactic',
+                  'rule.level',
+                  'rule.id',
+                  'rule.description',
+                ]}
                 implicitFilters={implicitFilters}
                 initialFilters={[]}
                 updateTotalHits={(total) => this.updateTotalHits(total)}
-                openIntelligence={(e,redirectTo,itemId) => this.props.openIntelligence(e,redirectTo,itemId)}
+                openIntelligence={(e, redirectTo, itemId) =>
+                  this.props.openIntelligence(e, redirectTo, itemId)
+                }
               />
             </EuiFlexItem>
           </EuiFlexGroup>
         </EuiAccordion>
-      
       </EuiFlyoutBody>
     );
   }
 
   updateTotalHits = (total) => {
-    this.setState({totalHits : total});
-  }
+    this.setState({ totalHits: total });
+  };
 
-  renderLoading(){
+  renderLoading() {
     return (
-    <EuiFlyoutBody>
-      <EuiLoadingContent lines={2} />
-      <EuiLoadingContent lines={3} />
-    </EuiFlyoutBody>
-    )
+      <EuiFlyoutBody>
+        <EuiLoadingContent lines={2} />
+        <EuiLoadingContent lines={3} />
+      </EuiFlyoutBody>
+    );
   }
 
   render() {
     const { techniqueData } = this.state;
     const { onChangeFlyout } = this.props;
-    return(
-        <EuiFlyout
-          onClose={() => onChangeFlyout(false)}
-          size="l"
-          className="flyout-no-overlap wz-inventory wzApp"
-          aria-labelledby="flyoutSmallTitle"
-          > 
-          { techniqueData &&
-            this.renderHeader()
-          }
-          {
-            this.renderBody()
-          }
-          { this.state.loading &&
-            this.renderLoading()
-          }
-        </EuiFlyout>
+    return (
+      <EuiFlyout
+        onClose={() => onChangeFlyout(false)}
+        size="l"
+        className="flyout-no-overlap wz-inventory wzApp"
+        aria-labelledby="flyoutSmallTitle"
+      >
+        {techniqueData && this.renderHeader()}
+        {this.renderBody()}
+        {this.state.loading && this.renderLoading()}
+      </EuiFlyout>
     );
   }
 }

--- a/public/components/overview/mitre/components/techniques/components/flyout-technique/flyout-technique.tsx
+++ b/public/components/overview/mitre/components/techniques/components/flyout-technique/flyout-technique.tsx
@@ -339,13 +339,24 @@ export class FlyoutTechnique extends Component {
                 kbnSearchBar
                 shareFilterManager={this.filterManager}
                 initialColumns={[
-                  'icon',
-                  'timestamp',
-                  'rule.mitre.id',
-                  'rule.mitre.tactic',
-                  'rule.level',
-                  'rule.id',
-                  'rule.description',
+                  { field: 'icon' },
+                  { field: 'timestamp' },
+                  { field: 'agent.id', label: 'Agent' },
+                  { field: 'agent.name', label: 'Agent Name' },
+                  { field: 'rule.mitre.id', label: 'Technique(s)' },
+                  { field: 'rule.mitre.tactic', label: 'Tactic(s)' },
+                  { field: 'rule.level', label: 'Level' },
+                  { field: 'rule.id', label: 'Rule ID' },
+                  { field: 'rule.description', label: 'Description' },
+                ]}
+                initialAgentColumns={[
+                  { field: 'icon' },
+                  { field: 'timestamp' },
+                  { field: 'rule.mitre.id', label: 'Technique(s)' },
+                  { field: 'rule.mitre.tactic', label: 'Tactic(s)' },
+                  { field: 'rule.level', label: 'Level' },
+                  { field: 'rule.id', label: 'Rule ID' },
+                  { field: 'rule.description', label: 'Description' },
                 ]}
                 implicitFilters={implicitFilters}
                 initialFilters={[]}

--- a/public/components/overview/office-panel/config/drilldown-ip-config.tsx
+++ b/public/components/overview/office-panel/config/drilldown-ip-config.tsx
@@ -70,12 +70,13 @@ export const drilldownIPConfig = {
               <EuiPanel paddingSize={'s'}>
                 <SecurityAlerts
                   initialColumns={[
-                    'icon',
-                    'timestamp',
-                    'data.office365.UserId',
-                    'rule.description',
-                    'data.office365.Operation',
+                    { field: 'icon' },
+                    { field: 'timestamp' },
+                    { field: 'data.office365.UserId', label: 'User ID' },
+                    { field: 'rule.description', label: 'Description' },
+                    { field: 'data.office365.Operation', label: 'Operation' },
                   ]}
+                  useAgentColumns={false}
                 />
               </EuiPanel>
             </EuiFlexItem>

--- a/public/components/overview/office-panel/config/drilldown-operations-config.tsx
+++ b/public/components/overview/office-panel/config/drilldown-operations-config.tsx
@@ -59,12 +59,13 @@ export const drilldownOperationsConfig = {
               <EuiPanel paddingSize={'s'}>
                 <SecurityAlerts
                   initialColumns={[
-                    'icon',
-                    'timestamp',
-                    'data.office365.UserId',
-                    'data.office365.ClientIP',
-                    'rule.description',
+                    { field: 'icon' },
+                    { field: 'timestamp' },
+                    { field: 'data.office365.UserId', label: 'User ID' },
+                    { field: 'data.office365.ClientIP', label: 'Client IP' },
+                    { field: 'rule.description', label: 'Description' },
                   ]}
+                  useAgentColumns={false}
                 />
               </EuiPanel>
             </EuiFlexItem>

--- a/public/components/overview/office-panel/config/drilldown-rules-config.tsx
+++ b/public/components/overview/office-panel/config/drilldown-rules-config.tsx
@@ -65,12 +65,13 @@ export const drilldownRulesConfig = {
               <EuiPanel paddingSize={'s'}>
                 <SecurityAlerts
                   initialColumns={[
-                    'icon',
-                    'timestamp',
-                    'data.office365.UserId',
-                    'data.office365.ClientIP',
-                    'data.office365.Operation',
+                    { field: 'icon' },
+                    { field: 'timestamp' },
+                    { field: 'data.office365.UserId', label: 'User ID' },
+                    { field: 'data.office365.ClientIP', label: 'Client IP' },
+                    { field: 'data.office365.Operation', label: 'Operation' },
                   ]}
+                  useAgentColumns={false}
                 />
               </EuiPanel>
             </EuiFlexItem>

--- a/public/components/overview/office-panel/config/drilldown-user-config.tsx
+++ b/public/components/overview/office-panel/config/drilldown-user-config.tsx
@@ -70,12 +70,13 @@ export const drilldownUserConfig = {
               <EuiPanel paddingSize={'s'}>
                 <SecurityAlerts
                   initialColumns={[
-                    'icon',
-                    'timestamp',
-                    'data.office365.ClientIP',
-                    'rule.description',
-                    'data.office365.Operation',
+                    { field: 'icon' },
+                    { field: 'timestamp' },
+                    { field: 'data.office365.ClientIP', label: 'Client IP' },
+                    { field: 'rule.description', label: 'Description' },
+                    { field: 'data.office365.Operation', label: 'Operation' },
                   ]}
+                  useAgentColumns={false}
                 />
               </EuiPanel>
             </EuiFlexItem>

--- a/public/components/visualize/components/security-alerts.tsx
+++ b/public/components/visualize/components/security-alerts.tsx
@@ -16,22 +16,33 @@ import { useAllowedAgents } from '../../common/hooks/useAllowedAgents';
 
 export const SecurityAlerts = ({
   initialColumns = [
-    'icon',
-    'timestamp',
-    'rule.mitre.id',
-    'rule.mitre.tactic',
-    'rule.description',
-    'rule.level',
-    'rule.id',
+    { field: 'icon' },
+    { field: 'timestamp' },
+    { field: 'agent.id', label: 'Agent' },
+    { field: 'agent.name', label: 'Agent name' },
+    { field: 'rule.mitre.id', label: 'Technique(s)' },
+    { field: 'rule.mitre.tactic', label: 'Tactic(s)' },
+    { field: 'rule.description', label: 'Description' },
+    { field: 'rule.level', label: 'Level' },
+    { field: 'rule.id', label: 'Rule ID' },
   ],
+  initialAgentColumns = [
+    { field: 'icon' },
+    { field: 'timestamp' },
+    { field: 'rule.mitre.id', label: 'Technique(s)' },
+    { field: 'rule.mitre.tactic', label: 'Tactic(s)' },
+    { field: 'rule.description', label: 'Description' },
+    { field: 'rule.level', label: 'Level' },
+    { field: 'rule.id', label: 'Rule ID' },
+  ],
+  useAgentColumns = true,
 }) => {
   const [query] = useQuery();
   const { filterManager } = useFilterManager();
-  const copyOfFilterManager = filterManager;
   const refreshAngularDiscover = useRefreshAngularDiscover();
 
   const customFilterWithAllowedAgents = [];
-  const { allowedAgents, filterAllowedAgents } = useAllowedAgents();
+  const { filterAllowedAgents } = useAllowedAgents();
   filterAllowedAgents && customFilterWithAllowedAgents.push(filterAllowedAgents);
 
   return (
@@ -40,6 +51,7 @@ export const SecurityAlerts = ({
       shareFilterManagerWithUserAuthorized={customFilterWithAllowedAgents}
       query={query}
       initialColumns={initialColumns}
+      initialAgentColumns={useAgentColumns ? initialAgentColumns : undefined}
       implicitFilters={[]}
       initialFilters={[]}
       updateTotalHits={(total) => {}}

--- a/public/components/visualize/components/security-alerts.tsx
+++ b/public/components/visualize/components/security-alerts.tsx
@@ -1,39 +1,49 @@
 /*
-* Wazuh app - React component for Visualize.
-* Copyright (C) 2015-2021 Wazuh, Inc.
-*
-* This program is free software; you can redistribute it and/or modify
-* it under the terms of the GNU General Public License as published by
-* the Free Software Foundation; either version 2 of the License, or
-* (at your option) any later version.
-*
-* Find more information about this on the LICENSE file.
-*/
+ * Wazuh app - React component for Visualize.
+ * Copyright (C) 2015-2021 Wazuh, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Find more information about this on the LICENSE file.
+ */
 import React from 'react';
 import { useFilterManager, useQuery, useRefreshAngularDiscover } from '../../common/hooks';
 import { Discover } from '../../common/modules/discover';
-import { useAllowedAgents } from '../../common/hooks/useAllowedAgents'
- 
-export const SecurityAlerts = ({initialColumns = ["icon", "timestamp", 'rule.mitre.id', 'rule.mitre.tactic', 'rule.description', 'rule.level', 'rule.id']}) => {
- const [query] = useQuery();
- const {filterManager} = useFilterManager();
- const copyOfFilterManager = filterManager
- const refreshAngularDiscover = useRefreshAngularDiscover();
- 
- const customFilterWithAllowedAgents = [];
- const {allowedAgents, filterAllowedAgents} = useAllowedAgents();
- filterAllowedAgents && customFilterWithAllowedAgents.push(filterAllowedAgents);
+import { useAllowedAgents } from '../../common/hooks/useAllowedAgents';
 
- return (
-   <Discover
-     shareFilterManager={filterManager}
-     shareFilterManagerWithUserAuthorized={customFilterWithAllowedAgents}
-     query={query}
-     initialColumns={initialColumns}
-     implicitFilters={[]}
-     initialFilters={[]}
-     updateTotalHits={(total) => { }}
-     refreshAngularDiscover={refreshAngularDiscover}
-     />
- )
-}
+export const SecurityAlerts = ({
+  initialColumns = [
+    'icon',
+    'timestamp',
+    'rule.mitre.id',
+    'rule.mitre.tactic',
+    'rule.description',
+    'rule.level',
+    'rule.id',
+  ],
+}) => {
+  const [query] = useQuery();
+  const { filterManager } = useFilterManager();
+  const copyOfFilterManager = filterManager;
+  const refreshAngularDiscover = useRefreshAngularDiscover();
+
+  const customFilterWithAllowedAgents = [];
+  const { allowedAgents, filterAllowedAgents } = useAllowedAgents();
+  filterAllowedAgents && customFilterWithAllowedAgents.push(filterAllowedAgents);
+
+  return (
+    <Discover
+      shareFilterManager={filterManager}
+      shareFilterManagerWithUserAuthorized={customFilterWithAllowedAgents}
+      query={query}
+      initialColumns={initialColumns}
+      implicitFilters={[]}
+      initialFilters={[]}
+      updateTotalHits={(total) => {}}
+      refreshAngularDiscover={refreshAngularDiscover}
+    />
+  );
+};


### PR DESCRIPTION
This pr closes https://github.com/wazuh/wazuh-kibana-app/issues/3527

On this PR, I have refactored the properties used in the component `Discover` and all the components that use it.

[The first commit](https://github.com/wazuh/wazuh-kibana-app/commit/02f941ef98fb8ac42939fcc433e4fce4ab11d723) simply applies `prettier` to the files that will be modified.

[The second commit](https://github.com/wazuh/wazuh-kibana-app/commit/5c5287e68a3194eaf8b4e673cc50e2af9169c329) changes the behavior of Discover. A brief summary of the changes as intended:

- A new interface is defined within the component:
```
interface ColumnDefinition {
  field: string;
  label?: string;
}
```

- The prop `initialColumns` is set as an array of `ColumnDefinition` , the prop `initialAgentColumns` is created as optional to be used when an agent is pinned.
- The method `getColumns` of `Discover` now extracts the selected fields from one of these properties, if `initialAgentColumns` is not defined it should always use `initialColumns` regadless of whether there is an agent pinned.
- The names for the columns are extracted from the `label` field in `ColumnDefinition`, defaults to `field` if not specificed
- All files that used the property initialColumns have been edited to use this new structure.