### PR TITLE
Test Fixed, change decoder/rule tittle for correct execution

### DIFF
--- a/test/cypress/cypress/integration/step-definitions/management/decoders/the-user-creates-a-new-decoder-when.js
+++ b/test/cypress/cypress/integration/step-definitions/management/decoders/the-user-creates-a-new-decoder-when.js
@@ -3,10 +3,14 @@ import { fillField, elementIsVisible, getSelector } from '../../../utils/driver'
 import { DECODERS_PAGE as pageName} from '../../../utils/pages-constants';
 const decoderTitleSelector = getSelector('decoderTitleSelector', pageName);
 const codeEditorSelector = getSelector('codeEditorSelector', pageName);
-const testXmlText = '<decoder name="json"><prematch>^{\s*"</prematch><plugin_decoder>JSON_Decoder</plugin_decoder></decoder>';
+const testXmlText = '<decoder name="wazuh"><prematch>^wazuh2: </prematch></decoder>';
 
 When('The user writes a new decoder', () => {
   elementIsVisible(decoderTitleSelector);
-  fillField(decoderTitleSelector,'Test');
+  fillField(decoderTitleSelector,'Example decoder');
   fillField(codeEditorSelector,testXmlText);
 })
+
+//Test comments:
+//To the correct execution of this test, the decoder that is going to be created must not exist in the decoders list.
+// If the decoder already exists, the test will fail.

--- a/test/cypress/cypress/integration/step-definitions/management/decoders/the-user-creates-a-new-decoder-when.js
+++ b/test/cypress/cypress/integration/step-definitions/management/decoders/the-user-creates-a-new-decoder-when.js
@@ -1,5 +1,5 @@
 import { When } from 'cypress-cucumber-preprocessor/steps';
-import { fillField, elementIsVisible, getSelector } from '../../../utils/driver';
+import { fillField, elementIsVisible, getSelector, generateRandomName } from '../../../utils/driver';
 import { DECODERS_PAGE as pageName} from '../../../utils/pages-constants';
 const decoderTitleSelector = getSelector('decoderTitleSelector', pageName);
 const codeEditorSelector = getSelector('codeEditorSelector', pageName);
@@ -7,10 +7,6 @@ const testXmlText = '<decoder name="wazuh"><prematch>^wazuh2: </prematch></decod
 
 When('The user writes a new decoder', () => {
   elementIsVisible(decoderTitleSelector);
-  fillField(decoderTitleSelector,'Example decoder');
+  fillField(decoderTitleSelector,generateRandomName());
   fillField(codeEditorSelector,testXmlText);
-})
-
-//Test comments:
-//To the correct execution of this test, the decoder that is going to be created must not exist in the decoders list.
-// If the decoder already exists, the test will fail.
+});

--- a/test/cypress/cypress/integration/step-definitions/management/rules/the-user-writes-a-new-rule-when.js
+++ b/test/cypress/cypress/integration/step-definitions/management/rules/the-user-writes-a-new-rule-when.js
@@ -1,12 +1,13 @@
 import { When } from 'cypress-cucumber-preprocessor/steps';
-import { elementIsVisible, getSelector, fillField } from '../../../utils/driver';
+import { elementIsVisible, getSelector, fillField, generateRandomName } from '../../../utils/driver';
 import { RULES_PAGE as pageName} from '../../../utils/pages-constants';
 const codeEditorSelector = getSelector('codeEditorSelector', pageName);
 const rulesTitleSelector = getSelector('rulesTitleSelector', pageName);
+const testXmlText = '<group name="windows,"><rule id="6" level="0" noalert="1">  <category>windows</category>  <description>Generic template for all windows rules.</description></rule></group>';
 
 When('The user writes a new rule', () => {
   elementIsVisible(rulesTitleSelector);
-  fillField(rulesTitleSelector,'Test')
+  fillField(rulesTitleSelector,generateRandomName())
   elementIsVisible(codeEditorSelector);
-  fillField(codeEditorSelector,'Test');
+  fillField(codeEditorSelector,testXmlText);
 });

--- a/test/cypress/cypress/integration/utils/driver.js
+++ b/test/cypress/cypress/integration/utils/driver.js
@@ -117,6 +117,12 @@ export const xpathElementIsVisible = (xpathSelector) => {
   return getElementByXpath(xpathSelector).should('exist').should('be.visible');
 };
 
+export const generateRandomName = () => {
+  const uniqueSeed = Date.now().toString();
+  const getUniqueId = () => Cypress._.uniqueId(uniqueSeed);
+  return 'Test-'+getUniqueId();
+};
+
 export const timestampToDate = (e) => {
   let newDates = e.getDate() + "/" + (e.getMonth() + 1) + "/" + e.getFullYear() + " " + e.getHours() + ":" + e.getMinutes() + ":" + e.getSeconds();
   return newDates;


### PR DESCRIPTION
|Related issue|
|---|
|closes #4494   |

Description:

This PR implements a fix to Create new decoder/rule test for Wazuh Dashboard.
The main problem is related to the decoder name, the new decoder needs to have a unique name

Solution: 
The proposed solution is to use a random name for the new decoders based on the timestamp. I add this code in a new function in the controller so we can implement it in other test cases as well.

### E2E tests

<details>

![image](https://user-images.githubusercontent.com/104914131/189670983-5a41658a-55ba-4f48-9feb-e721d1ec35e1.png)

</details>