### PR TITLE
[Logtest] Enhance the output of Ruleset Test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the Wazuh app project will be documented in this file.
 
+## Wazuh v4.3.0 - Kibana 7.10.2 , 7.16.x, 7.17.x - Revision 4302
+
+### Fixed
+
+- Fixed the falsy values are displayed as not defined and enhanced the output of `Ruleset Test` [#4141](https://github.com/wazuh/wazuh-kibana-app/pull/4141)
+
 ## Wazuh v4.3.0 - Kibana 7.10.2 , 7.16.x, 7.17.x - Revision 4301
 
 ### Added

--- a/public/directives/wz-logtest/components/logtest.tsx
+++ b/public/directives/wz-logtest/components/logtest.tsx
@@ -46,6 +46,7 @@ import {
 import { UI_LOGGER_LEVELS } from '../../../../common/constants';
 import { getErrorOrchestrator } from '../../../react-services/common-services';
 import { WzFlyout } from '../../../components/common/flyouts';
+import _ from 'lodash';
 
 type LogstestProps = {
   openCloseFlyout: () => {};
@@ -69,41 +70,83 @@ export const Logtest = compose(
     setEvents(e.target.value.split('\n').filter((item) => item));
   };
 
+  // Format the result of the Wazuh API response to an output similar one to the `wazuh-logtest` utility
   const formatResult = (result, alert) => {
-    let returnedDataFormatted =
-      `**Phase 1: Completed pre-decoding. \n    ` +
-      `full event:  ${result.full_log || '-'}  \n    ` +
-      `timestamp: ${(result.predecoder || '').timestamp || '-'} \n    ` +
-      `hostname: ${(result.predecoder || '').hostname || '-'} \n    ` +
-      `program_name: ${(result.predecoder || '').program_name || '-'} \n\n` +
-      `**Phase 2: Completed decoding. \n    ` +
-      `name: ${(result.decoder || '').name || '-'} \n    ` +
-      `${(result.decoder || '').parent ? `parent: ${(result.decoder || '').parent} \n    ` : ''}` +
-      `data: ${JSON.stringify(result.data || '-', null, 6).replace('}', '    }')} \n\n`;
+    // How to the `wazuh-logtest` utility logs the output:
+    // https://github.com/wazuh/wazuh/blob/master/framework/scripts/wazuh-logtest.py#L359-L397
 
-    result.rule &&
-      (returnedDataFormatted +=
-        `**Phase 3: Completed filtering (rules). \n    ` +
-        `id: ${(result.rule || '').id || '-'} \n    ` +
-        `level: ${(result.rule || '').level || '-'} \n    ` +
-        `description: ${(result.rule || '').description || '-'} \n    ` +
-        `groups: ${JSON.stringify((result.rule || '').groups || '-')} \n    ` +
-        `firedtimes: ${(result.rule || '').firedtimes || '-'} \n    ` +
-        `gdpr: ${JSON.stringify((result.rule || '').gdpr || '-')} \n    ` +
-        `gpg13: ${JSON.stringify((result.rule || '').gpg13 || '-')} \n    ` +
-        `hipaa: ${JSON.stringify((result.rule || '').hipaa || '-')} \n    ` +
-        `mail: ${JSON.stringify((result.rule || '').mail || '-')} \n    ` +
-        `mitre.id: ${JSON.stringify((result.rule || '').mitre || ''.id || '-')} \n    ` +
-        `mitre.technique: ${JSON.stringify(
-          (result.rule || '').mitre || ''.technique || '-'
-        )} \n    ` +
-        `nist_800_53: ${JSON.stringify((result.rule || '').nist_800_53 || '-')} \n    ` +
-        `pci_dss: ${JSON.stringify((result.rule || '').pci_dss || '-')} \n    ` +
-        `tsc: ${JSON.stringify((result.rule || '').tsc || '-')} \n`);
 
-    returnedDataFormatted += `${alert ? `**Alert to be generated. \n\n\n` : '\n\n'}`;
-    return returnedDataFormatted;
-  };
+    const logging = [];
+    
+    const showFieldInfo = (item, path, label = '') => {
+      _.has(item, path) && logging.push(
+        `\t${label || path}: '${Array.isArray(_.get(item, path))
+          ? JSON.stringify(_.get(item, path))
+          : _.get(item, path)}'`
+        );
+    };
+
+    const showPhaseInfo = (item, showFirst = [], prefix = '') => {
+      showFirst && showFirst.forEach(field => {
+        showFieldInfo(item, field, prefix+field);
+        _.unset(item, field);
+      });
+      typeof item === 'object' && Object.keys(item).sort().forEach((field) => {
+        if(typeof item[field] === 'object' && !Array.isArray(item[field])){
+          showPhaseInfo(item[field],[], prefix + field + '.');
+        }else{
+          showFieldInfo(item, field, prefix+field);
+        };
+      });
+    }
+
+    // Pre-decoding phase
+    logging.push('**Phase 1: Completed pre-decoding.');
+    // Check in case rule has no_full_log attribute
+    if(result.full_log){
+      showFieldInfo(result, 'full_log', 'full event');
+    };
+
+    if(result.predecoder){
+      showPhaseInfo(result.predecoder, ['timestamp', 'hostname', 'program_name']);
+    }
+
+    // Decoding phase
+    logging.push('');
+    logging.push('**Phase 2: Completed decoding.');
+
+    if(result.decoder && Object.keys(result.decoder).length > 0){
+      showPhaseInfo(result.decoder, ['name', 'parent']);
+      if(result.data){
+        showPhaseInfo(result.data, []);
+      };
+    }else{
+      logging.push('\tNo decoder matched.')
+    }
+
+    // Rule phase
+
+    // Rule debugging
+    // The output has data if the utility is ran in verbose mode: `wazuh-logtest -v`.
+    // At this moment, the Wazuh API doesn't let run in verbose mode.
+    if(result.rules_debug){
+      logging.push('');
+      logging.push('**Rule debugging:');
+      result.rules_debug.forEach(debugMessage => logging.push(`${debugMessage[0] === '*' ? '\t\t' : '\t'}${debugMessage}`));
+    };
+    
+    if(result.rule){
+      logging.push('');
+      logging.push('**Phase 3: Completed filtering (rules).');
+      showPhaseInfo(result.rule, ['id', 'level', 'description', 'groups', 'firedtimes']);
+    };
+
+    if(alert){
+      logging.push('**Alert to be generated.');
+    };
+
+    return logging.join('\n');
+  };  
 
   const runAllTests = async () => {
     setTestResult('');
@@ -129,8 +172,8 @@ export const Logtest = compose(
       const testResults = responses.map((response) => {
         return response.data.data.output || ''
           ? formatResult(response.data.data.output, response.data.data.alert)
-          : `No result found for: ${response.data.data.output.full_log} \n\n\n`;
-      });
+          : `No result found for: ${response.data.data.output.full_log}`;
+      }).join('\n\n');
       setTestResult(testResults);
     } finally {
       setTesting(false);


### PR DESCRIPTION
# Description
This PR enhances the output of the `Ruleset Test` utility by replicating the output of the `wazuh-logtest` utility.

Unique log:
![image](https://user-images.githubusercontent.com/34042064/167619835-8fb8004b-af0f-480c-ad45-de82f5cc7e1f.png)

Multiple logs:
![image](https://user-images.githubusercontent.com/34042064/167619958-df150f75-2be8-42b1-b0d9-862590b947f9.png)

Log no match a decoder:
![image](https://user-images.githubusercontent.com/34042064/167619785-476881fb-9ef7-4373-8c4f-8e40174a4737.png)

# Changes
- Remove the logging of the specific fields
- Replicate the output of the `wazuh-logtest` utility:
  - Add tabulations
  - Fix phase text
  - Wrap the values in single quotes
  - Displays the fields that are defined
  
# Test
Go to `Tools/Ruleset Test` and check the next cases are working as expected:
- Unique log that matches a decoder and rule

> For example:
> ```
> Jul 06 22:00:22 linux-agent sshd[29205]: Invalid user blimey from 1.3.1.3 port 48928
> ```

- Multiple logs (match or not)
> For example:
> ```
> Jul 06 22:00:22 linux-agent sshd[29205]: Invalid user blimey from 1.3.1.3 port 48928
> Jul 06 22:00:22 linux-agent custom[10215]: Invalid user custom_user from 0.0.0.0 port 48900
> ```

- Log that doesn't match a decoder
> For example:
> ```
> custom Jul 06 22:00:22 linux-agent sshd[29205]: Invalid user blimey from 1.3.1.3 port 48928
> ```
The message `No decoder matched.` in phase 2 should appear.


- Any other case that is not defined here.