### PR TITLE
Simple filters change between panel and drilldown panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Added base Module Panel view with Office365 setup [#3518](https://github.com/wazuh/wazuh-kibana-app/pull/3518)
 - Added specifics and custom filters for Office365 search bar [#3533](https://github.com/wazuh/wazuh-kibana-app/pull/3533)
 - Adding Pagination and filter to drilldown tables at Office pannel [#3544](https://github.com/wazuh/wazuh-kibana-app/issues/3544).
+- Simple filters change between panel and drilldown panel [#3568](https://github.com/wazuh/wazuh-kibana-app/issues/3568).
 
 ### Changed
 

--- a/public/components/common/custom-search-bar/components/multi-select.tsx
+++ b/public/components/common/custom-search-bar/components/multi-select.tsx
@@ -50,8 +50,7 @@ export const MultiSelect = ({ item, onChange, selectedOptions, onRemove, isDisab
             value: item.key,
             filterByKey: item.filterByKey,
             checked: selectedOptions.find((element) => element.label === value) ? ON as FilterChecked: OFF as FilterChecked,
-          }))
-          .sort((a, b) => a.label - b.label)
+          })).sort((a, b) => (a.label < b.label ? 1 : -1)).sort((a, b) => (a.checked < b.checked ? 1 : -1))
       );
     }
   }, [suggestedValues, isLoading]);
@@ -60,8 +59,8 @@ export const MultiSelect = ({ item, onChange, selectedOptions, onRemove, isDisab
     setItems(
       items.map((item) => ({
         ...item,
-        checked: selectedOptions.find((element) => element.label === item.label) ? ON : OFF,
-      }))
+        checked: selectedOptions.find((element) => element.label === item.label) ? ON as FilterChecked: OFF as FilterChecked,
+      })).sort((a, b) => (a.label < b.label ? 1 : -1)).sort((a, b) => (a.checked < b.checked ? 1 : -1))
     );
     setActiveFilters(selectedOptions.length);
   }, [selectedOptions]);

--- a/public/components/common/custom-search-bar/components/multi-select.tsx
+++ b/public/components/common/custom-search-bar/components/multi-select.tsx
@@ -49,7 +49,7 @@ export const MultiSelect = ({ item, onChange, selectedOptions, onRemove, isDisab
             label: value,
             value: item.key,
             filterByKey: item.filterByKey,
-            checked: OFF as FilterChecked,
+            checked: selectedOptions.find((element) => element.label === value) ? ON as FilterChecked: OFF as FilterChecked,
           }))
           .sort((a, b) => a.label - b.label)
       );

--- a/public/components/common/custom-search-bar/components/multi-select.tsx
+++ b/public/components/common/custom-search-bar/components/multi-select.tsx
@@ -28,11 +28,12 @@ import { IValueSuggestion, useValueSuggestion } from '../../hooks';
 const ON = 'on';
 const OFF = 'off';
 
-export const MultiSelect = ({ item, onChange, selectedOptions, onRemove, isDisabled }) => {
+export const MultiSelect = ({ item, onChange, selectedOptions, onRemove, isDisabled, filterDrillDownValue }) => {
   const [isPopoverOpen, setIsPopoverOpen] = useState<boolean>(false);
   const { suggestedValues, isLoading, setQuery }: IValueSuggestion = useValueSuggestion(
     item.key,
-    item?.options
+    filterDrillDownValue,
+    item?.options,
   );
   const [items, setItems] = useState<
     { key: any; label: any; value: any; checked: FilterChecked }[]

--- a/public/components/common/custom-search-bar/custom-search-bar.tsx
+++ b/public/components/common/custom-search-bar/custom-search-bar.tsx
@@ -149,6 +149,7 @@ export const CustomSearchBar = ({ filtersValues, filterDrillDownValue = { field:
           onChange={onChange}
           onRemove={onRemove}
           isDisabled={checkSelectDrillDownValue(item.key)}
+          filterDrillDownValue={filterDrillDownValue}
         />
       ),
     };

--- a/public/components/common/hooks/use-value-suggestion.ts
+++ b/public/components/common/hooks/use-value-suggestion.ts
@@ -36,7 +36,7 @@ interface BoolFilter {
 
 export const useValueSuggestion = (
   filterField: string,
-  filterDrillDownValue: BoolFilter,
+  boolFilterValue: BoolFilter,
   options?: string[],
   type: 'string' | 'boolean' = 'string'
 ): IValueSuggestion => {
@@ -52,11 +52,11 @@ export const useValueSuggestion = (
 
   const getValueSuggestions = async (field) => {
     const boolFilter =
-      filterDrillDownValue && filterDrillDownValue.value !== ""
+      boolFilterValue && boolFilterValue.value !== ""
         ? [
             {
               term: {
-                [filterDrillDownValue.field]: `${filterDrillDownValue.value}`,
+                [boolFilterValue.field]: `${boolFilterValue.value}`,
               },
             },
           ]
@@ -99,7 +99,7 @@ export const useValueSuggestion = (
         }
       })();
     }
-  }, [indexPattern, query, filterField, type, filterDrillDownValue]);
+  }, [indexPattern, query, filterField, type, boolFilterValue]);
 
   return { suggestedValues, isLoading, setQuery };
 };

--- a/public/components/common/hooks/use-value-suggestion.ts
+++ b/public/components/common/hooks/use-value-suggestion.ts
@@ -30,13 +30,16 @@ export interface IValueSuggestion {
 }
 
 interface BoolFilter {
-  field:string;
-  value:string;
+  field: string;
+  value: string;
 }
 
 export const useValueSuggestion = (
   filterField: string,
-  boolFilterValue: BoolFilter,
+  boolFilterValue: BoolFilter = {
+    field: '',
+    value: '',
+  },
   options?: string[],
   type: 'string' | 'boolean' = 'string'
 ): IValueSuggestion => {
@@ -52,7 +55,7 @@ export const useValueSuggestion = (
 
   const getValueSuggestions = async (field) => {
     const boolFilter =
-      boolFilterValue && boolFilterValue.value !== ""
+      boolFilterValue.value !== ''
         ? [
             {
               term: {

--- a/public/components/common/hooks/use-value-suggestion.ts
+++ b/public/components/common/hooks/use-value-suggestion.ts
@@ -29,9 +29,14 @@ export interface IValueSuggestion {
   setQuery: React.Dispatch<React.SetStateAction<string>>;
 }
 
+interface BoolFilter {
+  field:string;
+  value:string;
+}
+
 export const useValueSuggestion = (
   filterField: string,
-  filterDrillDownValue,
+  filterDrillDownValue: BoolFilter,
   options?: string[],
   type: 'string' | 'boolean' = 'string'
 ): IValueSuggestion => {

--- a/public/components/common/hooks/use-value-suggestion.ts
+++ b/public/components/common/hooks/use-value-suggestion.ts
@@ -31,6 +31,7 @@ export interface IValueSuggestion {
 
 export const useValueSuggestion = (
   filterField: string,
+  filterDrillDownValue,
   options?: string[],
   type: 'string' | 'boolean' = 'string'
 ): IValueSuggestion => {
@@ -39,19 +40,29 @@ export const useValueSuggestion = (
   const [isLoading, setIsLoading] = useState(true);
   const data = getDataPlugin();
   const indexPattern = useIndexPattern();
-  //const { filters } = useFilterManager();
 
   const getOptions = (): string[] => {
     return options?.filter((element) => element.toLowerCase().includes(query.toLowerCase())) || [];
   };
 
   const getValueSuggestions = async (field) => {
+    const boolFilter =
+      filterDrillDownValue && filterDrillDownValue.value !== ""
+        ? [
+            {
+              term: {
+                [filterDrillDownValue.field]: `${filterDrillDownValue.value}`,
+              },
+            },
+          ]
+        : [];
     return options
       ? getOptions()
       : await data.autocomplete.getValueSuggestions({
           query,
           indexPattern: indexPattern as IIndexPattern,
           field,
+          boolFilter: boolFilter,
         });
   };
 
@@ -83,7 +94,7 @@ export const useValueSuggestion = (
         }
       })();
     }
-  }, [indexPattern, query, filterField, type]);
+  }, [indexPattern, query, filterField, type, filterDrillDownValue]);
 
   return { suggestedValues, isLoading, setQuery };
 };

--- a/public/components/overview/github-panel/github-panel.tsx
+++ b/public/components/overview/github-panel/github-panel.tsx
@@ -11,7 +11,7 @@
  * Find more information about this on the LICENSE file.
  */
 
-import React from 'react';
+import React, {useState} from 'react';
 import { MainPanel } from '../../common/modules/panel';
 import { withErrorBoundary } from '../../common/hocs';
 import { CustomSearchBar } from '../../common/custom-search-bar';
@@ -19,10 +19,15 @@ import { ModuleConfiguration } from './views';
 import { ModuleConfig, filtersValues } from './config';
 
 export const GitHubPanel = withErrorBoundary(() => {
+  const [drillDownValue, setDrillDownValue] = useState({ field: '', value: '' });
+  const filterDrillDownValue = (value) => {
+    setDrillDownValue(value)
+  }
   return (
     <>
-      <CustomSearchBar filtersValues={filtersValues} />
+      <CustomSearchBar filtersValues={filtersValues} filterDrillDownValue={drillDownValue}/>
       <MainPanel moduleConfig={ModuleConfig} tab={'github'}
+        filterDrillDownValue={filterDrillDownValue}
         sidePanelChildren={<ModuleConfiguration />} />
     </>
   )


### PR DESCRIPTION
Hi guys,

In this PR we try to change the simple filters between the vies of Panel and the view of Drilldown Panel (selecting a row in Panel)

To test it, go to GitHub Panel, see the Simple filters allocated there, then select a row and check if the filters have changed. Of course, only some of these rows have to change. Do more than 1 attempt.

Example:
- Panel view:
![image](https://user-images.githubusercontent.com/17100196/129885407-62801eeb-3097-409f-b441-e7473cf5ab4a.png)

- Drilldown view:
![image](https://user-images.githubusercontent.com/17100196/129885467-527a4afa-c745-4ecf-82d0-1a2146c0041a.png)


Closes #3563 