### PR TITLE
Added time subscription in discover component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Moved the filterManager subscription to the hook useFilterManager [#3517](https://github.com/wazuh/wazuh-kibana-app/pull/3517)
 - Change filter from is to is one of in custom searchbar [#3529](https://github.com/wazuh/wazuh-kibana-app/pull/3529)
 - Refactored as module tabs and buttons are rendered [#3494](https://github.com/wazuh/wazuh-kibana-app/pull/3494)
+- Added time subscription to Discover component [#3549](https://github.com/wazuh/wazuh-kibana-app/pull/3549)
 
 ### Fixed
 

--- a/public/components/common/modules/discover/discover.tsx
+++ b/public/components/common/modules/discover/discover.tsx
@@ -162,14 +162,12 @@ export const Discover = compose(
     async componentDidMount() {
       this._isMount = true;
       try {
-        this.timeSubscription = this.timefilter
-          .getTimeUpdate$()
-          .subscribe(() => {
-            this.setState({
-              dateRange: this.timefilter.getTime(),
-              dateRangeHistory: this.timefilter._history,
-            });
+        this.timeSubscription = this.timefilter.getTimeUpdate$().subscribe(() => {
+          this.setState({
+            dateRange: this.timefilter.getTime(),
+            dateRangeHistory: this.timefilter._history,
           });
+        });
         this.setState({ columns: this.getColumns() }); //initial columns
         await this.getIndexPattern();
         await this.getAlerts();

--- a/public/components/common/modules/discover/discover.tsx
+++ b/public/components/common/modules/discover/discover.tsx
@@ -119,6 +119,7 @@ export const Discover = compose(
       super(props);
       this.KibanaServices = getDataPlugin();
       this.timefilter = this.KibanaServices.query.timefilter.timefilter;
+      this.timeSubscription = null;
       this.state = {
         sort: {},
         selectedTechnique: '',
@@ -161,6 +162,14 @@ export const Discover = compose(
     async componentDidMount() {
       this._isMount = true;
       try {
+        this.timeSubscription = this.timefilter
+          .getTimeUpdate$()
+          .subscribe(() => {
+            this.setState({
+              dateRange: this.timefilter.getTime(),
+              dateRangeHistory: this.timefilter._history,
+            });
+          });
         this.setState({ columns: this.getColumns() }); //initial columns
         await this.getIndexPattern();
         await this.getAlerts();
@@ -182,6 +191,7 @@ export const Discover = compose(
 
     componentWillUnmount() {
       this._isMount = false;
+      this.timeSubscription && this.timeSubscription.unsubscribe();
     }
 
     async componentDidUpdate(prevProps, prevState) {


### PR DESCRIPTION
This pr closes https://github.com/wazuh/wazuh-kibana-app/issues/3522

We have added a time subscription to the lifecycle of the component Discover to change it's own timestate.

To test:

1. Go to the Office365 panel
2. Visit any drilldown
3. Change the time range in the search bar
4. See that the event table updates