### PR TITLE
Fixing blank screen before Health-Check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fixed handler of error on dev-tools [#3687](https://github.com/wazuh/wazuh-kibana-app/pull/3687)
 - Fixed compatibility wazuh 4.3 - kibana 7.13.4 [#3685](https://github.com/wazuh/wazuh-kibana-app/pull/3685)
 - Fixed breadcrumbs style compatibility for Kibana 7.14.2 [#3688](https://github.com/wazuh/wazuh-kibana-app/pull/3688)
+- Fixed blank screen in Kibana 7.10.2 [#3700](https://github.com/wazuh/wazuh-kibana-app/pull/3700)
 
 ## Wazuh v4.2.4 - Kibana 7.10.2 , 7.12.1, 7.13.4, 7.14.2 - Revision 4206
 

--- a/public/services/resolves/api-count.js
+++ b/public/services/resolves/api-count.js
@@ -21,21 +21,23 @@
 import { AppState } from '../../react-services/app-state';
 import { GenericRequest } from '../../react-services/generic-request';
 
-export async function apiCount($q, $location) {
+export function apiCount($q, $location) {
   const deferred = $q.defer();
-  try {
-    const apis = await GenericRequest.request('GET', '/hosts/apis');
-    if (!apis || !apis.data || !apis.data.length) throw new Error('No API entries found');
-    if (!AppState.getCurrentAPI()) {
-      await tryToSetDefault(data.data, AppState);
-    }
-    deferred.resolve();
-  } catch (error) {
-    $location.search('_a', null);
-    $location.search('tab', 'api');
-    $location.path('/settings');
-    deferred.resolve();
-  }
+
+  GenericRequest.request('GET', '/hosts/apis')
+    .then(async (data) => {
+      if (!data || !data.data || !data.data.length) throw new Error('No API entries found');
+      if (!AppState.getCurrentAPI()) {
+        await tryToSetDefault(data.data, AppState);
+      }
+      deferred.resolve();
+    })
+    .catch(() => {
+      $location.search('_a', null);
+      $location.search('tab', 'api');
+      $location.path('/settings');
+      deferred.resolve();
+    });
   return deferred.promise;
 }
 


### PR DESCRIPTION
In this PR we solve the bug that caused a blank tab to be shown before even passing the Health-Check, for this we have returned to the state of promises that was used, since when integrating a try catch strategy, we found this failure .
Closes #3699 