### PR TITLE
[FEAT]: Add new options of auth for the Registration service configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,7 +59,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Moved the filterManager subscription to the hook useFilterManager [#3517](https://github.com/wazuh/wazuh-kibana-app/pull/3517)
 - Change filter from is to is one of in custom searchbar [#3529](https://github.com/wazuh/wazuh-kibana-app/pull/3529)
 - Refactored as module tabs and buttons are rendered [#3494](https://github.com/wazuh/wazuh-kibana-app/pull/3494)
-- Updated depracated and new references authd [#3663](https://github.com/wazuh/wazuh-kibana-app/pull/3663)
+- Updated the deprecated and added new references authd [#3663](https://github.com/wazuh/wazuh-kibana-app/pull/3663) [#3806](https://github.com/wazuh/wazuh-kibana-app/pull/3806)
 - Added time subscription to Discover component [#3549](https://github.com/wazuh/wazuh-kibana-app/pull/3549)
 - Refactored as module tabs and buttons are rendered [#3494](https://github.com/wazuh/wazuh-kibana-app/pull/3494)
 - Testing logs using the Ruletest Test don't display the rule information if not matching a rule. [#3446](https://github.com/wazuh/wazuh-kibana-app/pull/3446)

--- a/public/controllers/management/components/management/configuration/registration-service/registration-service.js
+++ b/public/controllers/management/components/management/configuration/registration-service/registration-service.js
@@ -46,10 +46,25 @@ const mainSettings = [
     label: 'Limit registration to maximum number of agents'
   },
   {
-    field: 'force',
-    label: 'Force registration when using an existing IP address',
-    render: (value) =>  value.enabled
-  }
+    field: 'force.enabled',
+    label: 'Force registration when using an existing IP address'
+  },
+  {
+    field: 'force.after_registration_time',
+    label: 'Specifies that the agent replacement will be performed only when the time (seconds) passed since the agent registration is greater than the value configured in the setting'
+  },
+  {
+    field: 'force.key_mismatch',
+    label: 'Avoid re-registering agents that already have valid keys'
+  },
+  {
+    field: 'force.disconnected_time.enabled',
+    label: 'Specifies that the replacement will be performed only for agents that have been disconnected longer than a certain time'
+  },
+  {
+    field: 'force.disconnected_time.value',
+    label: 'Seconds since an agent is in a disconnected state'
+  },
 ];
 const sslSettings = [
   { field: 'ssl_verify_host', label: 'Verify agents using a CA certificate' },

--- a/public/controllers/management/components/management/configuration/util-components/configuration-settings-group.js
+++ b/public/controllers/management/components/management/configuration/util-components/configuration-settings-group.js
@@ -12,6 +12,7 @@
 
 import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
+import { get } from 'lodash';
 
 import {
   EuiFlexGroup,
@@ -56,6 +57,7 @@ class WzSettingsGroup extends Component {
               const keyItem = `${title || ''}-${item.label}-${
                 item.value
               }-${key}`;
+              const value = get(config, item.field);
               return (
                 <WzConfigurationSetting
                   key={keyItem}
@@ -63,8 +65,8 @@ class WzSettingsGroup extends Component {
                   label={item.label}
                   value={
                     item.render
-                      ? item.render(config[item.field])
-                      : config[item.field]
+                      ? item.render(value)
+                      : value
                   }
                 />
               );


### PR DESCRIPTION
## Description

This PR adds some settings related to the `auth.force` to the `Registration service` of `Management/Configuration` section

![image](https://user-images.githubusercontent.com/34042064/150178655-ea649aa0-7d2b-41a9-b6cb-e7d605d84b1f.png)

## Test
- Go to `Management/Configuration/Registration service and review the new settings are displayed as expected when are defined.

Related to #3597

