### PR TITLE
[UI] Replaced as the full and partial scan dates are displayed in the Details panel in Vulnerabilites/Inventory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 
 ### Changed
 
-- Replaced as the full and partial scan dates are displayed in the `Details` panel of `Vulnerabilities/Inventory` [#4169](https://github.com/wazuh/wazuh-kibana-app/pull/4169)
+- Replaced how the full and partial scan dates are displayed in the `Details` panel of `Vulnerabilities/Inventory` [#4169](https://github.com/wazuh/wazuh-kibana-app/pull/4169)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 All notable changes to the Wazuh app project will be documented in this file.
 
-## Wazuh v4.3.2 - Kibana 7.10.2, 7.16.x, 7.17.x - Revision 4301
+## Wazuh v4.3.2 - Kibana 7.10.2, 7.16.x, 7.17.x - Revision 4303
+
+### Changed
+
+- Replaced as the full and partial scan dates are displayed in the `Details` panel of `Vulnerabilities/Inventory` [#4169](https://github.com/wazuh/wazuh-kibana-app/pull/4169)
 
 ### Fixed
 

--- a/public/components/agents/vuls/inventory.tsx
+++ b/public/components/agents/vuls/inventory.tsx
@@ -248,6 +248,7 @@ export class Inventory extends Component {
                         title={last_full_scan}
                         description="Last full scan"
                         textAlign='center'
+                        titleSize='xs'
                       />
                     </EuiFlexItem>
                     <EuiFlexItem>
@@ -255,6 +256,7 @@ export class Inventory extends Component {
                         title={last_partial_scan}
                         description="Last partial scan"
                         textAlign='center'
+                        titleSize='xs'
                       />
                     </EuiFlexItem>
                   </EuiFlexGroup>

--- a/public/components/agents/vuls/inventory.tsx
+++ b/public/components/agents/vuls/inventory.tsx
@@ -36,6 +36,7 @@ import {
 import { ICustomBadges } from '../../wz-search-bar/components';
 import { formatUIDate } from '../../../react-services';
 import { VisualizationBasicWidgetSelector, VisualizationBasicWidget  } from '../../common/charts/visualizations/basic';
+import { WzStat } from '../../wz-stat';
 
 interface Aggregation { title: number, description: string, titleColor: string }
 interface pieStats { id: string, label: string, value: number }
@@ -243,14 +244,18 @@ export class Inventory extends Component {
                   </EuiFlexGroup>
                   <EuiFlexGroup style={{ marginTop: 'auto' }}>
                     <EuiFlexItem>
-                      <EuiText>
-                        <EuiIcon type="calendar" color={'primary'} /> Last full scan: {last_full_scan}
-                      </EuiText>
+                      <WzStat
+                        title={last_full_scan}
+                        description="Last full scan"
+                        textAlign='center'
+                      />
                     </EuiFlexItem>
                     <EuiFlexItem>
-                      <EuiText>
-                        <EuiIcon type="calendar" color={'primary'} /> Last partial scan: {last_partial_scan}
-                      </EuiText>
+                      <WzStat
+                        title={last_partial_scan}
+                        description="Last partial scan"
+                        textAlign='center'
+                      />
                     </EuiFlexItem>
                   </EuiFlexGroup>
                 </EuiFlexItem>


### PR DESCRIPTION
# Description

This PR replaces as the full and partial scan dates are displayed in the `Details` panel in `Vulnerabilities/Inventory`

# Changes
- Use the same component that renders data in the agent overview

# Screenshot
![image](https://user-images.githubusercontent.com/34042064/170490840-87eaa5a8-d175-4853-a40d-f538d5fd4deb.png)

# Test

- Generate vulnerabilities for an agent and go to `Vulnerabilities/Inventory and see the `Details` panel, the dates should be rendered as expected

Closes #4049 