### PR TITLE
Bugfix/3719 security user nonexistant unsubmitted changes warn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,7 +99,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fixed related decoder link undefined parameters error [#3704](https://github.com/wazuh/wazuh-kibana-app/pull/3704)
 - Fixing the bug of index patterns in health-check due to bad copy of a PR [#3707](https://github.com/wazuh/wazuh-kibana-app/pull/3707)
 - Fixing bug when create filename with spaces and throws a bad error [#3724] (https://github.com/wazuh/wazuh-kibana-app/pull/3724)
-- Fixing bug in security User flyout nonexistant unsubmitted changes warning []
+- Fixing bug in security User flyout nonexistant unsubmitted changes warning [#3731](https://github.com/wazuh/wazuh-kibana-app/pull/3731)
 
 ## Wazuh v4.2.4 - Kibana 7.10.2 , 7.12.1, 7.13.4, 7.14.2 - Revision 4206
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,7 +98,8 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fixed blank screen in Kibana 7.10.2 [#3700](https://github.com/wazuh/wazuh-kibana-app/pull/3700)
 - Fixed related decoder link undefined parameters error [#3704](https://github.com/wazuh/wazuh-kibana-app/pull/3704)
 - Fixing the bug of index patterns in health-check due to bad copy of a PR [#3707](https://github.com/wazuh/wazuh-kibana-app/pull/3707)
-- Fixing bug when create filename with spaces and throws a bad error [#3724] (https://github.com/wazuh/wazuh-kibana-app/pull/3724) 
+- Fixing bug when create filename with spaces and throws a bad error [#3724] (https://github.com/wazuh/wazuh-kibana-app/pull/3724)
+- Fixing bug in security User flyout nonexistant unsubmitted changes warning []
 
 ## Wazuh v4.2.4 - Kibana 7.10.2 , 7.12.1, 7.13.4, 7.14.2 - Revision 4206
 

--- a/public/components/security/users/components/edit-user.tsx
+++ b/public/components/security/users/components/edit-user.tsx
@@ -223,7 +223,7 @@ export const EditUser = ({ currentUser, closeFlyout, rolesObject }) => {
   useEffect(() => {
     if (
       initialPassword != password || initialPassword != confirmPassword ||
-      !_.isEqual(userRolesFormatted, selectedRoles) || allowRunAs
+      !_.isEqual(userRolesFormatted, selectedRoles) || allowRunAs != currentUser.allow_run_as
     ) {
       setHasChanges(true);
     } else {


### PR DESCRIPTION
Hi Team, this resolve:

- In user security section, if no changes were made there should be no warning

closes #3719 