### PR TITLE
[FIX] [Vulnerabilities/Inventory] Table not reload when changing the selected agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,6 +133,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fixed agents details card style [#3845](https://github.com/wazuh/wazuh-kibana-app/pull/3845) [#3860](https://github.com/wazuh/wazuh-kibana-app/pull/3860)
 - Fixed routing redirection in events documents discover links [#3866](https://github.com/wazuh/wazuh-kibana-app/pull/3866)
 - Fixed health-check [#3868](https://github.com/wazuh/wazuh-kibana-app/pull/3868)
+- Fixed the table of Vulnerabilities/Inventory doesn't reload when changing the selected agent [#3901](https://github.com/wazuh/wazuh-kibana-app/pull/3901)
 
 ## Wazuh v4.2.5 - Kibana 7.10.2, 7.11.2, 7.12.1, 7.13.4, 7.14.2 - Revision 4206
 

--- a/public/components/common/tables/__snapshots__/table-wz-api.test.tsx.snap
+++ b/public/components/common/tables/__snapshots__/table-wz-api.test.tsx.snap
@@ -66,6 +66,7 @@ exports[`Table WZ API component renders correctly to match the snapshot 1`] = `
   </EuiFlexGroup>
   <TableDefault
     downloadCsv={false}
+    endpoint="/"
     error={false}
     onSearch={[Function]}
     searchBar={false}

--- a/public/components/common/tables/table-default.tsx
+++ b/public/components/common/tables/table-default.tsx
@@ -59,6 +59,12 @@ export function TableDefault({
   };
   
   useEffect(() => {
+    // Reset the page index when the endpoint changes.
+    // This will cause that onSearch function is triggered because to changes in pagination in the another effect.
+    setPagination({pageIndex: 0, pageSize: pagination.pageSize});
+  }, [endpoint]);
+  
+  useEffect(() => {
     (async function(){
       try{
         setLoading(true);

--- a/public/components/common/tables/table-default.tsx
+++ b/public/components/common/tables/table-default.tsx
@@ -23,14 +23,14 @@ export function TableDefault({
   tableInitialSortingDirection = 'asc',
   tableInitialSortingField = '',
   tableProps = {},
-  reload
+  reload,
+  endpoint
 })
   {
 
   const [loading, setLoading] = useState(false);
   const [items, setItems] = useState([]);
   const [totalItems, setTotalItems] = useState(0);
-  const [filters, setFilters] = useState([]);
   const [pagination, setPagination] = useState({
     pageIndex: 0,
     pageSize: tablePageSizeOptions[0]
@@ -62,7 +62,7 @@ export function TableDefault({
     (async function(){
       try{
         setLoading(true);
-        const { items, totalItems } = await onSearch(filters, pagination, sorting);
+        const { items, totalItems } = await onSearch(endpoint, [], pagination, sorting);
         setItems(items);
         setTotalItems(totalItems);
       }catch(error){
@@ -82,7 +82,7 @@ export function TableDefault({
       }
       setLoading(false);
     })()
-  }, [filters, pagination, sorting, reload]);
+  }, [endpoint, pagination, sorting, reload]);
 
   const tablePagination = {
     ...pagination,

--- a/public/components/common/tables/table-with-search-bar.tsx
+++ b/public/components/common/tables/table-with-search-bar.tsx
@@ -29,6 +29,7 @@ export function TableWithSearchBar({
   tableInitialSortingField = '',
   tableProps = {},
   reload,
+  endpoint,
   ...rest
 }) {
   const [loading, setLoading] = useState(false);
@@ -66,7 +67,7 @@ export function TableWithSearchBar({
     (async function () {
       try {
         setLoading(true);
-        const { items, totalItems } = await onSearch(filters, pagination, sorting);
+        const { items, totalItems } = await onSearch(endpoint, filters, pagination, sorting);
         setItems(items);
         setTotalItems(totalItems);
       } catch (error) {
@@ -86,7 +87,7 @@ export function TableWithSearchBar({
       }
       setLoading(false);
     })();
-  }, [filters, pagination, sorting, reload]);
+  }, [endpoint, filters, pagination, sorting, reload]);
 
   useEffect(() => {
     setFilters(rest.filters || []);

--- a/public/components/common/tables/table-with-search-bar.tsx
+++ b/public/components/common/tables/table-with-search-bar.tsx
@@ -64,6 +64,12 @@ export function TableWithSearchBar({
   }
 
   useEffect(() => {
+    // Reset the page index when the endpoint changes.
+    // This will cause that onSearch function is triggered because to changes in pagination in the another effect.
+    setPagination({pageIndex: 0, pageSize: pagination.pageSize});
+  }, [endpoint]);
+
+  useEffect(() => {
     (async function () {
       try {
         setLoading(true);
@@ -87,7 +93,7 @@ export function TableWithSearchBar({
       }
       setLoading(false);
     })();
-  }, [endpoint, filters, pagination, sorting, reload]);
+  }, [filters, pagination, sorting, reload]);
 
   useEffect(() => {
     setFilters(rest.filters || []);

--- a/public/components/common/tables/table-wz-api.tsx
+++ b/public/components/common/tables/table-wz-api.tsx
@@ -26,14 +26,14 @@ import { UI_ERROR_SEVERITIES } from '../../../react-services/error-orchestrator/
 import { UI_LOGGER_LEVELS } from '../../../../common/constants';
 import { getErrorOrchestrator } from '../../../react-services/common-services';
 
-export function TableWzAPI({endpoint, ...rest}){
+export function TableWzAPI({...rest}){
 
   const [totalItems, setTotalItems] = useState(0);
   const [filters, setFilters] = useState([]);
   const [isLoading, setIsLoading] = useState(false);
   const onFiltersChange = filters => typeof rest.onFiltersChange === 'function' ? rest.onFiltersChange(filters) : null;
 
-  const onSearch = useCallback(async function(filters, pagination, sorting){
+  const onSearch = useCallback(async function(endpoint, filters, pagination, sorting){
     try {
       const { pageIndex, pageSize } = pagination;
       const { field, direction } = sorting.sort;
@@ -79,7 +79,7 @@ export function TableWzAPI({endpoint, ...rest}){
           </EuiTitle>
         )}
       </EuiFlexItem>
-      {rest.downloadCsv && <ExportTableCsv endpoint={endpoint} totalItems={totalItems} filters={filters} title={rest.title}/>}
+      {rest.downloadCsv && <ExportTableCsv endpoint={rest.endpoint} totalItems={totalItems} filters={filters} title={rest.title}/>}
     </EuiFlexGroup>
   )
 


### PR DESCRIPTION
## Description
This PRs fixes that the table in `Modules/Vulnerabilities/Inventory` doesn't refresh when changing the selected agent.

## Changes
- Added `endpoint` property as dependency and parameter to redo the request. The `endpoint` property contains the agent ID.

## Tests
- Requirements:
  - 2 agents at least
  - Vulnerability module is enabled and at least one scan should be done.
- Checks
  - Go to `Modules/Vulnerabilities/Inventory` and select one agent, change the selected agent and the data of table should change