### PR TITLE
Agent dissapear from url when unpin agent, fix visualization

### DIFF
--- a/public/components/wz-menu/wz-menu.js
+++ b/public/components/wz-menu/wz-menu.js
@@ -48,7 +48,7 @@ import { getDataPlugin } from '../../kibana-services';
 import { withWindowSize } from '../../components/common/hocs/withWindowSize';
 import { UI_LOGGER_LEVELS } from '../../../common/constants';
 import { UI_ERROR_SEVERITIES } from '../../react-services/error-orchestrator/types';
-import { getErrorOrchestrator } from '../../react-services/common-services'
+import { getErrorOrchestrator } from '../../react-services/common-services';
 
 
 const sections = {
@@ -649,6 +649,28 @@ export const WzMenu = withWindowSize(class WzMenu extends Component {
         </span>
       </span>
     )
+  }
+
+  async removeSelectedAgent() {
+    store.dispatch(updateCurrentAgentData({}));
+    if (window.location.href.includes("/agents?")) {
+      window.location.href = "#/agents-preview";
+      this.router.reload();
+      return;
+    }
+    await getAngularModule().$injector.get('$rootScope')._setAgent(false);
+    const { filterManager } = getDataPlugin().query;
+    const currentAppliedFilters = filterManager.getFilters();
+    const newFilters = currentAppliedFilters.filter(x => {
+      return x.meta.key !== 'agent.id';
+    });
+    filterManager.setFilters(newFilters);
+  }
+
+  getBadgeColor(agentStatus) {
+    if (agentStatus.toLowerCase() === 'active') { return 'secondary'; }
+    else if (agentStatus.toLowerCase() === 'disconnected') { return '#BD271E'; }
+    else if (agentStatus.toLowerCase() === 'never connected') { return 'default'; }
   }
 
   removeSelectedAgent() {

--- a/public/controllers/overview/overview.js
+++ b/public/controllers/overview/overview.js
@@ -156,6 +156,9 @@ export class OverviewController {
       this.$location.search('agentId', String(agent));
       this.updateSelectedAgents([formattedData.id]);
     }
+    // Bind a method to be accesible throuth the $rootScope. This is used by WzMenu which is not receiving
+    !this.$rootScope._setAgent && (this.$rootScope._setAgent = this.updateSelectedAgents.bind(this));
+    this.$rootScope.$applyAsync();
   }
 
   /**

--- a/public/react-services/vis-factory-handler.js
+++ b/public/react-services/vis-factory-handler.js
@@ -112,7 +112,7 @@ export class VisFactoryHandler {
 
     try {
       const data =
-        tab !== 'sca'
+        (!['sca', 'office'].includes(tab))
           ? await GenericRequest.request(
               'GET',
               `/elastic/visualizations/agents-${tab}/${AppState.getCurrentPattern()}`


### PR DESCRIPTION
Hi guys,

With this PR we solve the problem of blank visualizations when we pinned an agent and we solve that the agent persist in the URL when you unpinned it.

To test it:
- Try to pin an agent from a different place of SCA or Office pannel and make sure that visualizations are working properly.
- Try to unpin an agent from Office panel and check if the URL has changed too.

Closes #3564 