### PR TITLE
[FIX] Visualizations are not built due a Types was not set error in a production package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 
 - Replaced the visualization of `Status` panel in `Agents` [#4166](https://github.com/wazuh/wazuh-kibana-app/pull/4166)
 - Replaced the visualization of policy in `Modules/Security configuration assessment/Inventory` [#4166](https://github.com/wazuh/wazuh-kibana-app/pull/4166)
-- Consistency in the colors and labels used for the agent status [#4166](https://github.com/wazuh/wazuh-kibana-app/pull/4166)
+- Consistency in the colors and labels used for the agent status [#4166](https://github.com/wazuh/wazuh-kibana-app/pull/4166) [#4199](https://github.com/wazuh/wazuh-kibana-app/issues/4199)
 - Replaced how the full and partial scan dates are displayed in the `Details` panel of `Vulnerabilities/Inventory` [#4169](https://github.com/wazuh/wazuh-kibana-app/pull/4169)
 
 ### Fixed

--- a/public/kibana-integrations/kibana-vis.js
+++ b/public/kibana-integrations/kibana-vis.js
@@ -25,7 +25,7 @@ import { updateMetric } from '../redux/actions/visualizationsActions';
 import { GenericRequest } from '../react-services/generic-request';
 import { createSavedVisLoader } from './visualizations/saved_visualizations';
 import { WzDatePicker } from '../components/wz-date-picker/wz-date-picker';
-import { Vis } from '../../../../src/plugins/visualizations/public';
+import { PersistedState } from '../../../../src/plugins/visualizations/public';
 import {
   EuiLoadingChart,
   EuiLoadingSpinner,
@@ -289,9 +289,17 @@ class KibanaVis extends Component {
           // that the visualization, for example, doesn't use the defined colors in the `.uiStateJSON` property.
           // `createVis` method of Visualizations plugin: https://github.com/elastic/kibana/blob/v7.10.2/src/plugins/visualizations/public/plugin.ts#L207-L211
           // `Vis` class constructor: https://github.com/elastic/kibana/blob/v7.10.2/src/plugins/visualizations/public/vis.ts#L99-L104
-          // This problem is fixed replicating the logic of Visualization plugin's `createVis` method and pass the expected parameters to the `Vis` class constructor.
-          const vis = new Vis(visState.type, visState);
-          await vis.setState(visState);
+          // This problem would be fixed replicating the logic of Visualization plugin's `createVis` method and passing the expected parameters to the `Vis` class constructor
+          // but there is an error in the generated plugin package in production related to `Types was not set`.
+          // The remediation is creating the visualization with `.createVis` and set the `.params` and `.uiState` and `.id` properties
+          // as is done in the `Vis` class constructor https://github.com/elastic/kibana/blob/v7.10.2/src/plugins/visualizations/public/vis.ts#L99-L104
+          const vis = await getVisualizationsPlugin().createVis(
+            this.visualization.visState.type,
+            visState
+          );
+          vis.params = vis.getParams(visState.params);
+          vis.uiState = new PersistedState(visState.uiState);
+          vis.id = visState.id;
           
           this.visHandler = await getVisualizationsPlugin().__LEGACY.createVisEmbeddableFromObject(
             vis,


### PR DESCRIPTION
# Description

This PR fixes an error that appears in the production package when building the visualizations. The problem doesn't appear in development mode as they are rendered correctly.

# Changes
- Revert how the visualization is built
- Add logic to apply the params and uiStateJSON properties of the visualization that due a bung in KIbana 7.10.2 these are not working.

# Screenshots
![image](https://user-images.githubusercontent.com/34042064/171863599-c5cd8047-b1fe-440c-9f46-29d76024c3b3.png)

# Test

- The visualizations should be visible in development mode and in a production package without the mentioned error.
- Moreover, the visualizations should renders as expected related to the UI properties.
  - Use case: with data related to the monitoring job of the plugin (agent status), review that the `Evolution` visualization of `Agents` section is displayed with the expected colors for the status labels.
- Review each visualization is visible without problems to see if there is not any problem with the new logic to set some properties of the visualization

Closes https://github.com/wazuh/wazuh-kibana-app/issues/4199