### PR TITLE
Added link to upgrade guide when Wazuh API version missmatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,6 +135,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Added node name of agent list and detail [#3039](https://github.com/wazuh/wazuh-kibana-app/pull/3039)
 - Added loading view while the user is logging to prevent permissions prompts [#3041](https://github.com/wazuh/wazuh-kibana-app/pull/3041)
 - Added custom message for each possible run_as setup [#3048](https://github.com/wazuh/wazuh-kibana-app/pull/3048)
+- Added link to the upgrade guide when the Wazuh API version and the Wazuh App version mismatch [#3592](https://github.com/wazuh/wazuh-kibana-app/pull/3592).
 
 ### Changed 
 

--- a/public/components/health-check/components/check-result.tsx
+++ b/public/components/health-check/components/check-result.tsx
@@ -53,18 +53,6 @@ export function CheckResult(props) {
     }
   }, [isCheckFinished])
 
-  useEffect(() => {
-    if (isCheckFinished){
-      const errors = verboseInfo.filter(log => log.type === 'error');
-      if(errors.length){
-        props.canRetry ? setResult('error_retry') : setResult('error');
-        props.handleErrors(props.name, errors.map(({message}) => message));
-      }else{
-        setResult('ready');
-        setAsReady();
-      }
-    }
-  }, [isCheckFinished])
 
   const setAsReady = () => {
     props.handleCheckReady(props.name, true);

--- a/public/components/health-check/container/health-check.container.tsx
+++ b/public/components/health-check/container/health-check.container.tsx
@@ -199,7 +199,7 @@ function HealthCheckComponent() {
       checkErrors[checkID].map((error, index) => (
         <Fragment key={index}>
           <EuiCallOut
-            title={`[${checks[checkID].label}] ${error}`}
+            title={(<>{`[${checks[checkID].label}]`} <span dangerouslySetInnerHTML={{__html: error}}></span></>)}
             color="danger"
             iconType="alert"
             style={{ textAlign: 'left' }}

--- a/public/components/health-check/services/check-setup.service.ts
+++ b/public/components/health-check/services/check-setup.service.ts
@@ -42,7 +42,7 @@ export const checkSetupService = appInfo => async (checkLogger: CheckLogger) => 
         api.groups.version !== appSplit[0] ||
         api.groups.minor !== appSplit[1]
       ) {
-        checkLogger.error(`API and APP version mismatch. API version: ${apiVersion}. App version: ${setupData.data.data['app-version']}. At least, major and minor should match`);
+        checkLogger.error(`Wazuh API and Wazuh App version mismatch. API version: ${apiVersion}. App version: ${setupData.data.data['app-version']}. At least, major and minor should match. Check more info about upgrading Wazuh App <a target='_blank' href='https://documentation.wazuh.com/current/upgrade-guide/elasticsearch-kibana-filebeat/index.html#upgrade-elasticsearch-filebeat-kibana'>here</a>.`);
       }
     }
   }


### PR DESCRIPTION
Hi team, this resolves: 

- Add a link to the upgrade guide when the Wazuh API and the Wazuh App version mismatch. 

To testing, you can easily change in the package.json the version of the app to another than the Wazuh API.

Closes #3591