### PR TITLE
[FIX] [HEALH CHECK] Fix `listValidIndexPatterns.find is not a function` error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fixing double flyout clicking in a policy [#3676](https://github.com/wazuh/wazuh-kibana-app/pull/3676)
 - Fixed error conflict setting kibana settings from the health check [#3678](https://github.com/wazuh/wazuh-kibana-app/pull/3678)
 - Fixed compatibility to get the valid index patterns and refresh fields for Kibana 7.10.2-7.13.4 [3681](https://github.com/wazuh/wazuh-kibana-app/pull/3681)
+- Fixed error getting the index pattern data when there is not `attributes.fields` in the saved object [3689](https://github.com/wazuh/wazuh-kibana-app/pull/3698)
 
 ## Wazuh v4.2.4 - Kibana 7.10.2, 7.11.2, 7.12.1 - Revision 4205
 

--- a/public/components/health-check/services/check-index-pattern/check-index-pattern-object.service.ts
+++ b/public/components/health-check/services/check-index-pattern/check-index-pattern-object.service.ts
@@ -54,7 +54,7 @@ export const checkIndexPatternObjectService =  async (appConfig, checkLogger: Ch
         // show error
         checkLogger.error(`Default index pattern not found`);
       }
-      checkLogger.info(`Getting list of valid index patterns [${patternId}]...`);
+      checkLogger.info(`Getting list of valid index patterns...`);
       listValidIndexPatterns = await SavedObject.getListOfWazuhValidIndexPatterns(defaultIndexPatterns, HEALTH_CHECK);
       checkLogger.info(`Valid index patterns found: ${listValidIndexPatterns.length || 0}`);
       if(!AppState.getCurrentPattern()){

--- a/public/controllers/settings/settings.js
+++ b/public/controllers/settings/settings.js
@@ -248,11 +248,9 @@ export class SettingsController {
   // Get settings function
   async getSettings() {
     try {
-      const patternList = await SavedObject.getListOfWazuhValidIndexPatterns();
-
-      this.indexPatterns = patternList;
-
-      if (!this.indexPatterns.length) {
+      try{
+        this.indexPatterns = await SavedObject.getListOfWazuhValidIndexPatterns();
+      }catch(error){
         this.wzMisc.setBlankScr('Sorry but no valid index patterns were found');
         this.$location.search('tab', null);
         this.$location.path('/blank-screen');


### PR DESCRIPTION
### Description

This PR fixes the problem in the `Alerts index pattern ` check of the health check caused by `listValidIndexPatterns.find is not a function`. This error could be caused due to a problem when parsing the `attributes.fields` of index pattern data.

### Changes

  - Ensure the `attributes.fields` exists in the index pattern data before parsing it
  - Removed returning with error message or error in `SavedObjects.getListOfIndexPatterns` and `SavedObjects.getListOfWazuhValidIndexPatterns`

### Tests
- The `Alerts index pattern` check shouldn't display the error and the index patterns should be checked and created (if necessary without problems) when the index pattern data has not `attributes.fields`.

*Steps to reproduce*:
1. Create an index pattern through a request to Elasticsearch API:
```
curl -XPOST "https://<ELASTICSEARCH_HOST_IP>:9200/.kibana/_doc/wazuh-alerts-4.x-env-1-* -u admin:admin -H 'Content-Type: application/json' -d '{"type":"index-pattern","index-pattern":{"title":"wazuh-alerts-4.x-env-1-*","timeFieldName":"timestamp"}}'
```
2. Go to the app (ensure accessing to health check) and see the error

Close #3695