### PR TITLE
Export a valid json

### DIFF
--- a/public/controllers/dev-tools/dev-tools.ts
+++ b/public/controllers/dev-tools/dev-tools.ts
@@ -811,10 +811,7 @@ export class DevToolsController {
           }
           else {
             this.apiOutputBox.setValue(
-              JSON.stringify((output || {}).data || {}, null, 2).replace(
-                /\\\\/g,
-                '\\'
-              )
+              JSON.stringify((output || {}).data || {}, null, 2)
             );
           }
         }


### PR DESCRIPTION
**Description:**

Removed backslash replacement to display the same answer on the page

**Issues Resolved:**

Backslash breaks the exported JSON result [#3902](https://github.com/wazuh/wazuh-kibana-app/issues/3902)

**Test:**

1. Navigate to '"API Console'
2. Retrieve results for SCA win policy `GET /sca/004/checks/sca_win_audit?result=failed`
3. Export it
4. Copy the exported into a json validator


**Screenshot:**
![image](https://user-images.githubusercontent.com/63758389/159505798-dae5aaa3-7973-4064-8471-b09632b38217.png)
![image](https://user-images.githubusercontent.com/63758389/159505895-c1f645f5-951f-4213-8282-5720647c2675.png)
