### PR TITLE
The icon correct groups files

### DIFF
--- a/public/controllers/management/components/management/groups/utils/columns-files.js
+++ b/public/controllers/management/components/management/groups/utils/columns-files.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { EuiToolTip, EuiButtonIcon } from '@elastic/eui';
 import GroupsHandler from '../utils/groups-handler';
 import beautifier from '../../../../../../utils/json-beautifier';
+import { WzButtonPermissions } from '../../../../../../components/common/permissions/button';
 
 export default class GroupsFilesColumns {
   constructor(tableProps) {
@@ -9,6 +10,50 @@ export default class GroupsFilesColumns {
 
     const { itemDetail } = this.tableProps.state;
     this.groupsHandler = GroupsHandler;
+
+    this.showFile = async(item) => {
+      let result = await this.groupsHandler.getFileContent(
+        `/groups/${itemDetail.name}/files/${item.filename}/xml`
+      );
+
+      if (Object.keys(result).length == 0) {
+        result = '';
+      }
+
+      const data =  typeof result === 'object'
+          ? JSON.stringify(result, null, 2)
+          : result.toString()
+
+      const file = {
+        name: item.filename,
+        content: data,
+        isEditable: false,
+        groupName: itemDetail.name
+      };
+
+      this.tableProps.updateFileContent(file);
+    }
+
+    this.editFile = async (item) => {
+
+      let result = await this.groupsHandler.getFileContent(
+        `/groups/${itemDetail.name}/files/${item.filename}/xml`
+      );
+      if (Object.keys(result).length == 0) {
+        result = '';
+      }
+
+      const data = this.autoFormat(result);
+
+      const file = {
+        name: 'agent.conf',
+        content: data,
+        isEditable: true,
+        groupName: itemDetail.name,
+      };
+
+      this.tableProps.updateFileContent(file);
+    }
 
     this.buildColumns = () => {
       this.columns = [
@@ -35,30 +80,24 @@ export default class GroupsFilesColumns {
                 <EuiButtonIcon
                   aria-label="See file content"
                   iconType="eye"
-                  onClick={async () => {
-                    let result = await this.groupsHandler.getFileContent(
-                      `/groups/${itemDetail.name}/files/${item.filename}/xml`
-                    );
-                    if (Object.keys(result).length == 0) {
-                      result = '';
-                    }
-                    const isEditable = item.filename === 'agent.conf';
-                    const data = !isEditable
-                      ? typeof result === 'object'
-                        ? JSON.stringify(result, null, 2)
-                        : result.toString()
-                      : this.autoFormat(result);
-                    const file = {
-                      name: item.filename,
-                      content: data,
-                      isEditable: isEditable,
-                      groupName: itemDetail.name
-                    };
-                    this.tableProps.updateFileContent(file);
-                  }}
+                  onClick={() => this.showFile(item)}
                   color="primary"
                 />
               </EuiToolTip>
+              {
+                item.filename === 'agent.conf' &&
+                <WzButtonPermissions
+                  buttonType="icon"
+                  aria-label="Edit content"
+                  iconType="pencil"
+                  permissions={[
+                    { action: 'group:read', resource: `group:id:${itemDetail.name}` },
+                  ]}
+                  tooltip={{ position: 'top', content: `Edit ${item.filename}` }}
+                  onClick={() => this.editFile(item)}
+                  color="primary"
+                />
+              }
             </div>
           );
         }


### PR DESCRIPTION
**Description:**

In the groups file table, there was a file (agent.conf) that showed you the only read icon and sent you to the view to edit the file, so I separated the show and edit function and added the edit button

**Issue:**

- #4064

**Test:**

1. Navigate to 'Management/Groups'
2. Select any group
3. Select the 'Files' tab within the group details
4. Use the actions from the `agent.conf` file

**Screenshot:**

![button](https://user-images.githubusercontent.com/63758389/165769872-5eef71c9-e34e-4a9c-af7f-e696e34c0d69.gif)

