### PR TITLE
Can remove custom filter

### DIFF
--- a/public/components/common/modules/modules-helper.js
+++ b/public/components/common/modules/modules-helper.js
@@ -51,16 +51,18 @@ export class ModulesHelper {
     }
     const filters = $(`.globalFilterItem .euiBadge__childButton`);
     for (let i = 0; i < filters.length; i++) {
+      const data = filters[i].attributes[3];
       let found = false;
       (implicitFilters || []).forEach(x => {
-        const objKey = x.query && x.query.match ? Object.keys(x.query.match)[0] : x.meta.key;
-        const key = `filter-key-${objKey}`;
-        const value = x.query && x.query.match
-          ? `filter-value-${x.query.match[objKey].query}`
-          : `filter-value-${x.meta.value}`;
-        const data = filters[i].attributes[3];
-        if (data.value.includes(key) && data.value.includes(value)) {
-          found = true;
+        if(!x.used){
+          const objKey = x.query && x.query.match ? Object.keys(x.query.match)[0] : x.meta.key;
+          const objValue = x.query && x.query.match ? x.query.match[objKey].query : x.meta.value;
+          const key = `filter-key-${objKey}`;
+          const value = `filter-value-${objValue}`;
+          if (data.value.includes(key) && data.value.includes(value) && !data.value.includes('filter-pinned')) {
+            found = true;
+            x.used = true;
+          }
         }
       });
       if (!found) {

--- a/public/components/common/modules/modules-helper.js
+++ b/public/components/common/modules/modules-helper.js
@@ -49,31 +49,35 @@ export class ModulesHelper {
         this.activeNoImplicitsFilters();
       }, 100);
     }
-    const filters = $(`.globalFilterItem .euiBadge__childButton`);
-    for (let i = 0; i < filters.length; i++) {
-      const data = filters[i].attributes[3];
+    // With the filter classes decide if they are from the module view or not
+    const allFilters = $(`.globalFilterItem .euiBadge__childButton`);
+    for (let i = 0; i < allFilters.length; i++) {
+      const data = allFilters[i].attributes['data-test-subj'];
       let found = false;
-      (implicitFilters || []).forEach(x => {
-        // The IF: checks if the filter is already in use
-        // Check which of the filters are from the view and which are not pinned filters
-        if(!x.used){
-          const objKey = x.query && x.query.match ? Object.keys(x.query.match)[0] : x.meta.key;
-          const objValue = x.query && x.query.match ? x.query.match[objKey].query : x.meta.value;
+      (implicitFilters || []).forEach(mooduleFilter => {
+        // Checks if the filter is already in use
+        // Check which of the filters are from the module view and which are not pinned filters
+        if(!mooduleFilter.used){
+          const objKey = mooduleFilter.query?.match ? Object.keys(mooduleFilter.query.match)[0] : mooduleFilter.meta.key;
+          const objValue = mooduleFilter.query?.match ? mooduleFilter.query.match[objKey].query : mooduleFilter.meta.value;
           const key = `filter-key-${objKey}`;
           const value = `filter-value-${objValue}`;
-          //
-          if (data.value.includes(key) && data.value.includes(value) && !data.value.includes('filter-pinned')) {
+
+          const noExcludedValues = !data.value.includes('filter-pinned') && !data.value.includes('filter-negated') 
+          const acceptedValues = data.value.includes(key) && data.value.includes(value)
+
+          if ( acceptedValues && noExcludedValues) {
             found = true;
-            x.used = true;
+            mooduleFilter.used = true;
           }
         }
       });
       if (!found) {
-        $(filters[i]).siblings('.euiBadge__iconButton').removeClass('hide-close-button');       
-        $(filters[i]).off('click'); 
+        $(allFilters[i]).siblings('.euiBadge__iconButton').removeClass('hide-close-button');       
+        $(allFilters[i]).off('click'); 
       } else {
-        $(filters[i]).siblings('.euiBadge__iconButton').addClass('hide-close-button');
-        $(filters[i]).on('click', ev => {
+        $(allFilters[i]).siblings('.euiBadge__iconButton').addClass('hide-close-button');
+        $(allFilters[i]).on('click', ev => {
           ev.stopPropagation();
         });
       }

--- a/public/components/common/modules/modules-helper.js
+++ b/public/components/common/modules/modules-helper.js
@@ -5,7 +5,7 @@ export class ModulesHelper {
     const $injector = getAngularModule().$injector;
     const location = $injector.get('$location');
     const initialTab = location.search().tab;
-    return new Promise(resolve => {
+    return new Promise((resolve) => {
       const checkExist = setInterval(() => {
         const app = getAngularModule();
         if (app.discoverScope) {
@@ -21,11 +21,9 @@ export class ModulesHelper {
   }
 
   static async cleanAvailableFields() {
-    const fields = document.querySelectorAll(
-      `.dscFieldChooser .dscFieldList--unpopular li`
-    );
+    const fields = document.querySelectorAll(`.dscFieldChooser .dscFieldList--unpopular li`);
     if (fields.length) {
-      fields.forEach(field => {
+      fields.forEach((field) => {
         const attr = field.getAttribute('data-attr-field');
         if (attr.startsWith('_')) {
           field.style.display = 'none';
@@ -35,15 +33,14 @@ export class ModulesHelper {
   }
 
   static hideCloseButtons = () => {
-    this.activeNoImplicitsFilters()
+    this.activeNoImplicitsFilters();
   };
 
   static activeNoImplicitsFilters() {
     const { filterManager } = getDataPlugin().query;
     const implicitFilters = filterManager.getFilters().filter((x) => {
-      return x.$state.isImplicit
-    }
-    );
+      return x.$state.isImplicit;
+    });
     if (!(implicitFilters || []).length) {
       setTimeout(() => {
         this.activeNoImplicitsFilters();
@@ -54,30 +51,35 @@ export class ModulesHelper {
     for (let i = 0; i < allFilters.length; i++) {
       const data = allFilters[i].attributes['data-test-subj'];
       let found = false;
-      (implicitFilters || []).forEach(mooduleFilter => {
+      (implicitFilters || []).forEach((moduleFilter) => {
         // Checks if the filter is already in use
         // Check which of the filters are from the module view and which are not pinned filters
-        if(!mooduleFilter.used){
-          const objKey = mooduleFilter.query?.match ? Object.keys(mooduleFilter.query.match)[0] : mooduleFilter.meta.key;
-          const objValue = mooduleFilter.query?.match ? mooduleFilter.query.match[objKey].query : mooduleFilter.meta.value;
+        if (!moduleFilter.used) {
+          const objKey = moduleFilter.query?.match
+            ? Object.keys(moduleFilter.query.match)[0]
+            : moduleFilter.meta.key;
+          const objValue = moduleFilter.query?.match
+            ? moduleFilter.query.match[objKey].query
+            : moduleFilter.meta.value;
           const key = `filter-key-${objKey}`;
           const value = `filter-value-${objValue}`;
 
-          const noExcludedValues = !data.value.includes('filter-pinned') && !data.value.includes('filter-negated') 
-          const acceptedValues = data.value.includes(key) && data.value.includes(value)
+          const noExcludedValues =
+            !data.value.includes('filter-pinned') && !data.value.includes('filter-negated');
+          const acceptedValues = data.value.includes(key) && data.value.includes(value);
 
-          if ( acceptedValues && noExcludedValues) {
+          if (acceptedValues && noExcludedValues) {
             found = true;
-            mooduleFilter.used = true;
+            moduleFilter.used = true;
           }
         }
       });
       if (!found) {
-        $(allFilters[i]).siblings('.euiBadge__iconButton').removeClass('hide-close-button');       
-        $(allFilters[i]).off('click'); 
+        $(allFilters[i]).siblings('.euiBadge__iconButton').removeClass('hide-close-button');
+        $(allFilters[i]).off('click');
       } else {
         $(allFilters[i]).siblings('.euiBadge__iconButton').addClass('hide-close-button');
-        $(allFilters[i]).on('click', ev => {
+        $(allFilters[i]).on('click', (ev) => {
           ev.stopPropagation();
         });
       }

--- a/public/components/common/modules/modules-helper.js
+++ b/public/components/common/modules/modules-helper.js
@@ -54,11 +54,14 @@ export class ModulesHelper {
       const data = filters[i].attributes[3];
       let found = false;
       (implicitFilters || []).forEach(x => {
+        // The IF: checks if the filter is already in use
+        // Check which of the filters are from the view and which are not pinned filters
         if(!x.used){
           const objKey = x.query && x.query.match ? Object.keys(x.query.match)[0] : x.meta.key;
           const objValue = x.query && x.query.match ? x.query.match[objKey].query : x.meta.value;
           const key = `filter-key-${objKey}`;
           const value = `filter-value-${objValue}`;
+          //
           if (data.value.includes(key) && data.value.includes(value) && !data.value.includes('filter-pinned')) {
             found = true;
             x.used = true;


### PR DESCRIPTION
**Description:**

Changes in the function where it checks if the filter is from the modules view or if it is an added filter, since currently the filters that can be added, such as the negation of the filters of each module, cannot be removed, and ideally they are have to be able to remove all custom filters.

**issue:**

- #4045

**Test:**

You should always be able to remove the filter

1. Navigate to any module, for example, Security Events
2. Add filter `NOT cluster.name: wazuh` 
3. Pin filter
4. Unpin filter

**Screenshot:**

![Filtros](https://user-images.githubusercontent.com/63758389/165717120-260bb366-4c8c-40e7-9c31-df45fb7af79e.gif)


