### PR TITLE
Removed office365 section from agent sections

### DIFF
--- a/public/components/common/welcome/components/agent-sections.ts
+++ b/public/components/common/welcome/components/agent-sections.ts
@@ -44,11 +44,6 @@ export const getAgentSections = (menuAgent) => {
       text: 'Integrity monitoring',
       isPin: menuAgent.fim ? menuAgent.fim : false,
     },
-    office: { 
-      id: WAZUH_MODULES_ID.OFFICE_365, 
-      text: 'Office 365', 
-      isPin: menuAgent.office ? menuAgent.office : false 
-    },
     aws: {
       id: WAZUH_MODULES_ID.AMAZON_WEB_SERVICES,
       text: 'Amazon AWS',

--- a/public/components/common/welcome/components/menu-agent.js
+++ b/public/components/common/welcome/components/menu-agent.js
@@ -36,7 +36,6 @@ class WzMenuAgent extends Component {
     this.securityInformationItems = [
       this.agentSections.general,
       this.agentSections.fim,
-      this.agentSections.office,
       this.agentSections.aws,
       this.agentSections.gcp,
     ];


### PR DESCRIPTION
This PR closes https://github.com/wazuh/wazuh-kibana-app/issues/3550

The office365 section should not appear under the agents sections as it is not applicable. This PR removes it.
To test:

1. Visit an agent panel
2. Click on more
3. See that Office365 is missing
![image](https://user-images.githubusercontent.com/80431234/128828596-f415ac4a-c9bf-42e1-82d0-fb8bf2743f9e.png)
