### PR TITLE
Fixed Group Configuration and Management configuration error after trying to going back after you save

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 
 - Fixed compatibility wazuh 4.2 - kibana 7.13.4 [#3653](https://github.com/wazuh/wazuh-kibana-app/pull/3653)
 - Fixed interative register windows agent screen error [#3654](https://github.com/wazuh/wazuh-kibana-app/pull/3654)
+- Fixed Group Configuration and Management configuration error after trying to going back after you save [#3672](https://github.com/wazuh/wazuh-kibana-app/pull/3672)
 
 ## Wazuh v4.2.4 - Kibana 7.10.2, 7.11.2, 7.12.1 - Revision 4205
 

--- a/public/components/security/users/components/edit-user.tsx
+++ b/public/components/security/users/components/edit-user.tsx
@@ -209,7 +209,7 @@ export const EditUser = ({ currentUser, closeFlyout, rolesObject }) => {
   useEffect(() => {
     if (
       initialPassword != password || initialPassword != confirmPassword || 
-      !_.isEqual(userRolesFormatted, selectedRoles) || allowRunAs
+      !_.isEqual(userRolesFormatted, selectedRoles) || allowRunAs !== currentUser.allow_run_as
     ) {
       setHasChanges(true);
     } else {

--- a/public/controllers/management/components/management/configuration/edit-configuration/edit-configuration.js
+++ b/public/controllers/management/components/management/configuration/edit-configuration/edit-configuration.js
@@ -81,7 +81,7 @@ class WzEditConfiguration extends Component {
             this.props.clusterNodeSelected
           )
         : await saveFileManager(this.state.editorValue);
-      this.setState({ saving: false, infoChangesAfterRestart: true });
+      this.setState({ saving: false, infoChangesAfterRestart: true, hasChanges: false });
       this.addToast({
         title: (
           <Fragment>

--- a/public/controllers/management/components/management/groups/groups-editor.js
+++ b/public/controllers/management/components/management/groups/groups-editor.js
@@ -117,7 +117,7 @@ class WzGroupsEditor extends Component {
         this.showToast('warning', warning.savedMessage, error, 3000);
         return;
       }
-      this.setState({ isSaving: false });
+      this.setState({ isSaving: false, hasChanges: false });
       const textSuccess = 'File successfully edited';
       this.showToast('success', 'Success', textSuccess, 3000);
     } catch (error) {


### PR DESCRIPTION
Hi guys,
With this PR we solve the error when we modify the management configuration or of some group, we save and we give the back button, before it told us that we had not saved, when we had done it

To test it:
- Go to Management/Configuration edit the file, save and try to go back with the button, it doesn't have to ask you about unsaved changes
- Same as before but in Groups/Configuration of one of them

Closes #3671 and first problem of [this comment](https://github.com/wazuh/wazuh-kibana-app/issues/3310#issuecomment-954792529)