### PR TITLE
[FIX] [Modules] Avoid the implicit filters can be removables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fixed `Maximum call stack size exceeded` error exporting key-value pairs of a CDB List [#3738](https://github.com/wazuh/wazuh-kibana-app/pull/3738)
 - Fixed regex lookahead and lookbehind for safari [#3741](https://github.com/wazuh/wazuh-kibana-app/pull/3741)
 - Fixed Vulnerabilities Inventory flyout details filters [#3744](https://github.com/wazuh/wazuh-kibana-app/pull/3744)
+- Fix the implicit filters from the search bar can be removables [#3777](https://github.com/wazuh/wazuh-kibana-app/pull/3777)
 
 ## Wazuh v4.2.5 - Kibana 7.10.2, 7.11.2, 7.12.1, 7.13.4, 7.14.2 - Revision 4206
 

--- a/public/components/common/modules/modules-helper.js
+++ b/public/components/common/modules/modules-helper.js
@@ -57,7 +57,7 @@ export class ModulesHelper {
         const key = `filter-key-${objKey}`;
         const value = x.query && x.query.match_phrase
           ? `filter-value-${x.query.match_phrase[objKey].query}`
-          : `filter-value-${x.meta.value}`;
+          : `filter-value-${x.meta.value()}`;
         const data = filters[i].attributes[3];
         if (data.value.includes(key) && data.value.includes(value)) {
           found = true;


### PR DESCRIPTION
## Description

This PR hides the button of filters to remove them from the search bar.

![image](https://user-images.githubusercontent.com/34042064/147945841-cfe90942-abf8-4059-8041-cdeb8ea5048f.png)

## Changes
- Use `x.meta.value` as function instead of use the implementation of `toString` when interpolating the value of `x.meta.value`

## Tests
- Go to `Modules/Office 365/Panel` or `Modules/GitHub/Panel` and access a drill-down view. A new filter will be added with the accessed value, the button to remove the filters should not be visible

Closes #3769 