### PR TITLE
Fix internal xpack user request forbidden

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,6 +133,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fixed visualization tooltip position [#3781](https://github.com/wazuh/wazuh-kibana-app/pull/3781)
 - Fixed github/office365 multi-select filters suggested values [#3787](https://github.com/wazuh/wazuh-kibana-app/pull/3787)
 - Fixed the styles on the evolution card [#3796](https://github.com/wazuh/wazuh-kibana-app/pull/3796)
+- Fixed internal user no longer needs permission to make x-pack detection request [#3831](https://github.com/wazuh/wazuh-kibana-app/pull/3831)
 
 ## Wazuh v4.2.5 - Kibana 7.10.2, 7.11.2, 7.12.1, 7.13.4, 7.14.2 - Revision 4206
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "revision": "4301-0",
   "code": "4301-0",
   "pluginPlatform": {
-    "version": "7.10.2"
+    "version": "7.16.3"
   },
   "description": "Wazuh app",
   "keywords": [

--- a/server/lib/security-factory/security-factory.ts
+++ b/server/lib/security-factory/security-factory.ts
@@ -27,6 +27,11 @@ export async function SecurityObj(
       );
       return new XpackFactory(security);
     } catch (error) {
+
+      // In case of an forbidden resource error it's still good to know if it uses xpack
+      const validErrors: [number] = [403];
+      if (validErrors.includes(error?.meta?.statusCode)) return new XpackFactory(security);
+
       return new DefaultFactory();
     }
   } else {


### PR DESCRIPTION
Hi team,

this PR fixes a rejected request to know if x-pack is active. Now it tolerates the internal user not having the resource permission and contemplates this error.

Closes #3829 

To test it
- Setup an internal user in kibana.yml which causes a 403 error in a `GET /_security/user` request 
- Make sure you login without errors
- Go to `Wazuh menu -> Security -> Role mapping` and create a new role mapping without errors
- Go to `Wazuh menu -> Modules -> Security events` and create a PDF report 
- Check the PDF report was properly created 