### PR TITLE
Fixing EuiPannels in Overview Sections and disabled text in WzMenu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 
 - Fixed compatibility wazuh 4.2 - kibana 7.13.4 [#3653](https://github.com/wazuh/wazuh-kibana-app/pull/3653)
 - Fixed interative register windows agent screen error [#3654](https://github.com/wazuh/wazuh-kibana-app/pull/3654)
-
+- Fixing EuiPannels in Overview Sections and disabled text in WzMenu [#3674](https://github.com/wazuh/wazuh-kibana-app/pull/3674)
 ## Wazuh v4.2.4 - Kibana 7.10.2, 7.11.2, 7.12.1 - Revision 4205
 
 ### Added

--- a/public/components/agents/sca/inventory.tsx
+++ b/public/components/agents/sca/inventory.tsx
@@ -19,7 +19,8 @@ import {
   EuiButtonEmpty,
   EuiToolTip,
   EuiCallOut,
-  EuiPopover
+  EuiPopover,
+  EuiCard
 } from '@elastic/eui';
 import { WzRequest } from '../../../react-services/wz-request';
 import { formatUIDate } from '../../../react-services/time-service';
@@ -461,9 +462,9 @@ export class Inventory extends Component {
                 <EuiFlexGroup style={{ 'marginTop': 0 }}>
                   {(this.state.data || []).map((pie, idx) => (
                     <EuiFlexItem key={idx} grow={false}>
-                      <EuiPanel betaBadgeLabel={pie.name} style={{ paddingBottom: 0 }}>
+                      <EuiCard title description betaBadgeLabel={pie.name} style={{ paddingBottom: 0 }}>
                         <Pie width={325} height={130} data={pie.status} colors={['#00a69b', '#ff645c', '#5c6773']} />
-                      </EuiPanel>
+                      </EuiCard>
                     </EuiFlexItem>
                   ))}
                 </EuiFlexGroup>

--- a/public/components/common/welcome/management-welcome.js
+++ b/public/components/common/welcome/management-welcome.js
@@ -54,7 +54,7 @@ class ManagementWelcome extends Component {
         <EuiPage className="wz-welcome-page">
           <EuiFlexGroup>
             <EuiFlexItem>
-              <EuiPanel betaBadgeLabel="Administration">
+              <EuiCard title description betaBadgeLabel="Administration">
                 <EuiSpacer size="m" />
                 <EuiFlexGroup>
                   <EuiFlexItem>
@@ -139,10 +139,10 @@ class ManagementWelcome extends Component {
                   </EuiFlexItem>
                   <EuiFlexItem />
                 </EuiFlexGroup>
-              </EuiPanel>
+              </EuiCard>
             </EuiFlexItem>
             <EuiFlexItem>
-              <EuiPanel betaBadgeLabel="Status and reports">
+              <EuiCard title description betaBadgeLabel="Status and reports">
                 <EuiSpacer size="m" />
                 <EuiFlexGroup>
                   <EuiFlexItem>
@@ -220,7 +220,7 @@ class ManagementWelcome extends Component {
                   <EuiFlexItem>
                   </EuiFlexItem>
                 </EuiFlexGroup>
-              </EuiPanel>
+              </EuiCard>
             </EuiFlexItem>
           </EuiFlexGroup>
         </EuiPage>

--- a/public/components/common/welcome/overview-welcome.js
+++ b/public/components/common/welcome/overview-welcome.js
@@ -88,7 +88,7 @@ export class OverviewWelcome extends Component {
               {this.props.agentsCountTotal == 0 && this.addAgent()}
               <EuiFlexGroup>
                 <EuiFlexItem>
-                  <EuiPanel betaBadgeLabel="Security Information Management">
+                  <EuiCard title description betaBadgeLabel="Security Information Management">
                     <EuiSpacer size="s" />
                     <EuiFlexGrid columns={2}>
                       {this.buildTabCard('general', 'dashboardApp')}
@@ -98,10 +98,10 @@ export class OverviewWelcome extends Component {
                       {this.props.extensions.gcp &&
                         this.buildTabCard('gcp', 'logoGCPMono')}
                     </EuiFlexGrid>
-                  </EuiPanel>
+                  </EuiCard>
                 </EuiFlexItem>
                 <EuiFlexItem>
-                  <EuiPanel betaBadgeLabel="Auditing and Policy Monitoring">
+                  <EuiCard title description betaBadgeLabel="Auditing and Policy Monitoring">
                     <EuiSpacer size="s" />
                     <EuiFlexGrid columns={2}>
                       {this.buildTabCard('pm', 'advancedSettingsApp')}
@@ -113,14 +113,14 @@ export class OverviewWelcome extends Component {
                         this.buildTabCard('ciscat', 'auditbeatApp')}
                       {this.buildTabCard('sca', 'securityAnalyticsApp')}
                     </EuiFlexGrid>
-                  </EuiPanel>
+                  </EuiCard>
                 </EuiFlexItem>
               </EuiFlexGroup>
 
               <EuiSpacer size="xl" />
               <EuiFlexGroup>
                 <EuiFlexItem>
-                  <EuiPanel betaBadgeLabel="Threat Detection and Response">
+                  <EuiCard title description betaBadgeLabel="Threat Detection and Response">
                     <EuiSpacer size="s" />
                     <EuiFlexGrid columns={2}>
                       {this.buildTabCard('vuls', 'securityApp')}
@@ -133,11 +133,11 @@ export class OverviewWelcome extends Component {
                       {this.buildTabCard('mitre', 'spacesApp')}
                       {/* TODO- Change "spacesApp" icon*/}
                     </EuiFlexGrid>
-                  </EuiPanel>
+                  </EuiCard>
                 </EuiFlexItem>
 
                 <EuiFlexItem>
-                  <EuiPanel betaBadgeLabel="Regulatory Compliance">
+                  <EuiCard title description betaBadgeLabel="Regulatory Compliance">
                     <EuiSpacer size="s" />
                     {!this.props.extensions.pci &&
                       !this.props.extensions.gdpr &&
@@ -177,7 +177,7 @@ export class OverviewWelcome extends Component {
                             this.buildTabCard('hipaa', 'emsApp')}
                         </EuiFlexGrid>
                       )}
-                  </EuiPanel>
+                  </EuiCard>
                 </EuiFlexItem>
               </EuiFlexGroup>
             </EuiFlexItem>

--- a/public/components/wz-menu/wz-menu-management.js
+++ b/public/components/wz-menu/wz-menu-management.js
@@ -138,7 +138,7 @@ class WzMenuManagement extends Component {
         name: this.managementSections.administration.text,
         id: this.managementSections.administration.id,
         id: 0,
-        disabled: true,
+        disabled: false,
         icon: <EuiIcon type="managementApp" color="primary" />,
         items: [
           this.createItem(this.managementSections.rules),
@@ -154,7 +154,7 @@ class WzMenuManagement extends Component {
       {
         name: this.managementSections.statusReports.text,
         id: this.managementSections.statusReports.id,
-        disabled: true,
+        disabled: false,
         icon: <EuiIcon type="reportingApp" color="primary" />,
         items: [
           this.createItem(this.managementSections.status),

--- a/public/components/wz-menu/wz-menu-settings.js
+++ b/public/components/wz-menu/wz-menu-settings.js
@@ -124,7 +124,7 @@ class WzMenuSettings extends Component {
       {
         name: availableSettings.settings.text,
         id: availableSettings.settings.id,
-        disabled: true,
+        disabled: false,
         icon: <EuiIcon type="gear" color="primary" />,
         items: renderSettings
       }

--- a/public/controllers/agent/components/agents-preview.js
+++ b/public/controllers/agent/components/agents-preview.js
@@ -161,7 +161,9 @@ export const AgentsPreview = compose(
             ) || (
             <Fragment>
             <EuiFlexItem className="agents-status-pie" grow={false}>
-              <EuiPanel
+              <EuiCard
+                title
+                description 
                 betaBadgeLabel="Status"
                 className="eui-panel"
               >
@@ -180,11 +182,11 @@ export const AgentsPreview = compose(
                     </EuiFlexItem>
                   )}
                 </EuiFlexGroup>
-              </EuiPanel>
+              </EuiCard>
             </EuiFlexItem>
             {this.totalAgents > 0 && (
               <EuiFlexItem >
-                <EuiPanel betaBadgeLabel="Details">
+                <EuiCard title description  betaBadgeLabel="Details">
                   <EuiFlexGroup>
                     <EuiFlexItem>
                       {this.summary && (
@@ -281,14 +283,14 @@ export const AgentsPreview = compose(
                       </EuiFlexGroup>
                     </EuiFlexItem>
                   </EuiFlexGroup>
-                </EuiPanel>
+                </EuiCard>
               </EuiFlexItem>
             )}
             </Fragment>
             )}
             {this.state.showAgentsEvolutionVisualization && (
               <EuiFlexItem grow={false} className="agents-evolution-visualization" style={{ display: !this.state.loading ? 'block' : 'none', height: !this.state.loading ? '182px' : 0}}>
-                <EuiPanel paddingSize="none" betaBadgeLabel="Evolution" style={{ display: this.props.resultState === 'ready' ? 'block' : 'none'}}>
+                <EuiCard title description  paddingSize="none" betaBadgeLabel="Evolution" style={{ display: this.props.resultState === 'ready' ? 'block' : 'none'}}>
                   <EuiFlexGroup>
                     <EuiFlexItem>
                     <div style={{height: this.props.resultState === 'ready' ? '180px' : 0}}>
@@ -308,8 +310,8 @@ export const AgentsPreview = compose(
 
                     </EuiFlexItem>
                   </EuiFlexGroup>
-                </EuiPanel>
-                <EuiPanel paddingSize="none" betaBadgeLabel="Evolution" style={{ height: 180,  display: this.props.resultState === 'none' ? 'block' : 'none'}}>
+                </EuiCard>
+                <EuiCard title description  paddingSize="none" betaBadgeLabel="Evolution" style={{ height: 180,  display: this.props.resultState === 'none' ? 'block' : 'none'}}>
                   <EuiEmptyPrompt
                     className="wz-padding-21"
                     iconType="alert"
@@ -319,7 +321,7 @@ export const AgentsPreview = compose(
                       <WzDatePicker condensed={true} onTimeChange={() => { }} />
                     }
                   />
-                </EuiPanel>
+                </EuiCard>
               </EuiFlexItem>
 
             )}

--- a/public/controllers/agent/components/agents-preview.js
+++ b/public/controllers/agent/components/agents-preview.js
@@ -23,7 +23,8 @@ import {
   EuiSpacer,
   EuiText,
   EuiEmptyPrompt,
-  EuiToolTip
+  EuiToolTip,
+  EuiCard
 } from '@elastic/eui';
 import { Pie } from "../../../components/d3/pie";
 import { ProgressChart } from "../../../components/d3/progress";


### PR DESCRIPTION
In this PR we resolve:

- That the Panels and their titles are properly displayed in the Welcome Overview and in the Management Directory
- That in All the Wazuh menu everything looks good, without titles in gray (disabled)

Closes first 3 error of [this comment](https://github.com/wazuh/wazuh-kibana-app/issues/3310#issuecomment-954609355)