### PR TITLE
Fix/4143 the default filter does not disappear

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -186,6 +186,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fixed spinner not showing when export button is clicked in management views [#4120](https://github.com/wazuh/wazuh-kibana-app/pull/4120)
 - Correction of field and value in the section: last registered agent [#4127](https://github.com/wazuh/wazuh-kibana-app/pull/4127)
 - Fixed the download agent installer command [#4132] (https://github.com/wazuh/wazuh-kibana-app/pull/4132)
+- Remove filters when we click on the visualize button [#4154] (https://github.com/wazuh/wazuh-kibana-app/pull/4154)
 
 ## Wazuh v4.2.6 - Kibana 7.10.2, 7.11.2, 7.12.1, 7.13.0, 7.13.1, 7.13.2, 7.13.3, 7.13.4, 7.14.0, 7.14.1, 7.14.2 - Revision 4207
 

--- a/public/kibana-integrations/discover/application/components/sidebar/discover_field_details.tsx
+++ b/public/kibana-integrations/discover/application/components/sidebar/discover_field_details.tsx
@@ -30,6 +30,7 @@ import { Bucket, FieldDetails } from './types';
 import { IndexPatternField, IndexPattern } from '../../../../../../../../src/plugins/data/public';
 import './discover_field_details.scss';
 import { getDataPlugin } from '../../../../../kibana-services';
+
 interface DiscoverFieldDetailsProps {
   field: IndexPatternField;
   indexPattern: IndexPattern;

--- a/public/kibana-integrations/discover/application/components/sidebar/discover_field_details.tsx
+++ b/public/kibana-integrations/discover/application/components/sidebar/discover_field_details.tsx
@@ -29,7 +29,7 @@ import {
 import { Bucket, FieldDetails } from './types';
 import { IndexPatternField, IndexPattern } from '../../../../../../../../src/plugins/data/public';
 import './discover_field_details.scss';
-
+import { getDataPlugin } from '../../../../../kibana-services';
 interface DiscoverFieldDetailsProps {
   field: IndexPatternField;
   indexPattern: IndexPattern;
@@ -68,11 +68,15 @@ export function DiscoverFieldDetails({
   }, [field, indexPattern.id, details.columns]);
 
   const handleVisualizeLinkClick = (event: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => {
+    const { filterManager } = getDataPlugin().query;
+    if (filterManager.getFilters() && filterManager.getFilters().length) {
+      filterManager.removeAll();
+    }
     // regular link click. let the uiActions code handle the navigation and show popup if needed
     event.preventDefault();
     triggerVisualizeActions(field, indexPattern.id, details.columns);
   };
-
+  
   return (
     <>
       <div className="dscFieldDetails">

--- a/public/kibana-integrations/discover/application/components/sidebar/discover_field_details.tsx
+++ b/public/kibana-integrations/discover/application/components/sidebar/discover_field_details.tsx
@@ -68,6 +68,9 @@ export function DiscoverFieldDetails({
   }, [field, indexPattern.id, details.columns]);
 
   const handleVisualizeLinkClick = (event: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => {
+    // In branch 7.16.3 when clicking on the visualize button the filters are eliminated, in branch 7.10.2 the filters are also eliminated but visually we never stopped seeing them since the visualize plugin added them again.
+    // When clicking on the visualize button: In the 7.16.3 branch the lens plugin is used instead in the 7.10.2 branch the visualize plugin is used.
+    // We think it is best if the 7.10.2 branch behaves like the 7.16.3 branch and the filters are removed, when we click on the visualize button.
     const { filterManager } = getDataPlugin().query;
     if (filterManager.getFilters() && filterManager.getFilters().length) {
       filterManager.removeAll();


### PR DESCRIPTION
In branch 7.16.3 when clicking on the visualize button the filters are eliminated, in branch 7.10.2 the filters are also eliminated but visually we never stopped seeing them since the visualize plugin added them again.
When clicking on the visualize button: In the 7.16.3 branch the lens plugin is used instead in the 7.10.2 branch the visualize plugin is used.
We think it is best if the 7.10.2 branch behaves like the 7.16.3 branch and the filters are removed, when we click on the visualize button.

**Steps to test**

Navigate to Modules/Security Events
Click Events
Click Agent.name
Click the Visualize button in the popup window
Check that the filter has disappeared

https://user-images.githubusercontent.com/99441266/168912774-fdc8d777-413b-469c-a0ff-6d1e3025a69f.mp4

Closes #4143