### PR TITLE
[Fix] Displaying that an agent was removed successfully from a group and the agent appear in the agent group list

### DIFF
--- a/public/controllers/management/components/management/groups/group-agents-table.js
+++ b/public/controllers/management/components/management/groups/group-agents-table.js
@@ -274,10 +274,7 @@ class WzGroupAgentsTable extends Component {
     const { itemDetail } = this.props.state;
     this.props.updateLoadingStatus(true);
     try {
-      items.map(async (item) => {
-        await this.groupsHandler.deleteAgent(item.id, itemDetail.name);
-      });
-
+      await Promise.all(items.map(item => this.groupsHandler.deleteAgent(item.id, itemDetail.name)));
       this.props.updateIsProcessing(true);
       this.props.updateLoadingStatus(false);
       this.props.updateReload();


### PR DESCRIPTION
Previously the toast appear without awating the response to the Wazuh
API request to remove the agent
