### PR TITLE
Overwriting files in rules and decoders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Change Log
 
 All notable changes to the Wazuh app project will be documented in this file.
-## Wazuh v4.3.4 - Kibana 7.10.2, 7.16.x, 7.17.x - Revision 4303
+## Wazuh v4.3.4 - Kibana 7.10.2, 7.16.x, 7.17.x - Revision 4305
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Change Log
 
 All notable changes to the Wazuh app project will be documented in this file.
+## Wazuh v4.3.4 - Kibana 7.10.2, 7.16.x, 7.17.x - Revision 4303
+
+### Fixed
+
+- Fixed overwriting of rule and decoder imports [#4180](https://github.com/wazuh/wazuh-kibana-app/pull/4180)
 
 ## Wazuh v4.3.2 - Kibana 7.10.2, 7.16.x, 7.17.x - Revision 4301
 

--- a/public/controllers/management/components/management/ruleset/actions-buttons.js
+++ b/public/controllers/management/components/management/ruleset/actions-buttons.js
@@ -93,7 +93,7 @@ class WzRulesetActionButtons extends Component {
    * @param {Array} files
    * @param {String} path
    */
-  async uploadFiles(files, resource) {
+  async uploadFiles(files, resource, overwrite) {
     try {
       let errors = false;
       let results = [];
@@ -101,7 +101,7 @@ class WzRulesetActionButtons extends Component {
       for (let idx in files) {
         const { file, content } = files[idx];
         try {
-          await rulesetHandler.updateFile(file, content, resource !== RulesetResources.LISTS); // True does not overwrite the file
+          await rulesetHandler.updateFile(file, content, overwrite); // True does not overwrite the file
           results.push({
             index: idx,
             uploaded: true,
@@ -119,7 +119,7 @@ class WzRulesetActionButtons extends Component {
         }
       }
       if (errors) throw results;
-      return;
+      return results;
     } catch (error) {
       throw error;
     }
@@ -271,22 +271,13 @@ class WzRulesetActionButtons extends Component {
       </EuiButtonEmpty>
     );
 
-    const uploadFile = async (files, resource) => {
+    const uploadFile = async (files, resource, overwrite) => {
       try {
-        await this.uploadFiles(files, resource);
+        const result = await this.uploadFiles(files, resource, overwrite);
         await this.refresh();
+        return result
       } catch (error) {
-        const options = {
-          context: `${WzRulesetActionButtons.name}.uploadFile`,
-          level: UI_LOGGER_LEVELS.ERROR,
-          severity: UI_ERROR_SEVERITIES.BUSINESS,
-          error: {
-            error: error,
-            message: `Error files cannot be uploaded: ${error.message || error}`,
-            title: error.name || error,
-          },
-        };
-        getErrorOrchestrator().handleError(options);
+        return error
       }
     };
 

--- a/public/controllers/management/components/management/ruleset/actions-buttons.js
+++ b/public/controllers/management/components/management/ruleset/actions-buttons.js
@@ -101,7 +101,7 @@ class WzRulesetActionButtons extends Component {
       for (let idx in files) {
         const { file, content } = files[idx];
         try {
-          await rulesetHandler.updateFile(file, content, overwrite); // True does not overwrite the file
+          await rulesetHandler.updateFile(file, content, overwrite);
           results.push({
             index: idx,
             uploaded: true,

--- a/public/controllers/management/components/upload-files.js
+++ b/public/controllers/management/components/upload-files.js
@@ -48,7 +48,6 @@ export class UploadFiles extends Component {
     this.setOverwrite = this.setOverwrite.bind(this);
     this.closePopover = this.closePopover.bind(this);
     this.startUpload = this.startUpload.bind(this);
-    // this.closePopover = this.closePopover.bind(this);
   }
   
   setOverwrite(e) {

--- a/public/controllers/management/components/upload-files.js
+++ b/public/controllers/management/components/upload-files.js
@@ -360,7 +360,7 @@ export class UploadFiles extends Component {
                           iconType="sortUp"
                           onClick={() => this.startUpload()}
                         >
-                          Re-upload
+                          Upload
                         </EuiButton>
                       </EuiFlexItem>
                     </EuiFlexGroup>

--- a/public/controllers/management/components/upload-files.js
+++ b/public/controllers/management/components/upload-files.js
@@ -24,7 +24,7 @@ import {
   EuiText,
   EuiSpacer,
   EuiPopover,
-  EuiCheckbox,
+  EuiSwitch,
   EuiFlexGroup
 } from '@elastic/eui';
 
@@ -43,9 +43,15 @@ export class UploadFiles extends Component {
       overwrite: false
     };
     this.maxSize = 10485760; // 10Mb
+
+    this.onButtonClick = this.onButtonClick.bind(this);
+    this.setOverwrite = this.setOverwrite.bind(this);
+    this.closePopover = this.closePopover.bind(this);
+    this.startUpload = this.startUpload.bind(this);
+    // this.closePopover = this.closePopover.bind(this);
   }
   
-  activeOverwrite(e) {
+  setOverwrite(e) {
     this.setState({ overwrite: e.target.checked });
   }
 
@@ -286,7 +292,7 @@ export class UploadFiles extends Component {
         permissions={getPermissionsImportFiles()}
         iconType="importAction"
         iconSide="left"
-        onClick={() => this.onButtonClick()}
+        onClick={this.onButtonClick}
       >
         Import files
       </WzButtonPermissions>
@@ -297,18 +303,19 @@ export class UploadFiles extends Component {
         button={button}
         isOpen={this.state.isPopoverOpen}
         anchorPosition="downRight"
-        closePopover={() => this.closePopover()}
+        closePopover={this.closePopover}
       >
         <div style={{ width: '300px' }}>
           <EuiTitle size="m">
             <h1>{`Upload ${this.props.resource}`}</h1>
           </EuiTitle>
-          <EuiCheckbox
+          <EuiSwitch
             className='wz-margin-top-10 wz-margin-bottom-10'
             id="overwrite"
-            label="Activate overwriting"
+            label="Overwrite"
             checked={this.state.overwrite}
-            onChange={(e) => this.activeOverwrite(e)}
+            onChange={this.setOverwrite}
+            compressed
           />
           <EuiFlexItem>
             {!this.state.uploadErrors && (
@@ -317,9 +324,7 @@ export class UploadFiles extends Component {
                 multiple
                 compressed={false}
                 initialPromptText={`Select or drag and drop your ${this.props.resource} files here`}
-                onChange={files => {
-                  this.onChange(files);
-                }}
+                onChange={files => this.onChange(files)}
               />
             )}
           </EuiFlexItem>
@@ -339,7 +344,7 @@ export class UploadFiles extends Component {
                       className="upload-files-button"
                       fill
                       iconType="sortUp"
-                      onClick={() => this.startUpload()}
+                      onClick={this.startUpload}
                     >
                       Upload
                     </EuiButton>
@@ -348,7 +353,7 @@ export class UploadFiles extends Component {
                       <EuiFlexItem>
                         <EuiButtonEmpty
                           className="upload-files-button"
-                          onClick={() => this.closePopover()}
+                          onClick={this.closePopover}
                         >
                           Close
                         </EuiButtonEmpty>
@@ -358,7 +363,7 @@ export class UploadFiles extends Component {
                           className="upload-files-button"
                           fill
                           iconType="sortUp"
-                          onClick={() => this.startUpload()}
+                          onClick={this.startUpload}
                         >
                           Upload
                         </EuiButton>

--- a/public/controllers/management/components/upload-files.js
+++ b/public/controllers/management/components/upload-files.js
@@ -95,7 +95,7 @@ export class UploadFiles extends Component {
             clearInterval(interval);
             if (files.length === this.state.files.length) {
               try {
-                const noUploaded = [];
+                const failedUploads = [];
                 const data = await this.props.upload(
                   files,
                   this.props.resource,
@@ -103,9 +103,9 @@ export class UploadFiles extends Component {
                 );
                 this.props.onSuccess && this.props.onSuccess(files);
                 for (const index in data) {
-                  !data[index].uploaded && noUploaded.push(data[index]);
+                  !data[index].uploaded && failedUploads.push(data[index]);
                 }
-                if (noUploaded.length === 0) {
+                if (failedUploads.length === 0) {
                   this.closePopover();
                   this.showToast(
                     'success',

--- a/public/styles/common.scss
+++ b/public/styles/common.scss
@@ -1231,7 +1231,7 @@ wz-xml-file-editor {
 }
 
 .list-element-bad {
-  color: #bd3b4d !important;
+  color: #000 !important;
 }
 
 .logtest-side{


### PR DESCRIPTION
**Description:**

When trying to upload a file with the same name it overwrote it and did not warn you that a file existed. What I did is to recover a functionality that was lost that tells you which files were uploaded or not if any were not uploaded, and add a checkbox for the option to overwrite or not.

**Test:**

1. Go to "Management/Rules or Decoders"
2. Click on "Manage rules files" or "Manage decoders files"
3. Click on "Import files"
4. import files with or without the overwrite option

**Issue:** 

- #4056 

**Screenshot:**

https://user-images.githubusercontent.com/63758389/171361459-6071fe7b-e894-4167-8429-90d6ac85d27e.mp4


