### PR TITLE
Fix remove token on logout kibana 7.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 
 - Fixed compatibility wazuh 4.2 - kibana 7.13.4 [#3653](https://github.com/wazuh/wazuh-kibana-app/pull/3653)
 - Fixed interative register windows agent screen error [#3654](https://github.com/wazuh/wazuh-kibana-app/pull/3654)
+- Fixed Wazuh token is not removed after logout in Kibana 7.13 [#3670](https://github.com/wazuh/wazuh-kibana-app/pull/3670)
 
 ## Wazuh v4.2.4 - Kibana 7.10.2, 7.11.2, 7.12.1 - Revision 4205
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "revision": "4206-1",
   "code": "4206-1",
   "kibana": {
-    "version": "7.10.2"
+    "version": "7.13.4"
   },
   "description": "Wazuh app",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "revision": "4206-1",
   "code": "4206-1",
   "kibana": {
-    "version": "7.13.4"
+    "version": "7.14.2"
   },
   "description": "Wazuh app",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "revision": "4206-1",
   "code": "4206-1",
   "kibana": {
-    "version": "7.14.2"
+    "version": "7.10.2"
   },
   "description": "Wazuh app",
   "keywords": [

--- a/public/app.js
+++ b/public/app.js
@@ -114,7 +114,7 @@ app.run(function ($rootElement) {
   const urlToLogout = window.location.origin + '/logout';
 
   // Bind deleteExistentToken on Log out component.
-  $('.euiHeaderSectionItem__button').on('mouseleave', function () {
+  $('.euiHeaderSectionItem__button, .euiHeaderSectionItemButton').on('mouseleave', function () {
     // opendistro
     $('span:contains(Log out)').on('click', function () {
       WzAuthentication.deleteExistentToken();


### PR DESCRIPTION
Hi team this resolves: 

Remove Wazuh API token on logout with Kibana 7.13 and 7.14

To test:
- login and copy the wz-token and make a curl with this token
- logout and repeat the curl
- the second curl should return 401