### PR TITLE
Samplealerts warning readonly users

### DIFF
--- a/server/controllers/wazuh-elastic.ts
+++ b/server/controllers/wazuh-elastic.ts
@@ -613,7 +613,7 @@ export class WazuhElasticCtrl {
     try {
       // Check if wazuh sample alerts index exists
       const results = await Promise.all(Object.keys(WAZUH_SAMPLE_ALERTS_CATEGORIES_TYPE_ALERTS)
-        .map((category) => context.core.elasticsearch.client.asCurrentUser.indices.exists({
+        .map((category) => context.core.elasticsearch.client.asInternalUser.indices.exists({
           index: this.buildSampleIndexByCategory(category)
         })));
       return response.ok({
@@ -635,7 +635,7 @@ export class WazuhElasticCtrl {
     try {
       const sampleAlertsIndex = this.buildSampleIndexByCategory(request.params.category);
       // Check if wazuh sample alerts index exists
-      const existsSampleIndex = await context.core.elasticsearch.client.asCurrentUser.indices.exists({
+      const existsSampleIndex = await context.core.elasticsearch.client.asInternalUser.indices.exists({
         index: sampleAlertsIndex
       });
       return response.ok({


### PR DESCRIPTION
Hi team,
This PR resolves an error on the sample alerts 3620 component when the currentUser doesn't have permissions for index patterns.

Closes #3620 

Step to test:
1. Login with read-only user (sample alerts indexes)
2. Navigate to any Dashboard and check if the warning appears.
