### PR TITLE
Improve alerts summary performance

### DIFF
--- a/server/integration-files/visualizations/overview/overview-aws.ts
+++ b/server/integration-files/visualizations/overview/overview-aws.ts
@@ -592,7 +592,7 @@ export default [
               otherBucketLabel: 'Other',
               missingBucket: false,
               missingBucketLabel: 'Missing',
-              size: 1000,
+              size: 100,
               order: 'desc',
               orderBy: '1',
               customLabel: 'Description',

--- a/server/integration-files/visualizations/overview/overview-fim.ts
+++ b/server/integration-files/visualizations/overview/overview-fim.ts
@@ -476,7 +476,7 @@ export default [
               otherBucketLabel: 'Other',
               missingBucket: false,
               missingBucketLabel: 'Missing',
-              size: 1000,
+              size: 100,
               order: 'desc',
               orderBy: '1',
               customLabel: 'Agent',

--- a/server/integration-files/visualizations/overview/overview-general.ts
+++ b/server/integration-files/visualizations/overview/overview-general.ts
@@ -749,7 +749,7 @@ export default [
               otherBucketLabel: 'Other',
               missingBucket: false,
               missingBucketLabel: 'Missing',
-              size: 1000,
+              size: 100,
               order: 'desc',
               orderBy: '1',
               customLabel: 'Rule ID',

--- a/server/integration-files/visualizations/overview/overview-office.ts
+++ b/server/integration-files/visualizations/overview/overview-office.ts
@@ -830,7 +830,7 @@ export default [
               otherBucketLabel: 'Other',
               missingBucket: false,
               missingBucketLabel: 'Missing',
-              size: 1000,
+              size: 100,
               order: 'desc',
               orderBy: '1',
               customLabel: 'Rule ID',

--- a/server/integration-files/visualizations/overview/overview-pm.ts
+++ b/server/integration-files/visualizations/overview/overview-pm.ts
@@ -353,7 +353,7 @@ export default [
               otherBucketLabel: 'Other',
               missingBucket: false,
               missingBucketLabel: 'Missing',
-              size: 1000,
+              size: 100,
               order: 'desc',
               orderBy: '1',
               customLabel: 'Control',

--- a/server/integration-files/visualizations/overview/overview-virustotal.ts
+++ b/server/integration-files/visualizations/overview/overview-virustotal.ts
@@ -866,7 +866,7 @@ export default [
               otherBucketLabel: 'Other',
               missingBucket: false,
               missingBucketLabel: 'Missing',
-              size: 1000,
+              size: 100,
               order: 'desc',
               orderBy: '1',
               customLabel: 'Rule ID',


### PR DESCRIPTION
# Description
This PR reduces the Alerts Summary hidden table used in PDF reports to improve the dashboards loading time.

Closes https://github.com/wazuh/wazuh-kibana-app/issues/3812