### PR TITLE
Rollback modules hard coded log filter

### DIFF
--- a/public/controllers/management/components/management/mg-logs/logs.js
+++ b/public/controllers/management/components/management/mg-logs/logs.js
@@ -139,19 +139,13 @@ export default compose(
     }
 
     async initDaemonsList(logsPath) {
-      const daemonsNotIncluded = [
-        'wazuh-modulesd:task-manager',
-        'wazuh-modulesd:agent-upgrade'
-      ]
       try {
         const path = logsPath + '/summary';
         const data = await WzRequest.apiReq('GET', path, {});
         const formattedData = (((data || {}).data || {}).data || {}).affected_items;
         const daemonsList = [...['all']];
         for (const daemon of formattedData) {
-          if(!daemonsNotIncluded.includes(Object.keys(daemon)[0])){
             daemonsList.push(Object.keys(daemon)[0]);
-          }
         }
         this.setState({ daemonsList });
       } catch (error) {


### PR DESCRIPTION
Hi team,

this PR rollbacks modules hard coded log filter that was temporary added in a [previous issue](https://github.com/wazuh/wazuh-kibana-app/pull/3710) until Wazuh API was changed.

Closes #3879 

To test it:

- Verify all daemons in the dropdown are loading properly in `Management -> Logs`

![image](https://user-images.githubusercontent.com/9343732/156605815-b43828d0-a688-4874-95b5-b14e32e60a55.png)
