### PR TITLE
Fixed searchbar suggest handler undefined input ref

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -166,6 +166,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fixed agent breadcrumb routing minor error [#4101](https://github.com/wazuh/wazuh-kibana-app/pull/4101)
 - Fixed selected text not visible in API Console [#4102](https://github.com/wazuh/wazuh-kibana-app/pull/4102)
 - Fixed the 'missing parameters' error on the Manager Logs [#4110](https://github.com/wazuh/wazuh-kibana-app/pull/4110)
+- Fixed undefined input reference when switching between rule set view and rule files view [#4125](https://github.com/wazuh/wazuh-kibana-app/pull/4125)
 
 ## Wazuh v4.2.6 - Kibana 7.10.2, 7.11.2, 7.12.1, 7.13.0, 7.13.1, 7.13.2, 7.13.3, 7.13.4, 7.14.0, 7.14.1, 7.14.2 - Revision 4207
 

--- a/public/components/wz-search-bar/lib/suggest-handler.ts
+++ b/public/components/wz-search-bar/lib/suggest-handler.ts
@@ -41,7 +41,7 @@ export class SuggestHandler extends BaseHandler {
     ':': 'Equals',
   };
 
-  constructor(props, setInputValue) {
+  constructor(props, setInputValue, inputRef) {
     super();
     this.props = props;
     this.filters = props.filters;
@@ -50,6 +50,8 @@ export class SuggestHandler extends BaseHandler {
     this.suggestItems = props.suggestions;
     this.searchType = 'search';
     this.lastCall = 0;
+    if (inputRef)
+      this.inputRef = inputRef;
   }
 
   combine = (...args) => (input) => args.reduceRight((acc, arg) => (acc = arg(acc)), input);

--- a/public/components/wz-search-bar/wz-search-bar.tsx
+++ b/public/components/wz-search-bar/wz-search-bar.tsx
@@ -101,7 +101,7 @@ function useSuggestHandler(
 
   useEffect(() => {
     setHandler(
-      new SuggestHandler({ ...props, status, setStatus, setInvalid, setIsOpen }, setInputValue)
+      new SuggestHandler({ ...props, status, setStatus, setInvalid, setIsOpen }, setInputValue, inputRef)
     );
     !props.noDeleteFiltersOnUpdateSuggests && props.onFiltersChange([]);
   }, [props.suggestions]);


### PR DESCRIPTION
**This is a workaround for the issue #4105** 

The ruleset view and the rule files view share the same input, so the reference of the input does not trigger the useEffect and is lost. To fix this I added a possible pre-existing reference to the constructor of the suggestion component. 

This base issue also causes another problem, because changing the view doesn't reset the input and keeps the previous search. When a previous field has a query it fails on the new view. 

E.g.
![Peek 2022-04-29 20-26](https://user-images.githubusercontent.com/9343732/166006655-14ade2bd-1774-471c-9ede-d0055a9622ac.gif)
