### PR TITLE
Fixed dashboard nested fields filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ All notable changes to the Wazuh app project will be documented in this file.
 
 - Changed the HTTP verb from `GET` to `POST` in the requests to login to the Wazuh API [#4103](https://github.com/wazuh/wazuh-kibana-app/pull/4103)
 
+### Fixed
+
+- Fixed nested fields filtering in dashboards tables and KPIs [#4425](https://github.com/wazuh/wazuh-kibana-app/pull/4425)
+
 ## Wazuh v4.3.7 - Kibana 7.10.2, 7.16.x, 7.17.x - Revision 4308
 
 ### Fixed

--- a/public/components/common/modules/discover/discover.tsx
+++ b/public/components/common/modules/discover/discover.tsx
@@ -370,7 +370,7 @@ export const Discover = compose(
       const previousFilters =
         (this.PluginPlatformServices && this.PluginPlatformServices.query.filterManager.getFilters()) || [];
       const elasticQuery = buildEsQuery(
-        undefined,
+        this.indexPattern,
         query,
         _.union(
           previousFilters,

--- a/public/components/overview/metrics/metrics.tsx
+++ b/public/components/overview/metrics/metrics.tsx
@@ -317,9 +317,7 @@ export const Metrics = withAllowedAgents(
 
     async buildMetric() {
       if (!this.metricsList[this.props.section] || !this._isMount) return <></>;
-      const newFilters = this.filterManager.getFilters();
       const searchBarQuery = this.scope.state.query;
-      const newTime = this.timefilter.getTime();
       const filterParams = {};
       filterParams['time'] = this.timefilter.getTime();
       filterParams['query'] = searchBarQuery;

--- a/public/components/overview/mitre/lib/elastic-helpers.ts
+++ b/public/components/overview/mitre/lib/elastic-helpers.ts
@@ -90,7 +90,7 @@ function buildQuery(indexPattern, filterParams:IFilterParams) {
     indexPattern
   );
   return buildEsQuery(
-    undefined,
+    indexPattern,
     query,
     [...filters, timeFilter],
     getEsQueryConfig(getUiSettings()) 


### PR DESCRIPTION
### Description

In the dashboards, nested fields were not properly identified and because of this, the query results didn't work as expected. To fix it we added the index pattern information to the query building methods, so the field information can be retrieved and analyzed to structure the query object.

Closes https://github.com/wazuh/wazuh-kibana-app/issues/4430
