### PR TITLE
Render nested field rows in security alerts table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ All notable changes to the Wazuh app project will be documented in this file.
 
 - Changed the HTTP verb from `GET` to `POST` in the requests to login to the Wazuh API [#4103](https://github.com/wazuh/wazuh-kibana-app/pull/4103)
 
+### Fixed
+
+- Fixed nested field rendering in security alerts table details [#4428](https://github.com/wazuh/wazuh-kibana-app/pull/4428)
+
 ## Wazuh v4.3.7 - Kibana 7.10.2, 7.16.x, 7.17.x - Revision 4308
 
 ### Fixed

--- a/public/components/common/modules/discover/discover.scss
+++ b/public/components/common/modules/discover/discover.scss
@@ -47,7 +47,6 @@ div.euiPanel.euiComboBoxOptionsList.euiComboBoxOptionsList {
             word-break: break-all;
             word-wrap: break-word;
             white-space: pre-wrap;
-            color: #000;
             vertical-align: top;
             padding-top: 2px;
         }

--- a/public/components/common/modules/discover/discover.scss
+++ b/public/components/common/modules/discover/discover.scss
@@ -37,3 +37,19 @@ div.euiPanel.euiComboBoxOptionsList.euiComboBoxOptionsList {
 .hover-row{
     background-color: #fbfcfd;
 }
+
+.module-discover-table .module-discover-table-details {
+    td {
+        vertical-align: text-bottom;
+
+        .wzDocViewer__value {
+            display: inline-block;
+            word-break: break-all;
+            word-wrap: break-word;
+            white-space: pre-wrap;
+            color: #000;
+            vertical-align: top;
+            padding-top: 2px;
+        }
+    }
+}

--- a/public/components/common/modules/discover/discover.tsx
+++ b/public/components/common/modules/discover/discover.tsx
@@ -336,6 +336,7 @@ export const Discover = compose(
               addFilterOut={(filter) => this.addFilterOut(filter)}
               toggleColumn={(id) => this.addColumn(id)}
               rowDetailsFields={rowDetailsFields}
+              indexPattern={this.indexPattern}
             />
           </div>
         );


### PR DESCRIPTION
### Description

This PR fixes the issue where the **Dashboard** / **Security Alerts** table was not prepared to render an array of objects as a field value. It implements the components used in **Modules** / **Events** table to analyze and render possible nested fields.

Closes https://github.com/wazuh/wazuh-kibana-app/issues/4429

<details>
<summary>Screenshot</summary>

#### Security Alerts table
![image](https://user-images.githubusercontent.com/9343732/188125422-2e93c253-8393-44ad-858f-d777c5341d02.png)

***

#### Collapsed row:
![image](https://user-images.githubusercontent.com/9343732/188125086-01617135-7c81-4d87-90e4-8ae5b57fffdb.png)

***

#### Expanded row
![image](https://user-images.githubusercontent.com/9343732/188125242-025f7419-854c-4a1e-933e-3039c24e8911.png)


</details>