### PR TITLE
[Module] [Office365] Add `rule.level` and `rule.id` fields to alerts table of each drill down view

### DIFF
--- a/public/components/overview/office-panel/config/drilldown-ip-config.tsx
+++ b/public/components/overview/office-panel/config/drilldown-ip-config.tsx
@@ -72,9 +72,9 @@ export const drilldownIPConfig = {
                   initialColumns={[
                     { field: 'icon' },
                     { field: 'timestamp' },
+                    { field: 'rule.description', label: 'Description' },
                     { field: 'data.office365.UserId', label: 'User ID' },
                     { field: 'data.office365.Operation', label: 'Operation' },
-                    { field: 'rule.description', label: 'Description' },
                     { field: 'rule.level', label: 'Level' },
                     { field: 'rule.id', label: 'Rule ID' },
                   ]}

--- a/public/components/overview/office-panel/config/drilldown-ip-config.tsx
+++ b/public/components/overview/office-panel/config/drilldown-ip-config.tsx
@@ -73,8 +73,10 @@ export const drilldownIPConfig = {
                     { field: 'icon' },
                     { field: 'timestamp' },
                     { field: 'data.office365.UserId', label: 'User ID' },
-                    { field: 'rule.description', label: 'Description' },
                     { field: 'data.office365.Operation', label: 'Operation' },
+                    { field: 'rule.description', label: 'Description' },
+                    { field: 'rule.level', label: 'Level' },
+                    { field: 'rule.id', label: 'Rule ID' },
                   ]}
                   useAgentColumns={false}
                 />

--- a/public/components/overview/office-panel/config/drilldown-operations-config.tsx
+++ b/public/components/overview/office-panel/config/drilldown-operations-config.tsx
@@ -61,9 +61,9 @@ export const drilldownOperationsConfig = {
                   initialColumns={[
                     { field: 'icon' },
                     { field: 'timestamp' },
+                    { field: 'rule.description', label: 'Description' },
                     { field: 'data.office365.UserId', label: 'User ID' },
                     { field: 'data.office365.ClientIP', label: 'Client IP' },
-                    { field: 'rule.description', label: 'Description' },
                     { field: 'rule.level', label: 'Level' },
                     { field: 'rule.id', label: 'Rule ID' },
                   ]}

--- a/public/components/overview/office-panel/config/drilldown-operations-config.tsx
+++ b/public/components/overview/office-panel/config/drilldown-operations-config.tsx
@@ -64,6 +64,8 @@ export const drilldownOperationsConfig = {
                     { field: 'data.office365.UserId', label: 'User ID' },
                     { field: 'data.office365.ClientIP', label: 'Client IP' },
                     { field: 'rule.description', label: 'Description' },
+                    { field: 'rule.level', label: 'Level' },
+                    { field: 'rule.id', label: 'Rule ID' },
                   ]}
                   useAgentColumns={false}
                 />

--- a/public/components/overview/office-panel/config/drilldown-rules-config.tsx
+++ b/public/components/overview/office-panel/config/drilldown-rules-config.tsx
@@ -70,6 +70,9 @@ export const drilldownRulesConfig = {
                     { field: 'data.office365.UserId', label: 'User ID' },
                     { field: 'data.office365.ClientIP', label: 'Client IP' },
                     { field: 'data.office365.Operation', label: 'Operation' },
+                    { field: 'rule.description', label: 'Description' },
+                    { field: 'rule.level', label: 'Level' },
+                    { field: 'rule.id', label: 'Rule ID' },
                   ]}
                   useAgentColumns={false}
                 />

--- a/public/components/overview/office-panel/config/drilldown-rules-config.tsx
+++ b/public/components/overview/office-panel/config/drilldown-rules-config.tsx
@@ -67,10 +67,10 @@ export const drilldownRulesConfig = {
                   initialColumns={[
                     { field: 'icon' },
                     { field: 'timestamp' },
+                    { field: 'rule.description', label: 'Description' },
                     { field: 'data.office365.UserId', label: 'User ID' },
                     { field: 'data.office365.ClientIP', label: 'Client IP' },
                     { field: 'data.office365.Operation', label: 'Operation' },
-                    { field: 'rule.description', label: 'Description' },
                     { field: 'rule.level', label: 'Level' },
                     { field: 'rule.id', label: 'Rule ID' },
                   ]}

--- a/public/components/overview/office-panel/config/drilldown-user-config.tsx
+++ b/public/components/overview/office-panel/config/drilldown-user-config.tsx
@@ -72,10 +72,9 @@ export const drilldownUserConfig = {
                   initialColumns={[
                     { field: 'icon' },
                     { field: 'timestamp' },
+                    { field: 'rule.description', label: 'Description' },
                     { field: 'data.office365.ClientIP', label: 'Client IP' },
-                    { field: 'rule.description', label: 'Description' },
                     { field: 'data.office365.Operation', label: 'Operation' },
-                    { field: 'rule.description', label: 'Description' },
                     { field: 'rule.level', label: 'Level' },
                     { field: 'rule.id', label: 'Rule ID' },
                   ]}

--- a/public/components/overview/office-panel/config/drilldown-user-config.tsx
+++ b/public/components/overview/office-panel/config/drilldown-user-config.tsx
@@ -75,6 +75,9 @@ export const drilldownUserConfig = {
                     { field: 'data.office365.ClientIP', label: 'Client IP' },
                     { field: 'rule.description', label: 'Description' },
                     { field: 'data.office365.Operation', label: 'Operation' },
+                    { field: 'rule.description', label: 'Description' },
+                    { field: 'rule.level', label: 'Level' },
+                    { field: 'rule.id', label: 'Rule ID' },
                   ]}
                   useAgentColumns={false}
                 />


### PR DESCRIPTION
### Description
This PR adds the `rule.level` and `rule.id` alert fields to the alerts table in the drills down of the Office 365's Panel.

### Changes
- Add `rule.level` and `rule.id` fields to the drills down
- Add `rule.description` field to the table that was missing