### PR TITLE
[FIX] [GROUPS] Fixes creating a new group with invalid name and no display the remove button in the agents table for the `default` group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Added columns selector in agents table [#3691](https://github.com/wazuh/wazuh-kibana-app/pull/3691)
 - Added a new workflow for create wazuh packages [#3742](https://github.com/wazuh/wazuh-kibana-app/pull/3742)
 - Run `template` and `fields` checks in the health check depends on the app configuration [#3783](https://github.com/wazuh/wazuh-kibana-app/pull/3783)
+- Added a toast message when there is an error creating a new group [#3804](https://github.com/wazuh/wazuh-kibana-app/pull/3804)
 
 ### Changed
 
@@ -120,6 +121,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fix `Rule ID` value in reporting tables related to top results [#3774](https://github.com/wazuh/wazuh-kibana-app/issues/3774)
 - Fixed github/office365 multi-select filters suggested values [#3787](https://github.com/wazuh/wazuh-kibana-app/pull/3787)
 - Fix updating the aggregation data of Panel section when changing the time filter [#3790](https://github.com/wazuh/wazuh-kibana-app/pull/3790)
+- Removed the button to remove an agent for a group in the agents' table when it is the default group [#3804](https://github.com/wazuh/wazuh-kibana-app/pull/3804)
 
 ## Wazuh v4.2.5 - Kibana 7.10.2, 7.11.2, 7.12.1, 7.13.4, 7.14.2 - Revision 4206
 

--- a/public/controllers/management/components/management/groups/actions-buttons-main.js
+++ b/public/controllers/management/components/management/groups/actions-buttons-main.js
@@ -179,6 +179,19 @@ class WzGroupsActionButtons extends Component {
         this.closePopover();
       }
     } catch (error) {
+      const options = {
+        context: `${WzGroupsActionButtons.name}.createGroup`,
+        level: UI_LOGGER_LEVELS.ERROR,
+        severity: UI_ERROR_SEVERITIES.BUSINESS,
+        store: false,
+        display: true,
+        error: {
+          error: error,
+          message: error.message || error,
+          title: `Error creating a new group`,
+        },
+      };
+      getErrorOrchestrator().handleError(options);
       this.props.updateLoadingStatus(false);
       throw new Error(error);
     }

--- a/public/controllers/management/components/management/groups/group-agents-table.js
+++ b/public/controllers/management/components/management/groups/group-agents-table.js
@@ -206,30 +206,32 @@ class WzGroupAgentsTable extends Component {
                 }}
                 color="primary"
               />
-              <WzButtonPermissionsModalConfirm
-                buttonType="icon"
-                permissions={[
-                  [
-                    { action: 'agent:modify_group', resource: `agent:id:${item.id}` },
-                    ...(item.group || []).map((group) => ({
-                      action: 'agent:modify_group',
-                      resource: `agent:group:${group}`,
-                    })),
-                  ],
-                ]}
-                tooltip={{ position: 'top', content: 'Remove agent from this group' }}
-                aria-label="Remove agent from this group"
-                iconType="trash"
-                onConfirm={async () => {
-                  this.removeItems([item]);
-                }}
-                color="danger"
-                isDisabled={item.name === 'default'}
-                modalTitle={`Remove ${item.file || item.name} agent from this group?`}
-                modalProps={{
-                  buttonColor: 'danger',
-                }}
-              />
+              {this.props?.state?.itemDetail?.name !== 'default' && (
+                <WzButtonPermissionsModalConfirm
+                  buttonType="icon"
+                  permissions={[
+                    [
+                      { action: 'agent:modify_group', resource: `agent:id:${item.id}` },
+                      ...(item.group || []).map((group) => ({
+                        action: 'agent:modify_group',
+                        resource: `agent:group:${group}`,
+                      })),
+                    ],
+                  ]}
+                  tooltip={{ position: 'top', content: 'Remove agent from this group' }}
+                  aria-label="Remove agent from this group"
+                  iconType="trash"
+                  onConfirm={async () => {
+                    this.removeItems([item]);
+                  }}
+                  color="danger"
+                  isDisabled={item.name === 'default'}
+                  modalTitle={`Remove ${item.file || item.name} agent from this group?`}
+                  modalProps={{
+                    buttonColor: 'danger',
+                  }}
+                />
+              )}
             </div>
           );
         },


### PR DESCRIPTION
## Description

This PR fixes the next things:
- Added a toast message when there is an error creating a new group in `Management/Groups`
![image](https://user-images.githubusercontent.com/34042064/150092833-f1bc4290-13ea-4dc2-95c0-818cbeee2d53.png)
- Don't display the remove button in the table of agents for a group
  - `default` group:
![image](https://user-images.githubusercontent.com/34042064/150094496-10e68e9d-aede-4ab3-a81a-0125e1d7c466.png)
  - another group:
![image](https://user-images.githubusercontent.com/34042064/150094543-4528ee82-9d85-4dd8-b2f1-a36de523d6b3.png)

## Test
1. Go to `Management/Groups`. Click on the `Add new group` button and write an invalid name. Click on the `Save new group` button and a toast message should be displayed with the error.
2. Go to `Management/Groups`. Click on the `default` group and see the remove button is not displayed for the agent's table. Create a custom group, add some agents and review the agent's table for the group and should have the remove button.

Closes #3802 #3803
