### PR TITLE
Removed api selector toggle from the settings menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fixed Wazuh main menu and breadcrumb render issues [#3347](https://github.com/wazuh/wazuh-kibana-app/pull/3347)
 - Fixed generation of huge logs from backend errors [#3397](https://github.com/wazuh/wazuh-kibana-app/pull/3397)
 - Fixed vulnerabilities flyout not showing alerts if the vulnerability had a field missing [#3593](https://github.com/wazuh/wazuh-kibana-app/pull/3593)
+- Removed api selector toggle from settings menu since it performed no useful function [#3604](https://github.com/wazuh/wazuh-kibana-app/pull/3604)
 
 ## Wazuh v4.2.1 - Kibana 7.10.2 , 7.11.2 - Revision 4202
 

--- a/common/constants.ts
+++ b/common/constants.ts
@@ -150,7 +150,6 @@ export const WAZUH_DEFAULT_APP_CONFIG = {
   'extensions.osquery': false,
   'extensions.docker': false,
   timeout: 20000,
-  'api.selector': true,
   'ip.selector': true,
   'ip.ignore': [],
   'xpack.rbac.enabled': true,

--- a/public/components/settings/configuration/utils/configuration-handler.js
+++ b/public/components/settings/configuration/utils/configuration-handler.js
@@ -19,9 +19,6 @@ export default class ConfigurationHandler {
    */
   static async editKey(key, value) {
     try {
-      if (key === 'api.selector') {
-        AppState.setAPISelector(value);
-      }
       if (key === 'ip.selector') {
         AppState.setPatternSelector(value);
       }

--- a/public/react-services/app-state.js
+++ b/public/react-services/app-state.js
@@ -237,12 +237,6 @@ export class AppState {
    * Set a new value to the 'patternSelector' cookie
    * @param {*} value
    */
-  static setAPISelector(value) {
-    const encodedPattern = encodeURI(value);
-    getCookies().set('APISelector', encodedPattern, {
-      path: window.location.pathname
-    });
-  }
 
   /**
    * Get 'patternSelector' value

--- a/public/react-services/app-state.js
+++ b/public/react-services/app-state.js
@@ -234,11 +234,6 @@ export class AppState {
   }
 
   /**
-   * Set a new value to the 'patternSelector' cookie
-   * @param {*} value
-   */
-
-  /**
    * Get 'patternSelector' value
    */
   static getPatternSelector() {

--- a/public/react-services/wz-api-check.js
+++ b/public/react-services/wz-api-check.js
@@ -37,7 +37,6 @@ export class ApiCheck {
 
       if (Object.keys(configuration).length) {
         AppState.setPatternSelector(configuration['ip.selector']);
-        AppState.setAPISelector(configuration['api.selector']);
       }
 
       const response = await axios(options);

--- a/public/services/resolves/get-config.js
+++ b/public/services/resolves/get-config.js
@@ -45,7 +45,6 @@ export async function getWzConfig($q, genericReq, wazuhConfig) {
     'extensions.osquery': false,
     'extensions.docker': false,
     timeout: 20000,
-    'api.selector': true,
     'ip.selector': true,
     'ip.ignore': [],
     'xpack.rbac.enabled': true,

--- a/public/utils/config-equivalences.js
+++ b/public/utils/config-equivalences.js
@@ -37,8 +37,6 @@ export const configEquivalences = {
     'Enable or disable the Docker listener tab on Overview and Agents.',
   timeout:
     'Defines the maximum time the app will wait for an API response when making requests to it.',
-  'api.selector':
-    'Defines if the user is allowed to change the selected API directly from the top menu bar.',
   'ip.selector':
     'Defines if the user is allowed to change the selected index pattern directly from the top menu bar.',
   'ip.ignore':
@@ -90,7 +88,6 @@ export const nameEquivalence = {
   'checks.timeFilter': 'Set time filter to 24h',
   'checks.maxBuckets': 'Set max buckets to 200000',
   timeout: 'Request timeout',
-  'api.selector': 'API selector',
   'ip.selector': 'IP selector',
   'ip.ignore': 'IP ignore',
   'xpack.rbac.enabled': 'X-Pack RBAC',
@@ -137,7 +134,6 @@ export const categoriesEquivalence = {
   'checks.timeFilter': HEALTH_CHECK,
   'checks.maxBuckets': HEALTH_CHECK,
   timeout: GENERAL,
-  'api.selector': GENERAL,
   'ip.selector': GENERAL,
   'ip.ignore': GENERAL,
   'wazuh.monitoring.enabled': MONITORING,
@@ -182,7 +178,6 @@ export const formEquivalence = {
   'checks.timeFilter': { type: BOOLEAN },
   'checks.maxBuckets': { type: BOOLEAN },
   timeout: { type: NUMBER },
-  'api.selector': { type: BOOLEAN },
   'ip.selector': { type: BOOLEAN },
   'ip.ignore': { type: ARRAY },
   'xpack.rbac.enabled': { type: BOOLEAN },


### PR DESCRIPTION
This PR removes the api selector toggle from the settings menu, since it was not actually affecting the state of the selector in the menu bar.

Closes https://github.com/wazuh/wazuh-kibana-app/issues/3335

### To test

- **Given** the browser is in wazuh app
- **When** the user navigates to `settings/configuration`
- **Then** the configuration panel does not show an api selector toggle

### Screenshots
Before
![Before](https://user-images.githubusercontent.com/80431234/133404845-c7efbac3-6099-4e8b-9582-75a62cafa697.png)

After
![After](https://user-images.githubusercontent.com/80431234/133404714-a4988933-7e7b-406e-9655-482a85d64242.png)
