### PR TITLE
Update security alerts table when filters change

### DIFF
--- a/public/components/common/modules/discover/discover.tsx
+++ b/public/components/common/modules/discover/discover.tsx
@@ -303,8 +303,8 @@ export const Discover = compose(
     const range = {
       range: {
         timestamp: {
-         gte: dateParse(this.state.dateRange.from),
-         lte: dateParse(this.state.dateRange.to),
+         gte: dateParse(this.timefilter.getTime().from),
+         lte: dateParse(this.timefilter.getTime().to),
           format: 'epoch_millis'
         }
       }


### PR DESCRIPTION
Hi Team,
This PR resolves the security alerts table not refreshing when filters change.
Closes #3648 