### PR TITLE
[Statistics] Remove logged error related to the creation of an existent index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to the Wazuh app project will be documented in this file.
 
 ## Wazuh v4.3.4 - Kibana 7.10.2, 7.16.x, 7.17.x - Revision 4305
 
+### Fixed
+
+- Removed a logged error that appeared when the `statistics` tasks tried to create a index with the same name, causing that the second task failed the creation of the index because it already existed [#4235](https://github.com/wazuh/wazuh-kibana-app/pull/4235)
+
+## Wazuh v4.3.4 - Kibana 7.10.2, 7.16.x, 7.17.x - Revision 4305
+
 ### Added
 
 - Added the `pending` agent status to some sections that was missing 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to the Wazuh app project will be documented in this file.
 
-## Wazuh v4.3.4 - Kibana 7.10.2, 7.16.x, 7.17.x - Revision 4305
+## Wazuh v4.3.5 - Kibana 7.10.2, 7.16.x, 7.17.x - Revision 4306
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 
 ### Fixed
 
-- Removed a logged error that appeared when the `statistics` tasks tried to create a index with the same name, causing that the second task failed the creation of the index because it already existed [#4235](https://github.com/wazuh/wazuh-kibana-app/pull/4235)
+- Removed a logged error that appeared when the `statistics` tasks tried to create an index with the same name, causing the second task to fail on the creation of the index because it already exists [#4235](https://github.com/wazuh/wazuh-kibana-app/pull/4235)
 
 ## Wazuh v4.3.4 - Kibana 7.10.2, 7.16.x, 7.17.x - Revision 4305
 

--- a/server/start/cron-scheduler/save-document.ts
+++ b/server/start/cron-scheduler/save-document.ts
@@ -63,7 +63,6 @@ export class SaveDocument {
         }
       })();
     } catch (error) {
-      log(this.logPath, error.message || error);
       this.checkDuplicateIndexError(error);
     }
   }


### PR DESCRIPTION
# Description

This PR removes the logging when there is an error checking or creating the index.

If the error is not related to creating an existent index, this is thrown, caught, and logged in another method.

More information in:
- https://github.com/wazuh/wazuh-kibana-app/issues/4203#issuecomment-1147273268

The plugin logs, it should look similar to the screenshot when is initiated:
![image](https://user-images.githubusercontent.com/34042064/172794099-afe4bca7-afa7-4d63-9b59-965e9c05da91.png)
compare to the error seen in:
![image](https://user-images.githubusercontent.com/34042064/172794195-dd3d5da7-4202-4d68-97c3-496da5b959bd.png)

Closes https://github.com/wazuh/wazuh-kibana-app/issues/4203

# Tests
- It should not be logged an error related to `resource_already_exists_exception` when creating the index of `statistics` job.
Requirements:
  - Secure that depending on the `statistics` job configuration, a new index should be created when the job runs.
  - Give to the internal Kibana user, permissions to create and index data in the indices related to the `statistics` job
