### PR TITLE
Map visualization render problem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -139,6 +139,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fixed routing redirection in events documents discover links [#3866](https://github.com/wazuh/wazuh-kibana-app/pull/3866)
 - Fixed health-check [#3868](https://github.com/wazuh/wazuh-kibana-app/pull/3868)
 - Fixed the table of Vulnerabilities/Inventory doesn't reload when changing the selected agent [#3901](https://github.com/wazuh/wazuh-kibana-app/pull/3901)
+- Fixed a rendering problem in the map visualizations [#3942](https://github.com/wazuh/wazuh-kibana-app/pull/3942)
 
 ## Wazuh v4.2.6 - Kibana 7.10.2, 7.11.2, 7.12.1, 7.13.0, 7.13.1, 7.13.2, 7.13.3, 7.13.4, 7.14.0, 7.14.1, 7.14.2 - Revision 4207
 

--- a/public/kibana-integrations/kibana-vis.js
+++ b/public/kibana-integrations/kibana-vis.js
@@ -389,59 +389,45 @@ class KibanaVis extends Component {
     const isLoading = this.props.resultState === 'loading';
     return (
       this.visID && (
-        <span>
-          <div
-            style={{
-              display: this.state.visRefreshingIndex ? 'block' : 'none',
-              textAlign: 'center',
-              paddingTop: 100,
-            }}
-          >
-            <EuiFlexGroup style={{ placeItems: 'center' }}>
-              <EuiFlexItem></EuiFlexItem>
-              <EuiFlexItem grow={false}>
-                <EuiLoadingSpinner size="xl" />
-              </EuiFlexItem>
-              <EuiFlexItem grow={false}>Refreshing Index Pattern.</EuiFlexItem>
-
-              <EuiFlexItem></EuiFlexItem>
-            </EuiFlexGroup>
-          </div>
-          <div
-            style={{
-              display: isLoading && !this.state.visRefreshingIndex ? 'block' : 'none',
-              textAlign: 'center',
-              paddingTop: 100,
-            }}
-          >
-            <EuiLoadingChart size="xl" />
-          </div>
-          <div
-            style={{
-              display:
-                this.deadField && !isLoading && !this.state.visRefreshingIndex ? 'block' : 'none',
-              textAlign: 'center',
-              paddingTop: 100,
-            }}
-          >
-            No results found &nbsp;
-            <EuiToolTip
-              position="top"
-              content={
-                <span>
-                  No alerts were found with the field: <strong>{this.deadField}</strong>
-                </span>
-              }
-            >
-              <EuiIcon type="iInCircle" />
-            </EuiToolTip>
-          </div>
+        <div style={{position: 'relative', height: '100%'}}>
           <div
             id={this.visID}
             vis-id={this.visID}
-            style={{ display: isLoading ? 'none' : 'block', height: '100%' }}
+            style={{ visibility: isLoading ? 'hidden' : 'visible', height: '100%' }}
           ></div>
-        </span>
+          <div style={{
+                position: 'absolute',
+                top: '50%',
+                left: '50%',
+                transform: 'translate(-50%, -50%)',
+              }}>
+                {(isLoading && <div><EuiLoadingChart size="xl" /></div>)
+                  || (this.deadField && !isLoading && !this.state.visRefreshingIndex && (
+                    <div>
+                      No results found &nbsp;
+                      <EuiToolTip
+                        position="top"
+                        content={
+                          <span>
+                            No alerts were found with the field: <strong>{this.deadField}</strong>
+                          </span>
+                        }
+                      >
+                        <EuiIcon type="iInCircle" />
+                      </EuiToolTip>
+                    </div>
+                  ))
+                  || (this.state.visRefreshingIndex && (
+                    <EuiFlexGroup justifyContent="center" alignItems="center">
+                      <EuiFlexItem grow={false}>
+                        <EuiLoadingSpinner size="xl" />
+                      </EuiFlexItem>
+                      <EuiFlexItem grow={false}>Refreshing Index Pattern.</EuiFlexItem>
+                    </EuiFlexGroup>
+                  ))
+                }
+          </div>
+        </div>
       )
     );
   }


### PR DESCRIPTION
Hi team,

this PR fixes a miscalculation when the map gets its position relative to the map wrapper and the visualization is in a loading state. 

Closes #3919 

To test it, check all visualizations in all dashboards render properly.