### PR TITLE
fix regex lookahead and lookbehind for safari

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,7 +108,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fixing redirect to new tab when click in a link [#3732](https://github.com/wazuh/wazuh-kibana-app/pull/3732)
 - Fixed missing settings in `Management/Configuration/Global configuration/Global/Main settings` [#3737](https://github.com/wazuh/wazuh-kibana-app/pull/3737)
 - Fixed `Maximum call stack size exceeded` error exporting key-value pairs of a CDB List [#3738](https://github.com/wazuh/wazuh-kibana-app/pull/3738)
-- Fexed regex lookahead and lookbehind for safari [#3741](https://github.com/wazuh/wazuh-kibana-app/pull/3741)
+- Fixed regex lookahead and lookbehind for safari [#3741](https://github.com/wazuh/wazuh-kibana-app/pull/3741)
 
 ## Wazuh v4.2.5 - Kibana 7.10.2, 7.11.2, 7.12.1, 7.13.4, 7.14.2 - Revision 4206
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fixing redirect to new tab when click in a link [#3732](https://github.com/wazuh/wazuh-kibana-app/pull/3732)
 - Fixed missing settings in `Management/Configuration/Global configuration/Global/Main settings` [#3737](https://github.com/wazuh/wazuh-kibana-app/pull/3737)
 - Fixed `Maximum call stack size exceeded` error exporting key-value pairs of a CDB List [#3738](https://github.com/wazuh/wazuh-kibana-app/pull/3738)
+- Fexed regex lookahead and lookbehind for safari [#3741](https://github.com/wazuh/wazuh-kibana-app/pull/3741)
 
 ## Wazuh v4.2.5 - Kibana 7.10.2, 7.11.2, 7.12.1, 7.13.4, 7.14.2 - Revision 4206
 

--- a/public/components/common/custom-search-bar/components/multi-select.tsx
+++ b/public/components/common/custom-search-bar/components/multi-select.tsx
@@ -91,7 +91,6 @@ export const MultiSelect = ({
   }, [suggestedValues, isLoading]);
 
   const setSelectedKey = (item: Item) => {
-    //fix lookahead and lookbehind for Safari browser https://github.com/wazuh/wazuh-kibana-app/issues/3740
     const label = item.label.match(/\[.+?\]/g);
     if (label) {
       return parseInt(label[0].substring(1, label[0].length - 1));

--- a/public/components/common/custom-search-bar/components/multi-select.tsx
+++ b/public/components/common/custom-search-bar/components/multi-select.tsx
@@ -91,7 +91,13 @@ export const MultiSelect = ({
   }, [suggestedValues, isLoading]);
 
   const setSelectedKey = (item: Item) => {
-    return parseInt(item.label.match(/(?<=\[).+?(?=\])/g) || item.key);
+    //fix lookahead and lookbehind for Safari browser https://github.com/wazuh/wazuh-kibana-app/issues/3740
+    const label = item.label.match(/\[.+?\]/g);
+    if (label) {
+      return parseInt(label[0].substring(1, label[0].length - 1));
+    } else {
+      return parseInt(item.key);
+    }
   };
 
   const buildSelectedOptions = () => {


### PR DESCRIPTION
Hi team in this PR, I solved the error when navigating to wazuh application in safari browser

Closes #3740 