### PR TITLE
Related decoder link undefined parameters error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fixed security alerts table when filters change [#3682](https://github.com/wazuh/wazuh-kibana-app/pull/3682)
 - Fixed error that shows we're using X-Pack when we have Basic [#3692](https://github.com/wazuh/wazuh-kibana-app/pull/3692)
 - Fixed blank screen in Kibana 7.10.2 [#3700](https://github.com/wazuh/wazuh-kibana-app/pull/3700)
+- Fixed related decoder link undefined parameters error [#3704](https://github.com/wazuh/wazuh-kibana-app/pull/3704)
 
 ## Wazuh v4.2.4 - Kibana 7.10.2 , 7.12.1, 7.13.4, 7.14.2 - Revision 4206
 

--- a/public/controllers/management/components/management/ruleset/decoder-info.js
+++ b/public/controllers/management/components/management/ruleset/decoder-info.js
@@ -39,7 +39,7 @@ class WzDecoderInfo extends Component {
 
     this.rulesetHandler = new RulesetHandler(RulesetResources.DECODERS);
 
-    const handleFileClick = async () => {
+    const handleFileClick = async (value, item) => {
       try {
         const result = await this.rulesetHandler.getFileContent(value);
         const file = { name: value, content: result, path: item.relative_dirname };
@@ -86,7 +86,7 @@ class WzDecoderInfo extends Component {
         render: (value, item) => {
           return (
             <EuiToolTip position="top" content={`Show ${value} content`}>
-              <EuiLink onClick={async () => handleFileClick()}>{value}</EuiLink>
+              <EuiLink onClick={async () => handleFileClick(value, item)}>{value}</EuiLink>
             </EuiToolTip>
           );
         },


### PR DESCRIPTION
Hi team,

this PR fixes _Related decoders_ file link error when one clicked on it. 

Closes #3703 

To test it:

- Go to _Managment / Decoders_
- Select the name of a decoder in the table to access **Related decoders table**
- In Related decoders table click on a **file link** and see if it works
- Repeat the procedure with Rules


Test animation
![Peek 2021-12-01 12-47](https://user-images.githubusercontent.com/9343732/144229257-d6e69a33-378b-41b8-a7db-eda679442b3b.gif)

