### PR TITLE
Enhance rework vulnerabilities inventory flyout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Added a toast message when there is an error creating a new group [#3804](https://github.com/wazuh/wazuh-kibana-app/pull/3804)
 - Added a step to start the agent to the deploy new Windowns agent guide [#3846](https://github.com/wazuh/wazuh-kibana-app/pull/3846)
 - Added 3 new panels to `Vulnerabilities/Inventory` [#3893](https://github.com/wazuh/wazuh-kibana-app/pull/3893)
+- Added new fields of `Vulnerabilities` to the details flyout [#3893](https://github.com/wazuh/wazuh-kibana-app/pull/3893) [#3908](https://github.com/wazuh/wazuh-kibana-app/pull/3908)
 
 ### Changed
 
@@ -75,6 +76,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Changed agent install codeblock copy button and powershell terminal warning [#3792](https://github.com/wazuh/wazuh-kibana-app/pull/3792)
 - Refactored as the plugin platform name and references is managed [#3811](https://github.com/wazuh/wazuh-kibana-app/pull/3811)
 - Removed `Dashboard` tab for the `Vulnerabilities` modules [#3893](https://github.com/wazuh/wazuh-kibana-app/pull/3893)
+- Display all fields in the `Table` tab when expading an alert row in the alerts tables of flyouts and the `Modules/Security Events/Dashboard` table [#3908](https://github.com/wazuh/wazuh-kibana-app/pull/3908)
 
 ### Fixed
 

--- a/public/components/agents/vuls/inventory/detail.tsx
+++ b/public/components/agents/vuls/inventory/detail.tsx
@@ -132,14 +132,14 @@ export class Details extends Component {
         name: 'Last full scan',
         icon: 'clock',
         link: false,
-        transformValue: formatUIDate
+        transformValue: this.beautifyDate
       },
       {
         field: 'last_partial_scan',
         name: 'Last partial scan',
         icon: 'clock',
         link: false,
-        transformValue: formatUIDate
+        transformValue: this.beautifyDate
       },
       {
         field: 'published',
@@ -163,6 +163,13 @@ export class Details extends Component {
         transformValue: this.renderExternalReferences
       },
     ];
+  }
+
+  // This method was created because Wazuh API returns 1970-01-01T00:00:00Z dates
+  // when vulnerability module is not configured
+  // its meant to render nothing when such date is received
+  beautifyDate(date: string) {
+    return ['', '1970-01-01T00:00:00Z'].includes(date) ? '-' : formatUIDate(date);
   }
 
   viewInEvents = (ev) => {

--- a/public/components/agents/vuls/inventory/detail.tsx
+++ b/public/components/agents/vuls/inventory/detail.tsx
@@ -435,7 +435,6 @@ export class Details extends Component {
             <EuiFlexItem>
               <Discover
                 kbnSearchBar
-                showAllFields={true}
                 shareFilterManager={this.discoverFilterManager}
                 initialColumns={[
                   { field: 'icon' },

--- a/public/components/agents/vuls/inventory/detail.tsx
+++ b/public/components/agents/vuls/inventory/detail.tsx
@@ -129,14 +129,14 @@ export class Details extends Component {
       },
       {
         field: 'last_full_scan',
-        name: 'Last Full Scan',
+        name: 'Last full scan',
         icon: 'clock',
         link: false,
         transformValue: formatUIDate
       },
       {
         field: 'last_partial_scan',
-        name: 'Last Partial Scan',
+        name: 'Last partial scan',
         icon: 'clock',
         link: false,
         transformValue: formatUIDate
@@ -435,6 +435,7 @@ export class Details extends Component {
             <EuiFlexItem>
               <Discover
                 kbnSearchBar
+                showAllFields={true}
                 shareFilterManager={this.discoverFilterManager}
                 initialColumns={[
                   { field: 'icon' },
@@ -451,6 +452,7 @@ export class Details extends Component {
                   { field: 'rule.description', label: 'Description' },
                   { field: 'rule.level', label: 'Level' },
                   { field: 'rule.id', label: 'Rule ID' },
+                  { field: 'data.vulnerability.status', label: 'Status', width: '20%' },
                 ]}
                 includeFilters="vulnerability"
                 implicitFilters={implicitFilters}

--- a/public/components/common/modules/discover/discover.tsx
+++ b/public/components/common/modules/discover/discover.tsx
@@ -103,6 +103,7 @@ export const Discover = compose(
       initialFilters: object[];
       query?: { language: 'kuery' | 'lucene'; query: string };
       type?: any;
+      showAllFields?: boolean;
       updateTotalHits: Function;
       includeFilters?: string;
       initialColumns: ColumnDefinition[];
@@ -323,6 +324,8 @@ export const Discover = compose(
 
     toggleDetails = (item) => {
       const itemIdToExpandedRowMap = { ...this.state.itemIdToExpandedRowMap };
+      const { showAllFields } = this.props;
+
       if (itemIdToExpandedRowMap[item._id]) {
         delete itemIdToExpandedRowMap[item._id];
         this.setState({ itemIdToExpandedRowMap });
@@ -336,6 +339,7 @@ export const Discover = compose(
               addFilter={(filter) => this.addFilter(filter)}
               addFilterOut={(filter) => this.addFilterOut(filter)}
               toggleColumn={(id) => this.addColumn(id)}
+              showAllFields={showAllFields}
             />
           </div>
         );
@@ -474,7 +478,7 @@ export const Discover = compose(
       const columns = columnsList.map((item) => {
         if (item === 'icon') {
           return {
-            width: '25px',
+            width: '2.3%',
             isExpander: true,
             render: (item) => {
               return (

--- a/public/components/common/modules/discover/discover.tsx
+++ b/public/components/common/modules/discover/discover.tsx
@@ -103,7 +103,7 @@ export const Discover = compose(
       initialFilters: object[];
       query?: { language: 'kuery' | 'lucene'; query: string };
       type?: any;
-      showAllFields?: boolean;
+      rowDetailsFields?: string[];
       updateTotalHits: Function;
       includeFilters?: string;
       initialColumns: ColumnDefinition[];
@@ -324,7 +324,7 @@ export const Discover = compose(
 
     toggleDetails = (item) => {
       const itemIdToExpandedRowMap = { ...this.state.itemIdToExpandedRowMap };
-      const { showAllFields } = this.props;
+      const { rowDetailsFields } = this.props;
 
       if (itemIdToExpandedRowMap[item._id]) {
         delete itemIdToExpandedRowMap[item._id];
@@ -339,7 +339,7 @@ export const Discover = compose(
               addFilter={(filter) => this.addFilter(filter)}
               addFilterOut={(filter) => this.addFilterOut(filter)}
               toggleColumn={(id) => this.addColumn(id)}
-              showAllFields={showAllFields}
+              rowDetailsFields={rowDetailsFields}
             />
           </div>
         );

--- a/public/components/common/modules/discover/row-details.tsx
+++ b/public/components/common/modules/discover/row-details.tsx
@@ -147,7 +147,6 @@ export class RowDetails extends Component {
 
 
   renderRows() {
-    this.props.showAllFields
     const fieldsToShow = this.props.showAllFields ?
       Object.keys(this.props.item)
       :

--- a/public/components/common/modules/discover/row-details.tsx
+++ b/public/components/common/modules/discover/row-details.tsx
@@ -95,6 +95,15 @@ export class RowDetails extends Component {
 
     const paths = (obj = {}, head = '') => {
       return Object.entries(obj)
+        .sort(([keyA], [keyB]) => {
+          if (keyA > keyB) {
+            return 1;
+          } else if (keyA < keyB) {
+            return -1;
+          } else {
+            return 0;
+          };
+        })        
         .reduce((product, [key, value]) => {
           let fullPath = addDelimiter(head, key)
           return isObject(value) ?
@@ -149,7 +158,7 @@ export class RowDetails extends Component {
   renderRows() {
     // By default show all available fields, otherwise show the fields specified in rowDetailsFields string array
     const fieldsToShow = this.props.rowDetailsFields?.length ?
-      this.props.rowDetailsFields : Object.keys(this.props.item);
+      this.props.rowDetailsFields.sort() : Object.keys(this.props.item).sort();
 
     var rows: any[] = [];
     const isString = val => typeof val === 'string';

--- a/public/components/common/modules/discover/row-details.tsx
+++ b/public/components/common/modules/discover/row-details.tsx
@@ -60,7 +60,7 @@ export class RowDetails extends Component {
       },
       syscheck: Object
     }
-    showAllFields?: boolean
+    rowDetailsFields?: string[]
   }
 
   constructor(props) {
@@ -147,10 +147,10 @@ export class RowDetails extends Component {
 
 
   renderRows() {
-    const fieldsToShow = this.props.showAllFields ?
-      Object.keys(this.props.item)
-      :
-      ['agent', 'cluster', 'manager', 'rule', 'decoder', 'syscheck', 'full_log', 'location'];
+    // By default show all available fields, otherwise show the fields specified in rowDetailsFields string array
+    const fieldsToShow = this.props.rowDetailsFields?.length ?
+      this.props.rowDetailsFields : Object.keys(this.props.item);
+
     var rows: any[] = [];
     const isString = val => typeof val === 'string';
     for (var i = 0; i < fieldsToShow.length; i++) {

--- a/public/components/common/modules/discover/row-details.tsx
+++ b/public/components/common/modules/discover/row-details.tsx
@@ -60,6 +60,7 @@ export class RowDetails extends Component {
       },
       syscheck: Object
     }
+    showAllFields?: boolean
   }
 
   constructor(props) {
@@ -146,7 +147,11 @@ export class RowDetails extends Component {
 
 
   renderRows() {
-    const fieldsToShow = ['agent', 'cluster', 'manager', 'rule', 'decoder', 'syscheck', 'full_log', 'location'];
+    this.props.showAllFields
+    const fieldsToShow = this.props.showAllFields ?
+      Object.keys(this.props.item)
+      :
+      ['agent', 'cluster', 'manager', 'rule', 'decoder', 'syscheck', 'full_log', 'location'];
     var rows: any[] = [];
     const isString = val => typeof val === 'string';
     for (var i = 0; i < fieldsToShow.length; i++) {


### PR DESCRIPTION
Hi team,

this PR show all available fields in Discover Details Flyout table. Also fixes the open row icon width in the first column when the table has few columns.
Related PR #3893 


To test it:
- Have some vulnerability alerts
- Go to Vulnerabilities / Inventory
- Select a row in the table which has events
- Open the row to see the details and verify it show all available fields for that event

![image](https://user-images.githubusercontent.com/9343732/159505422-d5073857-9b23-42bc-8d77-cffe59a299c8.png)

![vulnerabilities](https://user-images.githubusercontent.com/9343732/159676010-b5128856-ebf0-4afd-91e7-8deb136c03df.gif)

