### PR TITLE
Ordering logs properly

### DIFF
--- a/public/controllers/management/components/management/mg-logs/logs.js
+++ b/public/controllers/management/components/management/mg-logs/logs.js
@@ -149,8 +149,8 @@ export default compose(
     if (this.state.selectedDaemon !== 'all')
       result['tag'] = this.state.selectedDaemon;
     if (this.state.appliedSearch) result['search'] = this.state.appliedSearch;
-    if (this.state.descendingSort) result['sort'] = '+timestamp';
-    else result['sort'] = '-timestamp';
+    if (this.state.descendingSort) result['sort'] = '-timestamp';
+    else result['sort'] = '+timestamp';
 
     return result;
   }


### PR DESCRIPTION
Hi guys,

In this PR we fix the button of Descending Sort that is sorting the opposite of we wanted.

To test it;
Go to /Management/Logs and check the order of them when Descending sort is checked and when it is not.

Closes #3577 