### PR TITLE
Github/Office365 multi-select filters fix to get suggested values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fixed `Maximum call stack size exceeded` error exporting key-value pairs of a CDB List [#3738](https://github.com/wazuh/wazuh-kibana-app/pull/3738)
 - Fixed regex lookahead and lookbehind for safari [#3741](https://github.com/wazuh/wazuh-kibana-app/pull/3741)
 - Fixed Vulnerabilities Inventory flyout details filters [#3744](https://github.com/wazuh/wazuh-kibana-app/pull/3744)
+- Fixed github/office365 multi-select filters suggested values [#3787](https://github.com/wazuh/wazuh-kibana-app/pull/3787)
 
 ## Wazuh v4.2.5 - Kibana 7.10.2, 7.11.2, 7.12.1, 7.13.4, 7.14.2 - Revision 4206
 

--- a/public/components/common/hooks/use-value-suggestion.ts
+++ b/public/components/common/hooks/use-value-suggestion.ts
@@ -69,7 +69,7 @@ export const useValueSuggestion = (
       : await data.autocomplete.getValueSuggestions({
           query,
           indexPattern: indexPattern as IIndexPattern,
-          field,
+          field: { ...field, toSpec: (options) => field },
           boolFilter: boolFilter,
         });
   };

--- a/public/react-services/saved-objects.js
+++ b/public/react-services/saved-objects.js
@@ -282,6 +282,7 @@ export class SavedObject {
               "data.vulnerability.reference":{"id":"url"},
               "data.url":{"id":"url"}
             }`,
+            fields: '[]',
             sourceFilters: '[{"value":"@timestamp"}]',
           },
         },


### PR DESCRIPTION
Hi team,

this PR fixes multi-select filters failing to get suggested values due to the index pattern not having **attribute.fields** property.

Closes #3779 

To test it: 

- Go to Github and/or Office365 module
- See each multi-select filter suggest values and apply selected filters

![Peek 2022-01-05 18-56](https://user-images.githubusercontent.com/9343732/148265853-d42ae867-3820-4b40-bb6c-796234770bef.gif)
