### PR TITLE
[FIX] [Compatibility] Get the valid index patterns to use in the app in Kibana 7.10.2 - 7.13.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,13 +11,14 @@ All notable changes to the Wazuh app project will be documented in this file.
 
 ### Fixed
 
-- Fixed compatibility wazuh 4.2 - kibana 7.13.4 [#3653](https://github.com/wazuh/wazuh-kibana-app/pull/3653)
+- Fixed compatibility Wazuh 4.2 - Kibana 7.13.4 [#3653](https://github.com/wazuh/wazuh-kibana-app/pull/3653)
 - Fixed interative register windows agent screen error [#3654](https://github.com/wazuh/wazuh-kibana-app/pull/3654)
 - Fixed breadcrumbs style compatibility for Kibana 7.14.2 [#3668](https://github.com/wazuh/wazuh-kibana-app/pull/3668)
 - Fixed Wazuh token is not removed after logout in Kibana 7.13 [#3670](https://github.com/wazuh/wazuh-kibana-app/pull/3670)
 - Fixed Group Configuration and Management configuration error after trying to going back after you save [#3672](https://github.com/wazuh/wazuh-kibana-app/pull/3672)
-- Fixing EuiPannels in Overview Sections and disabled text in WzMenu [#3674](https://github.com/wazuh/wazuh-kibana-app/pull/3674)
+- Fixing EuiPanels in Overview Sections and disabled text in WzMenu [#3674](https://github.com/wazuh/wazuh-kibana-app/pull/3674)
 - Fixing double flyout clicking in a policy [#3676](https://github.com/wazuh/wazuh-kibana-app/pull/3676)
+- Fixed compatibility to get the valid index patterns and refresh fields for Kibana 7.10.2-7.13.4 [3681](https://github.com/wazuh/wazuh-kibana-app/pull/3681)
 
 ## Wazuh v4.2.4 - Kibana 7.10.2, 7.11.2, 7.12.1 - Revision 4205
 

--- a/common/semver.ts
+++ b/common/semver.ts
@@ -1,0 +1,17 @@
+/*
+ * Wazuh app - Utils related to Kibana and app versions
+ *
+ * Copyright (C) 2015-2021 Wazuh, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Find more information about this on the LICENSE file.
+ *
+ */
+import { kibana as appPackageKibana } from '../package.json';
+import semver from 'semver';
+
+export const satisfyKibanaVersion = (requiredKibanaVersion: string) => semver.satisfies(appPackageKibana.version, requiredKibanaVersion);

--- a/public/components/common/modules/events.tsx
+++ b/public/components/common/modules/events.tsx
@@ -171,7 +171,7 @@ export class Events extends Component {
     if (!this.state.hasRefreshedKnownFields) {
       try {
         this.setState({ hasRefreshedKnownFields: true, isRefreshing: true });
-        if(satisfyKibanaVersion('<=7.10.2')){
+        if(satisfyKibanaVersion('<7.11')){
           await PatternHandler.refreshIndexPattern();
         };
         this.setState({ isRefreshing: false });
@@ -236,7 +236,7 @@ export class Events extends Component {
 
   reloadToast = () => {
     const toastLifeTimeMs = 300000;
-    if(satisfyKibanaVersion('<=7.10.2')){
+    if(satisfyKibanaVersion('<7.11')){
       getToasts().add({
         color: 'success',
         title: 'The index pattern was refreshed successfully.',
@@ -251,7 +251,7 @@ export class Events extends Component {
         </EuiFlexGroup>),
         toastLifeTimeMs
       });
-    }else if(satisfyKibanaVersion('>7.10.2')){
+    }else if(satisfyKibanaVersion('>=7.11')){
       getToasts().add({
         color: 'warning',
         title: 'Found unknown fields in the index pattern.',

--- a/public/components/health-check/services/check-index-pattern/check-index-pattern-object.service.ts
+++ b/public/components/health-check/services/check-index-pattern/check-index-pattern-object.service.ts
@@ -41,7 +41,7 @@ export const checkIndexPatternObjectService =  async (appConfig, checkLogger: Ch
       const existDefaultIndexPattern = await SavedObject.getExistingIndexPattern(defaultPatternId);
       checkLogger.info(`Index pattern id [${defaultPatternId}] exists: ${existDefaultIndexPattern ? 'yes' : 'no'}`);
       if (existDefaultIndexPattern) {
-        if(satisfyKibanaVersion('<=7.10.2')){
+        if(satisfyKibanaVersion('<7.11')){
           checkLogger.info(`Refreshing index pattern fields [${defaultPatternId}]...`);
           await SavedObject.refreshIndexPattern(defaultPatternId);
           checkLogger.action(`Refreshed index pattern fields [${defaultPatternId}]`);

--- a/public/components/health-check/services/check-index-pattern/check-index-pattern-object.service.ts
+++ b/public/components/health-check/services/check-index-pattern/check-index-pattern-object.service.ts
@@ -15,6 +15,7 @@ import { AppState, SavedObject } from '../../../../react-services';
 import { getDataPlugin } from '../../../../kibana-services';
 import { HEALTH_CHECK } from '../../../../../common/constants';
 import { CheckLogger } from '../../types/check_logger';
+import { satisfyKibanaVersion } from '../../../../../common/semver';
 
 export const checkIndexPatternObjectService =  async (appConfig, checkLogger: CheckLogger) => {
   const patternId: string = AppState.getCurrentPattern();
@@ -40,9 +41,11 @@ export const checkIndexPatternObjectService =  async (appConfig, checkLogger: Ch
       const existDefaultIndexPattern = await SavedObject.getExistingIndexPattern(defaultPatternId);
       checkLogger.info(`Index pattern id [${defaultPatternId}] exists: ${existDefaultIndexPattern ? 'yes' : 'no'}`);
       if (existDefaultIndexPattern) {
-        checkLogger.info(`Refreshing index pattern fields [${defaultPatternId}]...`);
-        await SavedObject.refreshIndexPattern(defaultPatternId);
-        checkLogger.action(`Refreshed index pattern fields [${defaultPatternId}]`);
+        if(satisfyKibanaVersion('<=7.10.2')){
+          checkLogger.info(`Refreshing index pattern fields [${defaultPatternId}]...`);
+          await SavedObject.refreshIndexPattern(defaultPatternId);
+          checkLogger.action(`Refreshed index pattern fields [${defaultPatternId}]`);
+        };
       } else if(shouldCreateIndex) {
         checkLogger.info(`Creating index pattern [${defaultPatternId}]...`);
         await SavedObject.createWazuhIndexPattern(defaultPatternId);

--- a/public/components/health-check/services/check-index-pattern/check-index-pattern.service.ts
+++ b/public/components/health-check/services/check-index-pattern/check-index-pattern.service.ts
@@ -26,7 +26,7 @@ const checkPattern = async (appConfig, checkLogger: CheckLogger) =>  {
   }else{
     await checkIndexPatternObjectService(appConfig, checkLogger);
     await checkTemplateService(appConfig, checkLogger);
-    if(satisfyKibanaVersion('<=7.10.2')){
+    if(satisfyKibanaVersion('<7.11')){
       await checkFieldsService(appConfig, checkLogger);
     };
   }

--- a/public/components/health-check/services/check-index-pattern/check-index-pattern.service.ts
+++ b/public/components/health-check/services/check-index-pattern/check-index-pattern.service.ts
@@ -15,6 +15,7 @@ import { CheckLogger } from '../../types/check_logger';
 import { checkFieldsService } from './check-fields.service';
 import { checkIndexPatternObjectService } from './check-index-pattern-object.service';
 import { checkTemplateService } from './check-template.service';
+import { satisfyKibanaVersion } from '../../../../../common/semver';
 
 export const checkIndexPatternService = (appConfig) => async (checkLogger: CheckLogger) =>  await checkPattern(appConfig, checkLogger);
 
@@ -25,7 +26,9 @@ const checkPattern = async (appConfig, checkLogger: CheckLogger) =>  {
   }else{
     await checkIndexPatternObjectService(appConfig, checkLogger);
     await checkTemplateService(appConfig, checkLogger);
-    await checkFieldsService(appConfig, checkLogger); 
+    if(satisfyKibanaVersion('<=7.10.2')){
+      await checkFieldsService(appConfig, checkLogger);
+    };
   }
   return;
 };

--- a/public/components/health-check/services/check-pattern-support.service.ts
+++ b/public/components/health-check/services/check-pattern-support.service.ts
@@ -22,7 +22,7 @@ export const checkPatternSupportService = (pattern: string, indexType : string) 
   
   if (!result.data) {
     let fields;
-    if(satisfyKibanaVersion('<=7.10.2')){
+    if(satisfyKibanaVersion('<7.11')){
       checkLogger.info(`Getting indices fields for the index pattern id [${pattern}]...`);
       fields = await SavedObject.getIndicesFields(pattern, indexType);
       checkLogger.info(`Fields for index pattern id [${pattern}] found: ${fields.length}`);

--- a/public/components/visualize/wz-visualize.js
+++ b/public/components/visualize/wz-visualize.js
@@ -139,7 +139,7 @@ export const WzVisualize = withReduxProvider(class WzVisualize extends Component
     if (!this.state.hasRefreshedKnownFields) { // Known fields are refreshed only once per dashboard loading
       try {
         this.setState({ hasRefreshedKnownFields: true, isRefreshing: true });
-        if(satisfyKibanaVersion('<=7.10.2')){
+        if(satisfyKibanaVersion('<7.11')){
           await PatternHandler.refreshIndexPattern(this.newFields);
         };
         this.setState({ isRefreshing: false });
@@ -157,7 +157,7 @@ export const WzVisualize = withReduxProvider(class WzVisualize extends Component
   }
   reloadToast = () => {
     const toastLifeTimeMs = 300000;
-    if(satisfyKibanaVersion('<=7.10.2')){
+    if(satisfyKibanaVersion('<7.11')){
       getToasts().add({
         color: 'success',
         title: 'The index pattern was refreshed successfully.',
@@ -172,7 +172,7 @@ export const WzVisualize = withReduxProvider(class WzVisualize extends Component
         </EuiFlexGroup>),
         toastLifeTimeMs
       });
-    }else if(satisfyKibanaVersion('>7.10.2')){
+    }else if(satisfyKibanaVersion('>=7.11')){
       getToasts().add({
         color: 'warning',
         title: 'Found unknown fields in the index pattern.',

--- a/public/components/visualize/wz-visualize.js
+++ b/public/components/visualize/wz-visualize.js
@@ -37,6 +37,7 @@ import { getToasts } from '../../kibana-services';
 import { SecurityAlerts } from './components';
 import { toMountPoint } from '../../../../../src/plugins/kibana_react/public';
 import { withReduxProvider } from '../common/hocs';
+import { satisfyKibanaVersion } from '../../../common/semver';
 
 
 const visHandler = new VisHandlers();
@@ -138,7 +139,9 @@ export const WzVisualize = withReduxProvider(class WzVisualize extends Component
     if (!this.state.hasRefreshedKnownFields) { // Known fields are refreshed only once per dashboard loading
       try {
         this.setState({ hasRefreshedKnownFields: true, isRefreshing: true });
-        await PatternHandler.refreshIndexPattern(this.newFields);
+        if(satisfyKibanaVersion('<=7.10.2')){
+          await PatternHandler.refreshIndexPattern(this.newFields);
+        };
         this.setState({ isRefreshing: false });
         this.reloadToast();
         this.newFields={};
@@ -153,19 +156,38 @@ export const WzVisualize = withReduxProvider(class WzVisualize extends Component
     }
   }
   reloadToast = () => {
-    getToasts().add({
-      color: 'success',
-      title: 'The index pattern was refreshed successfully.',
-      text: toMountPoint(<EuiFlexGroup justifyContent="flexEnd" gutterSize="s">
-        <EuiFlexItem grow={false}>
-          There were some unknown fields for the current index pattern.
-          You need to refresh the page to apply the changes.
-        </EuiFlexItem>
-        <EuiFlexItem grow={false}>
-          <EuiButton onClick={() => window.location.reload()} size="s">Reload page</EuiButton>
-        </EuiFlexItem>
-      </EuiFlexGroup>)
-    })
+    const toastLifeTimeMs = 300000;
+    if(satisfyKibanaVersion('<=7.10.2')){
+      getToasts().add({
+        color: 'success',
+        title: 'The index pattern was refreshed successfully.',
+        text: toMountPoint(<EuiFlexGroup justifyContent="flexEnd" gutterSize="s">
+          <EuiFlexItem grow={false}>
+            There were some unknown fields for the current index pattern.
+            You need to refresh the page to apply the changes.
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiButton onClick={() => window.location.reload()} size="s">Reload page</EuiButton>
+          </EuiFlexItem>
+        </EuiFlexGroup>),
+        toastLifeTimeMs
+      });
+    }else if(satisfyKibanaVersion('>7.10.2')){
+      getToasts().add({
+        color: 'warning',
+        title: 'Found unknown fields in the index pattern.',
+        text: toMountPoint(<EuiFlexGroup justifyContent="flexEnd" gutterSize="s">
+          <EuiFlexItem grow={false}>
+            There are some unknown fields for the current index pattern.
+            You need to refresh the page to update the fields.
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiButton onClick={() => window.location.reload()} size="s">Reload page</EuiButton>
+          </EuiFlexItem>
+        </EuiFlexGroup>),
+        toastLifeTimeMs
+      });
+    };
   }
   render() {
     const { visualizations } = this.state;

--- a/public/react-services/pattern-handler.js
+++ b/public/react-services/pattern-handler.js
@@ -44,7 +44,7 @@ export class PatternHandler {
   static async changePattern(selectedPattern) {
     try {
       AppState.setCurrentPattern(selectedPattern);
-      if(satisfyKibanaVersion('<=7.10.2')){
+      if(satisfyKibanaVersion('<7.11')){
         await this.refreshIndexPattern();
       };
       return AppState.getCurrentPattern();

--- a/public/react-services/pattern-handler.js
+++ b/public/react-services/pattern-handler.js
@@ -14,6 +14,7 @@ import { SavedObject } from './saved-objects';
 import { getDataPlugin, getToasts, getHttp } from '../kibana-services';
 import { WazuhConfig } from '../react-services/wazuh-config';
 import { HEALTH_CHECK } from '../../common/constants';
+import { satisfyKibanaVersion } from '../../common/semver';
 
 export class PatternHandler {
   /**
@@ -43,7 +44,9 @@ export class PatternHandler {
   static async changePattern(selectedPattern) {
     try {
       AppState.setCurrentPattern(selectedPattern);
-      await this.refreshIndexPattern();
+      if(satisfyKibanaVersion('<=7.10.2')){
+        await this.refreshIndexPattern();
+      };
       return AppState.getCurrentPattern();
     } catch (error) {
       throw new Error('Error Pattern Handler (changePattern)');

--- a/public/react-services/saved-objects.js
+++ b/public/react-services/saved-objects.js
@@ -36,9 +36,9 @@ export class SavedObject {
       let indexPatterns = ((savedObjects || {}).data || {}).saved_objects || [];
 
       let indexPatternsFields;
-      if(satisfyKibanaVersion('<=7.10.2')){
+      if(satisfyKibanaVersion('<7.11')){
         indexPatternsFields = indexPatterns.map(indexPattern => JSON.parse(indexPattern.attributes.fields));
-      }else if(satisfyKibanaVersion('>7.10.2')){
+      }else if(satisfyKibanaVersion('>=7.11')){
         indexPatternsFields = await Promise.all(indexPatterns.map(async indexPattern => {
           try{
             const {data: {fields}} = await GenericRequest.request(
@@ -111,7 +111,7 @@ export class SavedObject {
     const result = await SavedObject.existsIndexPattern(patternID);
     if (!result.data) {
       let fields = '';
-      if(satisfyKibanaVersion('<=7.10.2')){
+      if(satisfyKibanaVersion('<7.11')){
         fields = await SavedObject.getIndicesFields(patternID, WAZUH_INDEX_TYPE_ALERTS);
       };
       await this.createSavedObject(
@@ -171,9 +171,9 @@ export class SavedObject {
         true
       );
       let indexPatternFields;
-      if(satisfyKibanaVersion('<=7.10.2')){
+      if(satisfyKibanaVersion('<7.11')){
         indexPatternFields = JSON.parse(indexPatternData.data.attributes.fields);
-      }else if(satisfyKibanaVersion('>7.10.2')){
+      }else if(satisfyKibanaVersion('>=7.11')){
         try{
           const {data: {fields}} = await GenericRequest.request(
             'GET',
@@ -200,7 +200,7 @@ export class SavedObject {
         params
       );
 
-      if(satisfyKibanaVersion('<=7.10.2')){
+      if(satisfyKibanaVersion('<7.11')){
         if (type === 'index-pattern'){
           await this.refreshFieldsOfIndexPattern(id, params.attributes.title, fields);
         }
@@ -281,7 +281,7 @@ export class SavedObject {
   static async createWazuhIndexPattern(pattern) {
     try {
       let fields = '';
-      if(satisfyKibanaVersion('<=7.10.2')){
+      if(satisfyKibanaVersion('<7.11')){
         fields = await SavedObject.getIndicesFields(pattern, WAZUH_INDEX_TYPE_ALERTS);
       };
       await this.createSavedObject(

--- a/public/react-services/saved-objects.js
+++ b/public/react-services/saved-objects.js
@@ -200,10 +200,8 @@ export class SavedObject {
         params
       );
 
-      if(satisfyKibanaVersion('<7.11')){
-        if (type === 'index-pattern'){
-          await this.refreshFieldsOfIndexPattern(id, params.attributes.title, fields);
-        }
+      if(satisfyKibanaVersion('<7.11') && type === 'index-pattern'){
+        await this.refreshFieldsOfIndexPattern(id, params.attributes.title, fields);
       };
 
       return result;
@@ -280,10 +278,7 @@ export class SavedObject {
    */
   static async createWazuhIndexPattern(pattern) {
     try {
-      let fields = '';
-      if(satisfyKibanaVersion('<7.11')){
-        fields = await SavedObject.getIndicesFields(pattern, WAZUH_INDEX_TYPE_ALERTS);
-      };
+      const fields = satisfyKibanaVersion('<7.11') ? await SavedObject.getIndicesFields(pattern, WAZUH_INDEX_TYPE_ALERTS) : '';
       await this.createSavedObject(
         'index-pattern',
         pattern,

--- a/public/react-services/saved-objects.js
+++ b/public/react-services/saved-objects.js
@@ -20,6 +20,7 @@ import {
   WAZUH_INDEX_TYPE_MONITORING,
   WAZUH_INDEX_TYPE_STATISTICS
 } from '../../common/constants';
+import { satisfyKibanaVersion } from '../../common/semver';
 
 export class SavedObject {
   /**
@@ -28,11 +29,30 @@ export class SavedObject {
    */
   static async getListOfIndexPatterns() {
     try {
-      const result = await GenericRequest.request(
+      const savedObjects = await GenericRequest.request(
         'GET',
         `/api/saved_objects/_find?type=index-pattern&fields=title&fields=fields&per_page=9999`
       );
-      return ((result || {}).data || {}).saved_objects || [];
+      let indexPatterns = ((savedObjects || {}).data || {}).saved_objects || [];
+
+      let indexPatternsFields;
+      if(satisfyKibanaVersion('<=7.10.2')){
+        indexPatternsFields = indexPatterns.map(indexPattern => JSON.parse(indexPattern.attributes.fields));
+      }else if(satisfyKibanaVersion('>7.10.2')){
+        indexPatternsFields = await Promise.all(indexPatterns.map(async indexPattern => {
+          try{
+            const {data: {fields}} = await GenericRequest.request(
+              'GET',
+              `/api/index_patterns/_fields_for_wildcard?pattern=${indexPattern.attributes.title}`,
+              {}
+            );
+            return fields;
+          }catch(error){
+            return [];
+          }
+        }));
+      }
+      return indexPatterns.map((indexPattern, idx) => ({...indexPattern, _fields: indexPatternsFields[idx]}));
     } catch (error) {
       return ((error || {}).data || {}).message || false
         ? error.data.message
@@ -80,11 +100,8 @@ export class SavedObject {
       'agent.id',
     ];
     return list.filter(item => {
-      if (item.attributes && item.attributes.fields) {
-        const fields = JSON.parse(item.attributes.fields);
-        return requiredFields.every((reqField => {
-          return fields.find(field => field.name === reqField);
-        }));
+      if (item._fields) {
+        return requiredFields.every((reqField => item._fields.some(field => field.name === reqField)));
       }
       return false;
     });
@@ -93,7 +110,10 @@ export class SavedObject {
   static async existsOrCreateIndexPattern(patternID) {
     const result = await SavedObject.existsIndexPattern(patternID);
     if (!result.data) {
-      const fields = await SavedObject.getIndicesFields(patternID, WAZUH_INDEX_TYPE_ALERTS);
+      let fields = '';
+      if(satisfyKibanaVersion('<=7.10.2')){
+        fields = await SavedObject.getIndicesFields(patternID, WAZUH_INDEX_TYPE_ALERTS);
+      };
       await this.createSavedObject(
         'index-pattern',
         patternID,
@@ -112,40 +132,23 @@ export class SavedObject {
    *
    * Given an index pattern ID, checks if it exists
    */
-  static async getExistingIndexPattern(patternID) {
-    try {
-      const result = await GenericRequest.request(
-        'GET',
-        `/api/saved_objects/index-pattern/${patternID}?fields=title&fields=fields`
-      );
-
-      return result.data;
-    } catch (error) {
-      if (error && error.response && error.response.status == 404) return false;
-      return ((error || {}).data || {}).message || false ? error.data.message : error.message || false;
-    }
-  }
-
-  /**
-   *
-   * Given an index pattern ID, checks if it exists
-   */
   static async existsIndexPattern(patternID) {
     try {
-      const result = await GenericRequest.request(
+      const indexPatternData = await GenericRequest.request(
         'GET',
         `/api/saved_objects/index-pattern/${patternID}?fields=title&fields=fields`
       );
 
-      const title = (((result || {}).data || {}).attributes || {}).title;
-      const fields = (((result || {}).data || {}).attributes || {}).fields;
+      const title = (((indexPatternData || {}).data || {}).attributes || {}).title;
+      const id = ((indexPatternData || {}).data || {}).id;
+
       if (title) {
         return {
           data: 'Index pattern found',
           status: true,
           statusCode: 200,
           title,
-          fields
+          id
         };
       }
     } catch (error) {
@@ -161,14 +164,28 @@ export class SavedObject {
    */
   static async getExistingIndexPattern(patternID) {
     try {
-      const result = await GenericRequest.request(
+      const indexPatternData = await GenericRequest.request(
         'GET',
         `/api/saved_objects/index-pattern/${patternID}?fields=title&fields=fields`,
         null,
         true
       );
-
-      return result.data;
+      let indexPatternFields;
+      if(satisfyKibanaVersion('<=7.10.2')){
+        indexPatternFields = JSON.parse(indexPatternData.data.attributes.fields);
+      }else if(satisfyKibanaVersion('>7.10.2')){
+        try{
+          const {data: {fields}} = await GenericRequest.request(
+            'GET',
+            `/api/index_patterns/_fields_for_wildcard?pattern=${indexPatternData.data.attributes.title}`,
+            {}
+          );
+          indexPatternFields = fields;
+        }catch(error){
+          indexPatternFields = [];
+        };
+      };
+      return ({...indexPatternData.data, ...({_fields: indexPatternFields})});
     } catch (error) {
       if (error && error.response && error.response.status == 404) return false;
       return Promise.reject(((error || {}).data || {}).message || false ? error.data.message : error.message || `Error getting the '${patternID}' index pattern`);
@@ -183,8 +200,11 @@ export class SavedObject {
         params
       );
 
-      if (type === 'index-pattern')
-        await this.refreshFieldsOfIndexPattern(id, params.attributes.title, fields);
+      if(satisfyKibanaVersion('<=7.10.2')){
+        if (type === 'index-pattern'){
+          await this.refreshFieldsOfIndexPattern(id, params.attributes.title, fields);
+        }
+      };
 
       return result;
     } catch (error) {
@@ -205,8 +225,7 @@ export class SavedObject {
           attributes: {
             fields: JSON.stringify(fields),
             timeFieldName: 'timestamp',
-            title: title,
-            retry_on_conflict: 4,
+            title: title
           },
         }
       );
@@ -261,7 +280,10 @@ export class SavedObject {
    */
   static async createWazuhIndexPattern(pattern) {
     try {
-      const fields = await SavedObject.getIndicesFields(pattern, WAZUH_INDEX_TYPE_ALERTS);
+      let fields = '';
+      if(satisfyKibanaVersion('<=7.10.2')){
+        fields = await SavedObject.getIndicesFields(pattern, WAZUH_INDEX_TYPE_ALERTS);
+      };
       await this.createSavedObject(
         'index-pattern',
         pattern,


### PR DESCRIPTION
## Description

This PR adds compatibility to `Kibana version >= 7.11.x` to manage how the index pattern data is retrieved to check if meets the Wazuh requirements to use.

The index pattern of Wazuh alerts should own a minimum set of fields (`agent.id`, `manager.name`, `rule.groups` and `timestamp`) to be considered usable in the app. 

For Kibana `<7.11.0`, the index pattern fields are stored as the saved object's `attribute.fields` property and these are getting with the next request:
```
GET <KIBANA_PROTOCOL>://<KIBANA_HOST>:<KIBANA_PORT>/api/saved_objects/_find?type=index-pattern&fields=title&fields=fields&per_page=9999
```
but on `Kibana 7.11.x or newer` only the scripted fields are in the `attributes.fields` so is required getting the fields with:
```
GET <KIBANA_PROTOCOL>://<KIBANA_HOST>:<KIBANA_PORT>/api/index_patterns/_fields_for_wildcard?pattern=<INDEX_PATTERN_NAME>
```

More information in:
- [Kibana 7.11.0 changelog](https://www.elastic.co/guide/en/kibana/7.11/release-notes-7.11.0.html)
- [PR that modified the cache of index pattern fields](https://github.com/elastic/kibana/pull/82223)
- [New Index pattern API](https://github.com/elastic/kibana/pull/83576). This API is not used in the current app PR to maintain compatibility between Kibana versions

### Changes
  - Added a function to check if the Kibana version (`kibana.version` property of `package.json`) satisfies a specific version.
  - Modified some logic when getting the index patterns or refreshing them to be compatible with 7.10.2 and 7.13.4. A Kibana change was modified as getting the index pattern fields.
  - Added a toast when an unknown index pattern field is detected in
Kibana >7.10.2 in `Modules/<MODULE>/(Dashboard/Events)`
    - set its lifetime to `5 minutes` instead of the default time to the toast for the different versions.

### Notes about the fix
- The fix uses the `kibana.version` property of the `package.json`. Set this property to the Kibana version you are using.
- It was tested with Kibana 7.10.2 and 7.13.4 but should work in Kibana 7.11.x, 7.12.x. For 7.14.x or newer, this should be tested to check if works.

## Tests
- With a Kibana without index patterns, the app should create the index patterns (alerts, monitoring, statistics).
- Go to Settings/Configuration and change the default index pattern to one that matches the name of Wazuh alerts indices, save and push the button to `Execute the health check`. The new index pattern should be created correctly.
- Add some alerts that contain not existent fields, it could use the app sample data to generate alerts of AWS/GC by example, if there is no previous related data and appears new fields, go to `Modules/Amazon Web Services/Events` and explore the new alerts, expand the alert information and a message should be displayed saying you need to refresh the page to apply changes (`7.10.2`) or update de fields (`>7.11.0`)
- Create an index pattern from `Kibana>Stack management>Index patterns` that matches the name of Wazuh alerts indices and go to the app, when opening the menu, the index pattern should be retrieved and these should appear in the index pattern selector of the app. Create some index pattern that doesn't matches with the Wazuh alerts and check these don't appear in the index pattern selector

The next condition should be fulfilled:
  - `<=7.10.2`: the fields should be in the `attributes.fields` of the index pattern
  - `>=7.11.0`: the fields should not be in the `attributes.fields` of the index pattern
  ```
  GET <KIBANA_PROTOCOL>://<KIBANA_HOST>:<KIBANA_PORT>/api/saved_objects/_find?type=index-pattern&fields=title&fields=fields&per_page=9999
  ```
  
## Issues
This PR is related to a bug reported in https://github.com/wazuh/wazuh-kibana-app/issues/3310#issuecomment-954609355.