### PR TITLE
[FIX] [HEALTH CHECK] Run `template` and `fields` checks depends on the app configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Added new fields in Inventory table and Flyout Details [#3525](https://github.com/wazuh/wazuh-kibana-app/pull/3525)
 - Added columns selector in agents table [#3691](https://github.com/wazuh/wazuh-kibana-app/pull/3691)
 - Added a new workflow for create wazuh packages [#3742](https://github.com/wazuh/wazuh-kibana-app/pull/3742)
+- Run `template` and `fields` checks in the health check depends on the app configuration [#3783](https://github.com/wazuh/wazuh-kibana-app/pull/3783)
 
 ### Changed
 

--- a/public/utils/config-equivalences.js
+++ b/public/utils/config-equivalences.js
@@ -83,7 +83,7 @@ export const nameEquivalence = {
   'checks.template': 'Index template',
   'checks.api': 'API connection',
   'checks.setup': 'API version',
-  'checks.fields': 'Know fields',
+  'checks.fields': 'Known fields',
   'checks.metaFields': 'Remove meta fields',
   'checks.timeFilter': 'Set time filter to 24h',
   'checks.maxBuckets': 'Set max buckets to 200000',

--- a/server/lib/initial-wazuh-config.ts
+++ b/server/lib/initial-wazuh-config.ts
@@ -47,6 +47,7 @@ export const initialWazuhConfig: string = `---
 # step once the Wazuh app starts. Values must to be true or false.
 #checks.pattern : true
 #checks.template: true
+#checks.fields  : true
 #checks.api     : true
 #checks.setup   : true
 #checks.metaFields: true


### PR DESCRIPTION
## Description

This PR runs the checks related to the alerts index pattern if these are enabled in the app configuration. Add some messages to display when the check is disabled to be skipped or perform some tasks.

The checks when are disabled (value: `false` in the app configuration):
- `checks.pattern`: Some actions run.
- `checks.template`: it is skipped
- `checks.fields`: it is skipped

When the checks are disabled, it appears a message for each one of them.
![image](https://user-images.githubusercontent.com/34042064/148096745-916d1a57-6f45-4440-b616-3cba89f32036.png)

## Changes
- The check of template and index pattern known fields now depends on the app configuration (`checks.template` and `checks.fields`).
- Added messages for when the `checks.pattern`, `checks.template` and `checks.fields` are disabled.
- Fixed typo related to the know fields
- Added `checks.fields` to the default app configuration file

## Tests
- Tests with the next cases deleting all cookies and `localstorage` data. When a check is disabled, it should display some message about this to skip the check or run some tasks.
  - All checks related to the alerts index pattern enabled:
    ```
    checks.pattern: true
    checks.template: true
    checks.fields: true
    ```
  - Disabled `template` check:
    ```
    checks.pattern: true
    checks.template: false
    checks.fields: true
    ```
  - Disabled `fields` check:
    ```
    checks.pattern: true
    checks.template: true
    checks.fields: false
    ```
  - Disabled `template` and `fields` checks:
    ```
    checks.pattern: true
    checks.template: false
    checks.fields: false
    ```
  - Disabled all checks:
    ```
    checks.pattern: false
    checks.template: false
    checks.fields: false
    ```
    
Closes #3765