### PR TITLE
Changed breadcrumb agent push

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -157,6 +157,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fixed error not working the alerts displayed when changin the selected time in some flyouts [#3947](https://github.com/wazuh/wazuh-kibana-app/pull/3947)
 - Fixed the user can not logout when the Kibana server has a basepath configurated [#3957](https://github.com/wazuh/wazuh-kibana-app/pull/3957)
 - Fixed fatal cron-job error when Wazuh API is down [#3991](https://github.com/wazuh/wazuh-kibana-app/pull/3991)
+- Fixed agent breadcrumb routing minor error [#4101](https://github.com/wazuh/wazuh-kibana-app/pull/4101)
 
 ## Wazuh v4.2.6 - Kibana 7.10.2, 7.11.2, 7.12.1, 7.13.0, 7.13.1, 7.13.2, 7.13.3, 7.13.4, 7.14.0, 7.14.1, 7.14.2 - Revision 4207
 

--- a/public/components/common/globalBreadcrumb/globalBreadcrumb.tsx
+++ b/public/components/common/globalBreadcrumb/globalBreadcrumb.tsx
@@ -31,7 +31,13 @@ class WzGlobalBreadcrumb extends Component {
             max={6}
             breadcrumbs={this.props.state.breadcrumb.map(breadcrumb => breadcrumb.agent ? {
               className: "euiLink euiLink--subdued ",
-              onClick: (ev) => { ev.stopPropagation(); AppNavigate.navigateToModule(ev, 'agents', { "tab": "welcome", "agent": breadcrumb.agent.id }); this.router.reload(); },
+              onClick: (ev) => {
+                ev.stopPropagation();
+                AppNavigate.navigateToModule(ev, 'agents', {
+                  "tab": "welcome", "agent": breadcrumb.agent.id
+                });
+                this.router.reload();
+              },
               id: "breadcrumbNoTitle",
               truncate: true,
               text: (

--- a/public/components/common/modules/agents-current-section.tsx
+++ b/public/components/common/modules/agents-current-section.tsx
@@ -21,6 +21,8 @@ import { connect } from 'react-redux';
 import { WAZUH_MODULES } from '../../../../common/wazuh-modules';
 import { getAngularModule } from '../../../kibana-services';
 
+// TODO: check if this component is deprecated, if so remove it.
+// This component is wrapped by WzCurrentAgentsSectionWrapper
 class WzCurrentAgentsSection extends Component {
   constructor(props) {
     super(props);

--- a/public/components/common/modules/main-overview.tsx
+++ b/public/components/common/modules/main-overview.tsx
@@ -74,15 +74,7 @@ export const MainModuleOverview = connect(mapStateToProps)(class MainModuleOverv
       ];
       if (currentAgent.id) {
         breadcrumb.push({
-          className: "euiLink euiLink--subdued ",
-          onClick: (ev) => { ev.stopPropagation(); AppNavigate.navigateToModule(ev, 'agents', { "tab": "welcome", "agent": currentAgent.id }); this.router.reload(); },
-          id: "breadcrumbNoTitle",
-          truncate: true,
-          text: (
-            <EuiToolTip position="bottom" content={"View agent summary"} display="inlineBlock">
-              <span>{currentAgent.name}</span>
-            </EuiToolTip>
-          ),
+          agent: currentAgent
         })
       }
       breadcrumb.push({


### PR DESCRIPTION
## Description

This PR a `main-overview.tsx` leftover code. When `globalBreadcrumb.tsx` was refactored to centralize the agent routing, **_main-overview_** should have been modified to just send the agent information, so **_globalBreadcrumb_** creates the routing object.

Closes #4093 

### Steps to reproduce
- Go to Agents > Name of the agent > System auditing
- Return to the agent summary menu 
- See the undefined router error in the console

![image](https://user-images.githubusercontent.com/9343732/165289111-80cf6607-a0de-402f-8283-b441ce1745ea.png)


#### Additional information
The class **_WzCurrentAgentsSection_** also has deprecated code and doesn't seem to be used by the application. I suggest creating an issue to clean code and remove deprecated classes, commented code, functions not being used, etc