### PR TITLE
[FIX] [TELEMETRY] Hide the banner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 
 - Support for Kibana 7.13.4
 - Support for Kibana 7.14.2
+- Hide the `telemetry` banner [#3709](https://github.com/wazuh/wazuh-kibana-app/pull/3709)
 
 ### Fixed
 

--- a/kibana.json
+++ b/kibana.json
@@ -17,7 +17,8 @@
     "savedObjects",
     "kibanaReact",
     "kibanaUtils",
-    "securityOss"
+    "securityOss",
+    "telemetry"
   ],
   "optionalPlugins": [
     "security",

--- a/public/plugin.ts
+++ b/public/plugin.ts
@@ -100,7 +100,7 @@ export class WazuhPlugin implements Plugin<WazuhSetup, WazuhStart, WazuhSetupPlu
 
     // hide the telemetry banner. Remove the banner from the UI and set the flag in the telemetry saved object as the notice was seen and dismissed
     if(plugins?.telemetry?.telemetryNotifications?.setOptedInNoticeSeen) {
-      plugins.telemetry.telemetryNotifications.setOptedInNoticeSeen()
+      plugins.telemetry.telemetryNotifications.setOptedInNoticeSeen();
     };
 
     // we need to register the application service at setup, but to render it

--- a/public/plugin.ts
+++ b/public/plugin.ts
@@ -33,6 +33,7 @@ export class WazuhPlugin implements Plugin<WazuhSetup, WazuhStart, WazuhSetupPlu
   public initializeInnerAngular?: () => void;
   private innerAngularInitialized: boolean = false;
   private stateUpdater = new BehaviorSubject<AppUpdater>(() => ({}));
+  private hideTelemetryBanner?: () => void;
   
   public setup(core: CoreSetup, plugins: WazuhSetupPlugins): WazuhSetup {
     core.application.register({
@@ -43,6 +44,11 @@ export class WazuhPlugin implements Plugin<WazuhSetup, WazuhStart, WazuhSetupPlu
         if (!this.initializeInnerAngular) {
           throw Error('Wazuh plugin method initializeInnerAngular is undefined');
         }
+
+        // hide the telemetry banner. 
+        // Set the flag in the telemetry saved object as the notice was seen and dismissed
+        this.hideTelemetryBanner && await this.hideTelemetryBanner();
+        
         setScopedHistory(params.history);
         // Load application bundle
         const { renderApp } = await import('./application');
@@ -98,11 +104,10 @@ export class WazuhPlugin implements Plugin<WazuhSetup, WazuhStart, WazuhSetupPlu
       plugins.securityOss.insecureCluster.hideAlert(true);
     };
 
-    // hide the telemetry banner. Remove the banner from the UI and set the flag in the telemetry saved object as the notice was seen and dismissed
     if(plugins?.telemetry?.telemetryNotifications?.setOptedInNoticeSeen) {
-      plugins.telemetry.telemetryNotifications.setOptedInNoticeSeen();
+      // assign to a method to hide the telemetry banner used when the app is mounted
+      this.hideTelemetryBanner = () => plugins.telemetry.telemetryNotifications.setOptedInNoticeSeen();
     };
-
     // we need to register the application service at setup, but to render it
     // there are some start dependencies necessary, for this reason
     // initializeInnerAngular + initializeServices are assigned at start and used

--- a/public/plugin.ts
+++ b/public/plugin.ts
@@ -92,11 +92,16 @@ export class WazuhPlugin implements Plugin<WazuhSetup, WazuhStart, WazuhSetupPlu
     return {};
   }
 
-  public async start(core: CoreStart, plugins: AppPluginStartDependencies): Promise<WazuhStart> {
+  public start(core: CoreStart, plugins: AppPluginStartDependencies): WazuhStart {
     // hide security alert
     if(plugins.securityOss) {
       plugins.securityOss.insecureCluster.hideAlert(true);
-    }
+    };
+
+    // hide the telemetry banner. Remove the banner from the UI and set the flag in the telemetry saved object as the notice was seen and dismissed
+    if(plugins?.telemetry?.telemetryNotifications?.setOptedInNoticeSeen) {
+      plugins.telemetry.telemetryNotifications.setOptedInNoticeSeen()
+    };
 
     // we need to register the application service at setup, but to render it
     // there are some start dependencies necessary, for this reason

--- a/public/types.ts
+++ b/public/types.ts
@@ -7,7 +7,7 @@ import { NavigationPublicPluginStart } from '../../../src/plugins/navigation/pub
 import { UiActionsSetup } from '../../../src/plugins/ui_actions/public';
 import { SecurityOssPluginStart } from '../../../src/plugins/security_oss/public/';
 import { SavedObjectsStart } from '../../../src/plugins/saved_objects/public';
-import { TelemetryPluginStart } from '../../../src/plugins/telemetry/public';
+import { TelemetryPluginStart, TelemetryPluginSetup } from '../../../src/plugins/telemetry/public';
 
 export interface AppPluginStartDependencies {
   navigation: NavigationPublicPluginStart;
@@ -30,6 +30,7 @@ export type WazuhSetupPlugins = {
   visualizations: VisualizationsSetup;
   data: DataPublicPluginSetup;
   navigation: NavigationPublicPluginStart;
+  telemetry: TelemetryPluginSetup;
 }
 
 export type WazuhStartPlugins = AppPluginStartDependencies;

--- a/public/types.ts
+++ b/public/types.ts
@@ -7,6 +7,7 @@ import { NavigationPublicPluginStart } from '../../../src/plugins/navigation/pub
 import { UiActionsSetup } from '../../../src/plugins/ui_actions/public';
 import { SecurityOssPluginStart } from '../../../src/plugins/security_oss/public/';
 import { SavedObjectsStart } from '../../../src/plugins/saved_objects/public';
+import { TelemetryPluginStart } from '../../../src/plugins/telemetry/public';
 
 export interface AppPluginStartDependencies {
   navigation: NavigationPublicPluginStart;
@@ -15,7 +16,8 @@ export interface AppPluginStartDependencies {
   discover: DiscoverStart;
   charts: ChartsPluginStart
   securityOss: SecurityOssPluginStart,
-  savedObjects: SavedObjectsStart
+  savedObjects: SavedObjectsStart,
+  telemetry: TelemetryPluginStart
 }
 export interface AppDependencies {
   core: CoreStart;


### PR DESCRIPTION
## Description
This PR hides the `telemetry` banner from UI and saves that the banner was seen to avoid the banner is displayed on the next times.

The status of if the banner was seen/dismissed of `telemetry` banner is stored in a saved object. This is persistent. For new environments, the attribute that controls this is not stored so the banner is displayed, if use the `Dismiss` button, store the flag in the saved objects for next times.

Moreover, the status is saved as a property i the `telemetry` plugin.

## Changed
  
- Hide the telemetry banner from UI and set a flag in the saved object that controls if the banner was seen and dismissed
- Changed the `wazuh` `public` `start` method to sync instead of `async` function

## Tests
- In new environments, the flag in a saved object of the `telemetry` banner is not set, so this is displayed. The PR, removes the banner from UI and sets the flag in the saved object and this should not be displayed.

Note:
Delete the `telemetry` object so this should be displayed again, or remove the indices `.kibana*` (where the telemetry saved object is stored) so it could test it again.