### PR TITLE
Enhance agent deployment UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Testing logs using the Ruletest Test don't display the rule information if not matching a rule. [#3446](https://github.com/wazuh/wazuh-kibana-app/pull/3446)
 - Changed format permissions in FIM inventory [#3649](https://github.com/wazuh/wazuh-kibana-app/pull/3649)
 - Changed of request for one that does not return data that is not necessary to optimize times. [#3686](https://github.com/wazuh/wazuh-kibana-app/pull/3686) [#3728](https://github.com/wazuh/wazuh-kibana-app/pull/3728)
+- Changed agent install codeblock copy button and powershell terminal warning [#3792](https://github.com/wazuh/wazuh-kibana-app/pull/3792)
 
 ### Fixed
 

--- a/public/controllers/agent/components/agents-preview.scss
+++ b/public/controllers/agent/components/agents-preview.scss
@@ -50,3 +50,50 @@
 .columnsSelectedCheckboxs div {
   margin-right: 20px;
 }
+.copy-codeblock-wrapper {
+  position: relative;
+
+  .euiToolTipAnchor {
+    opacity: 0;
+    transition: 150ms opacity ease-in-out;
+    position: absolute;
+    top: 0;
+    width: 100%;
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    background-color: rgba(255, 255, 255, 0.75);
+    
+    &:hover {
+      opacity: 1;
+    }
+    .copy-overlay {
+      display: flex;
+      flex: 1;
+      align-items: center;
+      justify-content: center;
+      cursor: pointer;
+      width: 100%;
+      p {
+        margin: 0;
+        -webkit-touch-callout: none;
+        -webkit-user-select: none;
+        -khtml-user-select: none;
+        -moz-user-select: none;
+        -ms-user-select: none;
+        user-select: none;
+      }
+    }
+  }
+
+  code.euiCodeBlock__code {
+    -webkit-touch-callout: none;
+    -webkit-user-select: none;
+    -khtml-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
+  }
+}

--- a/public/controllers/agent/components/register-agent.js
+++ b/public/controllers/agent/components/register-agent.js
@@ -543,11 +543,13 @@ export const RegisterAgent = withErrorBoundary(
                     )}
                   </EuiCopy>
                 </div>
-                <EuiSwitch
-                  label="Show password"
-                  checked={this.state.showPassword}
-                  onChange={(active) => this.setShowPassword(active)}
-                />
+                {this.state.needsPassword && (
+                  <EuiSwitch
+                    label="Show password"
+                    checked={this.state.showPassword}
+                    onChange={(active) => this.setShowPassword(active)}
+                  />
+                )}
                 <EuiSpacer />
                 {windowsAdvice}
               </EuiText>
@@ -600,11 +602,6 @@ export const RegisterAgent = withErrorBoundary(
                     )}
                   </EuiCopy>
                 </div>
-                <EuiSwitch
-                  label="Show password"
-                  checked={this.state.showPassword}
-                  onChange={(active) => this.setShowPassword(active)}
-                />
                 <EuiSpacer />
                 {textAndLinkToCheckConnectionDocumentation}
               </EuiText>

--- a/public/controllers/agent/components/register-agent.js
+++ b/public/controllers/agent/components/register-agent.js
@@ -34,6 +34,7 @@ import {
   EuiCode,
   EuiLink,
   EuiIcon,
+  EuiSwitch
 } from '@elastic/eui';
 import { WzRequest } from '../../../react-services/wz-request';
 import { withErrorBoundary } from '../../../components/common/hocs';
@@ -137,6 +138,7 @@ export const RegisterAgent = withErrorBoundary(
         groups: [],
         selectedGroup: [],
         udpProtocol: false,
+        showPassword: false,
       };
       this.restartAgentCommand = {
         rpm: this.systemSelector(),
@@ -264,6 +266,10 @@ export const RegisterAgent = withErrorBoundary(
 
     setWazuhPassword(event) {
       this.setState({ wazuhPassword: event.target.value });
+    }
+
+    setShowPassword(event) {
+      this.setState({ showPassword: event.target.checked });
     }
 
     obfuscatePassword(text) {
@@ -478,7 +484,7 @@ export const RegisterAgent = withErrorBoundary(
             title="You will need administrator privileges to perform this installation."
             iconType="iInCircle"
             >
-              <p>Keep in mind you need to run this command in a Windows powershell terminal</p>
+              <p>Keep in mind you need to run this command in a Windows PowerShell terminal</p>
             </EuiCallOut>
           <EuiSpacer></EuiSpacer>
         </>
@@ -527,7 +533,7 @@ export const RegisterAgent = withErrorBoundary(
                 <EuiSpacer />
                 <div className="copy-codeblock-wrapper">
                   <EuiCodeBlock style={codeBlock} language={language}>
-                    {this.state.wazuhPassword ? this.obfuscatePassword(text) : text}
+                    {this.state.wazuhPassword && !this.state.showPassword ? this.obfuscatePassword(text) : text}
                   </EuiCodeBlock>
                   <EuiCopy textToCopy={text}>
                     {(copy) => (
@@ -537,6 +543,12 @@ export const RegisterAgent = withErrorBoundary(
                     )}
                   </EuiCopy>
                 </div>
+                <EuiSwitch
+                  label="Show password"
+                  checked={this.state.showPassword}
+                  onChange={(active) => this.setShowPassword(active)}
+                />
+                <EuiSpacer />
                 {windowsAdvice}
               </EuiText>
             )}
@@ -563,6 +575,7 @@ export const RegisterAgent = withErrorBoundary(
                     )}
                   </EuiCopy>
                 </div>
+                <EuiSpacer />
                 {textAndLinkToCheckConnectionDocumentation}
               </EuiText>
             </Fragment>
@@ -587,6 +600,12 @@ export const RegisterAgent = withErrorBoundary(
                     )}
                   </EuiCopy>
                 </div>
+                <EuiSwitch
+                  label="Show password"
+                  checked={this.state.showPassword}
+                  onChange={(active) => this.setShowPassword(active)}
+                />
+                <EuiSpacer />
                 {textAndLinkToCheckConnectionDocumentation}
               </EuiText>
             </Fragment>

--- a/public/controllers/agent/components/register-agent.js
+++ b/public/controllers/agent/components/register-agent.js
@@ -24,7 +24,6 @@ import {
   EuiText,
   EuiCodeBlock,
   EuiTitle,
-  EuiButton,
   EuiButtonEmpty,
   EuiCopy,
   EuiPage,
@@ -34,6 +33,7 @@ import {
   EuiProgress,
   EuiCode,
   EuiLink,
+  EuiIcon,
 } from '@elastic/eui';
 import { WzRequest } from '../../../react-services/wz-request';
 import { withErrorBoundary } from '../../../components/common/hocs';
@@ -477,7 +477,9 @@ export const RegisterAgent = withErrorBoundary(
           <EuiCallOut
             title="You will need administrator privileges to perform this installation."
             iconType="iInCircle"
-          />
+            >
+              <p>Keep in mind you need to run this command in a Windows powershell terminal</p>
+            </EuiCallOut>
           <EuiSpacer></EuiSpacer>
         </>
       );
@@ -523,17 +525,19 @@ export const RegisterAgent = withErrorBoundary(
                   iconType="iInCircle"
                 />
                 <EuiSpacer />
-                <EuiCodeBlock style={codeBlock} language={language}>
-                  {this.state.wazuhPassword ? this.obfuscatePassword(text) : text}
-                </EuiCodeBlock>
+                <div className="copy-codeblock-wrapper">
+                  <EuiCodeBlock style={codeBlock} language={language}>
+                    {this.state.wazuhPassword ? this.obfuscatePassword(text) : text}
+                  </EuiCodeBlock>
+                  <EuiCopy textToCopy={text}>
+                    {(copy) => (
+                      <div className="copy-overlay"  onClick={copy}>
+                        <p><EuiIcon type="copy"/> Copy command</p>
+                      </div>
+                    )}
+                  </EuiCopy>
+                </div>
                 {windowsAdvice}
-                <EuiCopy textToCopy={text}>
-                  {(copy) => (
-                    <EuiButton fill iconType="copy" onClick={copy}>
-                      Copy command
-                    </EuiButton>
-                  )}
-                </EuiCopy>
               </EuiText>
             )}
         </div>
@@ -547,16 +551,18 @@ export const RegisterAgent = withErrorBoundary(
             <Fragment>
               <EuiSpacer />
               <EuiText>
-                <EuiCodeBlock style={codeBlock} language={language}>
-                  {this.systemSelector()}
-                </EuiCodeBlock>
-                <EuiCopy textToCopy={this.systemSelector()}>
-                  {(copy) => (
-                    <EuiButton fill iconType="copy" onClick={copy}>
-                      Copy command
-                    </EuiButton>
-                  )}
-                </EuiCopy>
+                <div className="copy-codeblock-wrapper">
+                  <EuiCodeBlock style={codeBlock} language={language}>
+                    {this.systemSelector()}
+                  </EuiCodeBlock>
+                  <EuiCopy textToCopy={this.systemSelector()}>
+                    {(copy) => (
+                      <div className="copy-overlay" onClick={copy}>
+                        <p><EuiIcon type="copy" /> Copy command</p>
+                      </div>
+                    )}
+                  </EuiCopy>
+                </div>
                 {textAndLinkToCheckConnectionDocumentation}
               </EuiText>
             </Fragment>
@@ -569,16 +575,18 @@ export const RegisterAgent = withErrorBoundary(
             <Fragment>
               <EuiSpacer />
               <EuiText>
-                <EuiCodeBlock style={codeBlock} language={language}>
-                  {this.systemSelector()}
-                </EuiCodeBlock>
-                <EuiCopy textToCopy={this.systemSelector()}>
-                  {(copy) => (
-                    <EuiButton fill iconType="copy" onClick={copy}>
-                      Copy command
-                    </EuiButton>
-                  )}
-                </EuiCopy>
+                <div className="copy-codeblock-wrapper">
+                  <EuiCodeBlock style={codeBlock} language={language}>
+                    {this.systemSelector()}
+                  </EuiCodeBlock>
+                  <EuiCopy textToCopy={this.systemSelector()}>
+                    {(copy) => (
+                      <div className="copy-overlay" onClick={copy}>
+                        <p><EuiIcon type="copy" /> Copy command</p>
+                      </div>
+                    )}
+                  </EuiCopy>
+                </div>
                 {textAndLinkToCheckConnectionDocumentation}
               </EuiText>
             </Fragment>
@@ -713,16 +721,18 @@ export const RegisterAgent = withErrorBoundary(
                 : (
                   <EuiFlexGroup direction="column">
                     <EuiText>
-                      <EuiCodeBlock style={codeBlock} language={language}>
-                        {restartAgentCommand}
-                      </EuiCodeBlock>
-                      <EuiCopy textToCopy={restartAgentCommand}>
-                        {(copy) => (
-                          <EuiButton fill iconType="copy" onClick={copy}>
-                            Copy command
-                          </EuiButton>
-                        )}
-                      </EuiCopy>
+                      <div className="copy-codeblock-wrapper">
+                        <EuiCodeBlock style={codeBlock} language={language}>
+                          {restartAgentCommand}
+                        </EuiCodeBlock>
+                        <EuiCopy textToCopy={restartAgentCommand}>
+                          {(copy) => (
+                            <div className="copy-overlay" onClick={copy}>
+                              <p><EuiIcon type="copy" /> Copy command</p>
+                            </div>
+                          )}
+                        </EuiCopy>
+                      </div>
                     </EuiText>
                   </EuiFlexGroup>
                 ),

--- a/public/styles/dark_theme/wz_theme_dark.scss
+++ b/public/styles/dark_theme/wz_theme_dark.scss
@@ -443,3 +443,7 @@ svg .legend text {
 .application .euiAccordion, .flyout-body .euiAccordion {
   border-bottom: 1px solid #343741!important;
 }
+
+.copy-codeblock-wrapper .euiToolTipAnchor {
+  background-color: rgba(0, 0, 0, 0.7);
+}


### PR DESCRIPTION
Hi team, 

this PR enhances the user experience when trying to copy an agent install code block. Also warns the user that the Windows script must be run in a PowerShell terminal.

Closes #3762 

![Peek 2022-01-07 17-11](https://user-images.githubusercontent.com/9343732/148578339-875e986c-379c-4f65-b667-29d7e42112ae.gif)


### Tests
- This should be tested with different browsers.