### PR TITLE
[FEAT] [Deploy agent guide] Add step to start the agent on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Added a new workflow for create wazuh packages [#3742](https://github.com/wazuh/wazuh-kibana-app/pull/3742)
 - Run `template` and `fields` checks in the health check depends on the app configuration [#3783](https://github.com/wazuh/wazuh-kibana-app/pull/3783)
 - Added a toast message when there is an error creating a new group [#3804](https://github.com/wazuh/wazuh-kibana-app/pull/3804)
+- Added a step to start the agent to the deploy new Windowns agent guide [#3846](https://github.com/wazuh/wazuh-kibana-app/pull/3846)
 
 ### Changed
 

--- a/public/controllers/agent/components/register-agent.js
+++ b/public/controllers/agent/components/register-agent.js
@@ -143,6 +143,7 @@ export const RegisterAgent = withErrorBoundary(
         rpm: this.systemSelector(),
         deb: this.systemSelector(),
         macos: 'sudo /Library/Ossec/bin/wazuh-control start',
+        win: 'NET START WazuhSvc'
       };
     }
 

--- a/public/controllers/agent/components/register-agent.js
+++ b/public/controllers/agent/components/register-agent.js
@@ -112,10 +112,6 @@ const sysButtons = [
   },
 ];
 
-const pTextCheckConnectionStyle = {
-  marginTop: '3em',
-};
-
 export const RegisterAgent = withErrorBoundary(
 
   class RegisterAgent extends Component {
@@ -398,7 +394,7 @@ export const RegisterAgent = withErrorBoundary(
       const appVersionMajorDotMinor = this.state.wazuhVersion.split('.').slice(0, 2).join('.');
       const urlCheckConnectionDocumentation = `https://documentation.wazuh.com/${appVersionMajorDotMinor}/user-manual/agents/agent-connection.html`;
       const textAndLinkToCheckConnectionDocumentation = (
-        <p style={pTextCheckConnectionStyle}>
+        <p>
           To verify the connection with the Manager, please follow this{' '}
           <a href={urlCheckConnectionDocumentation} target="_blank">
             document.
@@ -576,7 +572,7 @@ export const RegisterAgent = withErrorBoundary(
                     )}
                   </EuiCopy>
                 </div>
-                <EuiSpacer />
+                <EuiSpacer size='s'/>
                 {textAndLinkToCheckConnectionDocumentation}
               </EuiText>
             </Fragment>
@@ -601,7 +597,7 @@ export const RegisterAgent = withErrorBoundary(
                     )}
                   </EuiCopy>
                 </div>
-                <EuiSpacer />
+                <EuiSpacer size='s'/>
                 {textAndLinkToCheckConnectionDocumentation}
               </EuiText>
             </Fragment>


### PR DESCRIPTION
## Description

This PR adds a step to the deploy new agent guide to starting the agent on Windows.
 
 ![image](https://user-images.githubusercontent.com/34042064/154049407-764485ba-56e2-4f7f-bfa4-631cebeadd2f.png)

## Changes

- Added the step to start the agent for the Windows guide
- Reduced the vertical space to the info callout of installing the Windows agent

## Test
- Review the step to start the agent is displayed for the Windows OS

Closes #3843