### PR TITLE
add target blank in link table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,7 +98,8 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fixed blank screen in Kibana 7.10.2 [#3700](https://github.com/wazuh/wazuh-kibana-app/pull/3700)
 - Fixed related decoder link undefined parameters error [#3704](https://github.com/wazuh/wazuh-kibana-app/pull/3704)
 - Fixing the bug of index patterns in health-check due to bad copy of a PR [#3707](https://github.com/wazuh/wazuh-kibana-app/pull/3707)
-- Fixing bug when create filename with spaces and throws a bad error [#3724] (https://github.com/wazuh/wazuh-kibana-app/pull/3724) 
+- Fixing bug when create filename with spaces and throws a bad error [#3724] (https://github.com/wazuh/wazuh-kibana-app/pull/3724)
+- Fixing redirect to new tab when click in a link [#3732](https://github.com/wazuh/wazuh-kibana-app/pull/3732) 
 
 ## Wazuh v4.2.4 - Kibana 7.10.2 , 7.12.1, 7.13.4, 7.14.2 - Revision 4206
 

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "json2csv": "^4.1.2",
     "jwt-decode": "^2.2.0",
     "loglevel": "^1.7.1",
+    "markdown-it-link-attributes": "^3.0.0",
     "needle": "^2.0.1",
     "node-cron": "^1.1.2",
     "pdfmake": "0.1.65",

--- a/public/components/common/util/markdown/markdown.tsx
+++ b/public/components/common/util/markdown/markdown.tsx
@@ -11,6 +11,7 @@
  */
 import React from 'react';
 import MarkdownIt from 'markdown-it';
+import MarkdownItLinkAttributes from 'markdown-it-link-attributes';
 import classnames from 'classnames';
 
 const md = new MarkdownIt({
@@ -18,6 +19,10 @@ const md = new MarkdownIt({
   linkify: true,
   breaks: true,
   typographer: true
+}).use(MarkdownItLinkAttributes, {
+  attrs: {
+    target: '_blank'
+  }
 });
 
 interface MarkdownProps{


### PR DESCRIPTION
Hi Team, this resolve:

- Open external links in a new tab browser in Mitre Intelligence interface

closes #3729 