### PR TITLE
Fixed Office365/Github module the side panel tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fixed `Maximum call stack size exceeded` error exporting key-value pairs of a CDB List [#3738](https://github.com/wazuh/wazuh-kibana-app/pull/3738)
 - Fixed regex lookahead and lookbehind for safari [#3741](https://github.com/wazuh/wazuh-kibana-app/pull/3741)
 - Fixed Vulnerabilities Inventory flyout details filters [#3744](https://github.com/wazuh/wazuh-kibana-app/pull/3744)
+- Fixed Office365/Github module the side panel tab [#3778](https://github.com/wazuh/wazuh-kibana-app/pull/3778)
 
 ## Wazuh v4.2.5 - Kibana 7.10.2, 7.11.2, 7.12.1, 7.13.4, 7.14.2 - Revision 4206
 

--- a/public/components/common/modules/panel/components/module-side-panel.tsx
+++ b/public/components/common/modules/panel/components/module-side-panel.tsx
@@ -22,8 +22,7 @@ export const ModuleSidePanel = ({ navIsDocked = false, children, ...props }) => 
     <EuiCollapsibleNav
       isOpen={navIsOpen}
       isDocked={navIsDocked}
-      showCloseButton={true}
-      maskProps={{ headerZindexLocation: 'below', className: 'wz-no-display' }}
+      maskProps={{ headerZindexLocation: 'below' }}
       button={
         <EuiButtonEmpty
           className={'sidepanel-infoBtnStyle'}
@@ -34,11 +33,6 @@ export const ModuleSidePanel = ({ navIsDocked = false, children, ...props }) => 
       onClose={() => setNavIsOpen(false)}
     >
       <div>
-        <EuiButtonEmpty
-          style={{ position: 'absolute', right: 0 }}
-          onClick={() => setNavIsOpen(!navIsOpen)}
-          iconType={'cross'}
-        />
         <div className={'wz-padding-16'}>{children}</div>
       </div>
     </EuiCollapsibleNav>


### PR DESCRIPTION
Hi team,

this PR fixes styling and the collapsible navbar close button issue when the side panel tab is clicked.

Closes #3768 

To test it:

- Click on the side panel tab
- See a flyout open with additional module information

![image](https://user-images.githubusercontent.com/9343732/147951306-ec2888ce-1b2e-4d0a-bdd4-8816c563cb01.png)
