### PR TITLE
[FIX] [MODULES] [MITRE ATT&CK] [Intelligence] Wrap text in the `Description` column for the resources info table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fixed `Maximum call stack size exceeded` error exporting key-value pairs of a CDB List [#3738](https://github.com/wazuh/wazuh-kibana-app/pull/3738)
 - Fixed regex lookahead and lookbehind for safari [#3741](https://github.com/wazuh/wazuh-kibana-app/pull/3741)
 - Fixed Vulnerabilities Inventory flyout details filters [#3744](https://github.com/wazuh/wazuh-kibana-app/pull/3744)
+- Fixed no wrap text in MITRE ATT&CK intelligence table [#3780](https://github.com/wazuh/wazuh-kibana-app/pull/3780)
 
 ## Wazuh v4.2.5 - Kibana 7.10.2, 7.11.2, 7.12.1, 7.13.4, 7.14.2 - Revision 4206
 

--- a/public/components/overview/mitre_attack_intelligence/resources.tsx
+++ b/public/components/overview/mitre_attack_intelligence/resources.tsx
@@ -97,7 +97,6 @@ function buildResource(label: string, labelResource: string){
         name: 'Description',
         sortable: true,
         render: (value) => value ? <Markdown markdown={value} /> : '',
-        truncateText: true
       }
     ],
     mitreFlyoutHeaderProperties: [


### PR DESCRIPTION
## Description

This PR fixes the problem with the wrapping text in the MITRE ATT&CK intelligence table

![image](https://user-images.githubusercontent.com/34042064/148024928-af69124a-ffa7-4b46-b58f-4020a54fa6d9.png)

## Changes
- Removed the `truncateText` prop of `Descrition` table column.

## Tests
- Go to `Modules/MITRE ATT&CK/Intelligence and see the `Description` column wraps the text.

Closes #3767