### PR TITLE
Override the navigation drawer `Home` link behaviour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to the Wazuh app project will be documented in this file.
 
+## Wazuh v4.2.5 - Kibana 7.10.2, 7.11.2, 7.12.1, 7.13.4, 7.14.2 - Revision 4207
+
+### Added
+
+- Redirect the Home link in the navigation drawer to the Wazuh App [#3709](https://github.com/wazuh/wazuh-kibana-app/pull/3709)
+
+
 ## Wazuh v4.2.5 - Kibana 7.10.2, 7.11.2, 7.12.1, 7.13.4, 7.14.2 - Revision 4206
 
 ### Added

--- a/kibana.json
+++ b/kibana.json
@@ -1,6 +1,6 @@
 {
   "id": "wazuh",
-  "version": "4.2.5-4206-1",
+  "version": "4.2.5-4207-1",
   "kibanaVersion": "kibana",
   "configPath": [
     "wazuh"

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "wazuh",
   "version": "4.2.5",
-  "revision": "4206-1",
-  "code": "4206-1",
+  "revision": "4207-1",
+  "code": "4207-1",
   "kibana": {
     "version": "7.10.2"
   },

--- a/public/assets/custom-style.js
+++ b/public/assets/custom-style.js
@@ -121,5 +121,16 @@ let observer = new MutationObserver((mutations) => {
  * 
  * */
 function changeHomeLink(eLink) {
+  const parent = eLink.parentNode;
+  const wrapper = document.createElement('a');
   eLink.setAttribute('href', '/app/wazuh');
+  wrapper.setAttribute('href', '/app/wazuh');
+  wrapper.addEventListener('click', function (ev) {
+    ev.stopPropagation();
+    ev.preventDefault();
+    window.location.href = '/app/wazuh';
+    return
+  }, true);
+  parent.replaceChild(wrapper, eLink);
+  wrapper.appendChild(eLink);
 }

--- a/public/assets/custom-style.js
+++ b/public/assets/custom-style.js
@@ -45,21 +45,24 @@ const observerMainApp = new MutationObserver((mutations) => {
       $(mutation.target).find('a[href$="app/kibana_overview"]').parent().addClass('hide');
     }
     
-    let homeLink
     /**
      * Fix top-left Logo home link
      */
-    homeLink = document.querySelector('#globalHeaderBars a.euiHeaderLogo[href$="/app/home"]');
-    if (homeLink) {
-      changeHomeLink(homeLink);
+    const logoHomeLink = document.querySelector(
+      '#globalHeaderBars a.euiHeaderLogo[href$="/app/home"]'
+    )
+    if (logoHomeLink) {
+      changeHomeLink(logoHomeLink);
     }
 
     /**
      * Fix navigation drawer Home link
      */
-    homeLink = document.querySelector('nav a.euiListGroupItem__button[href$="/app/home"]');
-    if (homeLink) {
-      changeHomeLink(homeLink);
+    const menuHomeLink = document.querySelector(
+      'nav a.euiListGroupItem__button[href$="/app/home"]'
+    )
+    if (menuHomeLink) {
+      changeHomeLink(menuHomeLink);
     }
   })
 });

--- a/public/assets/custom-style.js
+++ b/public/assets/custom-style.js
@@ -44,10 +44,20 @@ const observerMainApp = new MutationObserver((mutations) => {
       mutation.target.className == 'hide-for-sharing headerGlobalNav') {
       $(mutation.target).find('a[href$="app/kibana_overview"]').parent().addClass('hide');
     }
+    
+    let homeLink
     /**
      * Fix top-left Logo home link
      */
-    const homeLink = document.querySelector('#globalHeaderBars a.euiHeaderLogo[href$="/app/home"]');
+    homeLink = document.querySelector('#globalHeaderBars a.euiHeaderLogo[href$="/app/home"]');
+    if (homeLink) {
+      changeHomeLink(homeLink);
+    }
+
+    /**
+     * Fix navigation drawer Home link
+     */
+    homeLink = document.querySelector('nav a.euiListGroupItem__button[href$="/app/home"]');
     if (homeLink) {
       changeHomeLink(homeLink);
     }
@@ -111,19 +121,5 @@ let observer = new MutationObserver((mutations) => {
  * 
  * */
 function changeHomeLink(eLink) {
-
-  const parent = eLink.parentNode;
-  const wrapper = document.createElement('a');
   eLink.setAttribute('href', '/app/wazuh');
-  wrapper.setAttribute('href', '/app/wazuh');
-  wrapper.addEventListener('click', function (ev) {
-    ev.stopPropagation();
-    ev.preventDefault();
-    window.location.href = '/app/wazuh';
-    return
-  }, true);
-  parent.replaceChild(wrapper, eLink);
-  wrapper.appendChild(eLink);
-
-
 }

--- a/public/assets/custom-style.js
+++ b/public/assets/custom-style.js
@@ -121,16 +121,11 @@ let observer = new MutationObserver((mutations) => {
  * 
  * */
 function changeHomeLink(eLink) {
-  const parent = eLink.parentNode;
-  const wrapper = document.createElement('a');
   eLink.setAttribute('href', '/app/wazuh');
-  wrapper.setAttribute('href', '/app/wazuh');
-  wrapper.addEventListener('click', function (ev) {
+  eLink.addEventListener('click', function (ev) {
     ev.stopPropagation();
     ev.preventDefault();
     window.location.href = '/app/wazuh';
     return
   }, true);
-  parent.replaceChild(wrapper, eLink);
-  wrapper.appendChild(eLink);
 }


### PR DESCRIPTION
Summary
---------
[This is a feature for Cloud / SaaS]
This PR changes the Home link URL in the navigation drawer with the Wazuh App URL, instead of the Kibana's Home page.

![Screenshot from 2022-02-03 14-42-44](https://user-images.githubusercontent.com/15186973/152354454-154ffdba-374f-4c48-aafc-28346bcfa3b8.png)

To test
----------
1. Check that the link redirects to `/app/wazuh` and not to `/app/home`.