### PR TITLE
Fix modules settings persistence between updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the Wazuh app project will be documented in this file.
 
+## Wazuh v4.3.7 - Kibana 7.10.2, 7.16.x, 7.17.x - Revision 4308
+
+### Fixed
+
+- Fixed the `hosts` data stored in the registry file was lost when changing the installed plugin. Migrate the `extensions` data [#4359](https://github.com/wazuh/wazuh-kibana-app/pull/4359)
+
 ## Wazuh v4.3.6 - Kibana 7.10.2, 7.16.x, 7.17.x - Revision 4307
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@ All notable changes to the Wazuh app project will be documented in this file.
 
 - Fixed an error during the generation of a group's report, if the request to the Wazuh API fails [#4350](https://github.com/wazuh/wazuh-kibana-app/pull/4350)
 - Fixed a problem with the group's report, when the group has no agents [#4350](https://github.com/wazuh/wazuh-kibana-app/pull/4350)
-
 - Fixed path in logo customization section [#4352](https://github.com/wazuh/wazuh-kibana-app/pull/4352)
 - Fixed an error of an undefined username hash related to reporting when using Kibana with X-Pack and security was disabled [#4358](https://github.com/wazuh/wazuh-kibana-app/pull/4358)
 - Fixed persistence of the plugin registry file between updates [#4359](https://github.com/wazuh/wazuh-kibana-app/pull/4359)

--- a/server/start/initialize/index.test.ts
+++ b/server/start/initialize/index.test.ts
@@ -1,0 +1,350 @@
+import fs from 'fs';
+import md5 from 'md5';
+import { execSync } from 'child_process';
+import path from 'path';
+import { jobInitializeRun } from './index';
+import { createDataDirectoryIfNotExists, createDirectoryIfNotExists } from '../../lib/filesystem';
+import { WAZUH_DATA_ABSOLUTE_PATH, WAZUH_DATA_CONFIG_DIRECTORY_PATH, WAZUH_DATA_CONFIG_REGISTRY_PATH } from '../../../common/constants';
+import packageInfo from '../../../package.json';
+
+function mockContextCreator(loggerLevel: string) {
+  const logs = [];
+  const levels = ['debug', 'info', 'warn', 'error'];
+
+  function createLogger(level: string) {
+    return jest.fn(function (message: string) {
+      const levelLogIncluded: number = levels.findIndex((level) => level === loggerLevel);
+      levelLogIncluded > -1
+        && levels.slice(levelLogIncluded).includes(level)
+        && logs.push({ level, message });
+    });
+  };
+
+  const ctx = {
+    wazuh: {
+      logger: {
+        info: createLogger('info'),
+        warn: createLogger('warn'),
+        error: createLogger('error'),
+        debug: createLogger('debug')
+      },
+    },
+    server: {
+        config: {
+            kibana: {
+                index: '.kibana'
+            }
+        }
+    },
+    core: {
+        elasticsearch: {
+            client: {
+                asInternalUser: {
+                    indices: {
+                        exists: jest.fn(() => ({body: true}))
+                    }
+                }
+            }
+        }
+    },
+    /* Mocked logs getter. It is only for testing purpose.*/
+    _getLogs(logLevel: string) {
+      return logLevel ? logs.filter(({ level }) => level === logLevel) : logs;
+    }
+  }
+  return ctx;
+};
+
+jest.mock('../../lib/logger', () => ({
+  log: jest.fn()
+}));
+
+jest.mock('../../lib/get-configuration', () => ({
+    getConfiguration: () => ({pattern: 'wazuh-alerts-*'})
+}));
+
+beforeAll(() => {
+  // Create <PLUGIN_PLATFORM_PATH>/data/wazuh directory.
+  createDataDirectoryIfNotExists();
+  // Create <PLUGIN_PLATFORM_PATH>/data/wazuh/config directory.
+  createDirectoryIfNotExists(WAZUH_DATA_CONFIG_DIRECTORY_PATH);
+});
+
+afterAll(() => {
+  // Remove <PLUGIN_PLATFORM_PATH>/data/wazuh directory.
+  execSync(`rm -rf ${WAZUH_DATA_ABSOLUTE_PATH}`);
+});
+
+describe("[initialize] `wazuh-registry.json` not created", () => {
+    let mockContext = mockContextCreator('debug');
+    afterEach(() => {
+        // Remove <PLUGIN_PLATFORM_PATH>/data/wazuh/config/wazuh-registry file.
+        execSync(`rm ${WAZUH_DATA_ABSOLUTE_PATH}/config/wazuh-registry.json || echo ""`);
+    });
+
+  it("Create registry file with plugin data and empty hosts", async () => {
+    // Migrate the directories
+    await jobInitializeRun(mockContext);
+    const contentRegistry = JSON.parse(fs.readFileSync(WAZUH_DATA_CONFIG_REGISTRY_PATH, 'utf8'));
+    
+    expect(contentRegistry.name).toMatch('Wazuh App');
+    expect(contentRegistry['app-version']).toMatch(packageInfo.version);
+    expect(contentRegistry['revision']).toMatch(packageInfo.revision);
+    expect(typeof contentRegistry.installationDate).toBe('string');
+    expect(typeof contentRegistry.lastRestart).toBe('string');
+    expect(Object.keys(contentRegistry.hosts)).toHaveLength(0);
+  });
+});
+
+describe("[initialize] `wazuh-registry.json` created", () => {
+    let testID = 0;
+    const contentRegistryFile = [
+        {
+          before: {
+              name: 'Wazuh App',
+              'app-version': packageInfo.version,
+              revision: packageInfo.revision,
+              installationDate: '2022-07-25T13:55:04.363Z',
+              lastRestart: '2022-07-25T13:55:04.363Z',
+              hosts: {}
+          },
+          after: {
+              name: 'Wazuh App',
+              'app-version': packageInfo.version,
+              revision: packageInfo.revision,
+              installationDate: '2022-07-25T13:55:04.363Z',
+              lastRestart: '2022-07-25T13:55:04.363Z',
+              hosts: {}
+          }
+        },
+        {
+          before: {
+              name: 'Wazuh App',
+              'app-version': '0.0.0',
+              revision: '0',
+              installationDate: '2022-07-25T13:55:04.363Z',
+              lastRestart: '2022-07-25T13:55:04.363Z',
+              hosts: {}
+          },
+          after: {
+              name: 'Wazuh App',
+              'app-version': packageInfo.version,
+              revision: packageInfo.revision,
+              installationDate: '2022-07-25T13:55:04.363Z',
+              lastRestart: '2022-07-25T13:55:04.363Z',
+              hosts: {}
+          }
+        },
+        {
+          before: {
+              name: 'Wazuh App',
+              'app-version': '0.0.0',
+              revision: '0',
+              installationDate: '2022-07-25T13:55:04.363Z',
+              lastRestart: '2022-07-25T13:55:04.363Z',
+              hosts: {
+                default: {
+                  extensions: {
+                    pci: true,
+                    gdpr: true,
+                    hipaa: true,
+                    nist: true,
+                    tsc: true,
+                    audit: true,
+                    oscap: false,
+                    ciscat: false,
+                    aws: false,
+                    office: false,
+                    github: false,
+                    gcp: false,
+                    virustotal: false,
+                    osquery: false,
+                    docker: false
+                  }
+                }
+              }
+          },
+          after: {
+              name: 'Wazuh App',
+              'app-version': packageInfo.version,
+              revision: packageInfo.revision,
+              installationDate: '2022-07-25T13:55:04.363Z',
+              lastRestart: '2022-07-25T13:55:04.363Z',
+              hosts: {
+                default: {
+                  extensions: {
+                    pci: true,
+                    gdpr: true,
+                    hipaa: true,
+                    nist: true,
+                    tsc: true,
+                    audit: true,
+                    oscap: false,
+                    ciscat: false,
+                    aws: false,
+                    office: false,
+                    github: false,
+                    gcp: false,
+                    virustotal: false,
+                    osquery: false,
+                    docker: false
+                  }
+                }
+              }
+          }
+        },
+        {
+          before: {
+              name: 'Wazuh App',
+              'app-version': '0.0.0',
+              revision: '0',
+              installationDate: '2022-07-25T13:55:04.363Z',
+              lastRestart: '2022-07-25T13:55:04.363Z',
+              hosts: {
+                default: {
+                  extensions: {
+                    pci: true,
+                    gdpr: true,
+                    hipaa: true,
+                    nist: true,
+                    tsc: true,
+                    audit: true,
+                    oscap: false,
+                    ciscat: false,
+                    aws: true,
+                    office: true,
+                    github: true,
+                    gcp: true,
+                    virustotal: false,
+                    osquery: false
+                  }
+                }
+              }
+          },
+          after: {
+              name: 'Wazuh App',
+              'app-version': packageInfo.version,
+              revision: packageInfo.revision,
+              installationDate: '2022-07-25T13:55:04.363Z',
+              lastRestart: '2022-07-25T13:55:04.363Z',
+              hosts: {
+                default: {
+                  extensions: {
+                    pci: true,
+                    gdpr: true,
+                    hipaa: true,
+                    nist: true,
+                    tsc: true,
+                    audit: true,
+                    oscap: false,
+                    ciscat: false,
+                    aws: true,
+                    office: true,
+                    github: true,
+                    gcp: true,
+                    virustotal: false,
+                    osquery: false,
+                    docker: false
+                  }
+                }
+              }
+          }
+        },
+        {
+          before: {
+              name: 'Wazuh App',
+              'app-version': '0.0.0',
+              revision: '0',
+              installationDate: '2022-07-25T13:55:04.363Z',
+              lastRestart: '2022-07-25T13:55:04.363Z',
+              hosts: {
+                default: {
+                  extensions: {
+                    pci: true,
+                    gdpr: true,
+                    hipaa: true,
+                    nist: true,
+                    tsc: true,
+                    audit: true,
+                    oscap: false,
+                    ciscat: false,
+                    aws: true,
+                    gcp: true,
+                    virustotal: false,
+                    osquery: false
+                  }
+                }
+              }
+          },
+          after: {
+              name: 'Wazuh App',
+              'app-version': packageInfo.version,
+              revision: packageInfo.revision,
+              installationDate: '2022-07-25T13:55:04.363Z',
+              lastRestart: '2022-07-25T13:55:04.363Z',
+              hosts: {
+                default: {
+                  extensions: {
+                    pci: true,
+                    gdpr: true,
+                    hipaa: true,
+                    nist: true,
+                    tsc: true,
+                    audit: true,
+                    oscap: false,
+                    ciscat: false,
+                    aws: true,
+                    office: false,
+                    github: false,
+                    gcp: true,
+                    virustotal: false,
+                    osquery: false,
+                    docker: false
+                  }
+                }
+              }
+          }
+        },
+    ];
+
+    beforeEach(() => {
+        // Remove <PLUGIN_PLATFORM_PATH>/data/wazuh/config/wazuh-registry.json.
+        execSync(`rm ${WAZUH_DATA_ABSOLUTE_PATH}/config/wazuh-registry.json || echo ""`);
+        // Create the wazuh-registry.json file.
+        fs.writeFileSync(WAZUH_DATA_CONFIG_REGISTRY_PATH, JSON.stringify(contentRegistryFile[testID].before), 'utf8');
+        testID++;
+    });
+    
+    it.each`
+        titleTest                                                                                                     | contentRegistryFile
+        ${'Registry file is not rebuilt due version and revision match'}                                              | ${JSON.stringify(contentRegistryFile[0].after)}
+        ${'Registry file is rebuilt due to version/revision changed'}                                                 | ${JSON.stringify(contentRegistryFile[1].after)}
+        ${'Registry file is rebuilt due to version/revision changed and keeps the extensions (no modified)'}          | ${JSON.stringify(contentRegistryFile[2].after)}
+        ${'Registry file is rebuilt due to version/revision changed and keeps the extensions (modified)'}             | ${JSON.stringify(contentRegistryFile[3].after)}
+        ${'Registry file is rebuilt due to version/revision changed and adds missing extensions with default values'} | ${JSON.stringify(contentRegistryFile[4].after)}
+    `(`$titleTest:
+      content: $contentRegistryFile`, async ({ contentRegistryFile: content }) => {
+      const mockContext = mockContextCreator('debug');
+      
+      const contentRegistryExpected = JSON.parse(content);
+      await jobInitializeRun(mockContext);
+      const contentRegistryFile = JSON.parse(fs.readFileSync(WAZUH_DATA_CONFIG_REGISTRY_PATH, 'utf8'));
+      
+      expect(contentRegistryFile.name).toMatch('Wazuh App');
+      expect(contentRegistryFile['app-version']).toMatch(contentRegistryExpected['app-version']);
+      expect(contentRegistryFile['revision']).toMatch(contentRegistryExpected.revision);
+      expect(typeof contentRegistryFile.installationDate).toBe('string');
+      expect(typeof contentRegistryFile.lastRestart).toBe('string');
+      expect(Object.keys(contentRegistryFile.hosts)).toHaveLength(Object.keys(contentRegistryExpected.hosts).length);
+
+      if ( Object.keys(contentRegistryFile.hosts).length ){
+        Object.entries(contentRegistryFile.hosts).forEach(([hostID, hostData]) => {
+          if(hostData.extensions){
+            Object.entries(hostData.extensions).forEach(([extensionID, extensionEnabled]) => {
+              expect(extensionEnabled).toBe(contentRegistryExpected.hosts[hostID].extensions[extensionID])
+            });
+          };
+        });
+      };
+    });
+  });


### PR DESCRIPTION
# Description

This PR fixes that the host extension configuration was lost when changing the installed plugin (changed version or revision) because the registry file was rebuilt with an empty configuration for the `hosts` field. Now, the `hosts` configuration is kept and migrates the extension configuration when changing the installed plugin.

Extension configuration migration:
- Keep the supported and existing extension with the configured value.
- Add the supported and missing extensions in the previous configuration
- Remove not supported extensions by the installed plugin

# Changes
- Migrated the existing host configuration in the registry file when changing the
  plugin version or revision, instead of removing it when it was rebuilt.
- Removed not necessary return statements
- Removed not necessary try/catch block
- Improved logging
- Created tests for the migration registry file

# Test

## Manual
- Same plugin version and revision, restart the plugin platform. The registry file should not be changed.
- Different plugin version or revision, restart the plugin platform. The registry file should be rebuilt and keeps the host configuration.
- Different plugin version or revision, removes some extension of any host in the registry file, restart the plugin platform. The registry file should be rebuilt and keeps the host configuration. The removed extension should be included in the host and have the default value.

## Automatic

A new test file was created. Run the test with:

```
# in the plugin root directory
yarn test:jest server/start/initialize/index.test.ts
```
