### PR TITLE
Change logout path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -154,6 +154,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Parse error when using `#` character not at the beginning of the line [#3877](https://github.com/wazuh/wazuh-kibana-app/pull/3877)
 - Fixed the `rule.mitre.id` cell enhancement that doesn't support values with sub techniques [#3944](https://github.com/wazuh/wazuh-kibana-app/pull/3944)
 - Fixed error not working the alerts displayed when changin the selected time in some flyouts [#3947](https://github.com/wazuh/wazuh-kibana-app/pull/3947)
+- Fixed the user can not logout when the Kibana server has a basepath configurated [#3957](https://github.com/wazuh/wazuh-kibana-app/pull/3957)
 
 ## Wazuh v4.2.6 - Kibana 7.10.2, 7.11.2, 7.12.1, 7.13.0, 7.13.1, 7.13.2, 7.13.3, 7.13.4, 7.14.0, 7.14.1, 7.14.2 - Revision 4207
 

--- a/public/app.js
+++ b/public/app.js
@@ -55,7 +55,7 @@ import store from './redux/store';
 import { updateCurrentPlatform } from './redux/actions/appStateActions';
 import { WzAuthentication, loadAppConfig } from './react-services';
 
-import { getAngularModule } from './kibana-services';
+import { getAngularModule, getHttp } from './kibana-services';
 import { addHelpMenuToAppChrome } from './utils';
 
 const app = getAngularModule();
@@ -112,7 +112,7 @@ app.run(function ($rootElement) {
   addHelpMenuToAppChrome();
 
   
-  const urlToLogout = window.location.origin + '/logout';
+  const urlToLogout = getHttp().basePath.prepend('/logout')
 
   // Bind deleteExistentToken on Log out component.
   $('.euiHeaderSectionItem__button, .euiHeaderSectionItemButton').on('mouseleave', function () {

--- a/public/app.js
+++ b/public/app.js
@@ -112,7 +112,7 @@ app.run(function ($rootElement) {
   addHelpMenuToAppChrome();
 
   
-  const urlToLogout = getHttp().basePath.prepend('/logout')
+  const urlToLogout = getHttp().basePath.prepend('/logout');
 
   // Bind deleteExistentToken on Log out component.
   $('.euiHeaderSectionItem__button, .euiHeaderSectionItemButton').on('mouseleave', function () {

--- a/public/controllers/management/components/management/configuration/office365/components/general-tab/__snapshots__/general-tab.test.tsx.snap
+++ b/public/controllers/management/components/management/configuration/office365/components/general-tab/__snapshots__/general-tab.test.tsx.snap
@@ -432,7 +432,7 @@ exports[`GeneralTab component renders correctly to match the snapshot 1`] = `
               },
               Object {
                 "field": "only_future_events",
-                "label": "Collect events generated since Wazuh is initialized",
+                "label": "Collect events generated since Wazuh manager is initialized",
               },
               Object {
                 "field": "interval",
@@ -586,9 +586,9 @@ exports[`GeneralTab component renders correctly to match the snapshot 1`] = `
                     </EuiSpacer>
                   </WzConfigurationSetting>
                   <WzConfigurationSetting
-                    key="-Collect events generated since Wazuh is initialized-undefined-1"
-                    keyItem="-Collect events generated since Wazuh is initialized-undefined-1"
-                    label="Collect events generated since Wazuh is initialized"
+                    key="-Collect events generated since Wazuh manager is initialized-undefined-1"
+                    keyItem="-Collect events generated since Wazuh manager is initialized-undefined-1"
+                    label="Collect events generated since Wazuh manager is initialized"
                     value="yes"
                   >
                     <div
@@ -615,7 +615,7 @@ exports[`GeneralTab component renders correctly to match the snapshot 1`] = `
                           <div
                             className="euiTextAlign euiTextAlign--right"
                           >
-                            Collect events generated since Wazuh is initialized
+                            Collect events generated since Wazuh manager is initialized
                           </div>
                         </EuiTextAlign>
                       </div>


### PR DESCRIPTION
**Description:**

The basePath was changed to take the kibana subpath

**Issues Resolved:**

Logout doesn't work with yarn start command [#3953](https://github.com/wazuh/wazuh-kibana-app/issues/3953)

**Test:**

1. Start kibana with the `yarn start` command
2. Navigate to `wazuh`
3. Click on `logout`
4. See that logout works
5. Start kibana with the `yarn start --no-base-path` command
6. Navigate to `wazuh`
7. Click on `logout`
8. See that logout works

**Screenshot:**

![image](https://user-images.githubusercontent.com/63758389/162219221-656780ca-8c2b-43f7-ace8-09d76e59a46e.png)
