### PR TITLE
[Backport 4.4-1.2-wzd] Render nested field rows in security alerts table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,13 @@ All notable changes to the Wazuh app project will be documented in this file.
 
 - Changed the HTTP verb from `GET` to `POST` in the requests to login to the Wazuh API [#4103](https://github.com/wazuh/wazuh-kibana-app/pull/4103)
 
-## Wazuh v4.3.7 - OpenSearch Dashboards 1.2.0 - Revision 4308
+### Fixed
+
+- Improved Agents Overview performance [#4363](https://github.com/wazuh/wazuh-kibana-app/pull/4363)
+- Fixed nested fields filtering in dashboards tables and KPIs [#4425](https://github.com/wazuh/wazuh-kibana-app/pull/4425)
+- Fixed nested field rendering in security alerts table details [#4428](https://github.com/wazuh/wazuh-kibana-app/pull/4428)
+
+## Wazuh v4.3.7 - Kibana 7.10.2, 7.16.x, 7.17.x - Revision 4308
 
 ### Fixed
 

--- a/public/components/common/modules/discover/discover.scss
+++ b/public/components/common/modules/discover/discover.scss
@@ -37,3 +37,18 @@ div.euiPanel.euiComboBoxOptionsList.euiComboBoxOptionsList {
 .hover-row{
     background-color: #fbfcfd;
 }
+
+.module-discover-table .module-discover-table-details {
+    td {
+        vertical-align: text-bottom;
+
+        .wzDocViewer__value {
+            display: inline-block;
+            word-break: break-all;
+            word-wrap: break-word;
+            white-space: pre-wrap;
+            vertical-align: top;
+            padding-top: 2px;
+        }
+    }
+}

--- a/public/components/common/modules/discover/discover.tsx
+++ b/public/components/common/modules/discover/discover.tsx
@@ -336,6 +336,7 @@ export const Discover = compose(
               addFilterOut={(filter) => this.addFilterOut(filter)}
               toggleColumn={(id) => this.addColumn(id)}
               rowDetailsFields={rowDetailsFields}
+              indexPattern={this.indexPattern}
             />
           </div>
         );


### PR DESCRIPTION

Backport https://github.com/wazuh/wazuh-kibana-app/commit/b2a6c10b5ae284bb25210e5c696750ec25efacdc from https://github.com/wazuh/wazuh-kibana-app/pull/4428.

* Evaluate nested fields and render object array

* Removed text color style

* Added changelog

(cherry picked from commit b2a6c10b5ae284bb25210e5c696750ec25efacdc)

