### PR TITLE
Fix add single agent to group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fixed `Maximum call stack size exceeded` error exporting key-value pairs of a CDB List [#3738](https://github.com/wazuh/wazuh-kibana-app/pull/3738)
 - Fixed regex lookahead and lookbehind for safari [#3741](https://github.com/wazuh/wazuh-kibana-app/pull/3741)
 - Fixed Vulnerabilities Inventory flyout details filters [#3744](https://github.com/wazuh/wazuh-kibana-app/pull/3744)
+- Fixed add single agent to group [#3776](https://github.com/wazuh/wazuh-kibana-app/pull/3776)
 
 ## Wazuh v4.2.5 - Kibana 7.10.2, 7.11.2, 7.12.1, 7.13.4, 7.14.2 - Revision 4206
 

--- a/public/components/management/groups/multiple-agent-selector.tsx
+++ b/public/components/management/groups/multiple-agent-selector.tsx
@@ -396,7 +396,8 @@ export const MultipleAgentSelector = withErrorBoundary(
     };
 
     unselectElementsOfSelectByID(containerID) {
-      document.getElementById(containerID).options.forEach((option) => {
+      const agentsSelect: HTMLSelectElement | null = document.getElementById(containerID) as HTMLSelectElement;
+      Array.prototype.forEach.call(agentsSelect?.options, (option) => {
         option.selected = false;
       });
     }


### PR DESCRIPTION
Hi team,

this PR fixes the disabled Add agent button when a single agent is selected in `7.16.1`

Closes #3761 

To test it try to add and remove a single agent to a group.

![Peek 2022-01-03 12-04](https://user-images.githubusercontent.com/9343732/147923789-f6c2aedb-2513-4123-b70d-7718d074337b.gif)
