### PR TITLE
Wazuh app not showing packages details in free bsd agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fix size api selector when name is too long [#3445](https://github.com/wazuh/wazuh-kibana-app/pull/3445)
 - Fixed error when edit a rule or decoder [#3456](https://github.com/wazuh/wazuh-kibana-app/pull/3456)
 - Fixed index pattern selector doesn't display the ignored index patterns [#3458](https://github.com/wazuh/wazuh-kibana-app/pull/3458)
+- Fixed not showing packages details in agent inventory for a freeBSD agent SO [#3651](https://github.com/wazuh/wazuh-kibana-app/pull/3651)
 
 ## Wazuh v4.2.3 - Kibana 7.10.2 , 7.12.1 - Revision 4204
 

--- a/public/components/agents/syscollector/columns/packages-columns.ts
+++ b/public/components/agents/syscollector/columns/packages-columns.ts
@@ -1,26 +1,35 @@
 const windowsColumns = [
   { id: 'name' },
-  { id: 'architecture', width: "10%" },
+  { id: 'architecture', width: '10%' },
   { id: 'version' },
-  { id: 'vendor', width: '30%' }
+  { id: 'vendor', width: '30%' },
 ];
 const linuxColumns = [
   { id: 'name' },
   { id: 'architecture', width: '10%' },
   { id: 'version' },
-  { id: 'vendor', width: "30%" },
-  { id: 'description', width: '30%' }
+  { id: 'vendor', width: '30%' },
+  { id: 'description', width: '30%' },
 ];
 const MacColumns = [
   { id: 'name' },
   { id: 'version' },
   { id: 'format' },
-  { id: 'location', width: "30%" },
-  { id: 'description', width: '20%' }
+  { id: 'location', width: '30%' },
+  { id: 'description', width: '20%' },
+];
+const FreebsdColumns = [
+  { id: 'name' },
+  { id: 'version' },
+  { id: 'format' },
+  { id: 'architecture', width: '20%' },
+  { id: 'vendor', width: '20%' },
+  { id: 'description', width: '30%' },
 ];
 
 export const packagesColumns = {
-  'windows': windowsColumns,
-  'linux': linuxColumns,
-  'apple': MacColumns
-}
+  windows: windowsColumns,
+  linux: linuxColumns,
+  apple: MacColumns,
+  freebsd: FreebsdColumns,
+};

--- a/public/components/agents/syscollector/columns/ports-columns.ts
+++ b/public/components/agents/syscollector/columns/ports-columns.ts
@@ -1,19 +1,20 @@
 const windowsColumns = [
-  { id: "process" },
-  { id: "local.ip", sortable: false },
-  { id: "local.port", sortable: false },
-  { id: "state" },
-  { id: "protocol" }
+  { id: 'process' },
+  { id: 'local.ip', sortable: false },
+  { id: 'local.port', sortable: false },
+  { id: 'state' },
+  { id: 'protocol' },
 ];
 const defaultColumns = [
-  { id: "local.ip", sortable: false },
-  { id: "local.port", sortable: false },
-  { id: "state" },
-  { id: "protocol" }
+  { id: 'local.ip', sortable: false },
+  { id: 'local.port', sortable: false },
+  { id: 'state' },
+  { id: 'protocol' },
 ];
 
 export const portsColumns = {
-  'windows': windowsColumns,
-  'linux': defaultColumns,
-  'apple': defaultColumns
-}
+  windows: windowsColumns,
+  linux: defaultColumns,
+  apple: defaultColumns,
+  freebsd: defaultColumns,
+};

--- a/public/components/agents/syscollector/columns/process-columns.ts
+++ b/public/components/agents/syscollector/columns/process-columns.ts
@@ -5,7 +5,8 @@ const windowsColumns = [
   { id: 'vm_size' },
   { id: 'priority' },
   { id: 'nlwp' },
-  { id: 'cmd', width: '30%' }];
+  { id: 'cmd', width: '30%' },
+];
 const linuxColumns = [
   { id: 'name', width: '10%' },
   { id: 'euser' },
@@ -13,12 +14,12 @@ const linuxColumns = [
   { id: 'pid' },
   { id: 'ppid' },
   { id: 'cmd', width: '15%' },
-  { id: 'argvs', width: "15%" },
+  { id: 'argvs', width: '15%' },
   { id: 'vm_size' },
   { id: 'size' },
   { id: 'session' },
   { id: 'nice' },
-  { id: 'state', width: "15%" }
+  { id: 'state', width: '15%' },
 ];
 const macColumns = [
   { id: 'name', width: '10%' },
@@ -27,11 +28,12 @@ const macColumns = [
   { id: 'ppid' },
   { id: 'vm_size' },
   { id: 'nice' },
-  { id: 'state', width: "15%" }
+  { id: 'state', width: '15%' },
 ];
 
 export const processColumns = {
-  'windows': windowsColumns,
-  'linux': linuxColumns,
-  'apple': macColumns
-}
+  windows: windowsColumns,
+  linux: linuxColumns,
+  apple: macColumns,
+  freebsd: linuxColumns,
+};

--- a/public/components/agents/syscollector/inventory.tsx
+++ b/public/components/agents/syscollector/inventory.tsx
@@ -51,7 +51,9 @@ export function SyscollectorInventory({ agent }) {
     soPlatform = 'windows';
   } else if ((agent.os || {}).platform === 'darwin') {
     soPlatform = 'apple';
-  }
+  } else if ((agent.os || {}).platform === 'freebsd') {
+    soPlatform = 'freebsd';
+  } 
 
   const netifaceColumns = [
     { id: 'name' },

--- a/public/components/agents/syscollector/inventory.tsx
+++ b/public/components/agents/syscollector/inventory.tsx
@@ -51,7 +51,7 @@ export function SyscollectorInventory({ agent }) {
     soPlatform = 'windows';
   } else if ((agent.os || {}).platform === 'darwin') {
     soPlatform = 'apple';
-  } else if (((agent.os || {}).uname || '').includes('FreeBSD')) {
+  } else if (((agent.os || {}).uname.toLowerCase() || '').includes('freebsd')) {
     soPlatform = 'freebsd';
   }
 

--- a/public/components/agents/syscollector/inventory.tsx
+++ b/public/components/agents/syscollector/inventory.tsx
@@ -51,9 +51,9 @@ export function SyscollectorInventory({ agent }) {
     soPlatform = 'windows';
   } else if ((agent.os || {}).platform === 'darwin') {
     soPlatform = 'apple';
-  } else if ((agent.os || {}).platform === 'freebsd') {
+  } else if (((agent.os || {}).uname || '').includes('FreeBSD')) {
     soPlatform = 'freebsd';
-  } 
+  }
 
   const netifaceColumns = [
     { id: 'name' },


### PR DESCRIPTION
Description

Agent packages with freeBSD were not displayed

Issues Resolved

Wazuh App not showing packages details in FreeBSD agent [#3586](https://github.com/wazuh/wazuh-kibana-app/issues/3586)

Test

To test it you need to have an agent installed in FreeBSD and be in Inventory data, there you can see the packages

1. Go to Inventory Section of an agent
- **Given** the browser is logged in the Wazuh kibana app and you have an FreeBSD active agent
- **When** the user navigate to `Agents` -> click on `FreeBSD agent` -> enter in FreeBSD agent section ->`Inventory Data`
- **Then** Package table will not be empty

Check List

- [x] Show FreeDBS Agent packages

![image](https://user-images.githubusercontent.com/63758389/137529069-33ad622c-2a9b-421c-bab8-e5e7e4a6a44e.png)
