### PR TITLE
Labels removed in pie chart

### DIFF
--- a/server/integration-files/visualizations/agents/agents-audit.ts
+++ b/server/integration-files/visualizations/agents/agents-audit.ts
@@ -349,6 +349,7 @@ export default [
           addLegend: true,
           legendPosition: 'right',
           isDonut: true,
+          labels: { show: false },
         },
         aggs: [
           { id: '1', enabled: true, type: 'count', schema: 'metric', params: {} },
@@ -387,6 +388,7 @@ export default [
           addLegend: true,
           legendPosition: 'right',
           isDonut: true,
+          labels: { show: false },
         },
         aggs: [
           { id: '1', enabled: true, type: 'count', schema: 'metric', params: {} },
@@ -528,6 +530,7 @@ export default [
           addLegend: true,
           legendPosition: 'right',
           isDonut: true,
+          labels: { show: false },
         },
         aggs: [
           { id: '1', enabled: true, type: 'count', schema: 'metric', params: {} },

--- a/server/integration-files/visualizations/agents/agents-fim.ts
+++ b/server/integration-files/visualizations/agents/agents-fim.ts
@@ -23,7 +23,7 @@ export default [
           addLegend: false,
           legendPosition: 'right',
           isDonut: true,
-          labels: { show: true, values: true, last_level: true, truncate: 100 },
+          labels: { show: false },
         },
         aggs: [
           { id: '1', enabled: true, type: 'count', schema: 'metric', params: {} },
@@ -71,7 +71,7 @@ export default [
           addLegend: false,
           legendPosition: 'right',
           isDonut: true,
-          labels: { show: true, values: true, last_level: true, truncate: 100 },
+          labels: { show: false },
         },
         aggs: [
           { id: '1', enabled: true, type: 'count', schema: 'metric', params: {} },
@@ -245,6 +245,7 @@ export default [
           addLegend: true,
           legendPosition: 'right',
           isDonut: true,
+          labels: { show: false },
         },
         aggs: [
           { id: '1', enabled: true, type: 'count', schema: 'metric', params: {} },
@@ -316,6 +317,7 @@ export default [
           addLegend: true,
           legendPosition: 'right',
           isDonut: true,
+          labels: { show: false },
         },
         aggs: [
           { id: '1', enabled: true, type: 'count', schema: 'metric', params: {} },
@@ -381,6 +383,7 @@ export default [
           addLegend: true,
           legendPosition: 'right',
           isDonut: true,
+          labels: { show: false },
         },
         aggs: [
           { id: '1', enabled: true, type: 'count', schema: 'metric', params: {} },

--- a/server/integration-files/visualizations/agents/agents-gdpr.ts
+++ b/server/integration-files/visualizations/agents/agents-gdpr.ts
@@ -23,6 +23,7 @@ export default [
           addLegend: true,
           legendPosition: 'right',
           isDonut: true,
+          labels: { show: false },
         },
         aggs: [
           { id: '1', enabled: true, type: 'count', schema: 'metric', params: {} },
@@ -61,6 +62,7 @@ export default [
           addLegend: true,
           legendPosition: 'right',
           isDonut: true,
+          labels: { show: false },
         },
         aggs: [
           { id: '1', enabled: true, type: 'count', schema: 'metric', params: {} },
@@ -99,6 +101,7 @@ export default [
           addLegend: true,
           legendPosition: 'right',
           isDonut: true,
+          labels: { show: false },
         },
         aggs: [
           { id: '1', enabled: true, type: 'count', schema: 'metric', params: {} },
@@ -137,7 +140,7 @@ export default [
           addLegend: false,
           legendPosition: 'right',
           isDonut: true,
-          labels: { show: true, values: true, last_level: true, truncate: 100 },
+          labels: { show: false },
         },
         aggs: [
           { id: '1', enabled: true, type: 'count', schema: 'metric', params: {} },

--- a/server/integration-files/visualizations/agents/agents-nist.ts
+++ b/server/integration-files/visualizations/agents/agents-nist.ts
@@ -81,7 +81,7 @@ export default [
           addLegend: true,
           legendPosition: 'right',
           isDonut: true,
-          labels: { show: false, values: true, last_level: true, truncate: 100 },
+          labels: { show: false },
           dimensions: {
             metric: { accessor: 0, format: { id: 'number' }, params: {}, aggType: 'count' },
           },
@@ -264,7 +264,7 @@ export default [
           addLegend: false,
           legendPosition: 'right',
           isDonut: true,
-          labels: { show: true, values: true, last_level: true, truncate: 100 },
+          labels: { show: false },
         },
         aggs: [
           { id: '1', enabled: true, type: 'count', schema: 'metric', params: {} },

--- a/server/integration-files/visualizations/agents/agents-oscap.ts
+++ b/server/integration-files/visualizations/agents/agents-oscap.ts
@@ -245,6 +245,7 @@ export default [
           addLegend: true,
           legendPosition: 'right',
           isDonut: true,
+          labels: { show: false },
         },
         aggs: [
           { id: '1', enabled: true, type: 'count', schema: 'metric', params: {} },
@@ -283,6 +284,7 @@ export default [
           addLegend: true,
           legendPosition: 'right',
           isDonut: true,
+          labels: { show: false },
         },
         aggs: [
           { id: '1', enabled: true, type: 'count', schema: 'metric', params: {} },
@@ -379,6 +381,7 @@ export default [
           addLegend: true,
           legendPosition: 'right',
           isDonut: true,
+          labels: { show: false },
         },
         aggs: [
           { id: '1', enabled: true, type: 'count', schema: 'metric', params: {} },
@@ -470,6 +473,7 @@ export default [
           addLegend: true,
           legendPosition: 'right',
           isDonut: true,
+          labels: { show: false },
         },
         aggs: [
           { id: '1', enabled: true, type: 'count', schema: 'metric', params: {} },
@@ -671,6 +675,7 @@ export default [
           addLegend: true,
           legendPosition: 'right',
           isDonut: true,
+          labels: { show: false },
         },
         aggs: [
           { id: '1', enabled: true, type: 'count', schema: 'metric', params: {} },
@@ -736,6 +741,7 @@ export default [
           addLegend: true,
           legendPosition: 'right',
           isDonut: true,
+          labels: { show: false },
         },
         aggs: [
           { id: '1', enabled: true, type: 'count', schema: 'metric', params: {} },

--- a/server/integration-files/visualizations/agents/agents-pci.ts
+++ b/server/integration-files/visualizations/agents/agents-pci.ts
@@ -23,6 +23,7 @@ export default [
           addLegend: true,
           legendPosition: 'right',
           isDonut: true,
+          labels: { show: false },
         },
         aggs: [
           { id: '1', enabled: true, type: 'count', schema: 'metric', params: {} },
@@ -61,6 +62,7 @@ export default [
           addLegend: true,
           legendPosition: 'right',
           isDonut: true,
+          labels: { show: false },
         },
         aggs: [
           { id: '1', enabled: true, type: 'count', schema: 'metric', params: {} },
@@ -99,6 +101,7 @@ export default [
           addLegend: true,
           legendPosition: 'right',
           isDonut: true,
+          labels: { show: false },
         },
         aggs: [
           { id: '1', enabled: true, type: 'count', schema: 'metric', params: {} },
@@ -137,7 +140,7 @@ export default [
           addLegend: false,
           legendPosition: 'right',
           isDonut: true,
-          labels: { show: true, values: true, last_level: true, truncate: 100 },
+          labels: { show: false },
         },
         aggs: [
           { id: '1', enabled: true, type: 'count', schema: 'metric', params: {} },

--- a/server/integration-files/visualizations/agents/agents-tsc.ts
+++ b/server/integration-files/visualizations/agents/agents-tsc.ts
@@ -23,6 +23,7 @@ export default [
           addLegend: true,
           legendPosition: 'right',
           isDonut: true,
+          labels: { show: false },
         },
         aggs: [
           { id: '1', enabled: true, type: 'count', schema: 'metric', params: {} },
@@ -61,6 +62,7 @@ export default [
           addLegend: true,
           legendPosition: 'right',
           isDonut: true,
+          labels: { show: false },
         },
         aggs: [
           { id: '1', enabled: true, type: 'count', schema: 'metric', params: {} },
@@ -99,6 +101,7 @@ export default [
           addLegend: true,
           legendPosition: 'right',
           isDonut: true,
+          labels: { show: false },
         },
         aggs: [
           { id: '1', enabled: true, type: 'count', schema: 'metric', params: {} },
@@ -137,7 +140,7 @@ export default [
           addLegend: false,
           legendPosition: 'right',
           isDonut: true,
-          labels: { show: true, values: true, last_level: true, truncate: 100 },
+          labels: { show: false },
         },
         aggs: [
           { id: '1', enabled: true, type: 'count', schema: 'metric', params: {} },

--- a/server/integration-files/visualizations/overview/overview-audit.ts
+++ b/server/integration-files/visualizations/overview/overview-audit.ts
@@ -23,6 +23,7 @@ export default [
           addLegend: true,
           legendPosition: 'right',
           isDonut: true,
+          labels: { show: false },
         },
         aggs: [
           { id: '1', enabled: true, type: 'count', schema: 'metric', params: {} },
@@ -61,6 +62,7 @@ export default [
           addLegend: true,
           legendPosition: 'right',
           isDonut: true,
+          labels: { show: false },
         },
         aggs: [
           { id: '1', enabled: true, type: 'count', schema: 'metric', params: {} },
@@ -99,6 +101,7 @@ export default [
           addLegend: true,
           legendPosition: 'right',
           isDonut: true,
+          labels: { show: false },
         },
         aggs: [
           { id: '1', enabled: true, type: 'count', schema: 'metric', params: {} },
@@ -137,6 +140,7 @@ export default [
           addLegend: true,
           legendPosition: 'right',
           isDonut: true,
+          labels: { show: false },
         },
         aggs: [
           { id: '1', enabled: true, type: 'count', schema: 'metric', params: {} },

--- a/server/integration-files/visualizations/overview/overview-gdpr.ts
+++ b/server/integration-files/visualizations/overview/overview-gdpr.ts
@@ -348,7 +348,8 @@ export default [
           addTooltip: true,
           addLegend: true,
           legendPosition: 'right',
-          isDonut: false,
+          isDonut: true,
+          labels: { show: false },
         },
         aggs: [
           { id: '1', enabled: true, type: 'count', schema: 'metric', params: {} },

--- a/server/integration-files/visualizations/overview/overview-oscap.ts
+++ b/server/integration-files/visualizations/overview/overview-oscap.ts
@@ -170,9 +170,15 @@ export default [
     _source: {
       title: 'Agents',
       visState: JSON.stringify({
-        params: { isDonut: false, shareYAxis: true, addTooltip: true, addLegend: true },
         listeners: {},
         type: 'pie',
+        params: { 
+          isDonut: true, 
+          shareYAxis: true, 
+          addTooltip: true, 
+          addLegend: true,
+          labels: { show: false }
+        },
         aggs: [
           { type: 'count', enabled: true, id: '1', params: {}, schema: 'metric' },
           {
@@ -231,11 +237,12 @@ export default [
       title: 'Profiles',
       visState: JSON.stringify({
         params: {
-          isDonut: false,
+          isDonut: true,
           legendPosition: 'right',
           shareYAxis: true,
           addTooltip: true,
           addLegend: true,
+          labels: { show: false }
         },
         listeners: {},
         type: 'pie',
@@ -302,11 +309,12 @@ export default [
       title: 'Content',
       visState: JSON.stringify({
         params: {
-          isDonut: false,
+          isDonut: true,
           legendPosition: 'right',
           shareYAxis: true,
           addTooltip: true,
           addLegend: true,
+          labels: { show: false }
         },
         listeners: {},
         type: 'pie',
@@ -375,6 +383,7 @@ export default [
           addLegend: true,
           legendPosition: 'right',
           isDonut: true,
+          labels: { show: false },
         },
         aggs: [
           { id: '1', enabled: true, type: 'count', schema: 'metric', params: {} },
@@ -569,6 +578,7 @@ export default [
           addLegend: true,
           legendPosition: 'right',
           isDonut: true,
+          labels: { show: false },
         },
         aggs: [
           { id: '1', enabled: true, type: 'count', schema: 'metric', params: {} },
@@ -634,6 +644,7 @@ export default [
           addLegend: true,
           legendPosition: 'right',
           isDonut: true,
+          labels: { show: false },
         },
         aggs: [
           { id: '1', enabled: true, type: 'count', schema: 'metric', params: {} },

--- a/server/integration-files/visualizations/overview/overview-pci.ts
+++ b/server/integration-files/visualizations/overview/overview-pci.ts
@@ -348,7 +348,8 @@ export default [
           addTooltip: true,
           addLegend: true,
           legendPosition: 'right',
-          isDonut: false,
+          isDonut: true,
+          labels: { show: false }
         },
         aggs: [
           { id: '1', enabled: true, type: 'count', schema: 'metric', params: {} },

--- a/server/integration-files/visualizations/overview/overview-tsc.ts
+++ b/server/integration-files/visualizations/overview/overview-tsc.ts
@@ -348,7 +348,8 @@ export default [
           addTooltip: true,
           addLegend: true,
           legendPosition: 'right',
-          isDonut: false,
+          isDonut: true,
+          labels: { show: false },
         },
         aggs: [
           { id: '1', enabled: true, type: 'count', schema: 'metric', params: {} },


### PR DESCRIPTION
**Description:**

Labels removed in the pie chart 

**Issues Resolved:**

Missing the information of the donut TCS plot [#3799](https://github.com/wazuh/wazuh-kibana-app/issues/3799)

**Test:**

1. Navigate to `Modules > any section that has a pie chart`
2. Look at the pie chart that has no labels

**Screenshot:**

![image](https://user-images.githubusercontent.com/63758389/158442607-cfefa7c1-3445-485c-908a-6e18a6f96a85.png)
![image](https://user-images.githubusercontent.com/63758389/158442674-fe057c32-e055-469f-9334-797d37b8ee02.png)
