### PR TITLE
GitHub configuration panel text overflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to the Wazuh app project will be documented in this file.
 
 - Support for Kibana 7.16.3
 - Support for Kibana 7.17.0
+- Added GitHub and Office365 modules [#3557](https://github.com/wazuh/wazuh-kibana-app/pull/3557)
+- Added a new `Panel` module tab for GitHub and Office365 modules [#3541](https://github.com/wazuh/wazuh-kibana-app/pull/3541) [#3945](https://github.com/wazuh/wazuh-kibana-app/pull/3945)
 - Added ability to filter the results fo the `Network Ports` table in the `Inventory data` section [#3639](https://github.com/wazuh/wazuh-kibana-app/pull/3639)
 - Added new endpoint service to collect the frontend logs into a file [#3324](https://github.com/wazuh/wazuh-kibana-app/pull/3324)
 - Improved the frontend handle errors strategy: UI, Toasts, console log and log in file 

--- a/public/components/common/modules/panel/components/module_configuration.scss
+++ b/public/components/common/modules/panel/components/module_configuration.scss
@@ -17,7 +17,11 @@ h5.euiTitle.module-panel-configuration-subtitle{
   justify-content: center;
 }
 
-.module-panel-configuration-list dt.euiDescriptionList__title, .module-panel-configuration-list dd.euiDescriptionList__description {
-  border-left: 2px solid rgba(0, 0, 0, 0.3);
-  padding-left: 10px;
+.module-panel-configuration-list{
+  dt.euiDescriptionList__title,
+  dd.euiDescriptionList__description {
+    border-left: 2px solid rgba(0, 0, 0, 0.3);
+    padding-left: 10px;
+    word-break: break-word;
+  }
 }

--- a/public/components/common/modules/panel/components/module_configuration.tsx
+++ b/public/components/common/modules/panel/components/module_configuration.tsx
@@ -109,7 +109,7 @@ export const PanelModuleConfiguration : FunctionalComponent<{h: string}> = conne
           </EuiTitle>
         </EuiFlexItem>
       </EuiFlexGroup>
-      <EuiFlexGroup>
+      <EuiFlexGroup direction="column">
         <EuiFlexItem>
           <ConfigurationWrapper configurations={asyncAction.data} settings={settings} loading={asyncAction.running} error={asyncAction.error}/>
         </EuiFlexItem>


### PR DESCRIPTION
Hi team,

this fixed the github and office 365  configuration panels overflow when a field was very long.

Closes #3938 


To test it generate a very long field to show in the panel, like the github auth token and check it renders properly.

![image](https://user-images.githubusercontent.com/9343732/161580712-83e6239f-8ba8-4941-a1a0-2ec327a78d6e.png)
