### PR TITLE
Changed terms of Office Max Rule Level

### DIFF
--- a/public/components/overview/metrics/metrics.tsx
+++ b/public/components/overview/metrics/metrics.tsx
@@ -273,7 +273,7 @@ export const Metrics = withAllowedAgents(
           },
         ],
         office: [
-          { name: "Max Rule Level", type: "custom", filter: { phrase: "office365", field: "rule.groups" }, agg: { "customAggResult": { "terms": { "field": "timestamp", "order": { "_term": "desc" }, "size": 1 }, "aggs": { "aggResult": { "terms": { "field": "rule.level" } } } } } },
+          { name: "Max Rule Level", type: "custom", filter: { phrase: "office365", field: "rule.groups" }, agg: { "customAggResult": { "terms": { "field": "rule.level", "order": { "_term": "desc" }, "size": 1 }, "aggs": { "aggResult": { "terms": { "field": "rule.level" } } } } } },
           { name: "Suspicious Downloads", type: "phrase", value: "91724", field: "rule.id", color: "danger" },
           { name: "Full Access Permissions", type: "phrase", value: "91725", field: "rule.id" },
           { name: "Phishing and Malware", type: "phrases", values: ["91556", "91575", "91700"], field: "rule.id", color: "danger" },


### PR DESCRIPTION
# Description
This PR fixes an issue with the main Office 365 dashboard, in which the Max Rule Level was not showing the correct value. 

# Changes

- Modified the file  `public/components/overview/metrics/metrics.tsx` for the office Max Rule Level to use the field rule.level instead of timestamp.  

Closes #4355 

**Screenshots**

- Before the changes:

![image](https://user-images.githubusercontent.com/42900763/189981546-5e6d1df6-94a0-4bb2-b3a5-0cd03df2872f.png)


- After the changes:
![image](https://user-images.githubusercontent.com/42900763/189981638-1da3f3b2-e242-40f2-bddd-d3bce3e4409e.png)


# Tests
Scenario: Open the main Office 365 dashboard
Given the alerts on the specified timeframe 
When the maximum alert level is defined
Then the Max Rule Level should show the correct value and match with the value shown in the `Events by severity over time` graphic