### PR TITLE
[BUG] [MODULES] [MITRE Att&ck] Bugs in the details flyouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ All notable changes to the Wazuh app project will be documented in this file.
   [#3464](https://github.com/wazuh/wazuh-kibana-app/pull/3464)
   [#3478](https://github.com/wazuh/wazuh-kibana-app/pull/3478)
 - Added fields status and type in vulnerabilities table [#3196](https://github.com/wazuh/wazuh-kibana-app/pull/3196)
-- Added Intelligence tab to Mitre Att&ck module [#3368](https://github.com/wazuh/wazuh-kibana-app/pull/3368) [#3344](https://github.com/wazuh/wazuh-kibana-app/pull/3344)
+- Added Intelligence tab to Mitre Att&ck module [#3368](https://github.com/wazuh/wazuh-kibana-app/pull/3368) [#3344](https://github.com/wazuh/wazuh-kibana-app/pull/3344) [#3726](https://github.com/wazuh/wazuh-kibana-app/pull/3726)
 - Added sample data for office365 events [#3424](https://github.com/wazuh/wazuh-kibana-app/pull/3424)
 - Created a separate component to check for sample data [#3475](https://github.com/wazuh/wazuh-kibana-app/pull/3475)
 - Added a new hook for getting value suggestions [#3506](https://github.com/wazuh/wazuh-kibana-app/pull/3506)

--- a/public/components/common/modules/discover/discover.tsx
+++ b/public/components/common/modules/discover/discover.tsx
@@ -82,7 +82,6 @@ export const Discover = compose(
     state: {
       sort: object;
       selectedTechnique: string;
-      showMitreFlyout: boolean;
       alerts: { _source: {}; _id: string }[];
       total: number;
       pageIndex: number;
@@ -107,7 +106,6 @@ export const Discover = compose(
       query?: { language: 'kuery' | 'lucene'; query: string };
       type?: any;
       updateTotalHits: Function;
-      openIntelligence: Function;
       includeFilters?: string;
       initialColumns: ColumnDefinition[];
       initialAgentColumns?: ColumnDefinition[];
@@ -123,7 +121,6 @@ export const Discover = compose(
       this.state = {
         sort: {},
         selectedTechnique: '',
-        showMitreFlyout: false,
         alerts: [],
         total: 0,
         pageIndex: 0,
@@ -536,7 +533,7 @@ export const Discover = compose(
           width = '15%';
         }
         if (item === 'rule.mitre.id') {
-          link = (ev, x, e) => this.props.openIntelligence(e, 'techniques', x);
+          link = (ev, x) => this.openIntelligence(ev, 'techniques', x);
         }
         if (arrayCompilance.indexOf(item) !== -1) {
           width = '30%';
@@ -700,13 +697,6 @@ export const Discover = compose(
       this.setState({ pageIndex: 0, tsUpdated: Date.now() });
     };
 
-    closeMitreFlyout = () => {
-      this.setState({ showMitreFlyout: false });
-    };
-
-    onMitreChangeFlyout = (showMitreFlyout: boolean) => {
-      this.setState({ showMitreFlyout });
-    };
 
     openDiscover(e, techniqueID) {
       AppNavigate.navigateToModule(e, 'overview', {
@@ -722,6 +712,10 @@ export const Discover = compose(
         tabView: 'dashboard',
         filters: { 'rule.mitre.id': techniqueID },
       });
+    }
+
+    openIntelligence(e, redirectTo, itemID) {
+      AppNavigate.navigateToModule(e, 'overview', { "tab": 'mitre', "tabView": "intelligence", "tabRedirect": redirectTo, "idToRedirect": itemID});
     }
 
     render() {
@@ -758,23 +752,6 @@ export const Discover = compose(
         pageSizeOptions: [10, 25, 50],
       };
       const noResultsText = `No results match for this search criteria`;
-      let flyout = this.state.showMitreFlyout ? (
-        <EuiOverlayMask headerZindexLocation="below">
-          <EuiOutsideClickDetector onOutsideClick={this.closeMitreFlyout}>
-            <div>
-              {/* EuiOutsideClickDetector needs a static first child */}
-              <FlyoutTechnique
-                openDashboard={(e, itemId) => this.openDashboard(e, itemId)}
-                openDiscover={(e, itemId) => this.openDiscover(e, itemId)}
-                onChangeFlyout={this.onMitreChangeFlyout}
-                currentTechnique={this.state.selectedTechnique}
-              />
-            </div>
-          </EuiOutsideClickDetector>
-        </EuiOverlayMask>
-      ) : (
-        <></>
-      );
       return (
         <div className="wz-discover hide-filter-control wz-inventory">
           {this.props.kbnSearchBar && (
@@ -818,7 +795,6 @@ export const Discover = compose(
               </EuiFlexItem>
             </EuiFlexGroup>
           )}
-          {flyout}
         </div>
       );
     }

--- a/public/components/overview/mitre/components/techniques/components/flyout-technique/flyout-technique.tsx
+++ b/public/components/overview/mitre/components/techniques/components/flyout-technique/flyout-technique.tsx
@@ -207,7 +207,7 @@ export class FlyoutTechnique extends Component {
           >
             <EuiLink
               onClick={(e) => {
-                this.props.openIntelligence(e, 'techniques', currentTechnique);
+                AppNavigate.navigateToModule(e, 'overview', { "tab": 'mitre', "tabView": "intelligence", "tabRedirect": 'techniques', "idToRedirect": currentTechnique});
                 e.stopPropagation();
               }}
             >
@@ -228,7 +228,7 @@ export class FlyoutTechnique extends Component {
                   >
                     <EuiLink
                       onClick={(e) => {
-                        this.props.openIntelligence(e, 'tactics', tactic.id);
+                        AppNavigate.navigateToModule(e, 'overview', { "tab": 'mitre', "tabView": "intelligence", "tabRedirect": 'tactics', "idToRedirect": tactic.id});
                         e.stopPropagation();
                       }}
                     >
@@ -353,9 +353,6 @@ export class FlyoutTechnique extends Component {
                 implicitFilters={implicitFilters}
                 initialFilters={[]}
                 updateTotalHits={(total) => this.updateTotalHits(total)}
-                openIntelligence={(e, redirectTo, itemId) =>
-                  this.props.openIntelligence(e, redirectTo, itemId)
-                }
               />
             </EuiFlexItem>
           </EuiFlexGroup>

--- a/public/components/overview/mitre/components/techniques/components/flyout-technique/flyout-technique.tsx
+++ b/public/components/overview/mitre/components/techniques/components/flyout-technique/flyout-technique.tsx
@@ -57,9 +57,7 @@ export class FlyoutTechnique extends Component {
   };
 
   props!: {
-    currentTechniqueData: any;
     currentTechnique: string;
-    tacticsObject: any;
   };
 
   filterManager: FilterManager;
@@ -132,13 +130,21 @@ export class FlyoutTechnique extends Component {
     try {
       this.setState({ loading: true, techniqueData: {} });
       const { currentTechnique } = this.props;
-      const result = await WzRequest.apiReq('GET', '/mitre/techniques', {
+      const techniqueResponse = await WzRequest.apiReq('GET', '/mitre/techniques', {
         params: {
           q: `external_id=${currentTechnique}`
         }
       });
-      const rawData = (((result || {}).data || {}).data || {}).affected_items;
-      !!rawData && this.formatTechniqueData(rawData[0]);
+      const [techniqueData] = (((techniqueResponse || {}).data || {}).data || {}).affected_items;
+      const tacticsResponse = await WzRequest.apiReq('GET', '/mitre/tactics', {});
+      const tacticsData = (((tacticsResponse || {}).data || {}).data || {}).affected_items;
+
+      techniqueData.tactics && (techniqueData.tactics = techniqueData.tactics.map(tacticID => {
+        const tactic = tacticsData.find(tacticData => tacticData.id === tacticID);
+        return { id: tactic.external_id, name: tactic.name }
+      }));
+      const { name, mitre_version, tactics } = techniqueData;
+      this._isMount &&  this.setState({ techniqueData: { name, mitre_version, tactics }, loading: false });
     } catch (error) {
       const options = {
         context: `${FlyoutTechnique.name}.getTechniqueData`,
@@ -155,20 +161,6 @@ export class FlyoutTechnique extends Component {
       getErrorOrchestrator().handleError(options);
       this.setState({ loading: false });
     }
-  }
-
-  findTacticName(tactics) {
-    const { tacticsObject } = this.props;
-    return tactics.map((element) => {
-      const tactic = Object.values(tacticsObject).find(obj => obj.id === element);
-      return { id:tactic.external_id, name: tactic.name};
-    });
-  }
-
-  formatTechniqueData(rawData) {
-    const { tactics, name, mitre_version } = rawData;
-    const tacticsObj = this.findTacticName(tactics);
-    this.setState({ techniqueData: { name, mitre_version, tacticsObj }, loading: false });
   }
 
   renderHeader() {
@@ -226,8 +218,8 @@ export class FlyoutTechnique extends Component {
       },
       {
         title: 'Tactics',
-        description: techniqueData.tacticsObj
-          ? techniqueData.tacticsObj.map((tactic) => {
+        description: techniqueData.tactics
+          ? techniqueData.tactics.map((tactic) => {
               return (
                 <>
                   <EuiToolTip

--- a/public/components/overview/mitre/components/techniques/techniques.tsx
+++ b/public/components/overview/mitre/components/techniques/techniques.tsx
@@ -418,11 +418,6 @@ export const Techniques = withWindowSize(
       this.props.onSelectedTabChanged('dashboard');
     }
 
-    openIntelligence(e, redirectTo, itemId) {
-      this.props.onSelectedTabChanged('intelligence');
-      window.location.href = window.location + `&tabRedirect=${redirectTo}&idToRedirect=${itemId}`;
-    }
-
     /**
      * Adds a new filter with format { "filter_key" : "filter_value" }, e.g. {"agent.id": "001"}
      * @param filter
@@ -558,7 +553,6 @@ export const Techniques = withWindowSize(
                   <FlyoutTechnique
                     openDashboard={(e, itemId) => this.openDashboard(e, itemId)}
                     openDiscover={(e, itemId) => this.openDiscover(e, itemId)}
-                    openIntelligence={(e, redirectTo, itemId) => this.openIntelligence(e, redirectTo, itemId)}
                     onChangeFlyout={this.onChangeFlyout}
                     currentTechnique={currentTechnique}
                    />

--- a/public/components/overview/mitre/components/techniques/techniques.tsx
+++ b/public/components/overview/mitre/components/techniques/techniques.tsx
@@ -58,7 +58,6 @@ export const Techniques = withWindowSize(
     state: {
       techniquesCount: { key: string; doc_count: number }[];
       isFlyoutVisible: Boolean;
-      currentTechniqueData: {};
       currentTechnique: string;
       hideAlerts: boolean;
       actionsOpen: string;
@@ -72,7 +71,6 @@ export const Techniques = withWindowSize(
 
       this.state = {
         isFlyoutVisible: false,
-        currentTechniqueData: {},
         techniquesCount: [],
         currentTechnique: '',
         hideAlerts: false,
@@ -502,7 +500,7 @@ export const Techniques = withWindowSize(
     }
 
     closeFlyout() {
-      this.setState({ isFlyoutVisible: false, currentTechniqueData: {} });
+      this.setState({ isFlyoutVisible: false });
     }
 
     onChangeFlyout = (isFlyoutVisible: boolean) => {
@@ -562,9 +560,8 @@ export const Techniques = withWindowSize(
                     openDiscover={(e, itemId) => this.openDiscover(e, itemId)}
                     openIntelligence={(e, redirectTo, itemId) => this.openIntelligence(e, redirectTo, itemId)}
                     onChangeFlyout={this.onChangeFlyout}
-                    currentTechniqueData={this.state.currentTechniqueData}
                     currentTechnique={currentTechnique}
-                    tacticsObject={this.props.tacticsObject} />
+                   />
                 </div>
               </EuiOutsideClickDetector>
             </EuiOverlayMask>

--- a/public/components/overview/mitre_attack_intelligence/all_resources.tsx
+++ b/public/components/overview/mitre_attack_intelligence/all_resources.tsx
@@ -23,7 +23,7 @@ export const ModuleMitreAttackIntelligenceAllResources = ({ results, loading }) 
   const [details, setDetails] = useState(null);
 
   const selectResource = useCallback((item) => {
-    setDetails(({...item, ['references.external_id']: item.references.find(reference => reference.source === 'mitre-attack')?.external_id}));
+    setDetails(item);
   },[]);
 
   const closeFlyout = useCallback(() => {

--- a/public/components/overview/mitre_attack_intelligence/resource.tsx
+++ b/public/components/overview/mitre_attack_intelligence/resource.tsx
@@ -34,7 +34,7 @@ export const ModuleMitreAttackIntelligenceResource = ({
     const redirectTab = urlParams.get('tabRedirect');
     const idToRedirect = urlParams.get("idToRedirect");
     if(redirectTab && idToRedirect){
-      const endpoint = `/mitre/${redirectTab}?q=references.external_id=${idToRedirect}`;
+      const endpoint = `/mitre/${redirectTab}?q=external_id=${idToRedirect}`;
       getMitreItemToRedirect(endpoint);
       urlParams.delete('tabRedirect');
       urlParams.delete('idToRedirect');
@@ -46,12 +46,7 @@ export const ModuleMitreAttackIntelligenceResource = ({
   const getMitreItemToRedirect = async (endpoint) => {
     try {
       const res = await WzRequest.apiReq("GET", endpoint, {});
-      const data = res?.data?.data.affected_items.map((item) => ({
-        ...item,
-        ["references.external_id"]: item?.references?.find(
-          (reference) => reference.source === "mitre-attack"
-        )?.external_id,
-      }));
+      const data = res?.data?.data.affected_items;
       setDetails(data[0]); 
     } catch (error) {
       const options = {
@@ -87,7 +82,6 @@ export const ModuleMitreAttackIntelligenceResource = ({
         searchBarSuggestions={searchBarSuggestions}
         endpoint={apiEndpoint}
         tablePageSizeOptions={[10]}
-        mapResponseItem={(item) => ({...item, ['references.external_id']: item?.references?.find(reference => reference.source === 'mitre-attack')?.external_id})}
         filters={resourceFilters}
       />
       {details && (

--- a/public/components/overview/mitre_attack_intelligence/resource_detail_references_table.tsx
+++ b/public/components/overview/mitre_attack_intelligence/resource_detail_references_table.tsx
@@ -54,7 +54,7 @@ export const ReferencesTable = ({referencesName, referencesArray, columns, backT
     try{
       const data = await Promise.all(namesConcatenated.map(async (nameConcatenated) => {
         const queryResult = await WzRequest.apiReq('GET', `/mitre/${referencesName}?${referencesName.replace(/s\s*$/, '')}_ids=${nameConcatenated}`, {});
-        return ((((queryResult || {}).data || {}).data || {}).affected_items || []).map((item) => ({...item, ['references.external_id']: item.references.find(reference => reference.source === 'mitre-attack')?.external_id}));  
+        return ((((queryResult || {}).data || {}).data || {}).affected_items || []);  
       }));
       setData(data.flat());  
     }

--- a/public/components/overview/mitre_attack_intelligence/resources.tsx
+++ b/public/components/overview/mitre_attack_intelligence/resources.tsx
@@ -24,10 +24,6 @@ const getMitreAttackIntelligenceSuggestions = (endpoint: string, field: string) 
   try{
     const response = await WzRequest.apiReq('GET', endpoint, {});
     return response?.data?.data.affected_items
-      .map(item => ({
-        ...item,
-        ['references.external_id']: item?.references?.find(reference => reference.source === 'mitre-attack')?.external_id
-      }))
       .map(item => item[field])
       .filter(item => item && item.toLowerCase().includes(input.toLowerCase()))
       .sort()
@@ -73,10 +69,10 @@ function buildResource(label: string, labelResource: string){
       },
       {
         type: 'q',
-        label: 'references.external_id',
+        label: 'external_id',
         description: `${labelResource} ID`,
         operators: ['=', '!='],
-        values: getMitreAttackIntelligenceSuggestions(endpoint, 'references.external_id')
+        values: getMitreAttackIntelligenceSuggestions(endpoint, 'external_id')
       }
     ],
     apiEndpoint: endpoint,
@@ -84,7 +80,7 @@ function buildResource(label: string, labelResource: string){
     initialSortingField: 'name',
     tableColumnsCreator: (openResourceDetails) => [
       {
-        field: 'references.external_id',
+        field: 'external_id',
         name: 'ID',
         width: '12%',
         render: (value, item) => <EuiLink onClick={() => openResourceDetails(item)}>{value}</EuiLink>
@@ -107,7 +103,7 @@ function buildResource(label: string, labelResource: string){
     mitreFlyoutHeaderProperties: [
       {
         label: 'ID',
-        id: 'references.external_id',
+        id: 'external_id',
       },
       {
         label: 'Name',

--- a/public/controllers/management/components/management/ruleset/rule-info.js
+++ b/public/controllers/management/components/management/ruleset/rule-info.js
@@ -412,7 +412,7 @@ class WzRuleInfo extends Component {
         compliance.map(async (i) => {
           const data = await WzRequest.apiReq('GET', '/mitre/techniques', {
             params: {
-              q: `references.external_id=${i}`,
+              q: `external_id=${i}`,
             },
           });
           const formattedData = (((data || {}).data.data || {}).affected_items || [])[0] || {};


### PR DESCRIPTION
## Description
This PR fixes some problems related to the MITRE Att&ck details flyout:
- Can't get the tactics of the technique when opening the flyout from `Modules/MITRE Att&ck/Events` tab and another sections
- Fixed the redirection to show information about some technique or tacts in the `Intelligence` tab (`Modules/MITRE Att&ck`)
  - Replaces `references.external_id` by `external_id`. This changed in the response of Wazuh API 

## Changes
- Removed `openIntelligence` component property in some components and moved the functionality to the component.


## Tests
- Open MITRE Att&ck details flyouts should render the data correctly.
- The links/buttons that open the details flyouts should work.
- The links of technique/tactic data in the alerts should redirect to `Intelligence` and show a flyout with information about the selected entity.
  
Closes #3725 