### PR TITLE
The selected text is visible in API Console

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -157,6 +157,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fixed error not working the alerts displayed when changin the selected time in some flyouts [#3947](https://github.com/wazuh/wazuh-kibana-app/pull/3947)
 - Fixed the user can not logout when the Kibana server has a basepath configurated [#3957](https://github.com/wazuh/wazuh-kibana-app/pull/3957)
 - Fixed fatal cron-job error when Wazuh API is down [#3991](https://github.com/wazuh/wazuh-kibana-app/pull/3991)
+- Fixed selected text not visible in API Console [#4102](https://github.com/wazuh/wazuh-kibana-app/pull/4102)
 
 ## Wazuh v4.2.6 - Kibana 7.10.2, 7.11.2, 7.12.1, 7.13.0, 7.13.1, 7.13.2, 7.13.3, 7.13.4, 7.14.0, 7.14.1, 7.14.2 - Revision 4207
 

--- a/public/utils/codemirror/codemirror.scss
+++ b/public/utils/codemirror/codemirror.scss
@@ -393,5 +393,5 @@ span.CodeMirror-selectedtext { background: none; }
 
 /* Fix the overflow code over the line numbers */
 .CodeMirror pre{
-  z-index: 0;
+  z-index: 1;
 }


### PR DESCRIPTION
**Description:**

Changed the z-index so that the background of the selected text is below the text

**Issue:** 

- #4051 

**Test:**

1. Navigate to `Tools>API Console`
2. Select text
3. See text
4. Scroll to the right 
5. The text shouldn't overflow the line numbers.

**Screenshots:**

Light Mode

![background](https://user-images.githubusercontent.com/63758389/165320203-c7f1c2bc-5675-4612-8a32-2d905d06ce2b.gif)

Dark Mode

![backgroundDark](https://user-images.githubusercontent.com/63758389/165320222-e2adf47a-5cee-42f9-ab21-07084325651c.gif)


