### PR TITLE
fix for #4527- remove filter from modules dashboard

### DIFF
--- a/test/cypress/cypress/integration/features/filters/remove-filter-from-module-dashboard.feature
+++ b/test/cypress/cypress/integration/features/filters/remove-filter-from-module-dashboard.feature
@@ -19,8 +19,8 @@ Feature: Validate that the added filter label is remove after click remove filte
       | Integrity Monitoring |
       | System Auditing      |
       | Mitre & Attack       |
-      | GDPR                 |
-      | HIPAA                |
+      # | GDPR                 |
+      # | HIPAA                |
       | NIST                 |
       | TSC                  |
       | Policy Monitoring    |

--- a/test/cypress/cypress/integration/features/filters/remove-filter-from-module-dashboard.feature
+++ b/test/cypress/cypress/integration/features/filters/remove-filter-from-module-dashboard.feature
@@ -19,8 +19,6 @@ Feature: Validate that the added filter label is remove after click remove filte
       | Integrity Monitoring |
       | System Auditing      |
       | Mitre & Attack       |
-      # | GDPR                 |
-      # | HIPAA                |
       | NIST                 |
       | TSC                  |
       | Policy Monitoring    |


### PR DESCRIPTION
Issue #4527 


## Description:

This PR includes the fix for the feature "remove filter from modules dashboard"

We decided to delete some modules because on wzd these modules are disabled by default
Modules:

- GDPR
- HIPAA

the feature remains:

```
  Scenario Outline: The user remove an added filter - Module - Dashboard <Module Name>
    When The user goes to <Module Name>
    And The user adds a new filter
    And The user checks filter label is added
    And The user removes the applied filter
    Then The user checks filter label is not added
    Examples:
      | Module Name          |
      | Security Events      |
      | Integrity Monitoring |
      | System Auditing      |
      | Mitre & Attack       |
      | NIST                 |
      | TSC                  |
      | Policy Monitoring    |
      | PCIDSS               |

```

### Test
<details>
<summary> Feature</summary>

![Screenshot from 2022-09-15 15-41-00](https://user-images.githubusercontent.com/76791841/190485334-87ee5f78-ef23-49a3-95de-2660b9390372.png)

</details>

<details>
<summary> Test execution</summary>

https://user-images.githubusercontent.com/76791841/190485555-fc66e88d-4441-4742-b714-72797c685c71.mp4




</details>