### PR TITLE
[FIX] [Monitoring] Retrieve data of all agents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,7 +62,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Refactored as module tabs and buttons are rendered [#3494](https://github.com/wazuh/wazuh-kibana-app/pull/3494)
 - Testing logs using the Ruletest Test don't display the rule information if not matching a rule. [#3446](https://github.com/wazuh/wazuh-kibana-app/pull/3446)
 - Changed format permissions in FIM inventory [#3649](https://github.com/wazuh/wazuh-kibana-app/pull/3649)
-- Changed of request for one that does not return data that is not necessary to optimize times. [#3686](https://github.com/wazuh/wazuh-kibana-app/pull/3686)
+- Changed of request for one that does not return data that is not necessary to optimize times. [#3686](https://github.com/wazuh/wazuh-kibana-app/pull/3686) [#3728](https://github.com/wazuh/wazuh-kibana-app/pull/3728)
 
 ### Fixed
 

--- a/server/start/monitoring/index.ts
+++ b/server/start/monitoring/index.ts
@@ -467,11 +467,26 @@ async function fetchAllAgentsFromApiHost(context, apiHost){
 
     let payload = {
       offset: 0,
+      limit: 500,
       q: 'id!=000'
     };
 
     while (agents.length < agentsCount && payload.offset < agentsCount) {
       try{
+        /* 
+        TODO: Improve the performance of request with:
+          - Reduce the number of requests to the Wazuh API
+          - Reduce (if possible) the quantity of data to index by document
+
+        Requirements:
+          - Research about the neccesary data to index.
+
+        How to do:
+          - Wazuh API request:
+            - select the required data to retrieve depending on is required to index (using the `select` query param)
+            - increase the limit of results to retrieve (currently, the requests use the recommended value: 500).
+              See the allowed values. This depends on the selected data because the response could fail if contains a lot of data
+        */
         const responseAgents = await context.wazuh.api.client.asInternalUser.request(
           'GET',
           `/agents`,


### PR DESCRIPTION
## Description

This PR fixes the problem of only index data of the first `500` agents in the `monitoring` job.

## Changes
- Fixed the `limit` query param to 500 for each request. This could be improved as described in a comment included in the PR changes but require researching.

## Tests
- With monitoring job running (and permission to do) and more than `500` agents check the `Evolution` visualization displays more than `500` as the sum of different agent status

Closes #3717