### PR TITLE
[FIX] Component rendering of command to deploy new Windows agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fixed `Maximum call stack size exceeded` error exporting key-value pairs of a CDB List [#3738](https://github.com/wazuh/wazuh-kibana-app/pull/3738)
 - Fixed regex lookahead and lookbehind for safari [#3741](https://github.com/wazuh/wazuh-kibana-app/pull/3741)
 - Fixed Vulnerabilities Inventory flyout details filters [#3744](https://github.com/wazuh/wazuh-kibana-app/pull/3744)
+- Fixed the rendering of the command to deploy new Windows agent not working in some Kibana versions [#3753](https://github.com/wazuh/wazuh-kibana-app/pull/3753)
 
 ## Wazuh v4.2.5 - Kibana 7.10.2, 7.11.2, 7.12.1, 7.13.4, 7.14.2 - Revision 4206
 

--- a/public/controllers/agent/components/register-agent.js
+++ b/public/controllers/agent/components/register-agent.js
@@ -10,7 +10,7 @@
  * Find more information about this on the LICENSE file.
  */
 import React, { Component, Fragment } from 'react';
-import { version, kibana } from '../../../../package.json';
+import { version } from '../../../../package.json';
 import { WazuhConfig } from '../../../react-services/wazuh-config';
 import {
   EuiSteps,
@@ -129,7 +129,6 @@ export const RegisterAgent = withErrorBoundary(
         neededSYS: false,
         selectedArchitecture: '',
         selectedVersion: '',
-        kibanaVersion: (kibana || {}).version || false,
         version: '',
         wazuhVersion: '',
         serverAddress: '',
@@ -382,8 +381,7 @@ export const RegisterAgent = withErrorBoundary(
 
     getHighlightCodeLanguage(selectedSO) {
       if (selectedSO.toLowerCase() === 'win') {
-        const iKibanaVersion = parseFloat(this.state.kibanaVersion.split('.').slice(0, 2).join('.'), 2);
-        return iKibanaVersion < 7.14 ? 'ps' : 'powershell';
+        return 'powershell';
       } else {
         return 'bash';
       }


### PR DESCRIPTION
### Description

Fixed the rendering component problem of `EuiCodeBlock` when displaying the command to deploy a new Windows agent.

### Changes
- Set `powershell` as the language that is a valid value for the versions of `@elastic/eui` used by Kibana 7.10.2 (`highlithg.js ^9.18.5`) to Kibana 7.16.2 (`refractor ^3.5.0`)

### Tests
- Go to deploy new Windows agent and see the command is highlighted and the view is displayed correctly for Kibana 7.10.2-7.16.x

> For Kibana 7.16.x, we should move this change to its development branch

Closes #3752  