### PR TITLE
[FIX] `Maximum call stack size exceeded` error exporting key-value pairs of a CDB List

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fixing bug when create filename with spaces and throws a bad error [#3724](https://github.com/wazuh/wazuh-kibana-app/pull/3724)
 - Fixing bug in security User flyout nonexistant unsubmitted changes warning [#3731](https://github.com/wazuh/wazuh-kibana-app/pull/3731)
 - Fixing redirect to new tab when click in a link [#3732](https://github.com/wazuh/wazuh-kibana-app/pull/3732)
+- Fixed `Maximum call stack size exceeded` error exporting key-value pairs of a CDB List [#3738](https://github.com/wazuh/wazuh-kibana-app/pull/3738)
 
 ## Wazuh v4.2.4 - Kibana 7.10.2 , 7.12.1, 7.13.4, 7.14.2 - Revision 4206
 

--- a/public/controllers/management/components/management/ruleset/list-editor.js
+++ b/public/controllers/management/components/management/ruleset/list-editor.js
@@ -536,7 +536,7 @@ class WzListEditor extends Component {
     const addingNew = name === false || !name;
     const listName = this.state.newListName || name;
 
-    const exportCsv = async () => {
+    const exportToCsv = async () => {
       try {
         this.setState({ generatingCsv: true });
         await exportCsv(
@@ -558,7 +558,7 @@ class WzListEditor extends Component {
         this.setState({ generatingCsv: false });
       } catch (error) {
         const options = {
-          context: `${WzListEditor.name}.exportCsv`,
+          context: `${WzListEditor.name}.exportToCsv`,
           level: UI_LOGGER_LEVELS.ERROR,
           severity: UI_ERROR_SEVERITIES.BUSINESS,
           error: {
@@ -590,7 +590,7 @@ class WzListEditor extends Component {
                       iconType="exportAction"
                       isDisabled={this.state.generatingCsv}
                       isLoading={this.state.generatingCsv}
-                      onClick={async () => exportCsv()}
+                      onClick={async () => exportToCsv()}
                     >
                       Export formatted
                     </EuiButtonEmpty>


### PR DESCRIPTION
## Description
This PR fixes an error displayed when exporting the key-value pairs of a CDB List.
![image](https://user-images.githubusercontent.com/34042064/146411717-0ece8cf3-87e0-4a6e-beb8-296824ff7c68.png)

## Test
- Go to `Management/CDB Lists`, select a list and export the `key-value` pairs to CSV. It should export to the file without problems.

Closes #3712 