### PR TITLE
Add powershell version warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 All notable changes to the Wazuh app project will be documented in this file.
 
-## Wazuh v4.3.0 - Kibana 7.10.2 , 7.16.x, 7.17.x - Revision 4302
+## Wazuh v4.3.1 - Kibana 7.10.2 , 7.16.x, 7.17.x - Revision 4302
+
+### Added
+
+- Added PowerShell version warning to Windows agent installation wizard [#4142](https://github.com/wazuh/wazuh-kibana-app/pull/4142)
 
 ### Fixed
 

--- a/public/controllers/agent/components/register-agent.js
+++ b/public/controllers/agent/components/register-agent.js
@@ -502,7 +502,7 @@ export const RegisterAgent = withErrorBoundary(
               <li><span>You will need administrator privileges to perform this installation.</span></li>
               <li><span>PowerShell 3.0 or greater is required.</span></li>
             </ul>
-            <p>Keep in mind you need to run this command in a Windows PowerShell terminal</p>
+            <p>Keep in mind you need to run this command in a Windows PowerShell terminal.</p>
           </EuiCallOut>
           <EuiSpacer></EuiSpacer>
         </>

--- a/public/controllers/agent/components/register-agent.js
+++ b/public/controllers/agent/components/register-agent.js
@@ -495,11 +495,15 @@ export const RegisterAgent = withErrorBoundary(
       const windowsAdvice = this.state.selectedOS === 'win' && (
         <>
           <EuiCallOut
-            title="You will need administrator privileges to perform this installation."
+            title="Requirements"
             iconType="iInCircle"
-            >
-              <p>Keep in mind you need to run this command in a Windows PowerShell terminal</p>
-            </EuiCallOut>
+          >
+            <ul class="wz-callout-list">
+              <li><span>You will need administrator privileges to perform this installation.</span></li>
+              <li><span>PowerShell 3.0 or greater is required.</span></li>
+            </ul>
+            <p>Keep in mind you need to run this command in a Windows PowerShell terminal</p>
+          </EuiCallOut>
           <EuiSpacer></EuiSpacer>
         </>
       );


### PR DESCRIPTION
### Description

This PR adds a warning about the PowerShell version requirement in the agent installation wizard. 

![image](https://user-images.githubusercontent.com/9343732/168044739-261c7fc0-f57f-4992-a1b5-4c7b36b04541.png)

Related with: #4085 