### PR TITLE
Fix MD5 dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "jwt-decode": "^2.2.0",
     "loglevel": "^1.7.1",
     "markdown-it-link-attributes": "^3.0.0",
+    "md5": "^2.3.0",
     "needle": "^2.0.1",
     "node-cron": "^1.1.2",
     "pdfmake": "0.1.65",


### PR DESCRIPTION
## Summary

This PR adds the MD5 node module dependency, as it is needed by the plugin.