### PR TITLE
[BUG] Plugin crash when searching with a query with syntax errors in Modules/Security events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the Wazuh app project will be documented in this file.
 
+## Wazuh v4.3.5 - Kibana 7.10.2, 7.16.x, 7.17.x - Revision 4306
+
+### Fixed
+
+- Fixed a UI crash due to a query with syntax errors in `Modules/Security events` [#4237](https://github.com/wazuh/wazuh-kibana-app/pull/4237)
+
 ## Wazuh v4.3.4 - Kibana 7.10.2, 7.16.x, 7.17.x - Revision 4305
 
 ### Added

--- a/public/components/common/modules/discover/discover.tsx
+++ b/public/components/common/modules/discover/discover.tsx
@@ -87,7 +87,6 @@ export const Discover = compose(
       sortField: string;
       sortDirection: Direction;
       isLoading: boolean;
-      requestFilters: object;
       requestSize: number;
       requestOffset: number;
       query: { language: 'kuery' | 'lucene'; query: string };
@@ -127,7 +126,6 @@ export const Discover = compose(
         sortField: 'timestamp',
         sortDirection: 'desc',
         isLoading: false,
-        requestFilters: {},
         requestSize: 500,
         requestOffset: 0,
         itemIdToExpandedRowMap: {},
@@ -171,8 +169,7 @@ export const Discover = compose(
         const options = {
           context: `${Discover.name}.componentDidMount`,
           level: UI_LOGGER_LEVELS.ERROR,
-          severity: UI_ERROR_SEVERITIES.CRITICAL,
-          store: true,
+          severity: UI_ERROR_SEVERITIES.BUSINESS,
           error: {
             error: error,
             message: error.message || error,
@@ -231,8 +228,7 @@ export const Discover = compose(
           const options = {
             context: `${Discover.name}.componentDidUpdate`,
             level: UI_LOGGER_LEVELS.ERROR,
-            severity: UI_ERROR_SEVERITIES.CRITICAL,
-            store: true,
+            severity: UI_ERROR_SEVERITIES.BUSINESS,
             error: {
               error: error,
               message: error.message || error,
@@ -421,9 +417,9 @@ export const Discover = compose(
     async getAlerts() {
       if (!this.indexPattern || this.state.isLoading) return;
       //compare filters so we only make a request into Elasticsearch if needed
-      const newFilters = this.buildFilter();
       try {
         this.setState({ isLoading: true });
+        const newFilters = this.buildFilter();
         const alerts = await GenericRequest.request('POST', `/elastic/alerts`, {
           index: this.indexPattern.title,
           body: newFilters,
@@ -433,13 +429,12 @@ export const Discover = compose(
             alerts: alerts.data.hits.hits,
             total: alerts.data.hits.total.value,
             isLoading: false,
-            requestFilters: newFilters,
           });
           this.props.updateTotalHits(alerts.data.hits.total.value);
         }
       } catch (error) {
         if (this._isMount) {
-          this.setState({ alerts: [], total: 0, isLoading: false, requestFilters: newFilters });
+          this.setState({ alerts: [], total: 0, isLoading: false });
           this.props.updateTotalHits(0);
         }
         throw error;


### PR DESCRIPTION
# Description

This PR fixes a plugin crash when searching with a query with syntax errors in `Modules/Security events`.

Screenshot
![image](https://user-images.githubusercontent.com/34042064/172871362-a6542d15-f5aa-47de-8d71-f31ea9bdabf7.png)

Closes https://github.com/wazuh/wazuh-kibana-app/issues/4168

# Test
- Go to `Modules/Security events` and search with a query with syntax errors, by example:
```test()```
The plugin UI should not crash and should display toast messages with the errors.