### PR TITLE
[FIX] Avoid to remove the implicit filters in the modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the Wazuh app project will be documented in this file.
 
+## Wazuh v4.3.2 - Kibana 7.10.2, 7.16.x, 7.17.x - Revision 4303
+
+### Fixed
+
+- Fixed the implicit filters in modules can be removed [#4146](https://github.com/wazuh/wazuh-kibana-app/pull/4146)
+
 ## Wazuh v4.3.1 - Kibana 7.10.2 , 7.16.x, 7.17.x - Revision 4302
 
 ### Added

--- a/public/components/common/modules/modules-helper.js
+++ b/public/components/common/modules/modules-helper.js
@@ -55,12 +55,12 @@ export class ModulesHelper {
         // Checks if the filter is already in use
         // Check which of the filters are from the module view and which are not pinned filters
         if (!moduleFilter.used) {
-          const objKey = moduleFilter.query?.match
-            ? Object.keys(moduleFilter.query.match)[0]
+          const objKey = moduleFilter.query?.match_phrase
+            ? Object.keys(moduleFilter.query.match_phrase)[0]
             : moduleFilter.meta.key;
-          const objValue = moduleFilter.query?.match
-            ? moduleFilter.query.match[objKey].query
-            : moduleFilter.meta.value;
+          const objValue = moduleFilter.query?.match_phrase
+            ? moduleFilter.query.match_phrase[objKey].query
+            : moduleFilter.meta.value();
           const key = `filter-key-${objKey}`;
           const value = `filter-value-${objValue}`;
 


### PR DESCRIPTION
# Description
This PR fixes the possibility to remove the implicit filters in the modules.

# Changes
- Restored the change from `match` to `match_phrase` when seeing the filters in the search bar.
- Restored the use of `.meta.value()` for Kibana 7.16.x-7.17.x.

These changes were introduced previously in:
- https://github.com/wazuh/wazuh-kibana-app/commit/b7f63d04c208e367bab9f7b8e1ef6b79aa532e39
- https://github.com/wazuh/wazuh-kibana-app/pull/3777/commits/e860353325d9015212004a85f73d5c9a2b7ee53b

Closes #4144