### PR TITLE
TypeError resolved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 ### Fixed
 
 - Fixed path in logo customization section [#4352](https://github.com/wazuh/wazuh-kibana-app/pull/4352)
-- Fixed a TypeError in Firefox. Change the Get request that was made with a Kibana core.http.get(/api/check-wazuh) resource to the WzRequest.genericReq resource and add a test capture to public/plugin.ts wrapping the request so that the error is detected when the navigator does not work with the V8 engine [#4362](https://github.com/wazuh/wazuh-kibana-app/pull/4362)
+- Fixed a TypeError in Firefox. Change the Get request that was made with a Kibana core.http.get(/api/check-wazuh) resource to the WzRequest.genericReq resource and it no longer fails, also add a test capture to public/plugin.ts that wraps the request and in case of failure, the error is detected when the browser does not work with the V8 engine. [#4362](https://github.com/wazuh/wazuh-kibana-app/pull/4362)
 - Fixed an error of an undefined username hash related to reporting when using Kibana with X-Pack and security was disabled [#4358](https://github.com/wazuh/wazuh-kibana-app/pull/4358)
 
 ## Wazuh v4.3.6 - Kibana 7.10.2, 7.16.x, 7.17.x - Revision 4307

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 ### Fixed
 
 - Fixed path in logo customization section [#4352](https://github.com/wazuh/wazuh-kibana-app/pull/4352)
-- Fixed a TypeError in Firefox [#4362](https://github.com/wazuh/wazuh-kibana-app/pull/4362)
+- Fixed a TypeError in Firefox. Change the Get request that was made with a Kibana core.http.get(/api/check-wazuh) resource to the WzRequest.genericReq resource and add a test capture to public/plugin.ts wrapping the request so that the error is detected when the navigator does not work with the V8 engine [#4362](https://github.com/wazuh/wazuh-kibana-app/pull/4362)
 - Fixed an error of an undefined username hash related to reporting when using Kibana with X-Pack and security was disabled [#4358](https://github.com/wazuh/wazuh-kibana-app/pull/4358)
 
 ## Wazuh v4.3.6 - Kibana 7.10.2, 7.16.x, 7.17.x - Revision 4307

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 ### Fixed
 
 - Fixed path in logo customization section [#4352](https://github.com/wazuh/wazuh-kibana-app/pull/4352)
+- Fixed a TypeError in Firefox [#4362](https://github.com/wazuh/wazuh-kibana-app/pull/4362)
 
 ## Wazuh v4.3.6 - Kibana 7.10.2, 7.16.x, 7.17.x - Revision 4307
 

--- a/public/plugin.ts
+++ b/public/plugin.ts
@@ -67,20 +67,21 @@ export class WazuhPlugin implements Plugin<WazuhSetup, WazuhStart, WazuhSetupPlu
             'GET',
             `/api/check-wazuh`,
           )
+          
           params.element.classList.add('dscAppWrapper', 'wz-app');
           const unmount = await renderApp(innerAngularName, params.element);
           //Update if user has Wazuh disabled
           this.stateUpdater.next(() => {
-            if (response.isWazuhDisabled) {
+            if (response.data.isWazuhDisabled) {
               unmount();
             }
             return {
-              status: response.isWazuhDisabled,
+              status: response.data.isWazuhDisabled,
               category: {
                 id: 'wazuh',
                 label: 'Wazuh',
                 order: 0,
-                euiIconType: core.http.basePath.prepend(response.logoSidebar ? getAssetURL(response.logoSidebar) : getThemeAssetURL('icon.svg', UI_THEME)),
+                euiIconType: core.http.basePath.prepend(response.data.logoSidebar ? getAssetURL(response.data.logoSidebar) : getThemeAssetURL('icon.svg', UI_THEME)),
               }}
           })
           return () => {

--- a/public/plugin.ts
+++ b/public/plugin.ts
@@ -37,7 +37,7 @@ export class WazuhPlugin implements Plugin<WazuhSetup, WazuhStart, WazuhSetupPlu
   private innerAngularInitialized: boolean = false;
   private stateUpdater = new BehaviorSubject<AppUpdater>(() => ({}));
   private hideTelemetryBanner?: () => void;
-  
+
   public setup(core: CoreSetup, plugins: WazuhSetupPlugins): WazuhSetup {
     const UI_THEME = core.uiSettings.get('theme:darkMode') ? 'dark' : 'light';
 
@@ -46,14 +46,17 @@ export class WazuhPlugin implements Plugin<WazuhSetup, WazuhStart, WazuhSetupPlu
       title: 'Wazuh',
       icon: core.http.basePath.prepend(getThemeAssetURL('icon.svg', UI_THEME)),
       mount: async (params: AppMountParameters) => {
+        try {
+          await core.http.get(`/api/check-wazuh`);
+        
         if (!this.initializeInnerAngular) {
           throw Error('Wazuh plugin method initializeInnerAngular is undefined');
         }
 
-        // hide the telemetry banner. 
+        // hide the telemetry banner.
         // Set the flag in the telemetry saved object as the notice was seen and dismissed
         this.hideTelemetryBanner && await this.hideTelemetryBanner();
-        
+
         setScopedHistory(params.history);
         // Load application bundle
         const { renderApp } = await import('./application');
@@ -92,6 +95,9 @@ export class WazuhPlugin implements Plugin<WazuhSetup, WazuhStart, WazuhSetupPlu
         return () => {
           unmount();
         };
+      }catch(error){
+        console.debug(error);
+      }
       },
       category: {
         id: 'wazuh',

--- a/public/plugin.ts
+++ b/public/plugin.ts
@@ -28,76 +28,67 @@ import { AppState } from './react-services/app-state';
 import { setErrorOrchestrator } from './react-services/common-services';
 import { ErrorOrchestratorService } from './react-services/error-orchestrator/error-orchestrator.service';
 import { getThemeAssetURL, getAssetURL } from './utils/assets';
-
+import { WzRequest } from './react-services/wz-request';
 const innerAngularName = 'app/wazuh';
-
 export class WazuhPlugin implements Plugin<WazuhSetup, WazuhStart, WazuhSetupPlugins, WazuhStartPlugins> {
   constructor(private readonly initializerContext: PluginInitializerContext) {}
   public initializeInnerAngular?: () => void;
   private innerAngularInitialized: boolean = false;
   private stateUpdater = new BehaviorSubject<AppUpdater>(() => ({}));
   private hideTelemetryBanner?: () => void;
-
   public setup(core: CoreSetup, plugins: WazuhSetupPlugins): WazuhSetup {
     const UI_THEME = core.uiSettings.get('theme:darkMode') ? 'dark' : 'light';
-
     core.application.register({
       id: `wazuh`,
       title: 'Wazuh',
       icon: core.http.basePath.prepend(getThemeAssetURL('icon.svg', UI_THEME)),
       mount: async (params: AppMountParameters) => {
         try {
-          await core.http.get(`/api/check-wazuh`);
-        
-        if (!this.initializeInnerAngular) {
-          throw Error('Wazuh plugin method initializeInnerAngular is undefined');
-        }
-
-        // hide the telemetry banner.
-        // Set the flag in the telemetry saved object as the notice was seen and dismissed
-        this.hideTelemetryBanner && await this.hideTelemetryBanner();
-
-        setScopedHistory(params.history);
-        // Load application bundle
-        const { renderApp } = await import('./application');
-        // Get start services as specified in kibana.json
-        const [coreStart, depsStart] = await core.getStartServices();
-        setErrorOrchestrator(ErrorOrchestratorService);
-        setHttp(core.http);
-        setCookies(new Cookies());
-        if(!AppState.checkCookies() || params.history.parentHistory.action === 'PUSH') {
-          window.location.reload();
-        }
-
-        await this.initializeInnerAngular();
-
-        //Check is user has Wazuh disabled
-        const response = await core.http.get(`/api/check-wazuh`);
-
-        params.element.classList.add('dscAppWrapper', 'wz-app');
-        const unmount = await renderApp(innerAngularName, params.element);
-
-        //Update if user has Wazuh disabled
-        this.stateUpdater.next(() => {
-          if (response.isWazuhDisabled) {
-            unmount();
+          if (!this.initializeInnerAngular) {
+            throw Error('Wazuh plugin method initializeInnerAngular is undefined');
           }
-
-          return {
-            status: response.isWazuhDisabled,
-            category: {
-              id: 'wazuh',
-              label: 'Wazuh',
-              order: 0,
-              euiIconType: core.http.basePath.prepend(response.logoSidebar ? getAssetURL(response.logoSidebar) : getThemeAssetURL('icon.svg', UI_THEME)),
-            }}
-        })
-        return () => {
-          unmount();
-        };
-      }catch(error){
-        console.debug(error);
-      }
+          // hide the telemetry banner.
+          // Set the flag in the telemetry saved object as the notice was seen and dismissed
+          this.hideTelemetryBanner && await this.hideTelemetryBanner();
+          setScopedHistory(params.history);
+          // Load application bundle
+          const { renderApp } = await import('./application');
+          // Get start services as specified in kibana.json
+          const [coreStart, depsStart] = await core.getStartServices();
+          setErrorOrchestrator(ErrorOrchestratorService);
+          setHttp(core.http);
+          setCookies(new Cookies());
+          if(!AppState.checkCookies() || params.history.parentHistory.action === 'PUSH') {
+            window.location.reload();
+          }
+          await this.initializeInnerAngular();
+          //Check is user has Wazuh disabled
+          const response = await WzRequest.genericReq(
+            'GET',
+            `/api/check-wazuh`,
+          )
+          params.element.classList.add('dscAppWrapper', 'wz-app');
+          const unmount = await renderApp(innerAngularName, params.element);
+          //Update if user has Wazuh disabled
+          this.stateUpdater.next(() => {
+            if (response.isWazuhDisabled) {
+              unmount();
+            }
+            return {
+              status: response.isWazuhDisabled,
+              category: {
+                id: 'wazuh',
+                label: 'Wazuh',
+                order: 0,
+                euiIconType: core.http.basePath.prepend(response.logoSidebar ? getAssetURL(response.logoSidebar) : getThemeAssetURL('icon.svg', UI_THEME)),
+              }}
+          })
+          return () => {
+            unmount();
+          };
+        }catch(error){
+          console.debug(error);
+        }
       },
       category: {
         id: 'wazuh',
@@ -109,13 +100,11 @@ export class WazuhPlugin implements Plugin<WazuhSetup, WazuhStart, WazuhSetupPlu
     });
     return {};
   }
-
   public start(core: CoreStart, plugins: AppPluginStartDependencies): WazuhStart {
     // hide security alert
     if(plugins.securityOss) {
       plugins.securityOss.insecureCluster.hideAlert(true);
     };
-
     if(plugins?.telemetry?.telemetryNotifications?.setOptedInNoticeSeen) {
       // assign to a method to hide the telemetry banner used when the app is mounted
       this.hideTelemetryBanner = () => plugins.telemetry.telemetryNotifications.setOptedInNoticeSeen();
@@ -139,8 +128,6 @@ export class WazuhPlugin implements Plugin<WazuhSetup, WazuhStart, WazuhSetupPlu
       setAngularModule(module);
       this.innerAngularInitialized = true;
     };
-
-
     setCore(core);
     setPlugins(plugins);
     setHttp(core.http);


### PR DESCRIPTION
## Research
In `public/plugin.ts` a Get request is done with a Kibana resource `core.http.get(/api/check-wazuh)`.

That resource fails in Chrome and Firefox browsers.

The Kibana core get resource is set up to catch the error with an `HttpFetchError` class that is a child of the Node Error class. Which is compatible only with browsers with V8 engine.
For this reason in Chrome it shows the error in the console as a debug and in Firefox it shows it in the console as an unrecognized error.

In the `http_fetch_errors.ts` and `globals.d.ts` files, kibana mentions V8 compatibility and that it will only work in browsers that use it. Attached screenshots
https://github.com/v8/v8/wiki/Stack%20Trace%20API#customizing-stack-traces

![Screenshot from 2022-08-03 07-10-11](https://user-images.githubusercontent.com/99441266/182584428-604180d9-a397-4ca6-8d0a-53dd1b98cdad.png)
![Screenshot from 2022-08-03 07-11-00](https://user-images.githubusercontent.com/99441266/182584437-298f82ff-3025-4571-a316-e46457f629b4.png)

## Proposed solution

Change the Get request that was made with a Kibana core.http.get(/api/check-wazuh) resource to the WzRequest.genericReq resource and it no longer fails, also add a test capture to public/plugin.ts that wraps the request and in case of failure, the error is detected when the browser does not work with the V8 engine.

## Test

- Click on the hamburger menu
- Click on dashboard
- Click on home
- Click on Wazuh
- Check that the console does not show: `TypeError: NetworkError when attempting to fetch resource`

https://user-images.githubusercontent.com/99441266/181495074-7394bc97-b81b-43ae-ac15-00dc1e134231.mp4