### PR TITLE
[FIX] [Modules] [Panel] Update aggregation data when the time filter is changed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fixed `Maximum call stack size exceeded` error exporting key-value pairs of a CDB List [#3738](https://github.com/wazuh/wazuh-kibana-app/pull/3738)
 - Fixed regex lookahead and lookbehind for safari [#3741](https://github.com/wazuh/wazuh-kibana-app/pull/3741)
 - Fixed Vulnerabilities Inventory flyout details filters [#3744](https://github.com/wazuh/wazuh-kibana-app/pull/3744)
+- Fix updating the aggregation data of Panel section when changing the time filter [#3790](https://github.com/wazuh/wazuh-kibana-app/pull/3790)
 
 ## Wazuh v4.2.5 - Kibana 7.10.2, 7.11.2, 7.12.1, 7.13.4, 7.14.2 - Revision 4206
 

--- a/public/components/common/hooks/use-es-search.ts
+++ b/public/components/common/hooks/use-es-search.ts
@@ -12,7 +12,7 @@
 
 import { SetStateAction, useEffect, useState } from 'react';
 import { getDataPlugin } from '../../../kibana-services';
-import { useFilterManager, useIndexPattern, useQueryManager } from '.';
+import { useFilterManager, useIndexPattern, useQueryManager, useTimeFilter } from '.';
 import { IndexPattern } from 'src/plugins/data/public';
 import {
   UI_ERROR_SEVERITIES,
@@ -45,6 +45,7 @@ const useEsSearch = ({ preAppliedFilters = [], preAppliedAggs = {}, size = 10 })
   const indexPattern = useIndexPattern();
   const {filters} = useFilterManager();
   const [query] = useQueryManager();
+  const { timeFilter } = useTimeFilter();
   const [esResults, setEsResults] = useState<SearchResponse>({} as SearchResponse);
   const [error, setError] = useState<Error>({} as Error);
   const [isLoading, setIsLoading] = useState<boolean>(true);
@@ -72,7 +73,7 @@ const useEsSearch = ({ preAppliedFilters = [], preAppliedAggs = {}, size = 10 })
         setIsLoading(false);
       }
     })();
-  }, [indexPattern, query, filters, page, preAppliedAggs]);
+  }, [indexPattern, query, filters, timeFilter, page, preAppliedAggs]);
 
   const search = async (): Promise<SearchResponse> => {
     if (indexPattern) {


### PR DESCRIPTION
## Description

This PR fixes the aggregation tables in `Modules/<Module>/Panel` are not updated when the time filter is changed

## Changes
  - Added the `timeFilter` as dependency to update the data
  
## Tests
- With alerts data about the module, go to `Modules/<Module>/Panel` (currently only the Office 365 and GitHub modules have this tab) and change the time filter, the displayed data should change according to the time range selected.

Closes #3789