### PR TITLE
[BUG][Tools/Api Console] Parse error when using  character on the line start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to the Wazuh app project will be documented in this file.
 
+## Wazuh v4.3.0 - Kibana 7.10.2 , 7.16.3, 7.17.0 - Revision 4302
+
+### Fixed
+- Parse error when using `#` character not at the beginning of the line [#3877](https://github.com/wazuh/wazuh-kibana-app/pull/3877)
+
 ## Wazuh v4.3.0 - Kibana 7.10.2 , 7.16.3, 7.17.0 - Revision 4301
 
 ### Added

--- a/public/controllers/dev-tools/dev-tools.ts
+++ b/public/controllers/dev-tools/dev-tools.ts
@@ -158,10 +158,9 @@ export class DevToolsController {
     try {
       const currentState = this.apiInputBox.getValue().toString();
       AppState.setCurrentDevTools(currentState);
-
       const tmpgroups = [];
       const splitted = currentState
-        .split(/[\r\n]+(?=(?:GET|PUT|POST|DELETE|#)\b)/gm)
+        .split(/[\r\n]+(?=(?:GET|PUT|POST|DELETE)\b)/gm)
         .filter(item => item.replace(/\s/g, '').length);
 
       let start = 0;
@@ -170,7 +169,7 @@ export class DevToolsController {
       const slen = splitted.length;
       for (let i = 0; i < slen; i++) {
         let tmp = splitted[i].split('\n');
-        if (Array.isArray(tmp)) tmp = tmp.filter(item => !item.includes('#'));
+        if (Array.isArray(tmp)) tmp = tmp.filter(item => !item.startsWith('#'));
         const cursor = this.apiInputBox.getSearchCursor(splitted[i], null, {
           multiline: true
         });
@@ -205,7 +204,7 @@ export class DevToolsController {
 
         const tmplen = tmp.length;
         for (let j = 1; j < tmplen; ++j) {
-          if (!!tmp[j] && !tmp[j].includes('#')) {
+          if (!!tmp[j] && !tmp[j].startsWith('#')) {
             tmpRequestTextJson += tmp[j];
           }
         }


### PR DESCRIPTION
## Description
This PR fixes when the `#` character is used not at the beginning of the line. This solves a parse error when using the character in the `password` field to create a new user.

## Tests
- Go to `Tools/API Console` and set the next query:
```
POST /security/users
{
  "username": "wazuh_test_user",
  "password": "Abcdef1#"
}
```

The query shouldn't display the parse error.

Closes #3810