### PR TITLE
Sorting by agents in the table groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 
 ### Added
 
-- Added the option to sort by agents in the group table. [#4323](https://github.com/wazuh/wazuh-kibana-app/pull/4323)
+- Added the option to sort by the agents count in the group table. [#4323](https://github.com/wazuh/wazuh-kibana-app/pull/4323)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the Wazuh app project will be documented in this file.
 
 ## Wazuh v4.4.0 - Kibana 7.10.2, 7.16.x, 7.17.x - Revision 4400
 
+### Added
+
+- Added the option to sort by agents in the group table. [#4323](https://github.com/wazuh/wazuh-kibana-app/pull/4323)
+
 ### Changed
 
 - Changed the HTTP verb from `GET` to `POST` in the requests to login to the Wazuh API [#4103](https://github.com/wazuh/wazuh-kibana-app/pull/4103)

--- a/public/controllers/management/components/management/groups/utils/columns-main.js
+++ b/public/controllers/management/components/management/groups/utils/columns-main.js
@@ -19,7 +19,8 @@ export default class GroupsColums {
         {
           field: 'count',
           name: 'Agents',
-          align: 'left'
+          align: 'left',
+          sortable: true
         },
         {
           field: 'configSum',


### PR DESCRIPTION
**Description:**

Added the option to sort by agents in the group table.

**Issue:**

- #3950

**Preconditions:**

Have more than 1 group with different numbers of agents

**Test:**

1. Navigate to "Management/Groups"
2. Click on "Agents"
3. See that they are sorted by number of agents 

**Screenshot:**

![image](https://user-images.githubusercontent.com/63758389/178692268-db79c33f-c5ca-46b0-9c8b-42dd8bc8a73e.png)
![image](https://user-images.githubusercontent.com/63758389/178692299-e5535c4c-26cd-469c-a895-c8752dbb7c7c.png)


