### PR TITLE
Add the spinner when exporting a table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -164,6 +164,8 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fixed agent breadcrumb routing minor error [#4101](https://github.com/wazuh/wazuh-kibana-app/pull/4101)
 - Fixed selected text not visible in API Console [#4102](https://github.com/wazuh/wazuh-kibana-app/pull/4102)
 - Fixed the 'missing parameters' error on the Manager Logs [#4110](https://github.com/wazuh/wazuh-kibana-app/pull/4110)
+- Fixed not being able to remove custom filters. [#4112](https://github.com/wazuh/wazuh-kibana-app/pull/4112)
+- Fixed spinner not showing when export button is clicked in management views [#4120](https://github.com/wazuh/wazuh-kibana-app/pull/4120)
 
 ## Wazuh v4.2.6 - Kibana 7.10.2, 7.11.2, 7.12.1, 7.13.0, 7.13.1, 7.13.2, 7.13.3, 7.13.4, 7.14.0, 7.14.1, 7.14.2 - Revision 4207
 

--- a/public/controllers/management/components/management/mg-logs/logs.js
+++ b/public/controllers/management/components/management/mg-logs/logs.js
@@ -403,7 +403,6 @@ export default compose(
             title: error.name,
           },
         };
-        this.setState({generatingCsv: false})
         getErrorOrchestrator().handleError(options);
       }
       this.setState({generatingCsv: false})

--- a/public/controllers/management/components/management/mg-logs/logs.js
+++ b/public/controllers/management/components/management/mg-logs/logs.js
@@ -90,6 +90,7 @@ export default compose(
 
         this.setState(
           {
+            generatingCsv: false,
             selectedNode,
             selectedDaemon: 'all',
             logLevelSelect: 'all',
@@ -382,6 +383,7 @@ export default compose(
 
     exportFormatted = async () => {
       try {
+        this.setState({generatingCsv: true})
         this.showToast('success', 'Your download should begin automatically...', 3000);
         const filters = this.buildFilters();
         await exportCsv(
@@ -401,9 +403,10 @@ export default compose(
             title: error.name,
           },
         };
-
+        this.setState({generatingCsv: false})
         getErrorOrchestrator().handleError(options);
       }
+      this.setState({generatingCsv: false})
     };
 
     header() {
@@ -422,7 +425,10 @@ export default compose(
             <EuiFlexItem grow={false}>
               <EuiFlexGroup>
                 <EuiFlexItem grow={false}>
-                  <EuiButtonEmpty iconType="importAction" onClick={this.exportFormatted}>
+                  <EuiButtonEmpty 
+                    iconType="importAction" 
+                    onClick={this.exportFormatted}
+                    isLoading={this.state.generatingCsv}>
                     Export formatted
                   </EuiButtonEmpty>
                 </EuiFlexItem>

--- a/public/controllers/management/components/management/ruleset/actions-buttons.js
+++ b/public/controllers/management/components/management/ruleset/actions-buttons.js
@@ -210,6 +210,7 @@ class WzRulesetActionButtons extends Component {
         iconType="exportAction"
         iconSide="left"
         onClick={async () => await this.generateCsv()}
+        isLoading={this.state.generatingCsv}
       >
         Export formatted
       </WzButtonPermissions>


### PR DESCRIPTION
**Description:**

The spinner is added when the Export formatted button is clicked on all views of Management since it was clicked and did not show anything to the user who was making the request

**Issue:**

- #4060 

**Test:**

1. Navigate to `Management/(Rules | Decoders | etc.)`
2. Click on 'Export formatted'
3. See spinner when requesting

**Screenshot:**

https://user-images.githubusercontent.com/63758389/165907441-6ce80c86-7940-4cda-bc90-7474538fab39.mp4

