### PR TITLE
Fix the `Missing parameters` error on the Manager Logs view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -158,6 +158,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fixed the user can not logout when the Kibana server has a basepath configurated [#3957](https://github.com/wazuh/wazuh-kibana-app/pull/3957)
 - Fixed fatal cron-job error when Wazuh API is down [#3991](https://github.com/wazuh/wazuh-kibana-app/pull/3991)
 - Fixed selected text not visible in API Console [#4102](https://github.com/wazuh/wazuh-kibana-app/pull/4102)
+- Fixed the 'missing parameters' error on the Manager Logs [#4110](https://github.com/wazuh/wazuh-kibana-app/pull/4110)
 
 ## Wazuh v4.2.6 - Kibana 7.10.2, 7.11.2, 7.12.1, 7.13.0, 7.13.1, 7.13.2, 7.13.3, 7.13.4, 7.14.0, 7.14.1, 7.14.2 - Revision 4207
 

--- a/public/controllers/management/components/management/mg-logs/logs.js
+++ b/public/controllers/management/components/management/mg-logs/logs.js
@@ -186,9 +186,6 @@ export default compose(
       let result = '';
       let totalItems = 0;
 
-      // ---------------
-      // NOTE fix-1
-      // ---------------
       // Avoid attempts to send invalid requests if the logsPath variable
       // hasn't been intialized yet (caused by the onSearchBarSearch event).
       if (logsPath === '') {

--- a/public/controllers/management/components/management/mg-logs/logs.js
+++ b/public/controllers/management/components/management/mg-logs/logs.js
@@ -81,7 +81,7 @@ export default compose(
 
     async componentDidMount() {
       try {
-        this.F = window.innerHeight - this.offset;
+        this.height = window.innerHeight - this.offset;
         window.addEventListener('resize', this.updateHeight);
         this.setState({ isLoading: true });
 

--- a/public/controllers/management/components/management/mg-logs/logs.js
+++ b/public/controllers/management/components/management/mg-logs/logs.js
@@ -43,11 +43,7 @@ import { UI_ERROR_SEVERITIES } from '../../../../../react-services/error-orchest
 import { getErrorOrchestrator } from '../../../../../react-services/common-services';
 
 export default compose(
-  withGlobalBreadcrumb([
-    { text: '' },
-    { text: 'Management', href: '#/manager' },
-    { text: 'Logs' }
-  ]),
+  withGlobalBreadcrumb([{ text: '' }, { text: 'Management', href: '#/manager' }, { text: 'Logs' }]),
   withUserAuthorizationPrompt([
     { action: 'cluster:status', resource: '*:*:*' },
     { action: 'cluster:read', resource: 'node:id:*' },
@@ -112,7 +108,6 @@ export default compose(
             });
           }
         );
-
       } catch (error) {
         this.setState({
           isLoading: false,
@@ -140,17 +135,14 @@ export default compose(
     }
 
     async initDaemonsList(logsPath) {
-      const daemonsNotIncluded = [
-        'wazuh-modulesd:task-manager',
-        'wazuh-modulesd:agent-upgrade'
-      ]
+      const daemonsNotIncluded = ['wazuh-modulesd:task-manager', 'wazuh-modulesd:agent-upgrade'];
       try {
         const path = logsPath + '/summary';
         const data = await WzRequest.apiReq('GET', path, {});
         const formattedData = (((data || {}).data || {}).data || {}).affected_items;
         const daemonsList = [...['all']];
         for (const daemon of formattedData) {
-          if(!daemonsNotIncluded.includes(Object.keys(daemon)[0])){
+          if (!daemonsNotIncluded.includes(Object.keys(daemon)[0])) {
             daemonsList.push(Object.keys(daemon)[0]);
           }
         }
@@ -362,10 +354,6 @@ export default compose(
     };
 
     onSearchBarSearch = (e) => {
-      if(logsPath === '' ) {
-        initLogsPath
-      }
-
       this.setState(
         {
           appliedSearch: e,

--- a/public/controllers/management/components/management/mg-logs/logs.js
+++ b/public/controllers/management/components/management/mg-logs/logs.js
@@ -85,7 +85,7 @@ export default compose(
 
     async componentDidMount() {
       try {
-        this.height = window.innerHeight - this.offset;
+        this.F = window.innerHeight - this.offset;
         window.addEventListener('resize', this.updateHeight);
         this.setState({ isLoading: true });
 
@@ -112,6 +112,7 @@ export default compose(
             });
           }
         );
+
       } catch (error) {
         this.setState({
           isLoading: false,
@@ -155,7 +156,7 @@ export default compose(
         }
         this.setState({ daemonsList });
       } catch (error) {
-        throw new Error(error);
+        throw new Error('Error fetching daemons list: ' + error);
       }
     }
 
@@ -192,7 +193,16 @@ export default compose(
       const { logsPath } = this.state;
       let result = '';
       let totalItems = 0;
- 
+
+      // ---------------
+      // NOTE fix-1
+      // ---------------
+      // Avoid attempts to send invalid requests if the logsPath variable
+      // hasn't been intialized yet (caused by the onSearchBarSearch event).
+      if (logsPath === '') {
+        return result;
+      }
+
       try {
         const tmpResult = await WzRequest.apiReq('GET', logsPath, {
           params: this.buildFilters(customOffset),
@@ -201,7 +211,7 @@ export default compose(
         totalItems = ((tmpResult || {}).data.data || {}).total_affected_items;
         result = this.parseLogsToText(resultItems) || '';
       } catch (error) {
-        throw new Error(error);
+        throw new Error('Error fetching logs: ' + error);
       }
 
       this.setState({ totalItems });
@@ -258,7 +268,7 @@ export default compose(
 
         return { nodeList: '', logsPath: '/manager/logs', selectedNode: '' };
       } catch (error) {
-        throw new Error(error);
+        throw new Error('Error building logs path: ' + error);
       }
     }
 
@@ -352,6 +362,10 @@ export default compose(
     };
 
     onSearchBarSearch = (e) => {
+      if(logsPath === '' ) {
+        initLogsPath
+      }
+
       this.setState(
         {
           appliedSearch: e,


### PR DESCRIPTION
## Summary

Closes #4089 

![missing-params](https://user-images.githubusercontent.com/15186973/165501759-f03d8d9b-946e-49e7-ad7a-df1f3d7fb469.gif)

## To test

- Go to the Manager logs section.
- No error should appear on start.