### PR TITLE
Added troubleshooting link to toast

### DIFF
--- a/public/components/visualize/wz-visualize.js
+++ b/public/components/visualize/wz-visualize.js
@@ -159,6 +159,11 @@ export const WzVisualize = compose(
     };
     reloadToast = () => {
       const toastLifeTimeMs = 300000;
+      const [mayor, minor] = localStorage.getItem('appInfo') ?
+        JSON.parse(localStorage.getItem('appInfo'))['app-version'].split('.')
+        : ['current'];
+      const wazuhVersion = minor ? `${mayor}.${minor}` : mayor;
+      const urlTroubleShootingDocs = `https://documentation.wazuh.com/${wazuhVersion}/user-manual/kibana-app/troubleshooting.html#no-template-found-for-the-selected-index-pattern`;
       if(satisfyPluginPlatformVersion('<7.11')){
         getToasts().add({
           color: 'success',
@@ -167,6 +172,13 @@ export const WzVisualize = compose(
             <EuiFlexItem grow={false}>
               There were some unknown fields for the current index pattern.
               You need to refresh the page to apply the changes.
+              <a
+                title="More information in Wazuh documentation"
+                href={urlTroubleShootingDocs}
+                target="documentation"
+              >
+                Troubleshooting
+                </a>
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
               <EuiButton onClick={() => window.location.reload()} size="s">Reload page</EuiButton>
@@ -182,6 +194,12 @@ export const WzVisualize = compose(
             <EuiFlexItem grow={false}>
               There are some unknown fields for the current index pattern.
               You need to refresh the page to update the fields.
+              <a
+                title="More information in Wazuh documentation"
+                href={urlTroubleShootingDocs}
+                target="documentation">
+                Troubleshooting
+                </a>
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
               <EuiButton onClick={() => window.location.reload()} size="s">Reload page</EuiButton>


### PR DESCRIPTION
Hi team, 

this adds a troubleshooting link to the "The index pattern was refreshed successfully" toast, which pops up whenever a visualization requires a new field. The need for a troubleshooting link is due to the need to update `wazuh-template.json` to avoid endless toasts popping up. 
The new `wazuh-template.json `file includes all visualizations required fields definitions, that way the fields are saved even when no alerts have them.

Related to https://github.com/wazuh/wazuh-kibana-app/issues/3918

![image](https://user-images.githubusercontent.com/9343732/161606623-f667c868-f974-4156-90c8-d86eb092e99a.png)
