### PR TITLE
Updating XML selector for decoder file

### DIFF
--- a/test/cypress/cypress/integration/pageobjects/xpack/wazuh-menu/decoders.page.js
+++ b/test/cypress/cypress/integration/pageobjects/xpack/wazuh-menu/decoders.page.js
@@ -10,7 +10,7 @@ export const DECODERS_PAGE = {
   messageConfirmSaveSelector: '.euiText > span',
   buttonRestartSelector: '.euiCallOut.euiCallOut--primary .euiButton.euiButton--primary',
   firstCustomDecoder: '[data-test-subj="row-local_decoder_example"]',
-  xmlDecoderFile:':nth-child(4) .euiTableCellContent .euiToolTipAnchor .euiLink',
+  xmlDecoderFile:':nth-child(4) .euiTableCellContent .euiToolTipAnchor .euiLink:contains("local_decoder.xml")',
   codeEditorSelector: '[data-test-subj="codeEditorContainer"]',
   backButtonSelector: '.euiFlexGroup .euiFlexItem .euiToolTipAnchor .euiButtonIcon',
   confirmModalSelector: '[data-test-subj="confirmModalTitleText"]',

--- a/test/cypress/cypress/integration/step-definitions/management/decoders/the-user-selects-a-custom-decoder-when.js
+++ b/test/cypress/cypress/integration/step-definitions/management/decoders/the-user-selects-a-custom-decoder-when.js
@@ -7,5 +7,6 @@ const xmlDecoderFile = getSelector('xmlDecoderFile', pageName);
 When('The user selects a custom decoders to edit', () => {
   elementIsVisible(firstCustomDecoder);
   elementIsVisible(xmlDecoderFile);
+  clickElement(firstCustomDecoder);
   clickElement(xmlDecoderFile);
 });

--- a/test/cypress/cypress/integration/step-definitions/management/decoders/the-user-selects-a-custom-decoder-when.js
+++ b/test/cypress/cypress/integration/step-definitions/management/decoders/the-user-selects-a-custom-decoder-when.js
@@ -6,7 +6,6 @@ const xmlDecoderFile = getSelector('xmlDecoderFile', pageName);
 
 When('The user selects a custom decoders to edit', () => {
   elementIsVisible(firstCustomDecoder);
-  clickElement(firstCustomDecoder);
   elementIsVisible(xmlDecoderFile);
   clickElement(xmlDecoderFile);
 });

--- a/test/cypress/cypress/integration/step-definitions/management/decoders/the-user-selects-a-custom-decoder-when.js
+++ b/test/cypress/cypress/integration/step-definitions/management/decoders/the-user-selects-a-custom-decoder-when.js
@@ -6,7 +6,7 @@ const xmlDecoderFile = getSelector('xmlDecoderFile', pageName);
 
 When('The user selects a custom decoders to edit', () => {
   elementIsVisible(firstCustomDecoder);
-  elementIsVisible(xmlDecoderFile);
   clickElement(firstCustomDecoder);
+  elementIsVisible(xmlDecoderFile);
   clickElement(xmlDecoderFile);
 });


### PR DESCRIPTION
After executing a complete execution of the automated test suite, it was detected a few errors on Kibana 7.16.3 with the Xpack plugin, so this PR is to solve the detected problem.

Closes: https://github.com/wazuh/wazuh-kibana-app/issues/4460

Executed Test:
![image](https://user-images.githubusercontent.com/104914131/188972580-6e6f3694-b277-4711-8e6e-8d883b5b274c.png)
![image](https://user-images.githubusercontent.com/104914131/188972634-8e520ef5-d29b-4914-94cc-f442b2c9a8d3.png)

This PR covers the solution to the edit-decoder-without-saving test.
After checking the existing selector, I saw that it was two web elements with the same selector, which was causing the problem.
Modify the selector and the problem is solved, test both xpack and wzd
Changed selector
![image](https://user-images.githubusercontent.com/104914131/188974018-72eb1f50-eece-4f3d-96ba-fd906a43bae5.png)
