### PR TITLE
Delete wazuh token called twice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fixed error when edit a rule or decoder [#3456](https://github.com/wazuh/wazuh-kibana-app/pull/3456)
 - Fixed index pattern selector doesn't display the ignored index patterns [#3458](https://github.com/wazuh/wazuh-kibana-app/pull/3458)
 - Fixed order logs properly in Management/Logs [#3609](https://github.com/wazuh/wazuh-kibana-app/pull/3609)
+- Fixed wazuh token deleted twice [#3652](https://github.com/wazuh/wazuh-kibana-app/pull/3652)
 
 ## Wazuh v4.2.4 - Kibana 7.10.2, 7.11.2, 7.12.1 - Revision 4205
 

--- a/public/app.js
+++ b/public/app.js
@@ -116,7 +116,7 @@ app.run(function ($rootElement) {
   // Bind deleteExistentToken on Log out component.
   $('.euiHeaderSectionItem__button').on('mouseleave', function () {
     // opendistro
-    $('span:contains(Log out)').on('click', function () {
+    $('button:contains(Log out)').on('click', function () {
       WzAuthentication.deleteExistentToken();
     });
     // x-pack


### PR DESCRIPTION
Hi team, this resolves 
- Delete wazuh token is called twice

Testing:
- Rollback the changes, add a console.log in [public/react-services/wz-authentication.ts#L151](https://github.com/wazuh/wazuh-kibana-app/blob/e22abcb81e2543d92f00c392785b11e5a981bbc0/public/react-services/wz-authentication.ts#L151)
- Run the logout and see the browser console

**To test it:**

**Precondition 1**: Location: [public/react-services/wz-authentication.ts#L151](https://github.com/wazuh/wazuh-kibana-app/blob/e22abcb81e2543d92f00c392785b11e5a981bbc0/public/react-services/wz-authentication.ts#L151)

1. Go to Inventory Section of an agent
- **Given** the browser is logged in the Wazuh kibana app
- **When** the put a console log in **Precondition 1**
- **And** the user will logged out
- **Then** the console log will appear properly in the browser console