### PR TITLE
Remove the filtered tags of manager logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 ### Changed
 
 - Changed the reference from Manager to Wazuh server in the guide to deploy a new agent [#4239](https://github.com/wazuh/wazuh-kibana-app/pull/4239)
+- Removed the filtered tags because they were not supported by the API endpoint [#4267](https://github.com/wazuh/wazuh-kibana-app/pull/4267)
 
 ### Fixed
 

--- a/common/api-info/endpoints.json
+++ b/common/api-info/endpoints.json
@@ -1352,38 +1352,7 @@
             "description": "Wazuh component that logged the event",
             "schema": {
               "type": "string",
-              "enum": [
-                "wazuh-agentlessd",
-                "wazuh-analysisd",
-                "wazuh-authd",
-                "wazuh-csyslogd",
-                "wazuh-dbd",
-                "wazuh-execd",
-                "wazuh-integratord",
-                "wazuh-maild",
-                "wazuh-monitord",
-                "wazuh-logcollector",
-                "wazuh-remoted",
-                "wazuh-reportd",
-                "wazuh-rootcheck",
-                "wazuh-syscheckd",
-                "sca",
-                "wazuh-db",
-                "wazuh-modulesd",
-                "wazuh-modulesd:agent-key-polling",
-                "wazuh-modulesd:aws-s3",
-                "wazuh-modulesd:azure-logs",
-                "wazuh-modulesd:ciscat",
-                "wazuh-modulesd:control",
-                "wazuh-modulesd:command",
-                "wazuh-modulesd:database",
-                "wazuh-modulesd:docker-listener",
-                "wazuh-modulesd:download",
-                "wazuh-modulesd:oscap",
-                "wazuh-modulesd:osquery",
-                "wazuh-modulesd:syscollector",
-                "wazuh-modulesd:vulnerability-detector"
-              ]
+              "format": "alphanumeric"
             }
           },
           {
@@ -4799,38 +4768,7 @@
             "description": "Wazuh component that logged the event",
             "schema": {
               "type": "string",
-              "enum": [
-                "wazuh-agentlessd",
-                "wazuh-analysisd",
-                "wazuh-authd",
-                "wazuh-csyslogd",
-                "wazuh-dbd",
-                "wazuh-execd",
-                "wazuh-integratord",
-                "wazuh-maild",
-                "wazuh-monitord",
-                "wazuh-logcollector",
-                "wazuh-remoted",
-                "wazuh-reportd",
-                "wazuh-rootcheck",
-                "wazuh-syscheckd",
-                "sca",
-                "wazuh-db",
-                "wazuh-modulesd",
-                "wazuh-modulesd:agent-key-polling",
-                "wazuh-modulesd:aws-s3",
-                "wazuh-modulesd:azure-logs",
-                "wazuh-modulesd:ciscat",
-                "wazuh-modulesd:control",
-                "wazuh-modulesd:command",
-                "wazuh-modulesd:database",
-                "wazuh-modulesd:docker-listener",
-                "wazuh-modulesd:download",
-                "wazuh-modulesd:oscap",
-                "wazuh-modulesd:osquery",
-                "wazuh-modulesd:syscollector",
-                "wazuh-modulesd:vulnerability-detector"
-              ]
+              "format": "alphanumeric"
             }
           },
           {
@@ -8906,7 +8844,7 @@
                 "severity",
                 "cvss2_score",
                 "cvss3_score",
-                "references",
+                "external_references",
                 "type",
                 "status",
                 "condition",

--- a/public/controllers/management/components/management/mg-logs/logs.js
+++ b/public/controllers/management/components/management/mg-logs/logs.js
@@ -136,17 +136,10 @@ export default compose(
     }
 
     async initDaemonsList(logsPath) {
-      const daemonsNotIncluded = ['wazuh-modulesd:task-manager', 'wazuh-modulesd:agent-upgrade'];
       try {
         const path = logsPath + '/summary';
-        const data = await WzRequest.apiReq('GET', path, {});
-        const formattedData = (((data || {}).data || {}).data || {}).affected_items;
-        const daemonsList = [...['all']];
-        for (const daemon of formattedData) {
-          if (!daemonsNotIncluded.includes(Object.keys(daemon)[0])) {
-            daemonsList.push(Object.keys(daemon)[0]);
-          }
-        }
+        const responseLogsSummary = await WzRequest.apiReq('GET', path, {});
+        const daemonsList = ['all', ...responseLogsSummary?.data?.data?.affected_items.map(logSummary => Object.keys(logSummary)[0]).sort()];
         this.setState({ daemonsList });
       } catch (error) {
         throw new Error('Error fetching daemons list: ' + error);


### PR DESCRIPTION
# Description

This PR removes the filtered tags of Wazuh manager logs, so they can appear in the tag selector of Management/Logs. This change is required because the API endpoint will be modified to accept any tag.
Issue: https://github.com/wazuh/wazuh/issues/13841
Pull request: https://github.com/wazuh/wazuh/pull/13867

The API changes should be integrated in the branch `4.3`. Use a manager with that version or secure the change is included in the manager you are using.

Related to https://github.com/wazuh/wazuh-kibana-app/issues/4242
