### PR TITLE
fix wrong deamons in filter list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fixed blank screen in Kibana 7.10.2 [#3700](https://github.com/wazuh/wazuh-kibana-app/pull/3700)
 - Fixed related decoder link undefined parameters error [#3704](https://github.com/wazuh/wazuh-kibana-app/pull/3704)
 - Fixing the bug of index patterns in health-check due to bad copy of a PR [#3707](https://github.com/wazuh/wazuh-kibana-app/pull/3707)
+- Fix wrong deamons in filter list [#3710] (https://github.com/wazuh/wazuh-kibana-app/pull/3710)
 
 ## Wazuh v4.2.4 - Kibana 7.10.2 , 7.12.1, 7.13.4, 7.14.2 - Revision 4206
 

--- a/public/controllers/management/components/management/mg-logs/logs.js
+++ b/public/controllers/management/components/management/mg-logs/logs.js
@@ -139,13 +139,19 @@ export default compose(
     }
 
     async initDaemonsList(logsPath) {
+      const daemonsNotIncluded = [
+        'wazuh-modulesd:task-manager',
+        'wazuh-modulesd:agent-upgrade'
+      ]
       try {
         const path = logsPath + '/summary';
         const data = await WzRequest.apiReq('GET', path, {});
         const formattedData = (((data || {}).data || {}).data || {}).affected_items;
         const daemonsList = [...['all']];
         for (const daemon of formattedData) {
-          daemonsList.push(Object.keys(daemon)[0]);
+          if(!daemonsNotIncluded.includes(Object.keys(daemon)[0])){
+            daemonsList.push(Object.keys(daemon)[0]);
+          }
         }
         this.setState({ daemonsList });
       } catch (error) {
@@ -186,7 +192,7 @@ export default compose(
       const { logsPath } = this.state;
       let result = '';
       let totalItems = 0;
-
+ 
       try {
         const tmpResult = await WzRequest.apiReq('GET', logsPath, {
           params: this.buildFilters(customOffset),


### PR DESCRIPTION
Hi Team, this resolve: 

When you select some daemon filters in the log section, the app throws an error:

![Peek 2021-12-07 10-49](https://user-images.githubusercontent.com/36004787/145058841-92a3bd07-25c6-4c5c-9a8a-94882fd49371.gif)

The items `'wazuh-modulesd:task-manager'`, `'wazuh-modulesd:agent-upgrade'` not supported by wazuh api as a filter.

Closes #3715 