### PR TITLE
Fixed parsedError string handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fixed type error when changing screen size in agents section [#4233](https://github.com/wazuh/wazuh-kibana-app/pull/4233)
 - Removed a logged error that appeared when the `statistics` tasks tried to create an index with the same name, causing the second task to fail on the creation of the index because it already exists [#4235](https://github.com/wazuh/wazuh-kibana-app/pull/4235)
 - Fixed an error when generating a module report after changing the selected agent [#4240](https://github.com/wazuh/wazuh-kibana-app/pull/4240)
+- Fixed an unhandled error when a Wazuh API request failed in the dev tools [#4266](https://github.com/wazuh/wazuh-kibana-app/pull/4266)
 
 ## Wazuh v4.3.4 - Kibana 7.10.2, 7.16.x, 7.17.x - Revision 4305
 

--- a/public/controllers/dev-tools/dev-tools.test.tsx
+++ b/public/controllers/dev-tools/dev-tools.test.tsx
@@ -1,0 +1,82 @@
+import { ErrorHandler } from '../../react-services';
+import { DevToolsController } from './dev-tools';
+
+// mocked some required kibana-services
+jest.mock('../../kibana-services', () => ({
+  ...(jest.requireActual('../../kibana-services') as object),
+  getUiSettings: jest.fn().mockReturnValue({
+    get: (name) => {
+      return true;
+    },
+  }),
+}));
+
+// mocked window object
+Object.defineProperty(window, 'location', {
+  value: {
+    hash: {
+      endsWith: jest.fn(),
+      includes: jest.fn(),
+    },
+    href: jest.fn(),
+    assign: jest.fn(),
+    search: jest.fn().mockResolvedValue({
+      tab: 'api',
+    }),
+    path: jest.fn(),
+  },
+  writable: true,
+});
+// mocked scope dependency
+const $scope = {
+  $applyAsync: jest.fn(),
+};
+// mocked getErrorOrchestrator
+const mockedGetErrorOrchestrator = {
+  handleError: jest.fn(),
+};
+
+jest.mock('../../react-services/common-services', () => {
+  return {
+    getErrorOrchestrator: () => mockedGetErrorOrchestrator,
+  };
+});
+
+describe('Devtools Controller', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('Devtools.Send()', () => {
+    it('Should return string type errors to print in the codemirror textarea output', async () => {
+
+      // Create new instance of the devtools controller
+      const controller = new DevToolsController($scope, window, ErrorHandler, [window.document]);
+
+      // Define possible error structures to parse
+      const errorTypes = {
+        dataObject: {
+          data: { message: 'Data Object Error' }
+        },
+        invalidObject: {
+          error: 'Invalid Object Error'
+        },
+        object: {
+          data: 'Object Error',
+          status: -1
+        },
+        string: "String Error",
+        null: null,
+        undefined: undefined,
+        number: 1,
+      }
+
+      expect(controller.parseError(errorTypes.object)).toEqual('Wazuh API is not reachable. Reason: timeout.');
+      expect(controller.parseError(errorTypes.string)).toEqual('String Error');
+      expect(controller.parseError(errorTypes.dataObject)).toEqual(errorTypes.dataObject.data.message);
+      expect(controller.parseError(errorTypes.invalidObject)).toEqual(JSON.stringify(errorTypes.invalidObject));
+      
+    })
+  })
+
+});

--- a/public/controllers/dev-tools/dev-tools.ts
+++ b/public/controllers/dev-tools/dev-tools.ts
@@ -838,7 +838,7 @@ export class DevToolsController {
       } else {
         const parsedError = ErrorHandler.handle(error, '', { silent: true });
         if (typeof parsedError === 'string') {
-          return this.apiOutputBox.setValue(error);
+          return this.apiOutputBox.setValue(parsedError);
         } else if (error && error.data && typeof error.data === 'object') {
           return this.apiOutputBox.setValue(JSON.stringify(error));
         } else {

--- a/public/controllers/dev-tools/dev-tools.ts
+++ b/public/controllers/dev-tools/dev-tools.ts
@@ -82,9 +82,9 @@ export class DevToolsController {
     $(this.$document[0]).keyup(e => {
       this.multipleKeyPressed = [];
     });
-
+    const element = this.$document[0].getElementById('api_input');
     this.apiInputBox = CodeMirror.fromTextArea(
-      this.$document[0].getElementById('api_input'),
+      element,
       {
         lineNumbers: true,
         matchBrackets: true,
@@ -831,19 +831,21 @@ export class DevToolsController {
       };
       getErrorOrchestrator().handleError(options);
 
-      if ((error || {}).status === -1) {
-        return this.apiOutputBox.setValue(
-          'Wazuh API is not reachable. Reason: timeout.'
-        );
+      return this.apiOutputBox.setValue(this.parseError(error));
+    }
+  }
+
+  parseError(error){
+    if ((error || {}).status === -1) {
+      return 'Wazuh API is not reachable. Reason: timeout.';
+    } else {
+      const parsedError = ErrorHandler.handle(error, '', { silent: true });
+      if (typeof parsedError === 'string') {
+        return parsedError;
+      } else if (error && error.data && typeof error.data === 'object') {
+        return JSON.stringify(error);
       } else {
-        const parsedError = ErrorHandler.handle(error, '', { silent: true });
-        if (typeof parsedError === 'string') {
-          return this.apiOutputBox.setValue(parsedError);
-        } else if (error && error.data && typeof error.data === 'object') {
-          return this.apiOutputBox.setValue(JSON.stringify(error));
-        } else {
-          return this.apiOutputBox.setValue('Empty');
-        }
+        return 'Empty';
       }
     }
   }


### PR DESCRIPTION
### Description

This PR fixes a string error handling generated when Wazuh API's request has failed in _Wazuh Dev Tools_. 

Closes https://github.com/wazuh/wazuh-kibana-app/issues/4260

To test it:

- Go to Wazuh devtools
- Add agents running this request 
```
POST /agents
{
  "name": "NewAgent3"
}
```
- Once agents were added, try to delete them with the request:
`DELETE /agents?agents_list=002&status=all`
- Verify the error can be seen properly in the right textarea _(API output)_

Other test cases:

- Inexistent endpoint
- Wazuh API is down

![image](https://user-images.githubusercontent.com/9343732/173856932-68a02a38-ff4e-4715-8ead-e51beecb15f9.png)
