### PR TITLE
Fixed agents details card style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,6 +127,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fix updating the aggregation data of Panel section when changing the time filter [#3790](https://github.com/wazuh/wazuh-kibana-app/pull/3790)
 - Removed the button to remove an agent for a group in the agents' table when it is the default group [#3804](https://github.com/wazuh/wazuh-kibana-app/pull/3804)
 - Fixed internal user no longer needs permission to make x-pack detection request [#3831](https://github.com/wazuh/wazuh-kibana-app/pull/3831)
+- Fixed agents details card style [#3845](https://github.com/wazuh/wazuh-kibana-app/pull/3845)
 
 ## Wazuh v4.2.5 - Kibana 7.10.2, 7.11.2, 7.12.1, 7.13.4, 7.14.2 - Revision 4206
 

--- a/public/controllers/agent/components/agents-preview.js
+++ b/public/controllers/agent/components/agents-preview.js
@@ -221,119 +221,109 @@ export const AgentsPreview = compose(
                     </EuiCard>
                   </EuiFlexItem>
                   {this.totalAgents > 0 && (
-                    <EuiFlexItem>
+                    <EuiFlexItem grow={false} className="agents-details-card">
                       <EuiCard title description betaBadgeLabel="Details">
-                        <EuiFlexGroup>
-                          <EuiFlexItem>
-                            {this.summary && (
-                              <EuiFlexGroup className="group-details">
-                                <EuiFlexItem>
-                                  <EuiStat
-                                    title={
-                                      <EuiToolTip position="top" content="Show active agents">
-                                        <a
-                                          onClick={() => this.showAgentsWithFilters(FILTER_ACTIVE)}
-                                        >
-                                          {this.state.data[0].value}
-                                        </a>
-                                      </EuiToolTip>
-                                    }
-                                    titleSize={'s'}
-                                    description="Active"
-                                    titleColor="secondary"
-                                    className="white-space-nowrap"
-                                  />
-                                </EuiFlexItem>
-                                <EuiFlexItem>
-                                  <EuiStat
-                                    title={
-                                      <EuiToolTip position="top" content="Show disconnected agents">
-                                        <a
-                                          onClick={() =>
-                                            this.showAgentsWithFilters(FILTER_DISCONNECTED)
-                                          }
-                                        >
-                                          {this.state.data[1].value}
-                                        </a>
-                                      </EuiToolTip>
-                                    }
-                                    titleSize={'s'}
-                                    description="Disconnected"
-                                    titleColor="danger"
-                                    className="white-space-nowrap"
-                                  />
-                                </EuiFlexItem>
-                                <EuiFlexItem>
-                                  <EuiStat
-                                    title={
-                                      <EuiToolTip
-                                        position="top"
-                                        content="Show never connected agents"
-                                      >
-                                        <a
-                                          onClick={() =>
-                                            this.showAgentsWithFilters(FILTER_NEVER_CONNECTED)
-                                          }
-                                        >
-                                          {this.state.data[2].value}
-                                        </a>
-                                      </EuiToolTip>
-                                    }
-                                    titleSize={'s'}
-                                    description="Never connected"
-                                    titleColor="subdued"
-                                    className="white-space-nowrap"
-                                  />
-                                </EuiFlexItem>
-                                <EuiFlexItem>
-                                  <EuiStat
-                                    title={`${this.agentsCoverity.toFixed(2)}%`}
-                                    titleSize={'s'}
-                                    description="Agents coverage"
-                                    className="white-space-nowrap"
-                                  />
-                                </EuiFlexItem>
-                              </EuiFlexGroup>
-                            )}
-                            <EuiFlexGroup className="mt-0">
-                              {this.lastAgent && (
-                                <EuiFlexItem>
-                                  <EuiStat
-                                    className="euiStatLink"
-                                    title={
-                                      <EuiToolTip position="top" content="View agent details">
-                                        <a onClick={() => this.showLastAgent()}>
-                                          {this.lastAgent.name}
-                                        </a>
-                                      </EuiToolTip>
-                                    }
-                                    titleSize="s"
-                                    description="Last registered agent"
-                                    titleColor="primary"
-                                    className="pb-12 white-space-nowrap"
-                                  />
-                                </EuiFlexItem>
-                              )}
-                              {this.mostActiveAgent && (
-                                <EuiFlexItem>
-                                  <EuiStat
-                                    className={this.mostActiveAgent.name ? 'euiStatLink' : ''}
-                                    title={
-                                      <EuiToolTip position="top" content="View agent details">
-                                        <a onClick={() => this.showMostActiveAgent()}>
-                                          {this.mostActiveAgent.name || '-'}
-                                        </a>
-                                      </EuiToolTip>
-                                    }
-                                    className="white-space-nowrap"
-                                    titleSize="s"
-                                    description="Most active agent"
-                                    titleColor="primary"
-                                  />
-                                </EuiFlexItem>
-                              )}
-                            </EuiFlexGroup>
-                          </EuiFlexItem>
+                        {this.summary && (
+                          <EuiFlexGroup className="group-details">
+                            <EuiFlexItem>
+                              <EuiStat
+                                title={
+                                  <EuiToolTip position="top" content="Show active agents">
+                                    <a onClick={() => this.showAgentsWithFilters(FILTER_ACTIVE)}>
+                                      {this.state.data[0].value}
+                                    </a>
+                                  </EuiToolTip>
+                                }
+                                titleSize={'s'}
+                                description="Active"
+                                titleColor="secondary"
+                                className="white-space-nowrap"
+                              />
+                            </EuiFlexItem>
+                            <EuiFlexItem>
+                              <EuiStat
+                                title={
+                                  <EuiToolTip position="top" content="Show disconnected agents">
+                                    <a
+                                      onClick={() =>
+                                        this.showAgentsWithFilters(FILTER_DISCONNECTED)
+                                      }
+                                    >
+                                      {this.state.data[1].value}
+                                    </a>
+                                  </EuiToolTip>
+                                }
+                                titleSize={'s'}
+                                description="Disconnected"
+                                titleColor="danger"
+                                className="white-space-nowrap"
+                              />
+                            </EuiFlexItem>
+                            <EuiFlexItem>
+                              <EuiStat
+                                title={
+                                  <EuiToolTip position="top" content="Show never connected agents">
+                                    <a
+                                      onClick={() =>
+                                        this.showAgentsWithFilters(FILTER_NEVER_CONNECTED)
+                                      }
+                                    >
+                                      {this.state.data[2].value}
+                                    </a>
+                                  </EuiToolTip>
+                                }
+                                titleSize={'s'}
+                                description="Never connected"
+                                titleColor="subdued"
+                                className="white-space-nowrap"
+                              />
+                            </EuiFlexItem>
+                            <EuiFlexItem>
+                              <EuiStat
+                                title={`${this.agentsCoverity.toFixed(2)}%`}
+                                titleSize={'s'}
+                                description="Agents coverage"
+                                className="white-space-nowrap"
+                              />
+                            </EuiFlexItem>
+                          </EuiFlexGroup>
+                        )}
+                        <EuiFlexGroup className="mt-0">
+                          {this.lastAgent && (
+                            <EuiFlexItem className="flex-45">
+                              <EuiStat
+                                className="euiStatLink last-agents-link"
+                                title={
+                                  <EuiToolTip position="top" content="View agent details">
+                                    <a onClick={() => this.showLastAgent()}>
+                                      {this.lastAgent.name}
+                                    </a>
+                                  </EuiToolTip>
+                                }
+                                titleSize="s"
+                                description="Last registered agent"
+                                titleColor="primary"
+                              />
+                            </EuiFlexItem>
+                          )}
+                          {this.mostActiveAgent && (
+                            <EuiFlexItem className="flex-45">
+                              <EuiStat
+                                className={this.mostActiveAgent.name ? 'euiStatLink' : ''}
+                                title={
+                                  <EuiToolTip position="top" content="View agent details">
+                                    <a onClick={() => this.showMostActiveAgent()}>
+                                      {this.mostActiveAgent.name || '-'}
+                                    </a>
+                                  </EuiToolTip>
+                                }
+                                className="last-agents-link"
+                                titleSize="s"
+                                description="Most active agent"
+                                titleColor="primary"
+                              />
+                            </EuiFlexItem>
+                          )}
                         </EuiFlexGroup>
                       </EuiCard>
                     </EuiFlexItem>

--- a/public/styles/common.scss
+++ b/public/styles/common.scss
@@ -1555,18 +1555,38 @@ div.euiPopover__panel.euiPopover__panel-isOpen.euiPopover__panel--bottom.wz-menu
   }
 }
 
+.agents-details-card {
+  .last-agents-link {
+    .euiToolTipAnchor {
+      white-space: nowrap;
+      max-width: 100%;
+      text-overflow: ellipsis;
+      overflow: hidden;
+    }
+  }
+}
+
+
 @media (min-width: 1600px) {
   .agents-evolution-visualization{
     width: 35vw;
   }
+
+  .agents-details-card {
+    width: 55vw;
+  }
+
 }
 
 @media (max-width: 1599px) {
   .agents-evolution-visualization{
     width: 30vw;
   }
-}
 
+  .agents-details-card {
+    width: 45vw;
+  }
+}
 
 @media (max-width: 1439px) {
   .agents-evolution-visualization{
@@ -1579,7 +1599,11 @@ div.euiPopover__panel.euiPopover__panel-isOpen.euiPopover__panel--bottom.wz-menu
     flex-wrap: wrap;
   }
   .agents-evolution-visualization{
-    width: 92vw;
+    width: 100vw;
+  }
+
+  .agents-details-card {
+    width: 100vw;
   }
   .agents-status-pie{
     flex-grow: 1 !important;


### PR DESCRIPTION
Hi Team,
This PR resolves a wrong width from the agent's details card. 
Because of that, In some resolutions, the agent's evolution visualization is off the screen.

Closes #3837 