### PR TITLE
Added status column to Vulnerabilities events

### DIFF
--- a/public/components/common/modules/events-selected-fields.js
+++ b/public/components/common/modules/events-selected-fields.js
@@ -87,7 +87,8 @@ export const EventsSelectedFiles = {
     'agent.name',
     'data.vulnerability.package.name',
     'data.vulnerability.cve',
-    'data.vulnerability.severity'
+    'data.vulnerability.severity',
+    'data.vulnerability.status'
   ],
   virustotal: [
     'agent.name',


### PR DESCRIPTION
Hi team,

this PR adds `status` column to Agents / Vulnerabilities / Events

Closes #3884 

To test it go to _Agents / Vulnerabilities / Events_ and check the existence of the `Status` column