### PR TITLE
Fixed async problem when checking for unknown fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -139,6 +139,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fixed routing redirection in events documents discover links [#3866](https://github.com/wazuh/wazuh-kibana-app/pull/3866)
 - Fixed health-check [#3868](https://github.com/wazuh/wazuh-kibana-app/pull/3868)
 - Fixed the table of Vulnerabilities/Inventory doesn't reload when changing the selected agent [#3901](https://github.com/wazuh/wazuh-kibana-app/pull/3901)
+- Fixed the Events view multiple "The index pattern was refreshed successfully" toast [#3937](https://github.com/wazuh/wazuh-kibana-app/pull/3937)
 
 ## Wazuh v4.2.6 - Kibana 7.10.2, 7.11.2, 7.12.1, 7.13.0, 7.13.1, 7.13.2, 7.13.3, 7.13.4, 7.14.0, 7.14.1, 7.14.2 - Revision 4207
 

--- a/public/components/common/modules/events.tsx
+++ b/public/components/common/modules/events.tsx
@@ -172,9 +172,12 @@ export const Events = compose(
       const discoverTableRows = document.querySelectorAll(`.kbn-table tbody tr.kbnDocTable__row`);
       const rowIndex = Array.from(discoverTableRows).indexOf(rowTable);
       const rowDetailsFields = mutation.addedNodes[0].querySelectorAll('.kbnDocViewer__field');
+      let hasUnknownFields = false;
       if (rowDetailsFields) {
-        rowDetailsFields.forEach((rowDetailField) => {
-          this.checkUnknownFields(rowDetailField);
+        rowDetailsFields.forEach(async (rowDetailField, i) => {
+          //check for unknown fields until 1 unknown field is found
+          if (!hasUnknownFields && this.checkUnknownFields(rowDetailField))
+            hasUnknownFields = true;
           const fieldName = rowDetailField.childNodes[0].childNodes[1].textContent || '';
           const fieldCell =
             rowDetailField.parentNode.childNodes &&
@@ -190,15 +193,16 @@ export const Events = compose(
             options
           );
         });
+        if (hasUnknownFields) {
+          this.refreshKnownFields();
+        }
       }
     }
-
-    checkUnknownFields(rowDetailField) {
+  
+    async checkUnknownFields(rowDetailField) {
       const fieldCell =
         rowDetailField.parentNode.childNodes && rowDetailField.parentNode.childNodes[2];
-      if (fieldCell.querySelector('svg[data-test-subj="noMappingWarning"]')) {
-        this.refreshKnownFields();
-      }
+      return (fieldCell.querySelector('svg[data-test-subj="noMappingWarning"]'))
     }
 
     refreshKnownFields = async () => {

--- a/public/components/common/modules/events.tsx
+++ b/public/components/common/modules/events.tsx
@@ -39,20 +39,20 @@ export const Events = compose(
   class Events extends Component {
     intervalCheckExistsDiscoverTableTime: number = 200;
     isMount: boolean;
+    hasRefreshedKnownFields: boolean;
+    isRefreshing: boolean;
     state: {
       flyout: false | { component: any; props: any };
       discoverRowsData: any[];
-      hasRefreshedKnownFields: boolean;
-      isRefreshing: boolean;
     };
     constructor(props) {
       super(props);
       this.isMount = true;
+      this.hasRefreshedKnownFields = false;
+      this.isRefreshing = false;
       this.state = {
         flyout: false,
         discoverRowsData: [],
-        hasRefreshedKnownFields: false,
-        isRefreshing: false,
       };
     }
 
@@ -206,19 +206,21 @@ export const Events = compose(
     }
 
     refreshKnownFields = async () => {
-      if (!this.state.hasRefreshedKnownFields) {
+      if (!this.hasRefreshedKnownFields) {
         try {
-          this.setState({ hasRefreshedKnownFields: true, isRefreshing: true });
+          this.hasRefreshedKnownFields = true;
+          this.isRefreshing = true;
+          
           if (satisfyPluginPlatformVersion('<7.11')) {
             await PatternHandler.refreshIndexPattern();
           }
-          this.setState({ isRefreshing: false });
+          this.isRefreshing = false;
           this.reloadToast();
         } catch (error) {
-          this.setState({ isRefreshing: false });
+          this.isRefreshing = false;
           throw error;
         }
-      } else if (this.state.isRefreshing) {
+      } else if (this.isRefreshing) {
         await new Promise((r) => setTimeout(r, 150));
         await this.refreshKnownFields();
       }

--- a/public/components/common/modules/events.tsx
+++ b/public/components/common/modules/events.tsx
@@ -199,7 +199,7 @@ export const Events = compose(
       }
     }
   
-    async checkUnknownFields(rowDetailField) {
+    checkUnknownFields(rowDetailField) {
       const fieldCell =
         rowDetailField.parentNode.childNodes && rowDetailField.parentNode.childNodes[2];
       return (fieldCell.querySelector('svg[data-test-subj="noMappingWarning"]'))

--- a/public/components/visualize/wz-visualize.js
+++ b/public/components/visualize/wz-visualize.js
@@ -56,10 +56,11 @@ export const WzVisualize = compose(
       this.state = {
         visualizations: !!props.isAgent ? agentVisualizations : visualizations,
         expandedVis: false,
-        hasRefreshedKnownFields: false,
         refreshingKnownFields: [],
         refreshingIndex: true,
       };
+      this.hasRefreshedKnownFields = false;
+      this.isRefreshing = false;
       this.metricValues = false;
       this.rawVisualizations = new RawVisualizations();
       this.wzReq = WzRequest;
@@ -126,18 +127,19 @@ export const WzVisualize = compose(
       if (newField && newField.name) {
         this.newFields[newField.name] = newField;
       }
-      if (!this.state.hasRefreshedKnownFields) {
+      if (!this.hasRefreshedKnownFields) {
         // Known fields are refreshed only once per dashboard loading
         try {
-          this.setState({ hasRefreshedKnownFields: true, isRefreshing: true });
+          this.hasRefreshedKnownFields = true;
+          this.isRefreshing = true;
           if(satisfyPluginPlatformVersion('<7.11')){
             await PatternHandler.refreshIndexPattern(this.newFields);
           };
-          this.setState({ isRefreshing: false });
+          this.isRefreshing = false;
           this.reloadToast();
           this.newFields = {};
         } catch (error) {
-          this.setState({ isRefreshing: false });
+          this.isRefreshing = false;
           const options = {
             context: `${WzVisualize.name}.refreshKnownFields`,
             level: UI_LOGGER_LEVELS.ERROR,
@@ -150,7 +152,7 @@ export const WzVisualize = compose(
           };
           getErrorOrchestrator().handleError(options);
         }
-      } else if (this.state.isRefreshing) {
+      } else if (this.isRefreshing) {
         await new Promise((r) => setTimeout(r, 150));
         await this.refreshKnownFields();
       }


### PR DESCRIPTION
Hi team,

this pull request solves an asynchronism issue when multiple fields are missing in the Events view rows details. Once this PR is applied **only 1 toast should pop** informing the index pattern was updated.

Closes #3923

To test it try to reproduce the linked issue. 