### PR TITLE
Dashboards PDF report error when switching pinned agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fixed `Maximum call stack size exceeded` error exporting key-value pairs of a CDB List [#3738](https://github.com/wazuh/wazuh-kibana-app/pull/3738)
 - Fixed regex lookahead and lookbehind for safari [#3741](https://github.com/wazuh/wazuh-kibana-app/pull/3741)
 - Fixed Vulnerabilities Inventory flyout details filters [#3744](https://github.com/wazuh/wazuh-kibana-app/pull/3744)
+- Fixed Dashboard PDF report error when switching pinned agent state [#3748](https://github.com/wazuh/wazuh-kibana-app/pull/3748)
 
 ## Wazuh v4.2.5 - Kibana 7.10.2, 7.11.2, 7.12.1, 7.13.4, 7.14.2 - Revision 4206
 

--- a/public/components/common/modules/buttons/generate_report.tsx
+++ b/public/components/common/modules/buttons/generate_report.tsx
@@ -45,7 +45,7 @@ export const ButtonModuleGenerateReport = ({agent, moduleID, disabledReport}) =>
     } else {
       await reportingService.startVis2Png(moduleID, agent?.id || false)
     }
-  });
+  }, [agent]);
   
   return (
     <WzButton


### PR DESCRIPTION
Hi team,

this PR fixes once a PDF report is generated, when an agent is pinned or unpinned and a NEW report is generated it fails.

Closes #3746 

To test it:
  1. Navigate to any Dashboard
  2. Click on Generate Report
  3. Pin an agent
  4. Generate a new report
  5. Check both reports were properly created

![Peek 2021-12-23 11-00](https://user-images.githubusercontent.com/9343732/147223921-505fc394-0d4d-44c4-b9df-af199e6ae492.gif)
