### PR TITLE
OS selection in agent installation

### DIFF
--- a/public/controllers/agent/components/register-agent.js
+++ b/public/controllers/agent/components/register-agent.js
@@ -344,6 +344,14 @@ export const RegisterAgent = withErrorBoundary(
           return `https://packages.wazuh.com/4.x/yum/wazuh-agent-${this.state.wazuhVersion}-1.x86_64.rpm`;
         case 'centos6-armhf':
           return `https://packages.wazuh.com/4.x/yum/wazuh-agent-${this.state.wazuhVersion}-1.armv7hl.rpm`;
+        case 'redhat6-i386':
+          return `https://packages.wazuh.com/4.x/yum/wazuh-agent-${this.state.wazuhVersion}-1.i386.rpm`;
+        case 'redhat6-aarch64':
+          return `https://packages.wazuh.com/4.x/yum/wazuh-agent-${this.state.wazuhVersion}-1.aarch64.rpm`;
+        case 'redhat6-x86_64':
+          return `https://packages.wazuh.com/4.x/yum/wazuh-agent-${this.state.wazuhVersion}-1.x86_64.rpm`;
+        case 'redhat6-armhf':
+          return `https://packages.wazuh.com/4.x/yum/wazuh-agent-${this.state.wazuhVersion}-1.armv7hl.rpm`;
         default:
           return `https://packages.wazuh.com/4.x/yum/wazuh-agent-${this.state.wazuhVersion}-1.x86_64.rpm`;
       }

--- a/public/controllers/agent/components/register-agent.js
+++ b/public/controllers/agent/components/register-agent.js
@@ -60,7 +60,7 @@ const architectureButtons = [
     label: 'aarch64',
   },
 ];
-const architectureCentos5 = [
+const architectureCentos5OrRedHat5 = [
   {
     id: 'i386',
     label: 'i386',
@@ -71,7 +71,7 @@ const architectureCentos5 = [
   },
 ];
 
-const versionButtonsCentos = [
+const versionButtonsCentosOrRedHat = [
   {
     id: 'centos5',
     label: 'CentOS5',
@@ -79,6 +79,14 @@ const versionButtonsCentos = [
   {
     id: 'centos6',
     label: 'CentOS6 or higher',
+  },
+  {
+    id: 'redhat5',
+    label: 'Red Hat 5',
+  },
+  {
+    id: 'redhat6',
+    label: 'Red Hat 6 or higher',
   },
 ];
 
@@ -169,9 +177,9 @@ export const RegisterAgent = withErrorBoundary(
           serverAddress,
           needsPassword,
           hidePasswordInput,
-          versionButtonsCentos,
+          versionButtonsCentosOrRedHat,
           architectureButtons,
-          architectureCentos5,
+          architectureCentos5OrRedHat5,
           wazuhPassword,
           udpProtocol,
           wazuhVersion,
@@ -323,6 +331,10 @@ export const RegisterAgent = withErrorBoundary(
         case 'centos5-i386':
           return `https://packages.wazuh.com/4.x/yum5/i386/wazuh-agent-${this.state.wazuhVersion}-1.el5.i386.rpm`;
         case 'centos5-x86_64':
+          return `https://packages.wazuh.com/4.x/yum5/x86_64/wazuh-agent-${this.state.wazuhVersion}-1.el5.x86_64.rpm`;
+        case 'redhat5-i386':
+          return `https://packages.wazuh.com/4.x/yum5/i386/wazuh-agent-${this.state.wazuhVersion}-1.el5.i386.rpm`;
+        case 'redhat5-x86_64':
           return `https://packages.wazuh.com/4.x/yum5/x86_64/wazuh-agent-${this.state.wazuhVersion}-1.el5.x86_64.rpm`;
         case 'centos6-i386':
           return `https://packages.wazuh.com/4.x/yum/wazuh-agent-${this.state.wazuhVersion}-1.i386.rpm`;
@@ -626,7 +638,7 @@ export const RegisterAgent = withErrorBoundary(
                 <EuiButtonGroup
                   color="primary"
                   legend="Choose the version"
-                  options={versionButtonsCentos}
+                  options={versionButtonsCentosOrRedHat}
                   idSelected={this.state.selectedVersion}
                   onChange={(version) => this.setVersion(version)}
                 />
@@ -634,7 +646,7 @@ export const RegisterAgent = withErrorBoundary(
             },
           ]
           : []),
-        ...(this.state.selectedOS == 'rpm' && this.state.selectedVersion == 'centos5'
+        ...(this.state.selectedOS == 'rpm' && this.state.selectedVersion == 'centos5' || this.state.selectedVersion == 'redhat5' 
           ? [
             {
               title: 'Choose the architecture',
@@ -642,7 +654,7 @@ export const RegisterAgent = withErrorBoundary(
                 <EuiButtonGroup
                   color="primary"
                   legend="Choose the architecture"
-                  options={architectureCentos5}
+                  options={architectureCentos5OrRedHat5}
                   idSelected={this.state.selectedArchitecture}
                   onChange={(architecture) => this.setArchitecture(architecture)}
                 />
@@ -651,7 +663,7 @@ export const RegisterAgent = withErrorBoundary(
           ]
           : []),
         ...(this.state.selectedOS == 'deb' ||
-          (this.state.selectedOS == 'rpm' && this.state.selectedVersion == 'centos6')
+          (this.state.selectedOS == 'rpm' && this.state.selectedVersion == 'centos6' || this.state.selectedVersion == 'redhat6')
           ? [
             {
               title: 'Choose the architecture',


### PR DESCRIPTION
**Description:**

The Red Hat options were added since only those of CentOS appeared. 

**Issue:**

Improve message for OS selection in agent installation walkthrough [#4038](https://github.com/wazuh/wazuh-kibana-app/issues/4038)

**Test:**

1. Navigate to `Agents`
2. Click on `Deploy a new agent`
3. Click on `Red Hat / CentOS`

**Screenshot:**

![image](https://user-images.githubusercontent.com/63758389/164263455-9cdc4196-f30e-4f7a-9eb7-5fae91458c36.png)
![image](https://user-images.githubusercontent.com/63758389/164263505-01599b9b-8489-46f3-9317-65efc4564e4d.png)


