### PR TITLE
Agents tooltip background

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fixed a toast message with a successful process appeared when removing an agent of a group in `Management/Groups` and the agent appears in the agent list after refreshing the table [#4167](https://github.com/wazuh/wazuh-kibana-app/pull/4167)
 - Fixed import of an empty rule or decoder file [#4176](https://github.com/wazuh/wazuh-kibana-app/pull/4176)
 - Fixed overwriting of rule and decoder imports [#4180](https://github.com/wazuh/wazuh-kibana-app/pull/4180)
+- fixed missing background in the status graph tooltip in agents [#4198](https://github.com/wazuh/wazuh-kibana-app/pull/4198)
 
 ## Wazuh v4.3.3 - Kibana 7.10.2, 7.16.x, 7.17.x - Revision 4304
 

--- a/public/components/common/charts/charts/donut.tsx
+++ b/public/components/common/charts/charts/donut.tsx
@@ -43,8 +43,10 @@ export const ChartDonut = (props : ChartDonutProps) => {
   const TooltipContent = ({ data }) => {
     const borderStyle = { borderLeft: `2px solid ${data.color}` };
     return (
-      <div style={borderStyle}>
-        <p style={{ marginLeft: '5px', fontSize: '0.8rem' }}>{data.label}: {data.value}</p>
+      <div className="echTooltip__list">
+        <div style={borderStyle}>
+          <p style={{ marginLeft: '5px', fontSize: '0.8rem' }}>{data.label}: {data.value}</p>
+        </div>
       </div>
     )
   }
@@ -53,7 +55,7 @@ export const ChartDonut = (props : ChartDonutProps) => {
   const onEnter = () => {
     tooltip = d3.select("body")
       .append("div")
-      .attr("class", "wz-chart-tooltip visTooltip");
+      .attr("class", "wz-chart-tooltip visTooltip echTooltip");
   }
 
   const onMove = (d) => {


### PR DESCRIPTION
**Description:**

The background of the tooltips of the agent module is fixed because the background was not appearing.

**Test:**

1. Navigate to Agents
2. Hover in the status chart

Screenshot:

![image](https://user-images.githubusercontent.com/63758389/171903433-4b662d89-c677-440b-833e-e44bf6a3b6dc.png)

Closes https://github.com/wazuh/wazuh-kibana-app/issues/4201