### PR TITLE
[Jobs] Change the `shards` configuration for the `statistics` indices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Refactored the table in `Vulnerabilities/Inventory` [#3196](https://github.com/wazuh/wazuh-kibana-app/pull/3196)
 - Changed Google Groups app icons  [#3949](https://github.com/wazuh/wazuh-kibana-app/pull/3949)
 - Removed sorting for `Agents` or `Configuration checksum` column in the table of `Management/Groups` due to this is not supported by the API [#3857](https://github.com/wazuh/wazuh-kibana-app/pull/3857)
+- Changed the default `wazuh.statistics.shards` setting from `2` to `1` [#4055](https://github.com/wazuh/wazuh-kibana-app/pull/4055)
 
 ### Fixed
 

--- a/common/constants.ts
+++ b/common/constants.ts
@@ -16,16 +16,13 @@ export const WAZUH_INDEX_TYPE_ALERTS = 'alerts';
 export const WAZUH_ALERTS_PREFIX = 'wazuh-alerts-';
 export const WAZUH_ALERTS_PATTERN = 'wazuh-alerts-*';
 
-// Default number of shards and replicas for indices
-export const WAZUH_INDEX_SHARDS = 2;
-export const WAZUH_INDEX_REPLICAS = 0;
-
 // Job - Wazuh monitoring
 export const WAZUH_INDEX_TYPE_MONITORING = "monitoring";
 export const WAZUH_MONITORING_PREFIX = "wazuh-monitoring-";
 export const WAZUH_MONITORING_PATTERN = "wazuh-monitoring-*";
 export const WAZUH_MONITORING_TEMPLATE_NAME = "wazuh-agent";
 export const WAZUH_MONITORING_DEFAULT_INDICES_SHARDS = 1;
+export const WAZUH_MONITORING_DEFAULT_INDICES_REPLICAS = 0;
 export const WAZUH_MONITORING_DEFAULT_CREATION = 'w';
 export const WAZUH_MONITORING_DEFAULT_ENABLED = true;
 export const WAZUH_MONITORING_DEFAULT_FREQUENCY = 900;
@@ -37,7 +34,8 @@ export const WAZUH_STATISTICS_DEFAULT_PREFIX = "wazuh";
 export const WAZUH_STATISTICS_DEFAULT_NAME = "statistics";
 export const WAZUH_STATISTICS_PATTERN = `${WAZUH_STATISTICS_DEFAULT_PREFIX}-${WAZUH_STATISTICS_DEFAULT_NAME}-*`;
 export const WAZUH_STATISTICS_TEMPLATE_NAME = `${WAZUH_STATISTICS_DEFAULT_PREFIX}-${WAZUH_STATISTICS_DEFAULT_NAME}`;
-export const WAZUH_STATISTICS_DEFAULT_INDICES_SHARDS = WAZUH_INDEX_SHARDS;
+export const WAZUH_STATISTICS_DEFAULT_INDICES_SHARDS = 1;
+export const WAZUH_STATISTICS_DEFAULT_INDICES_REPLICAS = 0;
 export const WAZUH_STATISTICS_DEFAULT_CREATION = 'w';
 export const WAZUH_STATISTICS_DEFAULT_STATUS = true;
 export const WAZUH_STATISTICS_DEFAULT_FREQUENCY = 900;
@@ -208,7 +206,7 @@ export const WAZUH_DEFAULT_APP_CONFIG = {
   'wazuh.monitoring.enabled': WAZUH_MONITORING_DEFAULT_ENABLED,
   'wazuh.monitoring.frequency': WAZUH_MONITORING_DEFAULT_FREQUENCY,
   'wazuh.monitoring.shards': WAZUH_MONITORING_DEFAULT_INDICES_SHARDS,
-  'wazuh.monitoring.replicas': WAZUH_INDEX_REPLICAS,
+  'wazuh.monitoring.replicas': WAZUH_MONITORING_DEFAULT_INDICES_REPLICAS,
   'wazuh.monitoring.creation': WAZUH_MONITORING_DEFAULT_CREATION,
   'wazuh.monitoring.pattern': WAZUH_MONITORING_PATTERN,
   'cron.prefix': WAZUH_STATISTICS_DEFAULT_PREFIX,
@@ -217,8 +215,8 @@ export const WAZUH_DEFAULT_APP_CONFIG = {
   'cron.statistics.interval': WAZUH_STATISTICS_DEFAULT_CRON_FREQ,
   'cron.statistics.index.name': WAZUH_STATISTICS_DEFAULT_NAME,
   'cron.statistics.index.creation': WAZUH_STATISTICS_DEFAULT_CREATION,
-  'cron.statistics.index.shards': WAZUH_INDEX_SHARDS,
-  'cron.statistics.index.replicas': WAZUH_INDEX_REPLICAS,
+  'cron.statistics.index.shards': WAZUH_STATISTICS_DEFAULT_INDICES_SHARDS,
+  'cron.statistics.index.replicas': WAZUH_STATISTICS_DEFAULT_INDICES_REPLICAS,
   'alerts.sample.prefix': WAZUH_SAMPLE_ALERT_PREFIX,
   hideManagerAlerts: false,
   'logs.level': 'info',

--- a/public/services/resolves/get-config.js
+++ b/public/services/resolves/get-config.js
@@ -12,11 +12,12 @@
 
 import {
   WAZUH_ALERTS_PATTERN,
-  WAZUH_INDEX_REPLICAS,
-  WAZUH_INDEX_SHARDS,
   WAZUH_MONITORING_DEFAULT_INDICES_SHARDS,
+  WAZUH_MONITORING_DEFAULT_INDICES_REPLICAS,
   WAZUH_MONITORING_PATTERN,
-  WAZUH_SAMPLE_ALERT_PREFIX
+  WAZUH_SAMPLE_ALERT_PREFIX,
+  WAZUH_STATISTICS_DEFAULT_INDICES_SHARDS,
+  WAZUH_STATISTICS_DEFAULT_INDICES_REPLICAS,
 } from "../../../common/constants";
 
 export async function getWzConfig($q, genericReq, wazuhConfig) {
@@ -53,7 +54,7 @@ export async function getWzConfig($q, genericReq, wazuhConfig) {
     'wazuh.monitoring.enabled': true,
     'wazuh.monitoring.frequency': 900,
     'wazuh.monitoring.shards': WAZUH_MONITORING_DEFAULT_INDICES_SHARDS,
-    'wazuh.monitoring.replicas': WAZUH_INDEX_REPLICAS,
+    'wazuh.monitoring.replicas': WAZUH_MONITORING_DEFAULT_INDICES_REPLICAS,
     'wazuh.monitoring.creation': 'w',
     'wazuh.monitoring.pattern': WAZUH_MONITORING_PATTERN,
     'cron.prefix': 'wazuh',
@@ -62,8 +63,8 @@ export async function getWzConfig($q, genericReq, wazuhConfig) {
     'cron.statistics.interval': '0 */5 * * * *',
     'cron.statistics.index.name': 'statistics',
     'cron.statistics.index.creation': 'w',
-    'cron.statistics.index.shards': WAZUH_INDEX_SHARDS,
-    'cron.statistics.index.replicas': WAZUH_INDEX_REPLICAS,
+    'cron.statistics.index.shards': WAZUH_STATISTICS_DEFAULT_INDICES_SHARDS,
+    'cron.statistics.index.replicas': WAZUH_STATISTICS_DEFAULT_INDICES_REPLICAS,
     'alerts.sample.prefix': WAZUH_SAMPLE_ALERT_PREFIX,
     hideManagerAlerts: false,
     'logs.level': 'info',

--- a/server/lib/initial-wazuh-config.ts
+++ b/server/lib/initial-wazuh-config.ts
@@ -10,7 +10,7 @@
  * Find more information about this on the LICENSE file.
  */
 
-import { ASSETS_BASE_URL_PREFIX } from "../../common/constants";
+import { ASSETS_BASE_URL_PREFIX, WAZUH_MONITORING_DEFAULT_INDICES_REPLICAS, WAZUH_MONITORING_DEFAULT_INDICES_SHARDS, WAZUH_STATISTICS_DEFAULT_INDICES_REPLICAS, WAZUH_STATISTICS_DEFAULT_INDICES_SHARDS } from "../../common/constants";
 
 export const initialWazuhConfig: string = `---
 #
@@ -120,8 +120,8 @@ export const initialWazuhConfig: string = `---
 #wazuh.monitoring.frequency: 900
 #
 # Configure wazuh-monitoring-* indices shards and replicas.
-#wazuh.monitoring.shards: 1
-#wazuh.monitoring.replicas: 0
+#wazuh.monitoring.shards: ${WAZUH_MONITORING_DEFAULT_INDICES_SHARDS}
+#wazuh.monitoring.replicas: ${WAZUH_MONITORING_DEFAULT_INDICES_REPLICAS}
 #
 # Configure wazuh-monitoring-* indices custom creation interval.
 # Values: h (hourly), d (daily), w (weekly), m (monthly)
@@ -164,8 +164,8 @@ export const initialWazuhConfig: string = `---
 #cron.statistics.index.creation: w
 #
 # Configure statistics indices shards and replicas.
-#cron.statistics.shards: 2
-#cron.statistics.replicas: 0
+#cron.statistics.shards: ${WAZUH_STATISTICS_DEFAULT_INDICES_SHARDS}
+#cron.statistics.replicas: ${WAZUH_STATISTICS_DEFAULT_INDICES_REPLICAS}
 #
 # ------------------------------ wazuh-logo-customization -------------------------------
 #

--- a/server/start/cron-scheduler/save-document.ts
+++ b/server/start/cron-scheduler/save-document.ts
@@ -2,8 +2,8 @@ import { BulkIndexDocumentsParams } from 'elasticsearch';
 import { getConfiguration } from '../../lib/get-configuration';
 import { log } from '../../lib/logger';
 import { indexDate } from '../../lib/index-date';
-import { WAZUH_INDEX_SHARDS, WAZUH_INDEX_REPLICAS } from '../../../common/constants'
-import { tryCatchForIndexPermissionError } from '../tryCatchForIndexPermissionError'
+import { WAZUH_STATISTICS_DEFAULT_INDICES_SHARDS, WAZUH_STATISTICS_DEFAULT_INDICES_REPLICAS } from '../../../common/constants';
+import { tryCatchForIndexPermissionError } from '../tryCatchForIndexPermissionError';
 
 export interface IIndexConfiguration {
   name: string
@@ -53,8 +53,8 @@ export class SaveDocument {
             body: {
               settings: {
                 index: {
-                  number_of_shards: shards || WAZUH_INDEX_SHARDS,
-                  number_of_replicas: replicas || WAZUH_INDEX_REPLICAS
+                  number_of_shards: shards ?? WAZUH_STATISTICS_DEFAULT_INDICES_SHARDS,
+                  number_of_replicas: replicas ?? WAZUH_STATISTICS_DEFAULT_INDICES_REPLICAS
                 }
               }
             }

--- a/server/start/monitoring/index.ts
+++ b/server/start/monitoring/index.ts
@@ -19,12 +19,12 @@ import { buildIndexSettings } from '../../lib/build-index-settings';
 import { WazuhHostsCtrl } from '../../controllers/wazuh-hosts';
 import { 
   WAZUH_MONITORING_PATTERN,
-  WAZUH_INDEX_REPLICAS,
   WAZUH_MONITORING_TEMPLATE_NAME,
-  WAZUH_MONITORING_DEFAULT_INDICES_SHARDS,
   WAZUH_MONITORING_DEFAULT_CREATION,
   WAZUH_MONITORING_DEFAULT_ENABLED,
   WAZUH_MONITORING_DEFAULT_FREQUENCY,
+  WAZUH_MONITORING_DEFAULT_INDICES_SHARDS,
+  WAZUH_MONITORING_DEFAULT_INDICES_REPLICAS,
 } from '../../../common/constants';
 import { tryCatchForIndexPermissionError } from '../tryCatchForIndexPermissionError';
 import { delayAsPromise } from '../../../common/utils';
@@ -259,7 +259,7 @@ async function createIndex(context, indexName: string) {
       settings: {
         index: {
           number_of_shards: getAppConfigurationSetting('wazuh.monitoring.shards', appConfig, WAZUH_MONITORING_DEFAULT_INDICES_SHARDS),
-          number_of_replicas: getAppConfigurationSetting('wazuh.monitoring.replicas', appConfig, WAZUH_INDEX_REPLICAS)
+          number_of_replicas: getAppConfigurationSetting('wazuh.monitoring.replicas', appConfig, WAZUH_MONITORING_DEFAULT_INDICES_REPLICAS)
         }
       }
     };


### PR DESCRIPTION
# Description
This PR modifies the default `shards` configuration for the `statistics` indices.

## Changes
- configuration:
  - shards: 1
  - replicas: 0
- affected:
  - configuration in the creation of indices
  - initial default plugin configuration
  - `getWzConfig` route resolver
  - constant with the default configuration

# Test
- The initial configuration should display the settings as:
  - `cron.statistics.shards`: `1`
  - `cron.statistics.replicas`: `0`
- The new `statistics` indices should be created with the new `shards` and `replicas` settings if there is no other configuration.

Closes #4053