### PR TITLE
[Fix] Unhandled promise error when Wazuh API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -155,6 +155,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fixed the `rule.mitre.id` cell enhancement that doesn't support values with sub techniques [#3944](https://github.com/wazuh/wazuh-kibana-app/pull/3944)
 - Fixed error not working the alerts displayed when changin the selected time in some flyouts [#3947](https://github.com/wazuh/wazuh-kibana-app/pull/3947)
 - Fixed the user can not logout when the Kibana server has a basepath configurated [#3957](https://github.com/wazuh/wazuh-kibana-app/pull/3957)
+- Fixed fatal cron-job error when Wazuh API is down [#3991](https://github.com/wazuh/wazuh-kibana-app/pull/3991)
 
 ## Wazuh v4.2.6 - Kibana 7.10.2, 7.11.2, 7.12.1, 7.13.0, 7.13.1, 7.13.2, 7.13.3, 7.13.4, 7.14.0, 7.14.1, 7.14.2 - Revision 4207
 

--- a/server/start/cron-scheduler/scheduler-job.ts
+++ b/server/start/cron-scheduler/scheduler-job.ts
@@ -37,10 +37,9 @@ export class SchedulerJob {
           return await this.getResponses(host);
         } catch (error) {
           ErrorHandler(error, this.logger);
-          return;
         }
       });
-      const data = (await Promise.all(jobPromises)).filter(promise => !!promise);
+      const data = (await Promise.all(jobPromises)).filter(promise => !!promise).flat();
       Array.isArray(data) && !!data.length && await this.saveDocument.save(data, index);
     } catch (error) {
       ErrorHandler(error, this.logger);

--- a/server/start/cron-scheduler/scheduler-job.ts
+++ b/server/start/cron-scheduler/scheduler-job.ts
@@ -27,23 +27,24 @@ export class SchedulerJob {
 
   public async run() {
     const { index, status } = configuredJobs({})[this.jobName];
-    if ( !status ) { return; }
+    if (!status) { return; }
     try {
       const hosts = await this.getApiObjects();
-      const data = await hosts.reduce(async (acc:Promise<object[]>, host) => {
-        const {status} = configuredJobs({host, jobName: this.jobName})[this.jobName];
-        if (!status) return acc;
-        const response = await this.getResponses(host);
-        const accResolve = await Promise.resolve(acc)
-        return [
-          ...accResolve,
-          ...response,
-        ];
-      }, Promise.resolve([]));
-      !!data.length && await this.saveDocument.save(data, index);
+      const jobPromises = hosts.map(async host => {
+        try {
+          const { status } = configuredJobs({ host, jobName: this.jobName })[this.jobName];
+          if (!status) return;
+          return await this.getResponses(host);
+        } catch (error) {
+          ErrorHandler(error, this.logger);
+          return;
+        }
+      });
+      const data = (await Promise.all(jobPromises)).filter(promise => !!promise);
+      Array.isArray(data) && !!data.length && await this.saveDocument.save(data, index);
     } catch (error) {
       ErrorHandler(error, this.logger);
-    } 
+    }
   }
 
   private async getApiObjects() {


### PR DESCRIPTION
### Description

This PR prevents Wazuh throwing an unhandled promise rejection error, which caused Kibana to crash node.options was not set up to only throw a warning after an unhandled promise rejection.

Closes #3887 

To test it:
- Start up / login in Kibana 
- Take down Wazuh API
- Wait for Wazuh to start cron-jobs
- Kibana should not exit on fatal exception and the promise rejection is handled