### PR TITLE
Add id when agent is not pinned

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fixed wazuh token deleted twice [#3652](https://github.com/wazuh/wazuh-kibana-app/pull/3652)
 - Fixed handler of error on dev-tools [#3687](https://github.com/wazuh/wazuh-kibana-app/pull/3687)
 - Fixed compatibility wazuh 4.3 - kibana 7.13.4 [#3685](https://github.com/wazuh/wazuh-kibana-app/pull/3685)
+- Fixed registry values ​​without agent pinned in FIM>Events [#3689](https://github.com/wazuh/wazuh-kibana-app/pull/3689)
 
 ## Wazuh v4.2.4 - Kibana 7.10.2 , 7.12.1, 7.13.4, 7.14.2 - Revision 4206
 

--- a/public/components/agents/fim/inventory/fileDetail.tsx
+++ b/public/components/agents/fim/inventory/fileDetail.tsx
@@ -425,7 +425,11 @@ export class FileDetails extends Component {
             >
               <EuiFlexGroup className="flyout-row">
                 <EuiFlexItem>
-                  <RegistryValues currentFile={currentFile} agent={agent} />
+                  <RegistryValues 
+                    currentFile={currentFile} 
+                    agent={agent} 
+                    agentId={implicitFilters[2]['agent.id']} 
+                  />
                 </EuiFlexItem>
               </EuiFlexGroup>
             </EuiAccordion>{' '}

--- a/public/components/agents/fim/inventory/fileDetail.tsx
+++ b/public/components/agents/fim/inventory/fileDetail.tsx
@@ -394,7 +394,7 @@ export class FileDetails extends Component {
   }
 
   render() {
-    const { fileName, type, implicitFilters, view, currentFile, agent } = this.props;
+    const { fileName, type, implicitFilters, view, currentFile, agent, agentId } = this.props;
     const inspectButtonText = view === 'extern' ? 'Inspect in FIM' : 'Inspect in Events';
     return (
       <Fragment>
@@ -428,7 +428,7 @@ export class FileDetails extends Component {
                   <RegistryValues 
                     currentFile={currentFile} 
                     agent={agent} 
-                    agentId={implicitFilters[2]['agent.id']} 
+                    agentId={agentId} 
                   />
                 </EuiFlexItem>
               </EuiFlexGroup>

--- a/public/components/agents/fim/inventory/registryValues/registryValues.tsx
+++ b/public/components/agents/fim/inventory/registryValues/registryValues.tsx
@@ -34,14 +34,18 @@ export const RegistryValues = (props) => {
   }, []);
 
   const getValues = async () => {
-    const { agent, currentFile } = props;
+    const { agent, currentFile, agentId } = props;
     try {
-      const values = await WzRequest.apiReq('GET', `/syscheck/${agent.id}`, {
-        params: {
-          q: `type=registry_value;file=${currentFile.file}`,
-          sort: '-date',
-        },
-      });
+      const values = await WzRequest.apiReq(
+        'GET',
+        `/syscheck/${agent.id ? agent.id : agentId}`,
+        {
+          params: {
+            q: `type=registry_value;file=${currentFile.file}`,
+            sort: '-date',
+          },
+        }
+      );
 
       setValues((((values || {}).data || {}).data || {}).affected_items || []);
     } catch (error) {


### PR DESCRIPTION
**Description**
It was added to see the ID of the agent that corresponds to the file that you want to see, since the ID of the pinned agent was being taken only

**Issue**

The registry values of are not displayed in FIM - Events [#3677](https://github.com/wazuh/wazuh-kibana-app/issues/3677)

**Test**

_Preconditions_
Without an agent selected.

_Steps_ 
1. Navigate to 'FIM/Events'
2. Click on the `syscheck.path` value of a Windows registry
3. See if the registry value table is not empty.
4. Pin an agent
5. Click on the `syscheck.path` value of a Windows registry
6. See if the registry value table is not empty.

**Check List**

- [x] See registry values ​​with a pinned agent
- [x] See registry values ​​without a pinned agent


**Screenshots**

_Without an agent selected_

![image](https://user-images.githubusercontent.com/63758389/142483345-e5ef9c30-d627-4da6-b70e-43875fccec5f.png)

_With an agent selected_

![image](https://user-images.githubusercontent.com/63758389/142483548-e804bbd1-ccc7-4ee4-9811-4b6e85e12b11.png)

