### PR TITLE
Fix #3578 Logging out of the API should deprecate the token

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -111,6 +111,8 @@ app.run(function ($rootElement) {
   // Add plugin help links as extension to Kibana help menu
   addHelpMenuToAppChrome();
 
+  const urlToLogout = window.location.origin + '/logout';
+
   // Bind deleteExistentToken on Log out component.
   $('.euiHeaderSectionItem__button').on('mouseleave', function () {
     // opendistro
@@ -118,8 +120,13 @@ app.run(function ($rootElement) {
       WzAuthentication.deleteExistentToken();
     });
     // x-pack
-    $('a:contains(Log out)').on('click', function () {
-      WzAuthentication.deleteExistentToken();
+    $('a:contains(Log out)').on('click', function (event) {
+      // Override href's behaviour and navigate programatically
+      // to '/logout' once the token has been deleted.
+      event.preventDefault();
+      WzAuthentication.deleteExistentToken().then(() => {
+        window.location.replace(urlToLogout);
+      });
     });
   });
 });

--- a/public/app.js
+++ b/public/app.js
@@ -55,7 +55,7 @@ import store from './redux/store';
 import { updateCurrentPlatform } from './redux/actions/appStateActions';
 import { WzAuthentication, loadAppConfig } from './react-services';
 
-import { getAngularModule} from './kibana-services';
+import { getAngularModule } from './kibana-services';
 import { addHelpMenuToAppChrome } from './utils';
 
 const app = getAngularModule();
@@ -81,9 +81,11 @@ app.run([
     app.$injector = _$injector;
 
     // Set currentSecurity platform in Redux when app starts.
-    checkCurrentSecurityPlatform().then((item) => {
-      store.dispatch(updateCurrentPlatform(item))
-    }).catch(() => {});
+    checkCurrentSecurityPlatform()
+      .then((item) => {
+        store.dispatch(updateCurrentPlatform(item));
+      })
+      .catch(() => {});
 
     // Init the process of refreshing the user's token when app start.
     checkPluginVersion().finally(WzAuthentication.refresh);

--- a/public/react-services/wz-authentication.ts
+++ b/public/react-services/wz-authentication.ts
@@ -24,7 +24,15 @@ import { WAZUH_ROLE_ADMINISTRATOR_ID, WAZUH_ROLE_ADMINISTRATOR_NAME } from '../.
 import { getToasts } from '../kibana-services';
 import { getAuthorizedAgents } from '../react-services/wz-agents';
 
+/**
+ * Wazuh user authentication class
+ */
 export class WzAuthentication {
+  /**
+   *
+   * @param force
+   * @returns
+   */
   private static async login(force = false) {
     try {
       var idHost = JSON.parse(AppState.getCurrentAPI()).id;
@@ -41,6 +49,12 @@ export class WzAuthentication {
       return Promise.reject(error);
     }
   }
+
+  /**
+   *
+   * @param force
+   * @returns
+   */
   static async refresh(force = false) {
     try {
       // Get user token
@@ -84,6 +98,11 @@ export class WzAuthentication {
       return Promise.reject(error);
     }
   }
+
+  /**
+   *
+   * @returns
+   */
   private static async getUserPolicies() {
     try {
       var idHost = JSON.parse(AppState.getCurrentAPI()).id;
@@ -99,19 +118,28 @@ export class WzAuthentication {
     }
   }
 
+  /**
+   *
+   * @param roles
+   * @returns
+   */
   private static mapUserRolesIDToAdministratorRole(roles) {
     return roles.map((role: number) =>
       role === WAZUH_ROLE_ADMINISTRATOR_ID ? WAZUH_ROLE_ADMINISTRATOR_NAME : role
     );
   }
 
+  /**
+   * Sends a request to the Wazuh's API to delete the user's token.
+   * @returns Object
+   */
   static async deleteExistentToken() {
     try {
       const response = await WzRequest.apiReq('DELETE', '/security/user/authenticate', {});
 
       return ((response || {}).data || {}).data || {};
     } catch (error) {
-      throw error;
+      return Promise.reject(error);
     }
   }
 

--- a/public/react-services/wz-authentication.ts
+++ b/public/react-services/wz-authentication.ts
@@ -14,17 +14,22 @@ import { WzRequest } from './wz-request';
 import { AppState } from './app-state';
 import jwtDecode from 'jwt-decode';
 import store from '../redux/store';
-import { updateUserPermissions, updateUserRoles, updateWithUserLogged, updateAllowedAgents } from '../redux/actions/appStateActions';
+import {
+  updateUserPermissions,
+  updateUserRoles,
+  updateWithUserLogged,
+  updateAllowedAgents,
+} from '../redux/actions/appStateActions';
 import { WAZUH_ROLE_ADMINISTRATOR_ID, WAZUH_ROLE_ADMINISTRATOR_NAME } from '../../common/constants';
 import { getToasts } from '../kibana-services';
 import { getAuthorizedAgents } from '../react-services/wz-agents';
 
-export class WzAuthentication{
-  private static async login(force=false){
-    try{
+export class WzAuthentication {
+  private static async login(force = false) {
+    try {
       var idHost = JSON.parse(AppState.getCurrentAPI()).id;
-      while(!idHost){
-        await new Promise(r => setTimeout(r, 500));
+      while (!idHost) {
+        await new Promise((r) => setTimeout(r, 500));
         idHost = JSON.parse(AppState.getCurrentAPI()).id;
       }
 
@@ -32,15 +37,15 @@ export class WzAuthentication{
 
       const token = ((response || {}).data || {}).token;
       return token as string;
-    }catch(error){
+    } catch (error) {
       return Promise.reject(error);
     }
   }
-  static async refresh(force = false){
+  static async refresh(force = false) {
     try {
       // Get user token
       const token: string = await WzAuthentication.login(force);
-      if(!token){
+      if (!token) {
         // Remove old existent token
         await WzAuthentication.deleteExistentToken();
         return;
@@ -51,53 +56,58 @@ export class WzAuthentication{
 
       // Get user Policies
       const userPolicies = await WzAuthentication.getUserPolicies();
-      
+
       //Get allowed agents for the current user
       let allowedAgents: any = [];
       if (WzAuthentication.userHasAgentsPermissions(userPolicies)) {
         allowedAgents = await getAuthorizedAgents();
         allowedAgents = allowedAgents.length ? allowedAgents : ['-1']; // users without read:agent police should not view info about any agent
-      } 
+      }
       store.dispatch(updateAllowedAgents(allowedAgents));
 
-      
       // Dispatch actions to set permissions and roles
       store.dispatch(updateUserPermissions(userPolicies));
-      store.dispatch(updateUserRoles(WzAuthentication.mapUserRolesIDToAdministratorRole(jwtPayload.rbac_roles || [])));
+      store.dispatch(
+        updateUserRoles(
+          WzAuthentication.mapUserRolesIDToAdministratorRole(jwtPayload.rbac_roles || [])
+        )
+      );
       store.dispatch(updateWithUserLogged(true));
-    }catch(error){
+    } catch (error) {
       getToasts().add({
         color: 'danger',
         title: 'Error getting the authorization token',
         text: error.message || error,
-        toastLifeTimeMs: 300000
+        toastLifeTimeMs: 300000,
       });
       store.dispatch(updateWithUserLogged(true));
       return Promise.reject(error);
     }
   }
-  private static async getUserPolicies(){
-    try{
+  private static async getUserPolicies() {
+    try {
       var idHost = JSON.parse(AppState.getCurrentAPI()).id;
-      while(!idHost){
-        await new Promise(r => setTimeout(r, 500));
+      while (!idHost) {
+        await new Promise((r) => setTimeout(r, 500));
         idHost = JSON.parse(AppState.getCurrentAPI()).id;
       }
       const response = await WzRequest.apiReq('GET', '/security/users/me/policies', { idHost });
       const policies = ((response || {}).data || {}).data || {};
       return policies;
-    }catch(error){
+    } catch (error) {
       return Promise.reject(error);
     }
   }
 
-  private static mapUserRolesIDToAdministratorRole(roles){
-    return roles.map((role: number) => role === WAZUH_ROLE_ADMINISTRATOR_ID ? WAZUH_ROLE_ADMINISTRATOR_NAME : role);
+  private static mapUserRolesIDToAdministratorRole(roles) {
+    return roles.map((role: number) =>
+      role === WAZUH_ROLE_ADMINISTRATOR_ID ? WAZUH_ROLE_ADMINISTRATOR_NAME : role
+    );
   }
 
   static async deleteExistentToken() {
     try {
-      const response = await WzRequest.apiReq('DELETE','/security/user/authenticate', {});
+      const response = await WzRequest.apiReq('DELETE', '/security/user/authenticate', {});
 
       return ((response || {}).data || {}).data || {};
     } catch (error) {
@@ -109,15 +119,17 @@ export class WzAuthentication{
    * This function returns true only if the user has some police that need be filtered.
    * Returns false if the user has permission for all agents.
    * Returns true if the user has no one police for agent:read.
-   * @param policies 
+   * @param policies
    * @returns boolean
    */
   static userHasAgentsPermissions(policies) {
     const agentReadPolicies = policies['agent:read'];
     if (agentReadPolicies) {
-      const allIds = agentReadPolicies['agent:id:*'] == 'allow';      
+      const allIds = agentReadPolicies['agent:id:*'] == 'allow';
       const allGroups = agentReadPolicies['agent:group:*'] == 'allow';
-      const denyAgents = Object.keys(agentReadPolicies).some(k => !k.includes('*') && agentReadPolicies[k] == 'deny');
+      const denyAgents = Object.keys(agentReadPolicies).some(
+        (k) => !k.includes('*') && agentReadPolicies[k] == 'deny'
+      );
       return !((allIds || allGroups) && !denyAgents);
     }
     // users without read:agent police should not view info about any agent


### PR DESCRIPTION
The request to deprecate the user's token was cancelled by the browser due to the removal of the DOM element that triggered the event. In this case, the logout button perfomed an inmediate redirect to the `'/logout'` page, and therefore, removing the element from the DOM, causing the failure of the request.

As a solution, the anchor's behaviour (<a href='logout'..>)(part of X-Pack plugin) has been overrided with `event.preventDefault()`, to later on navigate programatically to `'/logout'` once a response from the server has been received.

![image](https://user-images.githubusercontent.com/15186973/135436410-92c295d3-ff97-4a2b-b1d7-6cf651f9a17e.png)
