### PR TITLE
[FIX] [REPORTING] [MODULES] `Rule ID` value in tables related to top results

### DIFF
--- a/server/controllers/wazuh-reporting.ts
+++ b/server/controllers/wazuh-reporting.ts
@@ -576,7 +576,7 @@ export class WazuhReportingCtrl {
             rules.length &&
             printer.addSimpleTable({
               columns: [
-                { id: 'ruleId', label: 'Rule ID' },
+                { id: 'ruleID', label: 'Rule ID' },
                 { id: 'ruleDescription', label: 'Description' },
               ],
               items: rules,
@@ -619,7 +619,7 @@ export class WazuhReportingCtrl {
             rules.length &&
             printer.addSimpleTable({
               columns: [
-                { id: 'ruleId', label: 'Rule ID' },
+                { id: 'ruleID', label: 'Rule ID' },
                 { id: 'ruleDescription', label: 'Description' },
               ],
               items: rules,
@@ -662,7 +662,7 @@ export class WazuhReportingCtrl {
             rules.length &&
             printer.addSimpleTable({
               columns: [
-                { id: 'ruleId', label: 'Rule ID' },
+                { id: 'ruleID', label: 'Rule ID' },
                 { id: 'ruleDescription', label: 'Description' },
               ],
               items: rules,
@@ -726,7 +726,7 @@ export class WazuhReportingCtrl {
         if (rules && rules.length) {
           printer.addContentWithNewLine({ text: 'Top 3 FIM rules', style: 'h2' }).addSimpleTable({
             columns: [
-              { id: 'ruleId', label: 'Rule ID' },
+              { id: 'ruleID', label: 'Rule ID' },
               { id: 'ruleDescription', label: 'Description' },
             ],
             items: rules,


### PR DESCRIPTION
## Description
This PR fixes the problem that the `Rule ID` value is not displayed in the tables related to the tops results. 

Modules affected:
  - Intregrity monitoring
  - GDPR
  - PCI DSS
  - TSC

![image](https://user-images.githubusercontent.com/34042064/147922209-2eb69a7f-d517-4994-bc3d-dd1cb5747a03.png)
![image](https://user-images.githubusercontent.com/34042064/147922230-43e51dc2-4510-4b97-8bb4-f29cdc589f16.png)
![image](https://user-images.githubusercontent.com/34042064/147922239-d771b1d6-1e5a-4c25-bc62-76faf81934ef.png)
![image](https://user-images.githubusercontent.com/34042064/147922260-504dd7e2-bd79-4a95-9c86-7e079ffe2ebb.png)

## Changes
- Modified the key used by the printer that contains the value to display.
  `ruleId` -> `ruleID`

## Tests
- The tables related to the top results of affected modules should display the `Rule ID` value for each row.



Closes https://github.com/wazuh/wazuh-kibana-app/issues/3774

