### PR TITLE
Improve messages in the agent installation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Refactored the table in `Vulnerabilities/Inventory` [#3196](https://github.com/wazuh/wazuh-kibana-app/pull/3196)
 - Changed Google Groups app icons  [#3949](https://github.com/wazuh/wazuh-kibana-app/pull/3949)
 - Removed sorting for `Agents` or `Configuration checksum` column in the table of `Management/Groups` due to this is not supported by the API [#3857](https://github.com/wazuh/wazuh-kibana-app/pull/3857)
+- Changed messages in the agent installation guide [#4040](https://github.com/wazuh/wazuh-kibana-app/pull/4040)
 
 ### Fixed
 

--- a/public/controllers/agent/components/register-agent.js
+++ b/public/controllers/agent/components/register-agent.js
@@ -520,6 +520,7 @@ export const RegisterAgent = withErrorBoundary(
                   iconType="iInCircle"
                 />
                 <EuiSpacer />
+                {windowsAdvice}
                 <div className="copy-codeblock-wrapper">
                   <EuiCodeBlock style={codeBlock} language={language}>
                     {this.state.wazuhPassword && !this.state.showPassword ? this.obfuscatePassword(text) : text}
@@ -540,7 +541,6 @@ export const RegisterAgent = withErrorBoundary(
                   />
                 )}
                 <EuiSpacer />
-                {windowsAdvice}
               </EuiText>
             )}
         </div>

--- a/public/controllers/agent/components/register-agent.js
+++ b/public/controllers/agent/components/register-agent.js
@@ -516,7 +516,7 @@ export const RegisterAgent = withErrorBoundary(
                   title={
                     <>
                       Running this command will not enroll the agent if it is doing an upgrade. See{' '}
-                      <EuiLink href="https://documentation.wazuh.com/current/user-manual/registering/index.html">
+                      <EuiLink href="https://documentation.wazuh.com/current/user-manual/registering/index.html" target="_blank">
                         Wazuh documentation
                       </EuiLink>
                       .

--- a/public/controllers/agent/components/register-agent.js
+++ b/public/controllers/agent/components/register-agent.js
@@ -405,8 +405,8 @@ export const RegisterAgent = withErrorBoundary(
       const ipInput = (
         <EuiText>
           <p>
-            You can predefine the Wazuh server address with the <EuiCode>enrollment.dns</EuiCode>{' '}
-            Wazuh app setting.
+          Define the Wazuh server IP address/name using the <EuiCode>enrollment.dns</EuiCode>{' '}
+          setting below.
           </p>
           <EuiFieldText
             placeholder="Server address"
@@ -515,8 +515,7 @@ export const RegisterAgent = withErrorBoundary(
                   color="warning"
                   title={
                     <>
-                      Running this command on a host with an agent already installed upgrades the
-                      agent package without enrolling the agent. To enroll it, see the{' '}
+                      Running this command will not enroll the agent if it is doing an upgrade. See{' '}
                       <EuiLink href="https://documentation.wazuh.com/current/user-manual/registering/index.html">
                         Wazuh documentation
                       </EuiLink>

--- a/public/controllers/agent/components/register-agent.js
+++ b/public/controllers/agent/components/register-agent.js
@@ -514,11 +514,7 @@ export const RegisterAgent = withErrorBoundary(
                   color="warning"
                   title={
                     <>
-                      Running this command will not enroll the agent if it is doing an upgrade. See{' '}
-                      <EuiLink href="https://documentation.wazuh.com/current/user-manual/registering/index.html" target="_blank">
-                        Wazuh documentation
-                      </EuiLink>
-                      .
+                      If the installer finds another Wazuh agent in the system, it will upgrade it preserving the configuration.
                     </>
                   }
                   iconType="iInCircle"

--- a/public/controllers/agent/components/register-agent.js
+++ b/public/controllers/agent/components/register-agent.js
@@ -405,8 +405,7 @@ export const RegisterAgent = withErrorBoundary(
       const ipInput = (
         <EuiText>
           <p>
-          Define the Wazuh server IP address/name using the <EuiCode>enrollment.dns</EuiCode>{' '}
-          setting below.
+            This is the address the agent uses to communicate with the Wazuh server. It can be an IP address or a fully qualified domain name (FQDN).
           </p>
           <EuiFieldText
             placeholder="Server address"


### PR DESCRIPTION
**Description:**

Changes were made to the messages in the agent installation guide.

- From `You can predefine the Wazuh server address with the enrollment.dns setting` to `This is the address the agent uses to communicate with the Wazuh server. It can be an IP address or a fully qualified domain name (FQDN).`

- From `Running this command on a host with an agent already installed upgrades the agent package without enrolling the agent. To enroll it, see the Wazuh documentation` to `If the installer finds another Wazuh agent in the system, it will upgrade it preserving the configuration.`

**Test:**

1. Navigate to `Agents`
2. Click on `Deploy a new agent`
3. Look at the changes

**Issues:**

Improve messages on agent installation walkthrough [#4037](https://github.com/wazuh/wazuh-kibana-app/issues/4037)
Improve messages in the agent installation instructions [#4036](https://github.com/wazuh/wazuh-kibana-app/issues/4036)

**Screenshot:**
![image](https://user-images.githubusercontent.com/63758389/163971268-c68186fc-2e2c-4054-9466-e18ff39e4f11.png)
![image](https://user-images.githubusercontent.com/63758389/163971297-b3e84d25-1796-47d6-846b-6901a4cd4fe1.png)



