### PR TITLE
Fixed errors in group reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to the Wazuh app project will be documented in this file.
 
+## Wazuh v4.3.7 - Kibana 7.10.2, 7.16.x, 7.17.x - Revision 4308
+
+### Fixed
+
+- Fixed an error generating a group report when an Wazuh API request failed [#4350](https://github.com/wazuh/wazuh-kibana-app/pull/4350)
+- Fixed a problem of missing agents in the agents in group's table for the group reports [#4350](https://github.com/wazuh/wazuh-kibana-app/pull/4350)
+
+# Removed
+
+- Removed the use of `manager_host` field related to agent information of Wazuh API responses [#4350](https://github.com/wazuh/wazuh-kibana-app/pull/4350)
+
 ## Wazuh v4.3.6 - Kibana 7.10.2, 7.16.x, 7.17.x - Revision 4307
 
 ### Fixed

--- a/common/csv-key-equivalence.ts
+++ b/common/csv-key-equivalence.ts
@@ -50,7 +50,6 @@ export const KeyEquivalence: {[key: string]: string} = {
   architecture: 'Architecture',
   node_name: 'Node',
   dateAdd: 'Registration date',
-  manager_host: 'Manager',
   manager: 'Manager',
   lastKeepAlive: 'Last keep alive',
   os: 'OS',

--- a/public/utils/monitoring-fields.ts
+++ b/public/utils/monitoring-fields.ts
@@ -16,7 +16,6 @@ export const FieldsMonitoring =[
   { "name": "configSum", "type": "string", "count": 0, "scripted": false, "searchable": true, "aggregatable": false, "readFromDocValues": false },
   { "name": "node_name", "type": "string", "count": 0, "scripted": false, "searchable": true, "aggregatable": false, "readFromDocValues": false },
   { "name": "manager", "type": "string", "count": 0, "scripted": false, "searchable": true, "aggregatable": false, "readFromDocValues": false },
-  { "name": "manager_host", "type": "string", "count": 0, "scripted": false, "searchable": true, "aggregatable": false, "readFromDocValues": false },
   { "name": "name", "type": "string", "count": 0, "scripted": false, "searchable": true, "aggregatable": true, "readFromDocValues": true },
   { "name": "os.arch", "type": "string", "count": 0, "scripted": false, "searchable": true, "aggregatable": false, "readFromDocValues": false },
   { "name": "os.codename", "type": "string", "count": 0, "scripted": false, "searchable": true, "aggregatable": false, "readFromDocValues": false },

--- a/server/controllers/wazuh-reporting.ts
+++ b/server/controllers/wazuh-reporting.ts
@@ -146,7 +146,7 @@ export class WazuhReportingCtrl {
           printer,
           isAgents,
           apiId,
-          section === 'groupConfig' ? tab : null
+          section === 'groupConfig' ? tab : ''
         );
       }
 
@@ -191,7 +191,7 @@ export class WazuhReportingCtrl {
    * @param {Array<Strings>} ids ids of agents
    * @param {String} apiId API id
    */
-  private async buildAgentsTable(context, printer: ReportPrinter, agentIDs: string[], apiId: string, groupID: string | null = null) {
+  private async buildAgentsTable(context, printer: ReportPrinter, agentIDs: string[], apiId: string, groupID: string = '') {
     const dateFormat = await context.core.uiSettings.client.get('dateFormat');
     if ((!agentIDs || !agentIDs.length) && !groupID) return;
     log('reporting:buildAgentsTable', `${agentIDs.length} agents for API ${apiId}`, 'info');

--- a/server/controllers/wazuh-reporting.ts
+++ b/server/controllers/wazuh-reporting.ts
@@ -134,16 +134,8 @@ export class WazuhReportingCtrl {
         } else if (section === 'groupConfig') {
           printer.addContent({
             text: 'Agents in group',
-            style: { fontSize: 14, color: '#000' },
-            margin: [0, 20, 0, 0],
+            style: 'h1',
           });
-          if (section === 'groupConfig' && !Object.keys(isAgents).length) {
-            printer.addContent({
-              text: 'There are still no agents in this group.',
-              style: { fontSize: 12, color: '#000' },
-              margin: [0, 10, 0, 0],
-            });
-          }
         }
         printer.addNewLine();
       }
@@ -154,7 +146,7 @@ export class WazuhReportingCtrl {
           printer,
           isAgents,
           apiId,
-          section === 'groupConfig' ? tab : false
+          section === 'groupConfig' ? tab : null
         );
       }
 
@@ -188,8 +180,6 @@ export class WazuhReportingCtrl {
           style: 'standard',
         });
       }
-
-      return;
     } catch (error) {
       log('reporting:renderHeader', error.message || error);
       return Promise.reject(error);
@@ -201,57 +191,44 @@ export class WazuhReportingCtrl {
    * @param {Array<Strings>} ids ids of agents
    * @param {String} apiId API id
    */
-  private async buildAgentsTable(context, printer: ReportPrinter, agentIDs: string[], apiId: string, multi = false) {
+  private async buildAgentsTable(context, printer: ReportPrinter, agentIDs: string[], apiId: string, groupID: string | null = null) {
     const dateFormat = await context.core.uiSettings.client.get('dateFormat');
-    if (!agentIDs || !agentIDs.length) return;
+    if ((!agentIDs || !agentIDs.length) && !groupID) return;
     log('reporting:buildAgentsTable', `${agentIDs.length} agents for API ${apiId}`, 'info');
     try {
-      let agentRows = [];
-      if (multi) {
-        try {
-          const agentsResponse = await context.wazuh.api.client.asCurrentUser.request(
+      let agentsData = [];
+      if (groupID) {
+        let totalAgentsInGroup = null;
+        do{
+          const { data: { data: { affected_items, total_affected_items } } } = await context.wazuh.api.client.asCurrentUser.request(
             'GET',
-            `/groups/${multi}/agents`,
-            {},
+            `/groups/${groupID}/agents`,
+            {
+              params: {
+                offset: agentsData.length,
+                select: 'dateAdd,id,ip,lastKeepAlive,manager,name,os.name,os.version,version',
+              }
+            },
             { apiHostID: apiId }
           );
-          const agentsData =
-            agentsResponse &&
-            agentsResponse.data &&
-            agentsResponse.data.data &&
-            agentsResponse.data.data.affected_items;
-          agentRows = (agentsData || []).map((agent) => ({
-            ...agent,
-            manager: agent.manager || agent.manager_host,
-            os:
-              agent.os && agent.os.name && agent.os.version
-                ? `${agent.os.name} ${agent.os.version}`
-                : '',
-          }));
-        } catch (error) {
-          log(
-            'reporting:buildAgentsTable',
-            `Skip agent due to: ${error.message || error}`,
-            'debug'
-          );
-        }
+          !totalAgentsInGroup && (totalAgentsInGroup = total_affected_items);
+          agentsData = [...agentsData, ...affected_items];
+        }while(agentsData.length < totalAgentsInGroup);
       } else {
         for (const agentID of agentIDs) {
           try {
-            const agentResponse = await context.wazuh.api.client.asCurrentUser.request(
+            const { data: { data: { affected_items: [agent] } } } = await context.wazuh.api.client.asCurrentUser.request(
               'GET',
               `/agents`,
-              { params: { q: `id=${agentID}` } },
+              { 
+                params: {
+                  q: `id=${agentID}`,
+                  select: 'dateAdd,id,ip,lastKeepAlive,manager,name,os.name,os.version,version',
+                } 
+              },
               { apiHostID: apiId }
             );
-            const [agent] = agentResponse.data.data.affected_items;
-            agentRows.push({
-              ...agent,
-              manager: agent.manager || agent.manager_host,
-              os: (agent.os && agent.os.name && agent.os.version) ? `${agent.os.name} ${agent.os.version}` : '',
-              lastKeepAlive: moment(agent.lastKeepAlive).format(dateFormat),
-              dateAdd: moment(agent.dateAdd).format(dateFormat)
-            });
+            agentsData.push(agent);
           } catch (error) {
             log(
               'reporting:buildAgentsTable',
@@ -261,19 +238,37 @@ export class WazuhReportingCtrl {
           }
         }
       }
-      printer.addSimpleTable({
-        columns: [
-          { id: 'id', label: 'ID' },
-          { id: 'name', label: 'Name' },
-          { id: 'ip', label: 'IP' },
-          { id: 'version', label: 'Version' },
-          { id: 'manager', label: 'Manager' },
-          { id: 'os', label: 'OS' },
-          { id: 'dateAdd', label: 'Registration date' },
-          { id: 'lastKeepAlive', label: 'Last keep alive' },
-        ],
-        items: agentRows,
-      });
+
+      if(agentsData.length){
+        // Print a table with agent/s information
+        printer.addSimpleTable({
+          columns: [
+            { id: 'id', label: 'ID' },
+            { id: 'name', label: 'Name' },
+            { id: 'ip', label: 'IP' },
+            { id: 'version', label: 'Version' },
+            { id: 'manager', label: 'Manager' },
+            { id: 'os', label: 'OS' },
+            { id: 'dateAdd', label: 'Registration date' },
+            { id: 'lastKeepAlive', label: 'Last keep alive' },
+          ],
+          items: agentsData.map((agent) => {
+            return {
+              ...agent,
+              os: (agent.os && agent.os.name && agent.os.version) ? `${agent.os.name} ${agent.os.version}` : '',
+              lastKeepAlive: moment(agent.lastKeepAlive).format(dateFormat),
+              dateAdd: moment(agent.dateAdd).format(dateFormat)
+            }
+          }),
+        });
+      }else if(!agentsData.length && groupID){
+        // For group reports when there is no agents in the group
+        printer.addContent({
+          text: 'There are still no agents in this group.',
+          style: { fontSize: 12, color: '#000' },
+        });
+      }
+      
     } catch (error) {
       log('reporting:buildAgentsTable', error.message || error);
       return Promise.reject(error);
@@ -1249,19 +1244,15 @@ export class WazuhReportingCtrl {
         style: 'h1',
       });
 
+      // Group configuration
       if (components['0']) {
-        let configuration = {};
-        try {
-          const configurationResponse = await context.wazuh.api.client.asCurrentUser.request(
-            'GET',
-            `/groups/${groupID}/configuration`,
-            {},
-            { apiHostID: apiId }
-          );
-          configuration = configurationResponse.data.data;
-        } catch (error) {
-          log('reporting:createReportsGroups', error.message || error, 'debug');
-        }
+
+        const { data: { data: configuration } } = await context.wazuh.api.client.asCurrentUser.request(
+          'GET',
+          `/groups/${groupID}/configuration`,
+          {},
+          { apiHostID: apiId }
+        );
 
         if (
           configuration.affected_items.length > 0 &&
@@ -1441,25 +1432,15 @@ export class WazuhReportingCtrl {
           });
         }
       }
+
+      // Agents in group
       if (components['1']) {
-        let agentsInGroup = [];
-        try {
-          const agentsInGroupResponse = await context.wazuh.api.client.asCurrentUser.request(
-            'GET',
-            `/groups/${groupID}/agents`,
-            {},
-            { apiHostID: apiId }
-          );
-          agentsInGroup = agentsInGroupResponse.data.data.affected_items;
-        } catch (error) {
-          log('reporting:report', error.message || error, 'debug');
-        }
         await this.renderHeader(
           context,
           printer,
           'groupConfig',
           groupID,
-          (agentsInGroup || []).map((x) => x.id),
+          [],
           apiId
         );
       }

--- a/server/controllers/wazuh-reporting.ts
+++ b/server/controllers/wazuh-reporting.ts
@@ -264,7 +264,7 @@ export class WazuhReportingCtrl {
       }else if(!agentsData.length && groupID){
         // For group reports when there is no agents in the group
         printer.addContent({
-          text: 'There are still no agents in this group.',
+          text: 'There are no agents in this group.',
           style: { fontSize: 12, color: '#000' },
         });
       }

--- a/server/integration-files/monitoring-known-fields.ts
+++ b/server/integration-files/monitoring-known-fields.ts
@@ -175,15 +175,6 @@ export const monitoringKnownFields = [
     readFromDocValues: false
   },
   {
-    name: 'manager_host',
-    type: 'string',
-    count: 0,
-    scripted: false,
-    searchable: true,
-    aggregatable: false,
-    readFromDocValues: false
-  },
-  {
     name: 'name',
     type: 'string',
     count: 0,


### PR DESCRIPTION
# Description

This PRs fixes some problems when generating a group reports:
- Error due to accessing to a property of undefined
- The agent in group table doesn't display all the agents in the group.

Closes #4348

# Changes
- Fixed an error due to accessing to a property of undefined when the API request to get the group configuration failed due to token expiration or another error.
- Changed styles of `Agents in groups` title
- Fixed a problem with missing agents in the table for a group report.
  Now it gets all the agents.
- Removed unnecessary API request
- Optimized API requests to get the agent information required to print
  the agents in group's table
- Removed `manager_host` deprecated field ([more information](https://github.com/wazuh/wazuh-kibana-app/commit/320825de99791fc76fb826712f4bb37d557672db#diff-980834c867463b40f86ef51bd0a723ef2063b9c9ef7cead6cd0c8649dd9bc1ddR647-R648)):
  - Removed of monitoring template mapping
  - Removed field meaning
  - Removed displaying its value reports if the field `manager` doesn't exist

# Test

## Manual tests

Scenario: Error due to accessing to a property of undefined
Given: Logged user in Management/Groups/<Group>/Information, wait the time to the Wazuh API token expires.
When: The user click on "Export PDF" button.
Then: The PDF should be generated without errors. Check the generated PDF.

Scenario: Missing agents in the agent in group table of group report.
Given: group with more than 500 agents.
When: The user clicks on "Export PDF" button.
Then: The PDF should be genrated without errors and it should contains all the agents in the group displayed in a table.
