### PR TITLE
[BUG][Modules][Reports] Error when generating a report after changing the selected agent

### DIFF
--- a/public/components/visualize/wz-visualize.js
+++ b/public/components/visualize/wz-visualize.js
@@ -77,12 +77,21 @@ export const WzVisualize = compose(
     }
 
     async componentDidUpdate(prevProps) {
-      if (prevProps.isAgent !== this.props.isAgent) {
+      // When in a module changing from without selected agent to selected agent or viceversa, set the visualizations
+      // and remove the visualizations handlers of the VisHandlers singleton.
+      // The visualization handlers in the VisHandlers singleton are used in the generation of the reports
+      // getting the filters. Due to some side effects, and the two types of dashboard: without selected agent
+      // or with a selected agent, we can't remove the visualization handlers when changing of the selected agent
+      // that renders the same dashboard, only changing a filter, because would cause an error when generating
+      // the module report since the visualization handlers are used to get the applied filters and send the 
+      // data to the plugin endpoint that creates the report.
+      // More info: https://github.com/wazuh/wazuh-kibana-app/issues/4230#issuecomment-1152161434
+      if ((!prevProps.isAgent && this.props.isAgent) || (prevProps.isAgent && !this.props.isAgent)) {
         this._isMount &&
           this.setState({
             visualizations: !!this.props.isAgent ? agentVisualizations : visualizations,
           });
-        typeof prevProps.isAgent !== 'undefined' && visHandler.removeAll();
+        visHandler.removeAll();
       }
     }
 


### PR DESCRIPTION
# Description

This PR fixed an error when generating a module report after changing the selected agent.

Due to some side effects, it could not get the applied filters in the visualizations because the visualization handlers are removed of the `VisHanders` singleton class and the request done to a plugin endpoint sent properties values with no expected value.

Closes https://github.com/wazuh/wazuh-kibana-app/issues/4230

# Test

- Go to `Modules/<Module>` and generate a report
- Select an agent with the `Explore agent` button and generate a module report clicking on the `Generate report`
- Change the selected agent to another one, and generate a module report. This should be done without problem. Review the request that is sending the expected values and the generated PDF.
