### PR TITLE
Fixed vulnerability flyout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fixed Elastic UI breaking changes in 7.12 [#3345](https://github.com/wazuh/wazuh-kibana-app/pull/3345)
 - Fixed Wazuh main menu and breadcrumb render issues [#3347](https://github.com/wazuh/wazuh-kibana-app/pull/3347)
 - Fixed generation of huge logs from backend errors [#3397](https://github.com/wazuh/wazuh-kibana-app/pull/3397)
+- Fixed vulnerabilities flyout not showing alerts if the vulnerability had a field missing [#3593](https://github.com/wazuh/wazuh-kibana-app/pull/3593)
 
 ## Wazuh v4.2.0 - Kibana 7.10.2 , 7.11.2 - Revision 4201
 

--- a/public/components/agents/vuls/inventory/flyout.tsx
+++ b/public/components/agents/vuls/inventory/flyout.tsx
@@ -72,6 +72,25 @@ export class FlyoutDetail extends Component {
     const title = `${currentItem.cve}`;
     const id = title.replace(/ /g, '_');
 
+    const filterMap = {
+      name: 'data.vulnerability.package.name',
+      cve: 'data.vulnerability.cve',
+      architecture: 'data.vulnerability.package.architecture',
+      version: 'data.vulnerability.package.version',
+    };
+    const implicitFilters = [
+      { 'rule.groups': 'vulnerability-detector' },
+      { 'agent.id': this.props.agentId },
+      this.state.clusterFilter,
+      ...Object.keys(currentItem)
+        .map((key) => {
+          if (filterMap[key] && currentItem[key] != '') {
+            return { [filterMap[key]]: currentItem[key] };
+          }
+        })
+        .filter((item) => item),
+    ];
+
     return (
       <EuiFlyout
         onClose={() => this.props.closeFlyout()}
@@ -94,19 +113,7 @@ export class FlyoutDetail extends Component {
         )}
         {currentItem && !this.state.isLoading && (
           <EuiFlyoutBody className="flyout-body">
-            <Details
-              currentItem={currentItem}
-              {...this.props}
-              implicitFilters={[
-                { 'rule.groups': 'vulnerability-detector' },
-                { 'data.vulnerability.package.name': currentItem.name },
-                { 'data.vulnerability.cve': currentItem.cve },
-                { 'data.vulnerability.package.architecture': currentItem.architecture },
-                { 'data.vulnerability.package.version': currentItem.version },
-                { 'agent.id': this.props.agentId },
-                this.state.clusterFilter,
-              ]}
-            />
+            <Details currentItem={currentItem} {...this.props} implicitFilters={implicitFilters} />
           </EuiFlyoutBody>
         )}
       </EuiFlyout>

--- a/public/components/agents/vuls/inventory/flyout.tsx
+++ b/public/components/agents/vuls/inventory/flyout.tsx
@@ -84,7 +84,7 @@ export class FlyoutDetail extends Component {
       this.state.clusterFilter,
       ...Object.keys(filterMap)
         .map((key) => {
-          if (currentItem[key] && currentItem[key] != '') {
+          if (currentItem[key]) {
             return { [filterMap[key]]: currentItem[key] };
           }
         })

--- a/public/components/agents/vuls/inventory/flyout.tsx
+++ b/public/components/agents/vuls/inventory/flyout.tsx
@@ -82,9 +82,9 @@ export class FlyoutDetail extends Component {
       { 'rule.groups': 'vulnerability-detector' },
       { 'agent.id': this.props.agentId },
       this.state.clusterFilter,
-      ...Object.keys(currentItem)
+      ...Object.keys(filterMap)
         .map((key) => {
-          if (filterMap[key] && currentItem[key] != '') {
+          if (currentItem[key] && currentItem[key] != '') {
             return { [filterMap[key]]: currentItem[key] };
           }
         })


### PR DESCRIPTION
Set the implicit filters of the vulnerabilities flyout to be populated dynamically depending on the available data.
closes https://github.com/wazuh/wazuh-kibana-app/issues/3587

### To test

1. Set up an environment with vulnerabilty scanner enabled and a windows agent
2. Enable sample data
3. Make sure in the discover tab that the vulnerability `CVE-2020-0678` has alerts for the selected agent
4. See the details in the vulnerability inventory for `CVE-2020-0678` and see that it contains the same alerts as in step 3
