### PR TITLE
[FIX][Kibana][7.16.x-7.17.x] Fix error when building the visualizations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 
 ### Changed
 
-- Replaced the visualization of `Status` panel in `Agents` [#4166](https://github.com/wazuh/wazuh-kibana-app/pull/4166)
+- Replaced the visualization of `Status` panel in `Agents` [#4166](https://github.com/wazuh/wazuh-kibana-app/pull/4166) [#4196](https://github.com/wazuh/wazuh-kibana-app/pull/4196)
 - Replaced the visualization of policy in `Modules/Security configuration assessment/Inventory` [#4166](https://github.com/wazuh/wazuh-kibana-app/pull/4166)
 - Consistency in the colors and labels used for the agent status [#4166](https://github.com/wazuh/wazuh-kibana-app/pull/4166)
 - Replaced how the full and partial scan dates are displayed in the `Details` panel of `Vulnerabilities/Inventory` [#4169](https://github.com/wazuh/wazuh-kibana-app/pull/4169)

--- a/public/controllers/agent/components/agents-preview.js
+++ b/public/controllers/agent/components/agents-preview.js
@@ -81,14 +81,6 @@ export const AgentsPreview = compose(
         this._isMount && this.setState({ 
           showAgentsEvolutionVisualization: true 
         });
-        const tabVisualizations = new TabVisualizations();
-        tabVisualizations.removeAll();
-        tabVisualizations.setTab('general');
-        tabVisualizations.assign({
-          general: 1,
-        });
-        const filterHandler = new FilterHandler(AppState.getCurrentPattern());
-        await VisFactoryHandler.buildOverviewVisualizations(filterHandler, 'general', null);
       }
     }
 

--- a/public/kibana-integrations/kibana-vis.js
+++ b/public/kibana-integrations/kibana-vis.js
@@ -25,7 +25,6 @@ import { updateMetric } from '../redux/actions/visualizationsActions';
 import { GenericRequest } from '../react-services/generic-request';
 import { createSavedVisLoader } from './visualizations/saved_visualizations';
 import { WzDatePicker } from '../components/wz-date-picker/wz-date-picker';
-import { Vis } from '../../../../src/plugins/visualizations/public';
 import {
   EuiLoadingChart,
   EuiLoadingSpinner,
@@ -286,14 +285,10 @@ class KibanaVis extends Component {
             this.visualization
           );
           
-          // In Kibana 7.10.2, there is a bug when creating the visualization with `createVis` method of the Visualization plugin that doesn't pass the `visState` parameter to the `Vis` class constructor.
-          // This does the `.params`, `.uiState` and `.id` properties of the visualization are not set correctly in the `Vis` class constructor. This bug causes
-          // that the visualization, for example, doesn't use the defined colors in the `.uiStateJSON` property.
-          // `createVis` method of Visualizations plugin: https://github.com/elastic/kibana/blob/v7.10.2/src/plugins/visualizations/public/plugin.ts#L207-L211
-          // `Vis` class constructor: https://github.com/elastic/kibana/blob/v7.10.2/src/plugins/visualizations/public/vis.ts#L99-L104
-          // This problem is fixed replicating the logic of Visualization plugin's `createVis` method and pass the expected parameters to the `Vis` class constructor.
-          const vis = new Vis(visState.type, visState);
-          await vis.setState(visState);
+          const vis = await getVisualizationsPlugin().createVis(
+            this.visualization.visState.type,
+            visState
+          );
           
           this.visHandler = await getVisualizationsPlugin().__LEGACY.createVisEmbeddableFromObject(
             vis,


### PR DESCRIPTION
# Description

This PR fixes an error when building the core visualizations for the plugins for Kibana 7.16.x and 7.17.x.

# Changes
- fix an error when building the core visualizations
- fix error in the `Agents` section caused by a not defined class.

# Test
- Navigate to any section which has a core visualization. This should be displayed.