### PR TITLE
Display a message related to missing user permissions when finding index patterns in a route resolver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 
 - Added to the interface API messages in the Ruleset test module [#4244](https://github.com/wazuh/wazuh-kibana-app/pull/4244)
 - Added authorization prompt in Mitre > Intelligence [#4261](https://github.com/wazuh/wazuh-kibana-app/pull/4261)
+- Added a more descriptive message when there is an error related to the user permissions when getting the list of index patterns in a route resolver [#4280](https://github.com/wazuh/wazuh-kibana-app/pull/4280)
 
 ### Changed
 

--- a/public/services/resolves/get-ip.js
+++ b/public/services/resolves/get-ip.js
@@ -97,7 +97,7 @@ export function getIp(
         store: true,
         error: {
           error: error,
-          message: error.message || error,
+          message: (error?.body?.message?.includes('no permissions for') && `You have no permissions. Contact to an administrator:\n${error?.body?.message}`) || error.message || error,
           title: error.name || error,
         },
       };


### PR DESCRIPTION
# Description

This PR adds a more descriptive message when finding the index patterns and the user has no permission to do it.

Closes  #4216

## Screenshot

![image](https://user-images.githubusercontent.com/34042064/174317228-db676cb8-6aa7-4763-a093-08a03694963b.png)

## Notes

The proposed fix goes against the last work in frontend error management. We should consider if we want to include it or we should redefine how the errors are being managed to let this case.

# Test

Using OpenDistro for Elasticsearch or Wazuh dashboard:
1. create a new user without mapping any permissions
2. enable the `run_as` in the Wazuh API host entry of the Wazuh plugin. Restart Kibana/Wazuh dashboard to be sure the configuration is taken.
3. login using the created user, using `security_tenant=global` in the URL. For example: `https://localhost/5601/app/wazuh?security_tenant=global`
4. after the plugin loaded, it should redirect to the `blank-screen` and it should display a message related to the user permissions

