### PR TITLE
Feature/pagination drilldown tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Created a separate component to check for sample data [#3475](https://github.com/wazuh/wazuh-kibana-app/pull/3475)
 - Added a new hook for getting value suggestions [#3506](https://github.com/wazuh/wazuh-kibana-app/pull/3506)
 - Added base Module Panel view with Office365 setup [#3518](https://github.com/wazuh/wazuh-kibana-app/pull/3518)
+- Adding Pagination and filter to drilldown tables at Office pannel [#3544](https://github.com/wazuh/wazuh-kibana-app/issues/3544).
 
 ### Changed
 

--- a/public/components/common/hooks/use-es-search.ts
+++ b/public/components/common/hooks/use-es-search.ts
@@ -72,7 +72,7 @@ const useEsSearch = ({ preAppliedFilters = [], preAppliedAggs = {}, size = 10 })
         setIsLoading(false);
       }
     })();
-  }, [indexPattern, query, filters, page, preAppliedAggs.buckets.terms.order]);
+  }, [indexPattern, query, filters, page, preAppliedAggs]);
 
   const search = async (): Promise<SearchResponse> => {
     if (indexPattern) {

--- a/public/components/common/hooks/use-es-search.ts
+++ b/public/components/common/hooks/use-es-search.ts
@@ -72,7 +72,7 @@ const useEsSearch = ({ preAppliedFilters = [], preAppliedAggs = {}, size = 10 })
         setIsLoading(false);
       }
     })();
-  }, [indexPattern, query, filters, page]);
+  }, [indexPattern, query, filters, page, preAppliedAggs.buckets.terms.order]);
 
   const search = async (): Promise<SearchResponse> => {
     if (indexPattern) {

--- a/public/components/common/modules/panel/components/agg-table.tsx
+++ b/public/components/common/modules/panel/components/agg-table.tsx
@@ -13,7 +13,7 @@
 
 import { EuiPanel, EuiTitle, EuiBasicTableColumn, EuiInMemoryTable } from '@elastic/eui';
 import { useEsSearch } from '../../../hooks';
-import React, { useState } from 'react';
+import React, { useState, useMemo } from 'react';
 
 export const AggTable = ({
   onRowClick = (field, value) => {},
@@ -25,15 +25,18 @@ export const AggTable = ({
   titleProps,
 }) => {
   const [order, setOrder] = useState({ _count: 'desc' });
-  const preAppliedAggs = {
-    buckets: {
-      terms: {
-        field: aggTerm,
-        size: maxRows,
-        order,
+  const preAppliedAggs = useMemo(() => {
+    return {
+      buckets: {
+        terms: {
+          field: aggTerm,
+          size: maxRows,
+          order,
+        },
       },
-    },
-  };
+    };
+  }, [order, aggTerm, maxRows]);
+
   const { esResults, isLoading, error } = useEsSearch({ preAppliedAggs });
   const buckets = ((esResults.aggregations || {}).buckets || {}).buckets || [];
   const columns: EuiBasicTableColumn<any>[] = [

--- a/public/components/common/modules/panel/components/agg-table.tsx
+++ b/public/components/common/modules/panel/components/agg-table.tsx
@@ -24,7 +24,7 @@ export const AggTable = ({
   panelProps,
   titleProps,
 }) => {
-  const [order, setOrder] = useState({ _key: 'desc' });
+  const [order, setOrder] = useState({ _count: 'desc' });
   const preAppliedAggs = {
     buckets: {
       terms: {
@@ -35,7 +35,7 @@ export const AggTable = ({
     },
   };
   const { esResults, isLoading, error } = useEsSearch({ preAppliedAggs });
-  let buckets = ((esResults.aggregations || {}).buckets || {}).buckets || [];
+  const buckets = ((esResults.aggregations || {}).buckets || {}).buckets || [];
   const columns: EuiBasicTableColumn<any>[] = [
     {
       field: 'key',

--- a/public/components/common/modules/panel/components/agg-table.tsx
+++ b/public/components/common/modules/panel/components/agg-table.tsx
@@ -11,7 +11,7 @@
  * Find more information about this on the LICENSE file.
  */
 
-import { EuiBasicTable, EuiPanel, EuiTitle, EuiBasicTableColumn } from '@elastic/eui';
+import { EuiPanel, EuiTitle, EuiBasicTableColumn, EuiInMemoryTable } from '@elastic/eui';
 import { useEsSearch } from '../../../hooks';
 import React from 'react';
 
@@ -56,18 +56,29 @@ export const AggTable = ({
       },
     };
   };
-
+  const sorting = {
+    sort: {
+      field: 'doc_count',
+      direction: 'desc',
+    },
+  };
+  const pagination = {
+    hidePerPageOptions: true,
+    pageSize: 10,
+  };
   return (
     <EuiPanel data-test-subj={`${aggTerm}-aggTable`} {...panelProps}>
       <EuiTitle {...titleProps}>
         <h2>{tableTitle}</h2>
       </EuiTitle>
-      <EuiBasicTable
-        items={buckets}
+      <EuiInMemoryTable
         columns={columns}
-        rowProps={getRowProps}
+        items={buckets}
         loading={isLoading}
+        rowProps={getRowProps}
         error={error ? error.message : undefined}
+        pagination={pagination}
+        sorting={sorting}
       />
     </EuiPanel>
   );


### PR DESCRIPTION
Hi guys,

In this PR we switch from basic tables to memory tables to be able to show the paginated tables.

![image](https://user-images.githubusercontent.com/17100196/128481062-8807e5fd-00e9-4e2c-9750-f6036cc7f2a7.png)

To test it we will only have to get into the Office module and go to the Panel tab

