### PR TITLE
Fix creating PDF reports in x-pack without authentication context 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the Wazuh app project will be documented in this file.
 
+## Wazuh v4.3.7 - Kibana 7.10.2, 7.16.x, 7.17.x - Revision 4308
+
+### Fixed
+
+- Fixed an error of an undefined username hash related to reporting when using Kibana with X-Pack and security was disabled [#4358](https://github.com/wazuh/wazuh-kibana-app/pull/4358)
+
 ## Wazuh v4.3.6 - Kibana 7.10.2, 7.16.x, 7.17.x - Revision 4307
 
 ### Fixed

--- a/common/constants.ts
+++ b/common/constants.ts
@@ -403,3 +403,6 @@ export const UI_ORDER_AGENT_STATUS = [
 
 // Documentation
 export const DOCUMENTATION_WEB_BASE_URL = "https://documentation.wazuh.com";
+
+// Default Elasticsearch user name context
+export const ELASTIC_NAME = 'elastic';

--- a/server/lib/security-factory/factories/default-factory.ts
+++ b/server/lib/security-factory/factories/default-factory.ts
@@ -1,4 +1,5 @@
 import { ISecurityFactory } from '../';
+import { ELASTIC_NAME } from '../../../../common/constants';
 import { KibanaRequest, RequestHandlerContext } from 'src/core/server';
 import md5 from 'md5';
 
@@ -6,9 +7,9 @@ export class DefaultFactory implements ISecurityFactory{
   platform: string = '';
   async getCurrentUser(request: KibanaRequest, context?:RequestHandlerContext) {
     return { 
-      username: 'elastic',
-      authContext: { username: 'elastic' },
-      hashUsername: md5('elastic')
+      username: ELASTIC_NAME,
+      authContext: { username: ELASTIC_NAME },
+      hashUsername: md5(ELASTIC_NAME)
     };
   }
 }

--- a/server/lib/security-factory/factories/xpack-factory.ts
+++ b/server/lib/security-factory/factories/xpack-factory.ts
@@ -1,7 +1,7 @@
 import { ISecurityFactory } from '../'
 import { SecurityPluginSetup } from 'x-pack/plugins/security/server';
 import { KibanaRequest } from 'src/core/server';
-import { WAZUH_SECURITY_PLUGIN_XPACK_SECURITY } from '../../../../common/constants';
+import { WAZUH_SECURITY_PLUGIN_XPACK_SECURITY, ELASTIC_NAME } from '../../../../common/constants';
 import md5 from 'md5';
 
 export class XpackFactory implements ISecurityFactory {
@@ -11,7 +11,7 @@ export class XpackFactory implements ISecurityFactory {
   async getCurrentUser(request: KibanaRequest) {
     try {
       const authContext = await this.security.authc.getCurrentUser(request);
-      if(!authContext) return {username: 'elastic', authContext: { username: 'elastic'}};
+      if(!authContext) return {hashUsername: md5(ELASTIC_NAME), username: ELASTIC_NAME, authContext: { username: ELASTIC_NAME}};
       const username = this.getUserName(authContext);
       return { username, authContext, hashUsername: md5(username) };
     } catch (error) {


### PR DESCRIPTION
# Description

This PR fixes when x-pack is detected with no `authContext` available and no `hashUsername` is provided. Therefore in this kind of context, creating PDF reports fails.

