### PR TITLE
Fixed visualization echTooltip position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fixed missing settings in `Management/Configuration/Global configuration/Global/Main settings` [#3737](https://github.com/wazuh/wazuh-kibana-app/pull/3737)
 - Fixed `Maximum call stack size exceeded` error exporting key-value pairs of a CDB List [#3738](https://github.com/wazuh/wazuh-kibana-app/pull/3738)
 - Fixed regex lookahead and lookbehind for safari [#3741](https://github.com/wazuh/wazuh-kibana-app/pull/3741)
+- Fixed Vulnerabilities Inventory flyout details filters [#3744](https://github.com/wazuh/wazuh-kibana-app/pull/3744)
 - Fixed visualization tooltip position [#3781](https://github.com/wazuh/wazuh-kibana-app/pull/3781)
 
 ## Wazuh v4.2.5 - Kibana 7.10.2, 7.11.2, 7.12.1, 7.13.4, 7.14.2 - Revision 4206

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,7 +110,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fixed missing settings in `Management/Configuration/Global configuration/Global/Main settings` [#3737](https://github.com/wazuh/wazuh-kibana-app/pull/3737)
 - Fixed `Maximum call stack size exceeded` error exporting key-value pairs of a CDB List [#3738](https://github.com/wazuh/wazuh-kibana-app/pull/3738)
 - Fixed regex lookahead and lookbehind for safari [#3741](https://github.com/wazuh/wazuh-kibana-app/pull/3741)
-- Fixed Vulnerabilities Inventory flyout details filters [#3744](https://github.com/wazuh/wazuh-kibana-app/pull/3744)
+- Fixed visualization tooltip position [#3781](https://github.com/wazuh/wazuh-kibana-app/pull/3781)
 
 ## Wazuh v4.2.5 - Kibana 7.10.2, 7.11.2, 7.12.1, 7.13.4, 7.14.2 - Revision 4206
 

--- a/public/styles/7.9.0/index.dark.scss
+++ b/public/styles/7.9.0/index.dark.scss
@@ -112,8 +112,13 @@
   pointer-events: none;
   z-index: 10000000; }
 
-[id^='echTooltipPortalMainTooltip'] .echTooltip {
-    position: unset;
+[id^='echTooltipPortalMainTooltip'] {
+  .echTooltip {
+      position: unset;
+      .echTooltip__item {
+        border-left: 0;
+      }
+  }
 }
   
 .echTooltip {

--- a/public/styles/7.9.0/index.dark.scss
+++ b/public/styles/7.9.0/index.dark.scss
@@ -112,6 +112,10 @@
   pointer-events: none;
   z-index: 10000000; }
 
+[id^='echTooltipPortalMainTooltip'] .echTooltip {
+    position: unset;
+}
+  
 .echTooltip {
   position: absolute;
   -webkit-box-shadow: 0 12px 24px 0 rgba(0, 0, 0, 0.1), 0 6px 12px 0 rgba(0, 0, 0, 0.1), 0 4px 4px 0 rgba(0, 0, 0, 0.1), 0 2px 2px 0 rgba(0, 0, 0, 0.1);

--- a/public/styles/7.9.0/index.light.scss
+++ b/public/styles/7.9.0/index.light.scss
@@ -112,6 +112,10 @@
   pointer-events: none;
   z-index: 10000000; }
 
+[id^='echTooltipPortalMainTooltip'] .echTooltip {
+    position: unset;
+}
+
 .echTooltip {
   position: absolute;
   -webkit-box-shadow: 0 12px 24px 0 rgba(0, 0, 0, 0.1), 0 6px 12px 0 rgba(0, 0, 0, 0.1), 0 4px 4px 0 rgba(0, 0, 0, 0.1), 0 2px 2px 0 rgba(0, 0, 0, 0.1);

--- a/public/styles/7.9.0/index.light.scss
+++ b/public/styles/7.9.0/index.light.scss
@@ -112,8 +112,13 @@
   pointer-events: none;
   z-index: 10000000; }
 
-[id^='echTooltipPortalMainTooltip'] .echTooltip {
-    position: unset;
+[id^='echTooltipPortalMainTooltip'] {
+  .echTooltip {
+      position: unset;
+      .echTooltip__item {
+        border-left: 0;
+      }
+  }
 }
 
 .echTooltip {


### PR DESCRIPTION
Hi team,

This PR fixes visualizations tooltip styles to adjust its width when hovering charts.

Closes #3755 

To test it, try to reproduce the mentioned issue in all main browsers (including Safari).

![Peek 2022-01-04 12-35](https://user-images.githubusercontent.com/9343732/148053502-8906702c-1f65-4a4d-b7c6-f4f7d972072c.gif)
![Peek 2022-01-04 12-36](https://user-images.githubusercontent.com/9343732/148053511-13b8b2e6-c0fb-462f-9e24-e1342036ccb3.gif)
