### PR TITLE
[Panel] [Office365] [GitHub] Update data when clearing the query filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fixed blank screen in Kibana 7.10.2 [#3700](https://github.com/wazuh/wazuh-kibana-app/pull/3700)
 - Fixed related decoder link undefined parameters error [#3704](https://github.com/wazuh/wazuh-kibana-app/pull/3704)
 - Fixing the bug of index patterns in health-check due to bad copy of a PR [#3707](https://github.com/wazuh/wazuh-kibana-app/pull/3707)
+- Fix clearing the query filter doesn't update the data in Office 365 and GitHub Panel tab [#3722](https://github.com/wazuh/wazuh-kibana-app/pull/3722)
 
 ## Wazuh v4.2.4 - Kibana 7.10.2 , 7.12.1, 7.13.4, 7.14.2 - Revision 4206
 

--- a/public/components/common/hooks/use-es-search.ts
+++ b/public/components/common/hooks/use-es-search.ts
@@ -12,7 +12,7 @@
 
 import { SetStateAction, useEffect, useState } from 'react';
 import { getDataPlugin } from '../../../kibana-services';
-import { useFilterManager, useIndexPattern, useQuery } from '.';
+import { useFilterManager, useIndexPattern, useQueryManager } from '.';
 import { IndexPattern } from 'src/plugins/data/public';
 import {
   UI_ERROR_SEVERITIES,
@@ -44,7 +44,7 @@ const useEsSearch = ({ preAppliedFilters = [], preAppliedAggs = {}, size = 10 })
   const data = getDataPlugin();
   const indexPattern = useIndexPattern();
   const {filters} = useFilterManager();
-  const [query] = useQuery();
+  const [query] = useQueryManager();
   const [esResults, setEsResults] = useState<SearchResponse>({} as SearchResponse);
   const [error, setError] = useState<Error>({} as Error);
   const [isLoading, setIsLoading] = useState<boolean>(true);


### PR DESCRIPTION
…r in the search bar and the data is not updated

  - Now uses `useQueryManager` instead of `useQuery`
  
## Description
This PR solves when clearing the query filter in the search bar of `Panel` tab of modules `Office 365` and `GitHub`. See https://github.com/wazuh/wazuh-kibana-app/issues/3713#issue-1075421139

## Changes
- Replace the `hook` used by `useQueryManager` instead of `useQuery`.

## Tests
- Add a query filter in the search bar of `Panel` tab of modules `Office 365` and `GitHub` and apply the searching, after clearing the query string and updating the search, the data should be updated.