### PR TITLE
Changed phrase "Wazuh server"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the Wazuh app project will be documented in this file.
 
+## Wazuh v4.3.5 - Kibana 7.10.2, 7.16.x, 7.17.x - Revision 4306
+
+### Changed
+
+- Changed the word Manager to Wazuh server from the phrases that appeared in "Deploy a new agent". [#4239](https://github.com/wazuh/wazuh-kibana-app/pull/4239)
+
 ## Wazuh v4.3.4 - Kibana 7.10.2, 7.16.x, 7.17.x - Revision 4305
 
 ### Added

--- a/public/controllers/agent/components/register-agent.js
+++ b/public/controllers/agent/components/register-agent.js
@@ -415,7 +415,7 @@ export const RegisterAgent = withErrorBoundary(
       const urlCheckConnectionDocumentation = `https://documentation.wazuh.com/${appVersionMajorDotMinor}/user-manual/agents/agent-connection.html`;
       const textAndLinkToCheckConnectionDocumentation = (
         <p>
-          To verify the connection with the Manager, please follow this{' '}
+          To verify the connection with the Wazuh server, please follow this{' '}
           <a href={urlCheckConnectionDocumentation} target="_blank">
             document.
           </a>


### PR DESCRIPTION
**Description:**

Changed the word `Manager` to `Wazuh server` from the phrases that appeared in "Deploy a new agent". 

**Issue:**

- #4210 

**Test:**

1. Navigate to `Agents`
2. Click on 'Deploy new agent'
3. Complete everything and at the end Wazuh server appears.

**Screenshot:**

![image](https://user-images.githubusercontent.com/63758389/172891396-867d9e0c-c93d-4f83-ba12-f23b8694dca8.png)
