### PR TITLE
change format permissions in FIM inventory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Refactored all try catch value of context for ErrorOrchestrator service. [#3432](https://github.com/wazuh/wazuh-kibana-app/pull/3432)
 - Refactored all try catch strategy on Controller/Groups section [#3415](https://github.com/wazuh/wazuh-kibana-app/pull/3415)
 - Refactored as module tabs and buttons are rendered [#3494](https://github.com/wazuh/wazuh-kibana-app/pull/3494)
-- change format permissions in FIM inventory [#3649](https://github.com/wazuh/wazuh-kibana-app/pull/3649)
+- Changed format permissions in FIM inventory [#3649](https://github.com/wazuh/wazuh-kibana-app/pull/3649)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Refactored all try catch value of context for ErrorOrchestrator service. [#3432](https://github.com/wazuh/wazuh-kibana-app/pull/3432)
 - Refactored all try catch strategy on Controller/Groups section [#3415](https://github.com/wazuh/wazuh-kibana-app/pull/3415)
 - Refactored as module tabs and buttons are rendered [#3494](https://github.com/wazuh/wazuh-kibana-app/pull/3494)
+- change format permissions in FIM inventory [#3649](https://github.com/wazuh/wazuh-kibana-app/pull/3649)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,6 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Refactored all try catch value of context for ErrorOrchestrator service. [#3432](https://github.com/wazuh/wazuh-kibana-app/pull/3432)
 - Refactored all try catch strategy on Controller/Groups section [#3415](https://github.com/wazuh/wazuh-kibana-app/pull/3415)
 - Refactored as module tabs and buttons are rendered [#3494](https://github.com/wazuh/wazuh-kibana-app/pull/3494)
-- Change format permissions in FIM inventory [#3649](https://github.com/wazuh/wazuh-kibana-app/pull/3649)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,28 +7,28 @@ All notable changes to the Wazuh app project will be documented in this file.
 ### Added
 
 - Added new endpoint service to collect the frontend logs into a file [#3324](https://github.com/wazuh/wazuh-kibana-app/pull/3324)
-- Improved the frontend handle errors strategy: UI, Toasts, console log and log in file 
-  [#3327](https://github.com/wazuh/wazuh-kibana-app/pull/3327) 
-  [#3321](https://github.com/wazuh/wazuh-kibana-app/pull/3321) 
-  [#3367](https://github.com/wazuh/wazuh-kibana-app/pull/3367) 
-  [#3374](https://github.com/wazuh/wazuh-kibana-app/pull/3374) 
+- Improved the frontend handle errors strategy: UI, Toasts, console log and log in file
+  [#3327](https://github.com/wazuh/wazuh-kibana-app/pull/3327)
+  [#3321](https://github.com/wazuh/wazuh-kibana-app/pull/3321)
+  [#3367](https://github.com/wazuh/wazuh-kibana-app/pull/3367)
+  [#3374](https://github.com/wazuh/wazuh-kibana-app/pull/3374)
   [#3390](https://github.com/wazuh/wazuh-kibana-app/pull/3390)  
-  [#3410](https://github.com/wazuh/wazuh-kibana-app/pull/3410) 
-  [#3408](https://github.com/wazuh/wazuh-kibana-app/pull/3408) 
-  [#3429](https://github.com/wazuh/wazuh-kibana-app/pull/3429) 
-  [#3427](https://github.com/wazuh/wazuh-kibana-app/pull/3427) 
-  [#3417](https://github.com/wazuh/wazuh-kibana-app/pull/3417) 
-  [#3462](https://github.com/wazuh/wazuh-kibana-app/pull/3462) 
-  [#3451](https://github.com/wazuh/wazuh-kibana-app/pull/3451) 
+  [#3410](https://github.com/wazuh/wazuh-kibana-app/pull/3410)
+  [#3408](https://github.com/wazuh/wazuh-kibana-app/pull/3408)
+  [#3429](https://github.com/wazuh/wazuh-kibana-app/pull/3429)
+  [#3427](https://github.com/wazuh/wazuh-kibana-app/pull/3427)
+  [#3417](https://github.com/wazuh/wazuh-kibana-app/pull/3417)
+  [#3462](https://github.com/wazuh/wazuh-kibana-app/pull/3462)
+  [#3451](https://github.com/wazuh/wazuh-kibana-app/pull/3451)
   [#3442](https://github.com/wazuh/wazuh-kibana-app/pull/3442)
-  [#3480](https://github.com/wazuh/wazuh-kibana-app/pull/3480) 
-  [#3472](https://github.com/wazuh/wazuh-kibana-app/pull/3472) 
-  [#3434](https://github.com/wazuh/wazuh-kibana-app/pull/3434) 
+  [#3480](https://github.com/wazuh/wazuh-kibana-app/pull/3480)
+  [#3472](https://github.com/wazuh/wazuh-kibana-app/pull/3472)
+  [#3434](https://github.com/wazuh/wazuh-kibana-app/pull/3434)
   [#3392](https://github.com/wazuh/wazuh-kibana-app/pull/3392)
-  [#3404](https://github.com/wazuh/wazuh-kibana-app/pull/3404) 
-  [#3432](https://github.com/wazuh/wazuh-kibana-app/pull/3432) 
-  [#3415](https://github.com/wazuh/wazuh-kibana-app/pull/3415) 
-  [#3469](https://github.com/wazuh/wazuh-kibana-app/pull/3469) 
+  [#3404](https://github.com/wazuh/wazuh-kibana-app/pull/3404)
+  [#3432](https://github.com/wazuh/wazuh-kibana-app/pull/3432)
+  [#3415](https://github.com/wazuh/wazuh-kibana-app/pull/3415)
+  [#3469](https://github.com/wazuh/wazuh-kibana-app/pull/3469)
   [#3448](https://github.com/wazuh/wazuh-kibana-app/pull/3448)
   [#3465](https://github.com/wazuh/wazuh-kibana-app/pull/3465)
   [#3464](https://github.com/wazuh/wazuh-kibana-app/pull/3464)
@@ -49,7 +49,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 
 ### Fixed
 
-- Fixed creation of log files [#3384](https://github.com/wazuh/wazuh-kibana-app/pull/3384) 
+- Fixed creation of log files [#3384](https://github.com/wazuh/wazuh-kibana-app/pull/3384)
 - Fixed rules and decoders test flyout clickout event [#3412](https://github.com/wazuh/wazuh-kibana-app/pull/3412)
 - Notify when you are registering an agent without permissions [#3430](https://github.com/wazuh/wazuh-kibana-app/pull/3430)
 - Remove not used `redirectRule` query param when clicking the row table on CDB Lists/Decoders [#3438](https://github.com/wazuh/wazuh-kibana-app/pull/3438)
@@ -59,6 +59,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fix size api selector when name is too long [#3445](https://github.com/wazuh/wazuh-kibana-app/pull/3445)
 - Fixed error when edit a rule or decoder [#3456](https://github.com/wazuh/wazuh-kibana-app/pull/3456)
 - Fixed index pattern selector doesn't display the ignored index patterns [#3458](https://github.com/wazuh/wazuh-kibana-app/pull/3458)
+- change format permissions in FIM inventory [#3649](https://github.com/wazuh/wazuh-kibana-app/pull/3649)
 
 ## Wazuh v4.2.3 - Kibana 7.10.2 , 7.12.1 - Revision 4204
 
@@ -112,10 +113,10 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fixed modules are missing in the agent menu [#3244](https://github.com/wazuh/wazuh-kibana-app/pull/3244)
 - Fixed Alerts Summary of modules for reports [#3303](https://github.com/wazuh/wazuh-kibana-app/pull/3303)
 - Fixed dark mode visualization background in pdf reports [#3315](https://github.com/wazuh/wazuh-kibana-app/pull/3315)
-- Adapt Kibana integrations to Kibana 7.11 and 7.12  [#3309](https://github.com/wazuh/wazuh-kibana-app/pull/3309)
-- Fixed error agent view does not render correctly  [#3306](https://github.com/wazuh/wazuh-kibana-app/pull/3306)
-- Fixed miscalculation in table column width in PDF reports  [#3326](https://github.com/wazuh/wazuh-kibana-app/pull/3326)
-- Normalized visData table property for 7.12 retro-compatibility  [#3323](https://github.com/wazuh/wazuh-kibana-app/pull/3323)
+- Adapt Kibana integrations to Kibana 7.11 and 7.12 [#3309](https://github.com/wazuh/wazuh-kibana-app/pull/3309)
+- Fixed error agent view does not render correctly [#3306](https://github.com/wazuh/wazuh-kibana-app/pull/3306)
+- Fixed miscalculation in table column width in PDF reports [#3326](https://github.com/wazuh/wazuh-kibana-app/pull/3326)
+- Normalized visData table property for 7.12 retro-compatibility [#3323](https://github.com/wazuh/wazuh-kibana-app/pull/3323)
 - Fixed error that caused the labels in certain visualizations to overlap [#3355](https://github.com/wazuh/wazuh-kibana-app/pull/3355)
 - Fixed export to csv button in dashboards tables [#3358](https://github.com/wazuh/wazuh-kibana-app/pull/3358)
 - Fixed Elastic UI breaking changes in 7.12 [#3345](https://github.com/wazuh/wazuh-kibana-app/pull/3345)
@@ -147,7 +148,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 
 ### Changed
 
-- Moved Dev Tools inside of Tools menu as Api Console.  [#1434](https://github.com/wazuh/wazuh-kibana-app/pull/1434)
+- Moved Dev Tools inside of Tools menu as Api Console. [#1434](https://github.com/wazuh/wazuh-kibana-app/pull/1434)
 - Changed position of Top users on Integrity Monitoring Top 5 user. [#2892](https://github.com/wazuh/wazuh-kibana-app/pull/2892)
 - Changed user allow_run_as way of editing. [#3080](https://github.com/wazuh/wazuh-kibana-app/pull/3080)
 - Rename some ossec references to Wazuh [#3046](https://github.com/wazuh/wazuh-kibana-app/pull/3046)
@@ -191,6 +192,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 
 - Conflict with the creation of the index pattern when performing the Health Check [#3223](https://github.com/wazuh/wazuh-kibana-app/pull/3223)
 - Fixing mac os agents add command [#3207](https://github.com/wazuh/wazuh-kibana-app/pull/3207)
+
 ## Wazuh v4.1.5 - Kibana 7.10.0 , 7.10.2 - Revision 4106
 
 - Adapt for Wazuh 4.1.5
@@ -208,7 +210,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Added loading view while the user is logging to prevent permissions prompts [#3041](https://github.com/wazuh/wazuh-kibana-app/pull/3041)
 - Added custom message for each possible run_as setup [#3048](https://github.com/wazuh/wazuh-kibana-app/pull/3048)
 
-### Changed 
+### Changed
 
 - Change all dates labels to Kibana formatting time zone [#3047](https://github.com/wazuh/wazuh-kibana-app/pull/3047)
 - Improve toast message when selecting a default API [#3049](https://github.com/wazuh/wazuh-kibana-app/pull/3049)
@@ -315,6 +317,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 ## Wazuh v4.0.4 - Kibana 7.10.0 , 7.10.2 - Revision 4017
 
 ### Added
+
 - Adapt the app to the new Kibana platform [#2475](https://github.com/wazuh/wazuh-kibana-app/issues/2475)
 - Wazuh data directory moved from `optimize` to `data` Kibana directory [#2591](https://github.com/wazuh/wazuh-kibana-app/issues/2591)
 - Show the wui_rules belong to wazuh-wui API user [#2702](https://github.com/wazuh/wazuh-kibana-app/issues/2702)
@@ -325,7 +328,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fixed wrong shards and replicas for statistics indices and also fixed wrong prefix for monitoring indices [#2732](https://github.com/wazuh/wazuh-kibana-app/issues/2732)
 - Report's creation dates set to 1970-01-01T00:00:00.000Z [#2772](https://github.com/wazuh/wazuh-kibana-app/issues/2772)
 - Fixed bug for missing commands in ubuntu/debian and centos [#2786](https://github.com/wazuh/wazuh-kibana-app/issues/2786)
-- Fixed bug that show an hour before in /security-events/dashboard [#2785](https://github.com/wazuh/wazuh-kibana-app/issues/2785) 
+- Fixed bug that show an hour before in /security-events/dashboard [#2785](https://github.com/wazuh/wazuh-kibana-app/issues/2785)
 - Fixed permissions to access agents [#2838](https://github.com/wazuh/wazuh-kibana-app/issues/2838)
 - Fix searching in groups [#2825](https://github.com/wazuh/wazuh-kibana-app/issues/2825)
 - Fix the pagination in SCA ckecks table [#2815](https://github.com/wazuh/wazuh-kibana-app/issues/2815)
@@ -380,7 +383,6 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Wui rules label should have only one tooltip [#2723](https://github.com/wazuh/wazuh-kibana-app/issues/2723)
 - Move upper the Wazuh item in the Kibana menu and default index pattern [#2867](https://github.com/wazuh/wazuh-kibana-app/pull/2867)
 
-
 ## Wazuh v4.0.4 - Kibana v7.9.1, v7.9.3 - Revision 4015
 
 ### Added
@@ -411,7 +413,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 
 ### Added
 
-- Sample data indices name should take index pattern in use [#2593](https://github.com/wazuh/wazuh-kibana-app/issues/2593) 
+- Sample data indices name should take index pattern in use [#2593](https://github.com/wazuh/wazuh-kibana-app/issues/2593)
 - Added start option to macos Agents [#2653](https://github.com/wazuh/wazuh-kibana-app/pull/2653)
 
 ### Changed
@@ -483,8 +485,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Undefined field in event view [#2588](https://github.com/wazuh/wazuh-kibana-app/issues/2588)
 - Several calls to the same stats request (esAlerts) [#2586](https://github.com/wazuh/wazuh-kibana-app/issues/2586)
 - The filter options popup doesn't open on click once the filter is pinned [#2581](https://github.com/wazuh/wazuh-kibana-app/issues/2581)
-- The formatedFields are missing from the index-pattern of wazuh-alerts-* [#2574](https://github.com/wazuh/wazuh-kibana-app/issues/2574)
-
+- The formatedFields are missing from the index-pattern of wazuh-alerts-\* [#2574](https://github.com/wazuh/wazuh-kibana-app/issues/2574)
 
 ## Wazuh v4.0.0 - Kibana v7.9.3 - Revision 4005
 
@@ -530,6 +531,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Support for Wazuh v3.13.2
 
 ## Wazuh v3.13.2 - Kibana v7.8.0 - Revision 887
+
 ### Added
 
 - Support for Wazuh v3.13.2
@@ -546,13 +548,11 @@ All notable changes to the Wazuh app project will be documented in this file.
 
 - Support for Kibana v7.9.0
 
-
 ## Wazuh v3.13.1 - Kibana v7.8.1 - Revision 884
 
 ### Added
 
 - Support for Kibana v7.8.1
-
 
 ## Wazuh v3.13.1 - Kibana v7.8.0 - Revision 883
 
@@ -560,13 +560,11 @@ All notable changes to the Wazuh app project will be documented in this file.
 
 - Support for Wazuh v3.13.1
 
-
 ## Wazuh v3.13.0 - Kibana v7.8.0 - Revision 881
 
 ### Added
 
 - Support for Kibana v7.8.0
-
 
 ## Wazuh v3.13.0 - Kibana v7.7.0, v7.7.1 - Revision 880
 
@@ -600,13 +598,11 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Avoid creating the wazuh-monitoring index pattern if it is disabled [#2100](https://github.com/wazuh/wazuh-kibana-app/issues/2100)
 - SCA checks without compliance field can't be expanded [#2264](https://github.com/wazuh/wazuh-kibana-app/issues/2264)
 
-
 ## Wazuh v3.12.3 - Kibana v7.7.1 - Revision 876
 
 ### Added
 
 - Support for Kibana v7.7.1
-
 
 ## Wazuh v3.12.3 - Kibana v7.7.0 - Revision 875
 
@@ -614,20 +610,17 @@ All notable changes to the Wazuh app project will be documented in this file.
 
 - Support for Kibana v7.7.0
 
-
 ## Wazuh v3.12.3 - Kibana v6.8.8, v7.6.1, v7.6.2 - Revision 874
 
 ### Added
 
 - Support for Wazuh v3.12.3
 
-
 ## Wazuh v3.12.2 - Kibana v6.8.8, v7.6.1, v7.6.2 - Revision 873
 
 ### Added
 
 - Support for Wazuh v3.12.2
-
 
 ## Wazuh v3.12.1 - Kibana v6.8.8, v7.6.1, v7.6.2 - Revision 872
 
@@ -643,7 +636,6 @@ All notable changes to the Wazuh app project will be documented in this file.
 ### Fixed
 
 - Pagination is now shown in table-type visualizations. [#2180](https://github.com/wazuh/wazuh-kibana-app/issues/2180)
-
 
 ## Wazuh v3.12.0 - Kibana v6.8.8, v7.6.2 - Revision 871
 
@@ -672,13 +664,11 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Added the win_auth_failure rule group to Authentication failure metrics. [#2099](https://github.com/wazuh/wazuh-kibana-app/pull/2099)
 - Negative values in Syscheck attributes now have their correct value in reports. [7c3e84e](https://github.com/wazuh/wazuh-kibana-app/commit/7c3e84ec8f00760b4f650cfc00a885d868123f99)
 
-
 ## Wazuh v3.11.4 - Kibana v7.6.1 - Revision 858
 
 ### Added
 
 - Support for Kibana v7.6.1
-
 
 ## Wazuh v3.11.4 - Kibana v6.8.6, v7.4.2, v7.6.0 - Revision 857
 
@@ -686,13 +676,11 @@ All notable changes to the Wazuh app project will be documented in this file.
 
 - Support for Wazuh v3.11.4
 
-
 ## Wazuh v3.11.3 - Kibana v7.6.0 - Revision 856
 
 ### Added
 
 - Support for Kibana v7.6.0
-
 
 ## Wazuh v3.11.3 - Kibana v7.4.2 - Revision 855
 
@@ -710,13 +698,11 @@ All notable changes to the Wazuh app project will be documented in this file.
 
 - Windows Updates table is now displayed in the Inventory Data report [#2028](https://github.com/wazuh/wazuh-kibana-app/pull/2028)
 
-
 ## Wazuh v3.11.2 - Kibana v7.5.2 - Revision 853
 
 ### Added
 
 - Support for Kibana v7.5.2
-
 
 ## Wazuh v3.11.2 - Kibana v6.8.6, v7.3.2, v7.5.1 - Revision 852
 
@@ -733,12 +719,11 @@ All notable changes to the Wazuh app project will be documented in this file.
 - The xml validator now correctly handles the `--` string within comments [#1980](https://github.com/wazuh/wazuh-kibana-app/pull/1980)
 - The AWS map visualization wasn't been loaded until the user interacts with it [dd31bd7](https://github.com/wazuh/wazuh-kibana-app/commit/dd31bd7a155354bc50fe0af22fca878607c8936a)
 
-
 ## Wazuh v3.11.1 - Kibana v6.8.6, v7.3.2, v7.5.1 - Revision 581
 
 ### Added
-- Support for Wazuh v3.11.1.
 
+- Support for Wazuh v3.11.1.
 
 ## Wazuh v3.11.0 - Kibana v6.8.6, v7.3.2, v7.5.1 - Revision 580
 
@@ -784,13 +769,11 @@ All notable changes to the Wazuh app project will be documented in this file.
 
 - Support for Kibana v7.5.1
 
-
 ## Wazuh v3.10.2 - Kibana v7.5.0 - Revision 555
 
 ### Added
 
 - Support for Kibana v7.5.0
-
 
 ## Wazuh v3.10.2 - Kibana v7.4.2 - Revision 549
 
@@ -798,13 +781,11 @@ All notable changes to the Wazuh app project will be documented in this file.
 
 - Support for Kibana v7.4.2
 
-
 ## Wazuh v3.10.2 - Kibana v7.4.1 - Revision 548
 
 ### Added
 
 - Support for Kibana v7.4.1
-
 
 ## Wazuh v3.10.2 - Kibana v7.4.0 - Revision 547
 
@@ -813,13 +794,11 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Support for Kibana v7.4.0
 - Support for Wazuh v3.10.2.
 
-
 ## Wazuh v3.10.2 - Kibana v7.3.2 - Revision 546
 
 ### Added
 
 - Support for Wazuh v3.10.2.
-
 
 ## Wazuh v3.10.1 - Kibana v7.3.2 - Revision 545
 
@@ -827,14 +806,13 @@ All notable changes to the Wazuh app project will be documented in this file.
 
 - Support for Wazuh v3.10.1.
 
-
 ## Wazuh v3.10.0 - Kibana v7.3.2 - Revision 543
 
 ### Added
 
 - Support for Wazuh v3.10.0.
 - Added an interactive guide for registering agents, things are now easier for the user, guiding it through the steps needed ending in a _copy & paste_ snippet for deploying his agent [#1468](https://github.com/wazuh/wazuh-kibana-app/issues/1468).
-- Added new dashboards for the recently added regulatory compliance groups into the Wazuh core. They are HIPAA and NIST-800-53 [#1468](https://github.com/wazuh/wazuh-kibana-app/issues/1448), [#1638]( https://github.com/wazuh/wazuh-kibana-app/issues/1638).
+- Added new dashboards for the recently added regulatory compliance groups into the Wazuh core. They are HIPAA and NIST-800-53 [#1468](https://github.com/wazuh/wazuh-kibana-app/issues/1448), [#1638](https://github.com/wazuh/wazuh-kibana-app/issues/1638).
 - Make the app work under a custom Kibana space [#1234](https://github.com/wazuh/wazuh-kibana-app/issues/1234), [#1450](https://github.com/wazuh/wazuh-kibana-app/issues/1450).
 - Added the ability to manage the app as a native plugin when using Kibana spaces, now you can safely hide/show the app depending on the selected space [#1601](https://github.com/wazuh/wazuh-kibana-app/issues/1601).
 - Adapt the app the for Kibana dark mode [#1562](https://github.com/wazuh/wazuh-kibana-app/issues/1562).
@@ -842,13 +820,12 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Export all the information of a Wazuh group and its related agents in a PDF document [#1341](https://github.com/wazuh/wazuh-kibana-app/issues/1341).
 - Export the configuration of a certain agent as a PDF document. Supports granularity for exporting just certain sections of the configuration [#1340](https://github.com/wazuh/wazuh-kibana-app/issues/1340).
 
-
 ### Changed
 
 - Reduced _Agents preview_ load time using the new API endpoint `/summary/agents` [#1687](https://github.com/wazuh/wazuh-kibana-app/pull/1687).
 - Replaced most of the _md-nav-bar_ Angular.js components with React components using EUI [#1705](https://github.com/wazuh/wazuh-kibana-app/pull/1705).
 - Replaced the requirements slider component with a new styled component [#1708](https://github.com/wazuh/wazuh-kibana-app/pull/1708).
-- Soft deprecated the _.wazuh-version_ internal index, now the app dumps its content if applicable to a registry file, then the app removes that index. Further versions will hard deprecate this index [#1467](https://github.com/wazuh/wazuh-kibana-app/issues/1467). 
+- Soft deprecated the _.wazuh-version_ internal index, now the app dumps its content if applicable to a registry file, then the app removes that index. Further versions will hard deprecate this index [#1467](https://github.com/wazuh/wazuh-kibana-app/issues/1467).
 - Visualizations now don't fetch the documents _source_, also, they now use _size: 0_ for fetching [#1663](https://github.com/wazuh/wazuh-kibana-app/issues/1663).
 - The app menu is now fixed on top of the view, it's not being hidden on every state change. Also, the Wazuh logo was placed in the top bar of Kibana UI [#1502](https://github.com/wazuh/wazuh-kibana-app/issues/1502).
 - Improved _getTimestamp_ method not returning a promise object because it's no longer needed [014bc3a](https://github.com/wazuh/wazuh-kibana-app/commit/014b3aba0d2e9cda0c4d521f5f16faddc434a21e). Also improved main Discover listener for Wazuh not returning a promise object [bd82823](https://github.com/wazuh/wazuh-kibana-app/commit/bd8282391a402b8c567b32739cf914a0135d74bc).
@@ -869,7 +846,6 @@ All notable changes to the Wazuh app project will be documented in this file.
 - The app installation date was not being updated properly, now it's fixed [#1692](https://github.com/wazuh/wazuh-kibana-app/issues/1692).
 - Fixed _Network interfaces_ table in Inventory section, the table was not paginating [#1474](https://github.com/wazuh/wazuh-kibana-app/issues/1474).
 - Fixed APIs passwords are now obfuscated in server responses [adc3152](https://github.com/wazuh/wazuh-kibana-app/pull/1782/commits/adc31525e26b25e4cb62d81cbae70a8430728af5).
-
 
 ## Wazuh v3.9.5 - Kibana v6.8.2 / Kibana v7.2.1 / Kibana v7.3.0 - Revision 531
 
@@ -910,13 +886,13 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fix not properly updated breadcrumb in ruleset section [9645903](https://github.com/wazuh/wazuh-kibana-app/commit/96459031cd4edbe047970bf0d22d0c099771879f)
 - Fix badly dimensioned table in Integrity Monitoring section [9645903](https://github.com/wazuh/wazuh-kibana-app/commit/96459031cd4edbe047970bf0d22d0c099771879f)
 - Fix implicit filters can be destroyed [9cf8578](https://github.com/wazuh/wazuh-kibana-app/commit/9cf85786f504f5d67edddeea6cfbf2ab577e799b)
-- Windows agent dashboard doesn't show failure logon access. [d38d088](https://github.com/wazuh/wazuh-kibana-app/commit/d38d0881ac8e4294accde83d63108337b74cdd91) 
-- Number of agents is not properly updated.  [f7cbbe5](https://github.com/wazuh/wazuh-kibana-app/commit/f7cbbe54394db825827715c3ad4370ac74317108) 
-- Missing scrollbar on Firefox file viewer.  [df4e8f9](https://github.com/wazuh/wazuh-kibana-app/commit/df4e8f9305b35e9ee1473bed5f5d452dd3420567) 
-- Agent search filter by name, lost when refreshing. [71b5274](https://github.com/wazuh/wazuh-kibana-app/commit/71b5274ccc332d8961a158587152f7badab28a95) 
-- Alerts of level 12 cannot be displayed in the Summary table. [ec0e888](https://github.com/wazuh/wazuh-kibana-app/commit/ec0e8885d9f1306523afbc87de01a31f24e36309) 
-- Restored query from search bar in visualizations. [439128f](https://github.com/wazuh/wazuh-kibana-app/commit/439128f0a1f65b649a9dcb81ab5804ca20f65763) 
-- Fix Kibana filters loop in Firefox. [82f0f32](https://github.com/wazuh/wazuh-kibana-app/commit/82f0f32946d844ce96a28f0185f903e8e05c5589) 
+- Windows agent dashboard doesn't show failure logon access. [d38d088](https://github.com/wazuh/wazuh-kibana-app/commit/d38d0881ac8e4294accde83d63108337b74cdd91)
+- Number of agents is not properly updated. [f7cbbe5](https://github.com/wazuh/wazuh-kibana-app/commit/f7cbbe54394db825827715c3ad4370ac74317108)
+- Missing scrollbar on Firefox file viewer. [df4e8f9](https://github.com/wazuh/wazuh-kibana-app/commit/df4e8f9305b35e9ee1473bed5f5d452dd3420567)
+- Agent search filter by name, lost when refreshing. [71b5274](https://github.com/wazuh/wazuh-kibana-app/commit/71b5274ccc332d8961a158587152f7badab28a95)
+- Alerts of level 12 cannot be displayed in the Summary table. [ec0e888](https://github.com/wazuh/wazuh-kibana-app/commit/ec0e8885d9f1306523afbc87de01a31f24e36309)
+- Restored query from search bar in visualizations. [439128f](https://github.com/wazuh/wazuh-kibana-app/commit/439128f0a1f65b649a9dcb81ab5804ca20f65763)
+- Fix Kibana filters loop in Firefox. [82f0f32](https://github.com/wazuh/wazuh-kibana-app/commit/82f0f32946d844ce96a28f0185f903e8e05c5589)
 
 ## Wazuh v3.9.3 - Kibana v6.8.1 / v7.1.1 / v7.2.0 - Revision 523
 
@@ -975,7 +951,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 ### Fixed
 
 - Fixed missing dependency for Discover [43f5dd5](https://github.com/wazuh/wazuh-kibana-app/commit/43f5dd5f64065c618ba930b2a4087f0a9e706c0e).
-- Fixed visualization for Agents > Overview [#1477](https://github.com/wazuh/wazuh-kibana-app/pull/1477). 
+- Fixed visualization for Agents > Overview [#1477](https://github.com/wazuh/wazuh-kibana-app/pull/1477).
 - Fixed SCA policy checks table [#1478](https://github.com/wazuh/wazuh-kibana-app/pull/1478).
 
 ## Wazuh v3.9.1 - Kibana v7.1.0 - Revision 508

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,28 +7,28 @@ All notable changes to the Wazuh app project will be documented in this file.
 ### Added
 
 - Added new endpoint service to collect the frontend logs into a file [#3324](https://github.com/wazuh/wazuh-kibana-app/pull/3324)
-- Improved the frontend handle errors strategy: UI, Toasts, console log and log in file
-  [#3327](https://github.com/wazuh/wazuh-kibana-app/pull/3327)
-  [#3321](https://github.com/wazuh/wazuh-kibana-app/pull/3321)
-  [#3367](https://github.com/wazuh/wazuh-kibana-app/pull/3367)
-  [#3374](https://github.com/wazuh/wazuh-kibana-app/pull/3374)
+- Improved the frontend handle errors strategy: UI, Toasts, console log and log in file 
+  [#3327](https://github.com/wazuh/wazuh-kibana-app/pull/3327) 
+  [#3321](https://github.com/wazuh/wazuh-kibana-app/pull/3321) 
+  [#3367](https://github.com/wazuh/wazuh-kibana-app/pull/3367) 
+  [#3374](https://github.com/wazuh/wazuh-kibana-app/pull/3374) 
   [#3390](https://github.com/wazuh/wazuh-kibana-app/pull/3390)  
-  [#3410](https://github.com/wazuh/wazuh-kibana-app/pull/3410)
-  [#3408](https://github.com/wazuh/wazuh-kibana-app/pull/3408)
-  [#3429](https://github.com/wazuh/wazuh-kibana-app/pull/3429)
-  [#3427](https://github.com/wazuh/wazuh-kibana-app/pull/3427)
-  [#3417](https://github.com/wazuh/wazuh-kibana-app/pull/3417)
-  [#3462](https://github.com/wazuh/wazuh-kibana-app/pull/3462)
-  [#3451](https://github.com/wazuh/wazuh-kibana-app/pull/3451)
+  [#3410](https://github.com/wazuh/wazuh-kibana-app/pull/3410) 
+  [#3408](https://github.com/wazuh/wazuh-kibana-app/pull/3408) 
+  [#3429](https://github.com/wazuh/wazuh-kibana-app/pull/3429) 
+  [#3427](https://github.com/wazuh/wazuh-kibana-app/pull/3427) 
+  [#3417](https://github.com/wazuh/wazuh-kibana-app/pull/3417) 
+  [#3462](https://github.com/wazuh/wazuh-kibana-app/pull/3462) 
+  [#3451](https://github.com/wazuh/wazuh-kibana-app/pull/3451) 
   [#3442](https://github.com/wazuh/wazuh-kibana-app/pull/3442)
-  [#3480](https://github.com/wazuh/wazuh-kibana-app/pull/3480)
-  [#3472](https://github.com/wazuh/wazuh-kibana-app/pull/3472)
-  [#3434](https://github.com/wazuh/wazuh-kibana-app/pull/3434)
+  [#3480](https://github.com/wazuh/wazuh-kibana-app/pull/3480) 
+  [#3472](https://github.com/wazuh/wazuh-kibana-app/pull/3472) 
+  [#3434](https://github.com/wazuh/wazuh-kibana-app/pull/3434) 
   [#3392](https://github.com/wazuh/wazuh-kibana-app/pull/3392)
-  [#3404](https://github.com/wazuh/wazuh-kibana-app/pull/3404)
-  [#3432](https://github.com/wazuh/wazuh-kibana-app/pull/3432)
-  [#3415](https://github.com/wazuh/wazuh-kibana-app/pull/3415)
-  [#3469](https://github.com/wazuh/wazuh-kibana-app/pull/3469)
+  [#3404](https://github.com/wazuh/wazuh-kibana-app/pull/3404) 
+  [#3432](https://github.com/wazuh/wazuh-kibana-app/pull/3432) 
+  [#3415](https://github.com/wazuh/wazuh-kibana-app/pull/3415) 
+  [#3469](https://github.com/wazuh/wazuh-kibana-app/pull/3469) 
   [#3448](https://github.com/wazuh/wazuh-kibana-app/pull/3448)
   [#3465](https://github.com/wazuh/wazuh-kibana-app/pull/3465)
   [#3464](https://github.com/wazuh/wazuh-kibana-app/pull/3464)
@@ -46,10 +46,11 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Refactored all try catch value of context for ErrorOrchestrator service. [#3432](https://github.com/wazuh/wazuh-kibana-app/pull/3432)
 - Refactored all try catch strategy on Controller/Groups section [#3415](https://github.com/wazuh/wazuh-kibana-app/pull/3415)
 - Refactored as module tabs and buttons are rendered [#3494](https://github.com/wazuh/wazuh-kibana-app/pull/3494)
+- Change format permissions in FIM inventory [#3649](https://github.com/wazuh/wazuh-kibana-app/pull/3649)
 
 ### Fixed
 
-- Fixed creation of log files [#3384](https://github.com/wazuh/wazuh-kibana-app/pull/3384)
+- Fixed creation of log files [#3384](https://github.com/wazuh/wazuh-kibana-app/pull/3384) 
 - Fixed rules and decoders test flyout clickout event [#3412](https://github.com/wazuh/wazuh-kibana-app/pull/3412)
 - Notify when you are registering an agent without permissions [#3430](https://github.com/wazuh/wazuh-kibana-app/pull/3430)
 - Remove not used `redirectRule` query param when clicking the row table on CDB Lists/Decoders [#3438](https://github.com/wazuh/wazuh-kibana-app/pull/3438)
@@ -59,7 +60,6 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fix size api selector when name is too long [#3445](https://github.com/wazuh/wazuh-kibana-app/pull/3445)
 - Fixed error when edit a rule or decoder [#3456](https://github.com/wazuh/wazuh-kibana-app/pull/3456)
 - Fixed index pattern selector doesn't display the ignored index patterns [#3458](https://github.com/wazuh/wazuh-kibana-app/pull/3458)
-- change format permissions in FIM inventory [#3649](https://github.com/wazuh/wazuh-kibana-app/pull/3649)
 
 ## Wazuh v4.2.3 - Kibana 7.10.2 , 7.12.1 - Revision 4204
 
@@ -113,10 +113,10 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fixed modules are missing in the agent menu [#3244](https://github.com/wazuh/wazuh-kibana-app/pull/3244)
 - Fixed Alerts Summary of modules for reports [#3303](https://github.com/wazuh/wazuh-kibana-app/pull/3303)
 - Fixed dark mode visualization background in pdf reports [#3315](https://github.com/wazuh/wazuh-kibana-app/pull/3315)
-- Adapt Kibana integrations to Kibana 7.11 and 7.12 [#3309](https://github.com/wazuh/wazuh-kibana-app/pull/3309)
-- Fixed error agent view does not render correctly [#3306](https://github.com/wazuh/wazuh-kibana-app/pull/3306)
-- Fixed miscalculation in table column width in PDF reports [#3326](https://github.com/wazuh/wazuh-kibana-app/pull/3326)
-- Normalized visData table property for 7.12 retro-compatibility [#3323](https://github.com/wazuh/wazuh-kibana-app/pull/3323)
+- Adapt Kibana integrations to Kibana 7.11 and 7.12  [#3309](https://github.com/wazuh/wazuh-kibana-app/pull/3309)
+- Fixed error agent view does not render correctly  [#3306](https://github.com/wazuh/wazuh-kibana-app/pull/3306)
+- Fixed miscalculation in table column width in PDF reports  [#3326](https://github.com/wazuh/wazuh-kibana-app/pull/3326)
+- Normalized visData table property for 7.12 retro-compatibility  [#3323](https://github.com/wazuh/wazuh-kibana-app/pull/3323)
 - Fixed error that caused the labels in certain visualizations to overlap [#3355](https://github.com/wazuh/wazuh-kibana-app/pull/3355)
 - Fixed export to csv button in dashboards tables [#3358](https://github.com/wazuh/wazuh-kibana-app/pull/3358)
 - Fixed Elastic UI breaking changes in 7.12 [#3345](https://github.com/wazuh/wazuh-kibana-app/pull/3345)
@@ -148,7 +148,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 
 ### Changed
 
-- Moved Dev Tools inside of Tools menu as Api Console. [#1434](https://github.com/wazuh/wazuh-kibana-app/pull/1434)
+- Moved Dev Tools inside of Tools menu as Api Console.  [#1434](https://github.com/wazuh/wazuh-kibana-app/pull/1434)
 - Changed position of Top users on Integrity Monitoring Top 5 user. [#2892](https://github.com/wazuh/wazuh-kibana-app/pull/2892)
 - Changed user allow_run_as way of editing. [#3080](https://github.com/wazuh/wazuh-kibana-app/pull/3080)
 - Rename some ossec references to Wazuh [#3046](https://github.com/wazuh/wazuh-kibana-app/pull/3046)
@@ -192,7 +192,6 @@ All notable changes to the Wazuh app project will be documented in this file.
 
 - Conflict with the creation of the index pattern when performing the Health Check [#3223](https://github.com/wazuh/wazuh-kibana-app/pull/3223)
 - Fixing mac os agents add command [#3207](https://github.com/wazuh/wazuh-kibana-app/pull/3207)
-
 ## Wazuh v4.1.5 - Kibana 7.10.0 , 7.10.2 - Revision 4106
 
 - Adapt for Wazuh 4.1.5
@@ -210,7 +209,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Added loading view while the user is logging to prevent permissions prompts [#3041](https://github.com/wazuh/wazuh-kibana-app/pull/3041)
 - Added custom message for each possible run_as setup [#3048](https://github.com/wazuh/wazuh-kibana-app/pull/3048)
 
-### Changed
+### Changed 
 
 - Change all dates labels to Kibana formatting time zone [#3047](https://github.com/wazuh/wazuh-kibana-app/pull/3047)
 - Improve toast message when selecting a default API [#3049](https://github.com/wazuh/wazuh-kibana-app/pull/3049)
@@ -317,7 +316,6 @@ All notable changes to the Wazuh app project will be documented in this file.
 ## Wazuh v4.0.4 - Kibana 7.10.0 , 7.10.2 - Revision 4017
 
 ### Added
-
 - Adapt the app to the new Kibana platform [#2475](https://github.com/wazuh/wazuh-kibana-app/issues/2475)
 - Wazuh data directory moved from `optimize` to `data` Kibana directory [#2591](https://github.com/wazuh/wazuh-kibana-app/issues/2591)
 - Show the wui_rules belong to wazuh-wui API user [#2702](https://github.com/wazuh/wazuh-kibana-app/issues/2702)
@@ -328,7 +326,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fixed wrong shards and replicas for statistics indices and also fixed wrong prefix for monitoring indices [#2732](https://github.com/wazuh/wazuh-kibana-app/issues/2732)
 - Report's creation dates set to 1970-01-01T00:00:00.000Z [#2772](https://github.com/wazuh/wazuh-kibana-app/issues/2772)
 - Fixed bug for missing commands in ubuntu/debian and centos [#2786](https://github.com/wazuh/wazuh-kibana-app/issues/2786)
-- Fixed bug that show an hour before in /security-events/dashboard [#2785](https://github.com/wazuh/wazuh-kibana-app/issues/2785)
+- Fixed bug that show an hour before in /security-events/dashboard [#2785](https://github.com/wazuh/wazuh-kibana-app/issues/2785) 
 - Fixed permissions to access agents [#2838](https://github.com/wazuh/wazuh-kibana-app/issues/2838)
 - Fix searching in groups [#2825](https://github.com/wazuh/wazuh-kibana-app/issues/2825)
 - Fix the pagination in SCA ckecks table [#2815](https://github.com/wazuh/wazuh-kibana-app/issues/2815)
@@ -383,6 +381,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Wui rules label should have only one tooltip [#2723](https://github.com/wazuh/wazuh-kibana-app/issues/2723)
 - Move upper the Wazuh item in the Kibana menu and default index pattern [#2867](https://github.com/wazuh/wazuh-kibana-app/pull/2867)
 
+
 ## Wazuh v4.0.4 - Kibana v7.9.1, v7.9.3 - Revision 4015
 
 ### Added
@@ -413,7 +412,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 
 ### Added
 
-- Sample data indices name should take index pattern in use [#2593](https://github.com/wazuh/wazuh-kibana-app/issues/2593)
+- Sample data indices name should take index pattern in use [#2593](https://github.com/wazuh/wazuh-kibana-app/issues/2593) 
 - Added start option to macos Agents [#2653](https://github.com/wazuh/wazuh-kibana-app/pull/2653)
 
 ### Changed
@@ -485,7 +484,8 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Undefined field in event view [#2588](https://github.com/wazuh/wazuh-kibana-app/issues/2588)
 - Several calls to the same stats request (esAlerts) [#2586](https://github.com/wazuh/wazuh-kibana-app/issues/2586)
 - The filter options popup doesn't open on click once the filter is pinned [#2581](https://github.com/wazuh/wazuh-kibana-app/issues/2581)
-- The formatedFields are missing from the index-pattern of wazuh-alerts-\* [#2574](https://github.com/wazuh/wazuh-kibana-app/issues/2574)
+- The formatedFields are missing from the index-pattern of wazuh-alerts-* [#2574](https://github.com/wazuh/wazuh-kibana-app/issues/2574)
+
 
 ## Wazuh v4.0.0 - Kibana v7.9.3 - Revision 4005
 
@@ -531,7 +531,6 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Support for Wazuh v3.13.2
 
 ## Wazuh v3.13.2 - Kibana v7.8.0 - Revision 887
-
 ### Added
 
 - Support for Wazuh v3.13.2
@@ -548,11 +547,13 @@ All notable changes to the Wazuh app project will be documented in this file.
 
 - Support for Kibana v7.9.0
 
+
 ## Wazuh v3.13.1 - Kibana v7.8.1 - Revision 884
 
 ### Added
 
 - Support for Kibana v7.8.1
+
 
 ## Wazuh v3.13.1 - Kibana v7.8.0 - Revision 883
 
@@ -560,11 +561,13 @@ All notable changes to the Wazuh app project will be documented in this file.
 
 - Support for Wazuh v3.13.1
 
+
 ## Wazuh v3.13.0 - Kibana v7.8.0 - Revision 881
 
 ### Added
 
 - Support for Kibana v7.8.0
+
 
 ## Wazuh v3.13.0 - Kibana v7.7.0, v7.7.1 - Revision 880
 
@@ -598,11 +601,13 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Avoid creating the wazuh-monitoring index pattern if it is disabled [#2100](https://github.com/wazuh/wazuh-kibana-app/issues/2100)
 - SCA checks without compliance field can't be expanded [#2264](https://github.com/wazuh/wazuh-kibana-app/issues/2264)
 
+
 ## Wazuh v3.12.3 - Kibana v7.7.1 - Revision 876
 
 ### Added
 
 - Support for Kibana v7.7.1
+
 
 ## Wazuh v3.12.3 - Kibana v7.7.0 - Revision 875
 
@@ -610,17 +615,20 @@ All notable changes to the Wazuh app project will be documented in this file.
 
 - Support for Kibana v7.7.0
 
+
 ## Wazuh v3.12.3 - Kibana v6.8.8, v7.6.1, v7.6.2 - Revision 874
 
 ### Added
 
 - Support for Wazuh v3.12.3
 
+
 ## Wazuh v3.12.2 - Kibana v6.8.8, v7.6.1, v7.6.2 - Revision 873
 
 ### Added
 
 - Support for Wazuh v3.12.2
+
 
 ## Wazuh v3.12.1 - Kibana v6.8.8, v7.6.1, v7.6.2 - Revision 872
 
@@ -636,6 +644,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 ### Fixed
 
 - Pagination is now shown in table-type visualizations. [#2180](https://github.com/wazuh/wazuh-kibana-app/issues/2180)
+
 
 ## Wazuh v3.12.0 - Kibana v6.8.8, v7.6.2 - Revision 871
 
@@ -664,11 +673,13 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Added the win_auth_failure rule group to Authentication failure metrics. [#2099](https://github.com/wazuh/wazuh-kibana-app/pull/2099)
 - Negative values in Syscheck attributes now have their correct value in reports. [7c3e84e](https://github.com/wazuh/wazuh-kibana-app/commit/7c3e84ec8f00760b4f650cfc00a885d868123f99)
 
+
 ## Wazuh v3.11.4 - Kibana v7.6.1 - Revision 858
 
 ### Added
 
 - Support for Kibana v7.6.1
+
 
 ## Wazuh v3.11.4 - Kibana v6.8.6, v7.4.2, v7.6.0 - Revision 857
 
@@ -676,11 +687,13 @@ All notable changes to the Wazuh app project will be documented in this file.
 
 - Support for Wazuh v3.11.4
 
+
 ## Wazuh v3.11.3 - Kibana v7.6.0 - Revision 856
 
 ### Added
 
 - Support for Kibana v7.6.0
+
 
 ## Wazuh v3.11.3 - Kibana v7.4.2 - Revision 855
 
@@ -698,11 +711,13 @@ All notable changes to the Wazuh app project will be documented in this file.
 
 - Windows Updates table is now displayed in the Inventory Data report [#2028](https://github.com/wazuh/wazuh-kibana-app/pull/2028)
 
+
 ## Wazuh v3.11.2 - Kibana v7.5.2 - Revision 853
 
 ### Added
 
 - Support for Kibana v7.5.2
+
 
 ## Wazuh v3.11.2 - Kibana v6.8.6, v7.3.2, v7.5.1 - Revision 852
 
@@ -719,11 +734,12 @@ All notable changes to the Wazuh app project will be documented in this file.
 - The xml validator now correctly handles the `--` string within comments [#1980](https://github.com/wazuh/wazuh-kibana-app/pull/1980)
 - The AWS map visualization wasn't been loaded until the user interacts with it [dd31bd7](https://github.com/wazuh/wazuh-kibana-app/commit/dd31bd7a155354bc50fe0af22fca878607c8936a)
 
+
 ## Wazuh v3.11.1 - Kibana v6.8.6, v7.3.2, v7.5.1 - Revision 581
 
 ### Added
-
 - Support for Wazuh v3.11.1.
+
 
 ## Wazuh v3.11.0 - Kibana v6.8.6, v7.3.2, v7.5.1 - Revision 580
 
@@ -769,11 +785,13 @@ All notable changes to the Wazuh app project will be documented in this file.
 
 - Support for Kibana v7.5.1
 
+
 ## Wazuh v3.10.2 - Kibana v7.5.0 - Revision 555
 
 ### Added
 
 - Support for Kibana v7.5.0
+
 
 ## Wazuh v3.10.2 - Kibana v7.4.2 - Revision 549
 
@@ -781,11 +799,13 @@ All notable changes to the Wazuh app project will be documented in this file.
 
 - Support for Kibana v7.4.2
 
+
 ## Wazuh v3.10.2 - Kibana v7.4.1 - Revision 548
 
 ### Added
 
 - Support for Kibana v7.4.1
+
 
 ## Wazuh v3.10.2 - Kibana v7.4.0 - Revision 547
 
@@ -794,11 +814,13 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Support for Kibana v7.4.0
 - Support for Wazuh v3.10.2.
 
+
 ## Wazuh v3.10.2 - Kibana v7.3.2 - Revision 546
 
 ### Added
 
 - Support for Wazuh v3.10.2.
+
 
 ## Wazuh v3.10.1 - Kibana v7.3.2 - Revision 545
 
@@ -806,13 +828,14 @@ All notable changes to the Wazuh app project will be documented in this file.
 
 - Support for Wazuh v3.10.1.
 
+
 ## Wazuh v3.10.0 - Kibana v7.3.2 - Revision 543
 
 ### Added
 
 - Support for Wazuh v3.10.0.
 - Added an interactive guide for registering agents, things are now easier for the user, guiding it through the steps needed ending in a _copy & paste_ snippet for deploying his agent [#1468](https://github.com/wazuh/wazuh-kibana-app/issues/1468).
-- Added new dashboards for the recently added regulatory compliance groups into the Wazuh core. They are HIPAA and NIST-800-53 [#1468](https://github.com/wazuh/wazuh-kibana-app/issues/1448), [#1638](https://github.com/wazuh/wazuh-kibana-app/issues/1638).
+- Added new dashboards for the recently added regulatory compliance groups into the Wazuh core. They are HIPAA and NIST-800-53 [#1468](https://github.com/wazuh/wazuh-kibana-app/issues/1448), [#1638]( https://github.com/wazuh/wazuh-kibana-app/issues/1638).
 - Make the app work under a custom Kibana space [#1234](https://github.com/wazuh/wazuh-kibana-app/issues/1234), [#1450](https://github.com/wazuh/wazuh-kibana-app/issues/1450).
 - Added the ability to manage the app as a native plugin when using Kibana spaces, now you can safely hide/show the app depending on the selected space [#1601](https://github.com/wazuh/wazuh-kibana-app/issues/1601).
 - Adapt the app the for Kibana dark mode [#1562](https://github.com/wazuh/wazuh-kibana-app/issues/1562).
@@ -820,12 +843,13 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Export all the information of a Wazuh group and its related agents in a PDF document [#1341](https://github.com/wazuh/wazuh-kibana-app/issues/1341).
 - Export the configuration of a certain agent as a PDF document. Supports granularity for exporting just certain sections of the configuration [#1340](https://github.com/wazuh/wazuh-kibana-app/issues/1340).
 
+
 ### Changed
 
 - Reduced _Agents preview_ load time using the new API endpoint `/summary/agents` [#1687](https://github.com/wazuh/wazuh-kibana-app/pull/1687).
 - Replaced most of the _md-nav-bar_ Angular.js components with React components using EUI [#1705](https://github.com/wazuh/wazuh-kibana-app/pull/1705).
 - Replaced the requirements slider component with a new styled component [#1708](https://github.com/wazuh/wazuh-kibana-app/pull/1708).
-- Soft deprecated the _.wazuh-version_ internal index, now the app dumps its content if applicable to a registry file, then the app removes that index. Further versions will hard deprecate this index [#1467](https://github.com/wazuh/wazuh-kibana-app/issues/1467).
+- Soft deprecated the _.wazuh-version_ internal index, now the app dumps its content if applicable to a registry file, then the app removes that index. Further versions will hard deprecate this index [#1467](https://github.com/wazuh/wazuh-kibana-app/issues/1467). 
 - Visualizations now don't fetch the documents _source_, also, they now use _size: 0_ for fetching [#1663](https://github.com/wazuh/wazuh-kibana-app/issues/1663).
 - The app menu is now fixed on top of the view, it's not being hidden on every state change. Also, the Wazuh logo was placed in the top bar of Kibana UI [#1502](https://github.com/wazuh/wazuh-kibana-app/issues/1502).
 - Improved _getTimestamp_ method not returning a promise object because it's no longer needed [014bc3a](https://github.com/wazuh/wazuh-kibana-app/commit/014b3aba0d2e9cda0c4d521f5f16faddc434a21e). Also improved main Discover listener for Wazuh not returning a promise object [bd82823](https://github.com/wazuh/wazuh-kibana-app/commit/bd8282391a402b8c567b32739cf914a0135d74bc).
@@ -846,6 +870,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - The app installation date was not being updated properly, now it's fixed [#1692](https://github.com/wazuh/wazuh-kibana-app/issues/1692).
 - Fixed _Network interfaces_ table in Inventory section, the table was not paginating [#1474](https://github.com/wazuh/wazuh-kibana-app/issues/1474).
 - Fixed APIs passwords are now obfuscated in server responses [adc3152](https://github.com/wazuh/wazuh-kibana-app/pull/1782/commits/adc31525e26b25e4cb62d81cbae70a8430728af5).
+
 
 ## Wazuh v3.9.5 - Kibana v6.8.2 / Kibana v7.2.1 / Kibana v7.3.0 - Revision 531
 
@@ -886,13 +911,13 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fix not properly updated breadcrumb in ruleset section [9645903](https://github.com/wazuh/wazuh-kibana-app/commit/96459031cd4edbe047970bf0d22d0c099771879f)
 - Fix badly dimensioned table in Integrity Monitoring section [9645903](https://github.com/wazuh/wazuh-kibana-app/commit/96459031cd4edbe047970bf0d22d0c099771879f)
 - Fix implicit filters can be destroyed [9cf8578](https://github.com/wazuh/wazuh-kibana-app/commit/9cf85786f504f5d67edddeea6cfbf2ab577e799b)
-- Windows agent dashboard doesn't show failure logon access. [d38d088](https://github.com/wazuh/wazuh-kibana-app/commit/d38d0881ac8e4294accde83d63108337b74cdd91)
-- Number of agents is not properly updated. [f7cbbe5](https://github.com/wazuh/wazuh-kibana-app/commit/f7cbbe54394db825827715c3ad4370ac74317108)
-- Missing scrollbar on Firefox file viewer. [df4e8f9](https://github.com/wazuh/wazuh-kibana-app/commit/df4e8f9305b35e9ee1473bed5f5d452dd3420567)
-- Agent search filter by name, lost when refreshing. [71b5274](https://github.com/wazuh/wazuh-kibana-app/commit/71b5274ccc332d8961a158587152f7badab28a95)
-- Alerts of level 12 cannot be displayed in the Summary table. [ec0e888](https://github.com/wazuh/wazuh-kibana-app/commit/ec0e8885d9f1306523afbc87de01a31f24e36309)
-- Restored query from search bar in visualizations. [439128f](https://github.com/wazuh/wazuh-kibana-app/commit/439128f0a1f65b649a9dcb81ab5804ca20f65763)
-- Fix Kibana filters loop in Firefox. [82f0f32](https://github.com/wazuh/wazuh-kibana-app/commit/82f0f32946d844ce96a28f0185f903e8e05c5589)
+- Windows agent dashboard doesn't show failure logon access. [d38d088](https://github.com/wazuh/wazuh-kibana-app/commit/d38d0881ac8e4294accde83d63108337b74cdd91) 
+- Number of agents is not properly updated.  [f7cbbe5](https://github.com/wazuh/wazuh-kibana-app/commit/f7cbbe54394db825827715c3ad4370ac74317108) 
+- Missing scrollbar on Firefox file viewer.  [df4e8f9](https://github.com/wazuh/wazuh-kibana-app/commit/df4e8f9305b35e9ee1473bed5f5d452dd3420567) 
+- Agent search filter by name, lost when refreshing. [71b5274](https://github.com/wazuh/wazuh-kibana-app/commit/71b5274ccc332d8961a158587152f7badab28a95) 
+- Alerts of level 12 cannot be displayed in the Summary table. [ec0e888](https://github.com/wazuh/wazuh-kibana-app/commit/ec0e8885d9f1306523afbc87de01a31f24e36309) 
+- Restored query from search bar in visualizations. [439128f](https://github.com/wazuh/wazuh-kibana-app/commit/439128f0a1f65b649a9dcb81ab5804ca20f65763) 
+- Fix Kibana filters loop in Firefox. [82f0f32](https://github.com/wazuh/wazuh-kibana-app/commit/82f0f32946d844ce96a28f0185f903e8e05c5589) 
 
 ## Wazuh v3.9.3 - Kibana v6.8.1 / v7.1.1 / v7.2.0 - Revision 523
 
@@ -951,7 +976,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 ### Fixed
 
 - Fixed missing dependency for Discover [43f5dd5](https://github.com/wazuh/wazuh-kibana-app/commit/43f5dd5f64065c618ba930b2a4087f0a9e706c0e).
-- Fixed visualization for Agents > Overview [#1477](https://github.com/wazuh/wazuh-kibana-app/pull/1477).
+- Fixed visualization for Agents > Overview [#1477](https://github.com/wazuh/wazuh-kibana-app/pull/1477). 
 - Fixed SCA policy checks table [#1478](https://github.com/wazuh/wazuh-kibana-app/pull/1478).
 
 ## Wazuh v3.9.1 - Kibana v7.1.0 - Revision 508

--- a/public/components/agents/fim/inventory/fileDetail.tsx
+++ b/public/components/agents/fim/inventory/fileDetail.tsx
@@ -23,6 +23,7 @@ import {
   EuiStat,
   EuiToolTip,
   EuiBadge,
+  EuiCodeBlock,
 } from '@elastic/eui';
 import { Discover } from '../../../common/modules/discover';
 import { ModulesHelper } from '../../../common/modules/modules-helper';
@@ -132,13 +133,6 @@ export class FileDetails extends Component {
         link: true,
       },
       {
-        field: 'perm',
-        name: 'Permissions',
-        icon: 'lock',
-        link: false,
-        transformValue: (value) => this.renderFileDetailsPermissions(value),
-      },
-      {
         field: 'size',
         name: 'Size',
         icon: 'nested',
@@ -172,6 +166,13 @@ export class FileDetails extends Component {
         checksum: true,
         icon: 'check',
         link: true,
+      },
+      {
+        field: 'perm',
+        name: 'Permissions',
+        icon: 'lock',
+        link: false,
+        transformValue: (value) => this.renderFileDetailsPermissions(value),
       },
     ];
   }
@@ -329,11 +330,10 @@ export class FileDetails extends Component {
         );
       }
     });
-
     return (
       <div>
         <EuiFlexGrid columns={3}> {generalDetails} </EuiFlexGrid>
-      </div>
+      </div>        
     );
   }
 
@@ -344,43 +344,14 @@ export class FileDetails extends Component {
   renderFileDetailsPermissions(value) {
     if (((this.props.agent || {}).os || {}).platform === 'windows' && value && value !== '-') {
       const components = value
-        .split(', ')
-        .map((userNameAndPermissionsFullString) => {
-          const [_, username, userPermissionsString] = userNameAndPermissionsFullString.match(
-            /(\S+) \(allowed\): (\S+)/
-          );
-          const permissions = userPermissionsString.split('|').sort();
-          return { username, permissions };
-        })
-        .sort((a, b) => {
-          if (a.username > b.username) {
-            return 1;
-          } else if (a.username < b.username) {
-            return -1;
-          } else {
-            return 0;
-          }
-        })
-        .map(({ username, permissions }) => {
-          return (
-            <EuiToolTip
-              key={`permissions-windows-user-${username}`}
-              content={permissions.join(', ')}
-              title={`${username} permissions`}
-            >
-              <EuiBadge color="hollow" title={null} style={{ margin: '2px 2px' }}>
-                {username}
-              </EuiBadge>
-            </EuiToolTip>
-          );
-        });
       return (
-        <TruncateHorizontalComponents
-          components={components}
-          labelButtonHideComponents={(count) => `+${count} users`}
-          buttonProps={{ size: 'xs' }}
-          componentsWidthPercentage={0.85}
-        />
+        <EuiAccordion
+          id={Math.random().toString() }
+          paddingSize="none"
+          initialIsOpen={false}
+        >
+          <EuiCodeBlock language="json" paddingSize="l">{JSON.stringify(components, null, 2)}</EuiCodeBlock> 
+        </EuiAccordion>
       );
     }
     return value;

--- a/public/components/agents/fim/inventory/fileDetail.tsx
+++ b/public/components/agents/fim/inventory/fileDetail.tsx
@@ -331,7 +331,7 @@ export class FileDetails extends Component {
       }
     });
     return (
-      <div>
+      <div>      
         <EuiFlexGrid columns={3}> {generalDetails} </EuiFlexGrid>
       </div>        
     );
@@ -343,14 +343,11 @@ export class FileDetails extends Component {
 
   renderFileDetailsPermissions(value) {
     if (((this.props.agent || {}).os || {}).platform === 'windows' && value && value !== '-') {
-      const components = value
       return (
-        <EuiAccordion
-          id={Math.random().toString() }
-          paddingSize="none"
-          initialIsOpen={false}
-        >
-          <EuiCodeBlock language="json" paddingSize="l">{JSON.stringify(components, null, 2)}</EuiCodeBlock> 
+        <EuiAccordion id={Math.random().toString()} paddingSize="none" initialIsOpen={false}>
+          <EuiCodeBlock language="json" paddingSize="l">
+            {JSON.stringify(value, null, 2)}
+          </EuiCodeBlock>
         </EuiAccordion>
       );
     }

--- a/public/components/agents/fim/inventory/fileDetail.tsx
+++ b/public/components/agents/fim/inventory/fileDetail.tsx
@@ -96,7 +96,7 @@ export class FileDetails extends Component {
         grow: 2,
         icon: 'clock',
         link: true,
-        transformValue: formatUIDate
+        transformValue: formatUIDate,
       },
       {
         field: 'mtime',
@@ -104,7 +104,7 @@ export class FileDetails extends Component {
         grow: 2,
         icon: 'clock',
         link: true,
-        transformValue: formatUIDate
+        transformValue: formatUIDate,
       },
       {
         field: 'uname',
@@ -184,15 +184,15 @@ export class FileDetails extends Component {
         name: 'Last analysis',
         grow: 2,
         icon: 'clock',
-        transformValue: formatUIDate
+        transformValue: formatUIDate,
       },
       {
         field: 'mtime',
         name: 'Last modified',
         grow: 2,
         icon: 'clock',
-        transformValue: formatUIDate
-      }
+        transformValue: formatUIDate,
+      },
     ];
   }
 
@@ -265,7 +265,10 @@ export class FileDetails extends Component {
 
   getDetails() {
     const { view } = this.props;
-    const columns = this.props.type === 'registry_key' || this.props.currentFile.type === 'registry_key' ? this.registryDetails() : this.details();
+    const columns =
+      this.props.type === 'registry_key' || this.props.currentFile.type === 'registry_key'
+        ? this.registryDetails()
+        : this.details();
     const generalDetails = columns.map((item, idx) => {
       var value = this.props.currentFile[item.field] || '-';
       if (item.transformValue) {
@@ -333,7 +336,7 @@ export class FileDetails extends Component {
     return (
       <div>
         <EuiFlexGrid columns={3}> {generalDetails} </EuiFlexGrid>
-      </div>        
+      </div>
     );
   }
 
@@ -343,14 +346,11 @@ export class FileDetails extends Component {
 
   renderFileDetailsPermissions(value) {
     if (((this.props.agent || {}).os || {}).platform === 'windows' && value && value !== '-') {
-      const components = value
       return (
-        <EuiAccordion
-          id={Math.random().toString() }
-          paddingSize="none"
-          initialIsOpen={false}
-        >
-          <EuiCodeBlock language="json" paddingSize="l">{JSON.stringify(components, null, 2)}</EuiCodeBlock> 
+        <EuiAccordion id={Math.random().toString()} paddingSize="none" initialIsOpen={false}>
+          <EuiCodeBlock language="json" paddingSize="l">
+            {JSON.stringify(value, null, 2)}
+          </EuiCodeBlock>
         </EuiAccordion>
       );
     }
@@ -389,29 +389,27 @@ export class FileDetails extends Component {
         >
           <div className="flyout-row details-row">{this.getDetails()}</div>
         </EuiAccordion>
-        { (type === 'registry_key' || currentFile.type === 'registry_key') && <>
-        <EuiSpacer size="s" />
-        <EuiAccordion
-          id={fileName === undefined ? Math.random().toString() : `${fileName}_values`}
-          buttonContent={
-            <EuiTitle size="s">
-              <h3>
-                Registry values                
-              </h3>
-            </EuiTitle>
-          }
-          paddingSize="none"
-          initialIsOpen={true}
-        >
-          <EuiFlexGroup className="flyout-row">
-            <EuiFlexItem>
-              <RegistryValues 
-                currentFile={currentFile}
-                agent={agent}
-              />
-            </EuiFlexItem>
-          </EuiFlexGroup>
-        </EuiAccordion> </>}
+        {(type === 'registry_key' || currentFile.type === 'registry_key') && (
+          <>
+            <EuiSpacer size="s" />
+            <EuiAccordion
+              id={fileName === undefined ? Math.random().toString() : `${fileName}_values`}
+              buttonContent={
+                <EuiTitle size="s">
+                  <h3>Registry values</h3>
+                </EuiTitle>
+              }
+              paddingSize="none"
+              initialIsOpen={true}
+            >
+              <EuiFlexGroup className="flyout-row">
+                <EuiFlexItem>
+                  <RegistryValues currentFile={currentFile} agent={agent} />
+                </EuiFlexItem>
+              </EuiFlexGroup>
+            </EuiAccordion>{' '}
+          </>
+        )}
         <EuiSpacer />
         <EuiAccordion
           id={fileName === undefined ? Math.random().toString() : `${fileName}_events`}

--- a/public/components/agents/fim/inventory/fileDetail.tsx
+++ b/public/components/agents/fim/inventory/fileDetail.tsx
@@ -96,7 +96,7 @@ export class FileDetails extends Component {
         grow: 2,
         icon: 'clock',
         link: true,
-        transformValue: formatUIDate,
+        transformValue: formatUIDate
       },
       {
         field: 'mtime',
@@ -104,7 +104,7 @@ export class FileDetails extends Component {
         grow: 2,
         icon: 'clock',
         link: true,
-        transformValue: formatUIDate,
+        transformValue: formatUIDate
       },
       {
         field: 'uname',
@@ -184,15 +184,15 @@ export class FileDetails extends Component {
         name: 'Last analysis',
         grow: 2,
         icon: 'clock',
-        transformValue: formatUIDate,
+        transformValue: formatUIDate
       },
       {
         field: 'mtime',
         name: 'Last modified',
         grow: 2,
         icon: 'clock',
-        transformValue: formatUIDate,
-      },
+        transformValue: formatUIDate
+      }
     ];
   }
 
@@ -265,10 +265,7 @@ export class FileDetails extends Component {
 
   getDetails() {
     const { view } = this.props;
-    const columns =
-      this.props.type === 'registry_key' || this.props.currentFile.type === 'registry_key'
-        ? this.registryDetails()
-        : this.details();
+    const columns = this.props.type === 'registry_key' || this.props.currentFile.type === 'registry_key' ? this.registryDetails() : this.details();
     const generalDetails = columns.map((item, idx) => {
       var value = this.props.currentFile[item.field] || '-';
       if (item.transformValue) {
@@ -336,7 +333,7 @@ export class FileDetails extends Component {
     return (
       <div>
         <EuiFlexGrid columns={3}> {generalDetails} </EuiFlexGrid>
-      </div>
+      </div>        
     );
   }
 
@@ -346,11 +343,14 @@ export class FileDetails extends Component {
 
   renderFileDetailsPermissions(value) {
     if (((this.props.agent || {}).os || {}).platform === 'windows' && value && value !== '-') {
+      const components = value
       return (
-        <EuiAccordion id={Math.random().toString()} paddingSize="none" initialIsOpen={false}>
-          <EuiCodeBlock language="json" paddingSize="l">
-            {JSON.stringify(value, null, 2)}
-          </EuiCodeBlock>
+        <EuiAccordion
+          id={Math.random().toString() }
+          paddingSize="none"
+          initialIsOpen={false}
+        >
+          <EuiCodeBlock language="json" paddingSize="l">{JSON.stringify(components, null, 2)}</EuiCodeBlock> 
         </EuiAccordion>
       );
     }
@@ -389,27 +389,29 @@ export class FileDetails extends Component {
         >
           <div className="flyout-row details-row">{this.getDetails()}</div>
         </EuiAccordion>
-        {(type === 'registry_key' || currentFile.type === 'registry_key') && (
-          <>
-            <EuiSpacer size="s" />
-            <EuiAccordion
-              id={fileName === undefined ? Math.random().toString() : `${fileName}_values`}
-              buttonContent={
-                <EuiTitle size="s">
-                  <h3>Registry values</h3>
-                </EuiTitle>
-              }
-              paddingSize="none"
-              initialIsOpen={true}
-            >
-              <EuiFlexGroup className="flyout-row">
-                <EuiFlexItem>
-                  <RegistryValues currentFile={currentFile} agent={agent} />
-                </EuiFlexItem>
-              </EuiFlexGroup>
-            </EuiAccordion>{' '}
-          </>
-        )}
+        { (type === 'registry_key' || currentFile.type === 'registry_key') && <>
+        <EuiSpacer size="s" />
+        <EuiAccordion
+          id={fileName === undefined ? Math.random().toString() : `${fileName}_values`}
+          buttonContent={
+            <EuiTitle size="s">
+              <h3>
+                Registry values                
+              </h3>
+            </EuiTitle>
+          }
+          paddingSize="none"
+          initialIsOpen={true}
+        >
+          <EuiFlexGroup className="flyout-row">
+            <EuiFlexItem>
+              <RegistryValues 
+                currentFile={currentFile}
+                agent={agent}
+              />
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        </EuiAccordion> </>}
         <EuiSpacer />
         <EuiAccordion
           id={fileName === undefined ? Math.random().toString() : `${fileName}_events`}

--- a/public/components/agents/fim/inventory/fileDetail.tsx
+++ b/public/components/agents/fim/inventory/fileDetail.tsx
@@ -276,6 +276,7 @@ export class FileDetails extends Component {
       if (!item.onlyLinux || (item.onlyLinux && this.props.agent && agentPlatform !== 'windows')) {
         let className = item.checksum ? 'detail-value detail-value-checksum' : 'detail-value';
         className += item.field === 'perm' ? ' detail-value-perm' : '';
+        className += ' wz-width-100';
         return (
           <EuiFlexItem key={idx}>
             <EuiStat
@@ -320,7 +321,7 @@ export class FileDetails extends Component {
                   ) : (
                     this.userSvg
                   )}
-                  <span className="detail-title">{item.name}</span>
+                  {item.name === 'Permissions' &&  agentPlatform === 'windows' ? '' : <span className="detail-title">{item.name}</span> }
                 </span>
               }
               textAlign="left"
@@ -344,7 +345,27 @@ export class FileDetails extends Component {
   renderFileDetailsPermissions(value) {
     if (((this.props.agent || {}).os || {}).platform === 'windows' && value && value !== '-') {
       return (
-        <EuiAccordion id={Math.random().toString()} paddingSize="none" initialIsOpen={false}>
+        <EuiAccordion 
+          id={Math.random().toString()}
+          paddingSize="none" 
+          initialIsOpen={false} 
+          arrowDisplay="none"
+          buttonContent={
+          <EuiTitle size="s">
+            <h3>
+              Permissions
+                  <span style={{ marginLeft: 16 }}>
+                    <EuiToolTip position="top" content="Show">
+                      <EuiIcon
+                        className="euiButtonIcon euiButtonIcon--primary"
+                        type="inspect"
+                        aria-label="show"
+                      />
+                    </EuiToolTip>
+                  </span>
+            </h3>
+          </EuiTitle>
+        }>
           <EuiCodeBlock language="json" paddingSize="l">
             {JSON.stringify(value, null, 2)}
           </EuiCodeBlock>

--- a/public/components/agents/fim/inventory/fileDetail.tsx
+++ b/public/components/agents/fim/inventory/fileDetail.tsx
@@ -331,9 +331,9 @@ export class FileDetails extends Component {
       }
     });
     return (
-      <div>      
+      <div>
         <EuiFlexGrid columns={3}> {generalDetails} </EuiFlexGrid>
-      </div>        
+      </div>
     );
   }
 

--- a/public/components/agents/fim/inventory/table.tsx
+++ b/public/components/agents/fim/inventory/table.tsx
@@ -234,13 +234,6 @@ export class InventoryTable extends Component {
         width: `${width}`
       },
       {
-        field: 'perm',
-        name: 'Permissions',
-        sortable: true,
-        truncateText: true,
-        width: `${width}`
-      },
-      {
         field: 'size',
         name: 'Size',
         sortable: true,

--- a/public/components/health-check/container/__snapshots__/health-check.container.test.tsx.snap
+++ b/public/components/health-check/container/__snapshots__/health-check.container.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`Health Check container should render a Health check screen 1`] = `
   <img
     alt=""
     className="health-check-logo"
-    src="/plugins/wazuh/assets/icon_blue.svg"
+    src="/plugins/wazuh/assets/undefined"
   />
   <div
     className="margin-top-30"

--- a/public/styles/inventory.scss
+++ b/public/styles/inventory.scss
@@ -78,7 +78,8 @@
     padding: 0px 0px 8px 0;
   }
 
-  .events-accordion {
+  .events-accordion,
+  .euiStat .euiTitle .detail-value .euiAccordion {
     border-bottom: none !important;
   }
 


### PR DESCRIPTION
**Description**

The information is adapted to the new format

**Issues Resolved**

Format Windows permissions in FIM inventory [#3370](https://github.com/wazuh/wazuh-kibana-app/issues/3370)

**Test**

To test it you need an agent on windows with version 4.3 and enter FIM inventory and enter the details

1. Go to Inventory Section of an agent
- **Given** the browser is logged in the Wazuh kibana app and you have an Windows active agent
- **When** the user navigate to `Integrity Monitoring` -> pin  `Windows agent` -> enter in `Inventory` section -> click in some of the rows available -> `Permissions`
- **Then** the permissions will appear like a JSON correctly


**Check List**

- [x] Change format of viewing permissions.