### PR TITLE
String or function validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,8 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fixed a toast message with a successful process appeared when removing an agent of a group in `Management/Groups` and the agent appears in the agent list after refreshing the table [#4167](https://github.com/wazuh/wazuh-kibana-app/pull/4167)
 - Fixed import of an empty rule or decoder file [#4176](https://github.com/wazuh/wazuh-kibana-app/pull/4176)
 - Fixed overwriting of rule and decoder imports [#4180](https://github.com/wazuh/wazuh-kibana-app/pull/4180)
-- fixed missing background in the status graph tooltip in agents [#4198](https://github.com/wazuh/wazuh-kibana-app/pull/4198)
+- Fixed missing background in the status graph tooltip in agents [#4198](https://github.com/wazuh/wazuh-kibana-app/pull/4198)
+- Fixed the problem allowing to remove the filters from the module [#4219](https://github.com/wazuh/wazuh-kibana-app/pull/4219)
 
 ## Wazuh v4.3.3 - Kibana 7.10.2, 7.16.x, 7.17.x - Revision 4304
 

--- a/public/components/common/modules/modules-helper.js
+++ b/public/components/common/modules/modules-helper.js
@@ -60,7 +60,9 @@ export class ModulesHelper {
             : moduleFilter.meta.key;
           const objValue = moduleFilter.query?.match_phrase
             ? moduleFilter.query.match_phrase[objKey].query
-            : moduleFilter.meta.value();
+            : typeof moduleFilter.meta.value === 'function' // this check was added because sometimes it comes as a string and sometimes as a function.
+            ? moduleFilter.meta.value() //TODO see if it is used when it is a function
+            : moduleFilter.meta.value;
           const key = `filter-key-${objKey}`;
           const value = `filter-value-${objValue}`;
 


### PR DESCRIPTION
**Description:**

A validation is added to a section of the filter code, since sometimes `moduleFilter.meta.value` is a function and sometimes a string.
When it was a string it lost the check to be able to eliminate or not the filter.

For example in the Mitre Attack module

**Issue:**

- #4218 

**Test:**

1. Navigate  to 'Mitre Attack module'
2. Look at the module filters can''t be removed.
3. View the console without error

**Screenshot:**

![image](https://user-images.githubusercontent.com/63758389/172194477-f9c68194-c724-4d41-844c-3cf848d59741.png)
