### PR TITLE
Change message for API version mismatch in Kibana

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Improve alerts summary performance [#4376](https://github.com/wazuh/wazuh-kibana-app/pull/4376)
 - Endpoint `/agents/summary/status` response was adapted. [#3874](https://github.com/wazuh/wazuh-kibana-app/pull/3874)
 - Makes Agents Overview loading icons independent [#4363](https://github.com/wazuh/wazuh-kibana-app/pull/4363)
+- Enhance the message shown when a mismatch between Wazuh API and Wazuh APP occurs [#4529](https://github.com/wazuh/wazuh-kibana-app/pull/4529)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ All notable changes to the Wazuh app project will be documented in this file.
 ### Changed
 
 - Changed the HTTP verb from `GET` to `POST` in the requests to login to the Wazuh API [#4103](https://github.com/wazuh/wazuh-kibana-app/pull/4103)
+- Improved alerts summary performance [#4376](https://github.com/wazuh/wazuh-kibana-app/pull/4376)
+- The endpoint `/agents/summary/status` response was adapted. [#3874](https://github.com/wazuh/wazuh-kibana-app/pull/3874)
+- Made Agents Overview icons load independently [#4363](https://github.com/wazuh/wazuh-kibana-app/pull/4363)
+- Improved the message displayed when there is a versions mismatch between the Wazuh API and the Wazuh APP [#4529](https://github.com/wazuh/wazuh-kibana-app/pull/4529)
 
 ### Fixed
 
@@ -20,10 +24,6 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fixed nested field rendering in security alerts table details [#4428](https://github.com/wazuh/wazuh-kibana-app/pull/4428)
 - Fixed a bug where the Wazuh logo was used instead of the custom one [#4539](https://github.com/wazuh/wazuh-kibana-app/pull/4539)
 - Fixed rendering problems of the `Agent Overview` section in low resolutions [#4516](https://github.com/wazuh/wazuh-kibana-app/pull/4516)
-- Improved alerts summary performance [#4376](https://github.com/wazuh/wazuh-kibana-app/pull/4376)
-- The endpoint `/agents/summary/status` response was adapted. [#3874](https://github.com/wazuh/wazuh-kibana-app/pull/3874)
-- Made Agents Overview icons load independently [#4363](https://github.com/wazuh/wazuh-kibana-app/pull/4363)
-- Improved the message displayed when there is a versions mismatch between the Wazuh API and the Wazuh APP [#4529](https://github.com/wazuh/wazuh-kibana-app/pull/4529)
 
 ## Wazuh v4.3.8 - Kibana 7.10.2, 7.16.x, 7.17.x - Revision 4309
 

--- a/common/constants.ts
+++ b/common/constants.ts
@@ -372,6 +372,9 @@ export const PLUGIN_PLATFORM_REQUEST_HEADERS = {
   'kbn-xsrf': 'kibana'
 };
 
+// Plugin app
+export const PLUGIN_APP_NAME = 'Wazuh App';
+
 // UI
 export const API_NAME_AGENT_STATUS = {
   ACTIVE: 'active',

--- a/public/components/health-check/container/health-check.container.tsx
+++ b/public/components/health-check/container/health-check.container.tsx
@@ -199,10 +199,19 @@ function HealthCheckComponent() {
     const words = error.split(' ');
     words.forEach((word, index) => {
       if (word.includes('http://') || word.includes('https://')) {
-        if (word.endsWith('.') || word.endsWith(',')) {
-          words[index] = `<a href="${word.slice(0, -1)}" target="_blank">${word.slice(0, -1)}</a>${word.slice(-1)}`;
-        } else {
-          words[index] = `<a href="${word}" target="_blank">${word}</a>`;
+        if (words[index - 1] === 'guide:') {
+          if (word.endsWith('.') || word.endsWith(',')) {
+            words[index - 2] = `<a href="${word.slice(0, -1)}" target="_blank">${words[index - 2]} ${words[index - 1].slice(0, -1)}</a>${word.slice(-1)}`;
+          } else {
+            words[index - 2] = `<a href="${word}" target="_blank">${words[index - 2]} ${words[index - 1].slice(0, -1)}</a> `;
+          }
+          words.splice(index - 1, 2);
+        } else{
+          if (word.endsWith('.') || word.endsWith(',')) {
+            words[index] = `<a href="${word.slice(0, -1)}" target="_blank">${word.slice(0, -1)}</a>${word.slice(-1)}`;
+          } else {
+            words[index] = `<a href="${word}" target="_blank">${word}</a>`;
+          }
         }
       }
     });

--- a/public/components/health-check/container/health-check.container.tsx
+++ b/public/components/health-check/container/health-check.container.tsx
@@ -195,6 +195,7 @@ function HealthCheckComponent() {
       );
     });
   };
+  
   const addTagsToUrl = (error) => {
     const words = error.split(' ');
     words.forEach((word, index) => {
@@ -217,6 +218,7 @@ function HealthCheckComponent() {
     });
     return words.join(' ');
   };
+
   const renderErrors = () => {
     return Object.keys(checkErrors).map((checkID) => 
       checkErrors[checkID].map((error, index) => (

--- a/public/components/health-check/container/health-check.container.tsx
+++ b/public/components/health-check/container/health-check.container.tsx
@@ -12,17 +12,9 @@
  *
  */
 
-import {
-  EuiButton,
-  EuiCallOut,
-  EuiDescriptionList,
-  EuiSpacer,
-} from '@elastic/eui';
+import { EuiButton, EuiCallOut, EuiDescriptionList, EuiSpacer } from '@elastic/eui';
 import React, { Fragment, useState, useEffect, useRef } from 'react';
-import {
-  EuiFlexGroup,
-  EuiFlexItem
-} from '@elastic/eui';
+import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 import { AppState, ErrorHandler } from '../../../react-services';
 import { useAppConfig, useRootScope } from '../../../components/common/hooks';
 import {
@@ -53,7 +45,7 @@ import { compose } from 'redux';
 import { getThemeAssetURL, getAssetURL } from '../../../utils/assets';
 
 const checks = {
-  api: {    
+  api: {
     title: 'Check Wazuh API connection',
     label: 'API connection',
     validator: checkApiService,
@@ -64,7 +56,7 @@ const checks = {
     title: 'Check Wazuh API version',
     label: 'API version',
     validator: checkSetupService,
-    awaitFor: ["api"],
+    awaitFor: ['api'],
   },
   pattern: {
     title: 'Check alerts index pattern',
@@ -77,7 +69,11 @@ const checks = {
   patternMonitoring: {
     title: 'Check monitoring index pattern',
     label: 'Monitoring index pattern',
-    validator: (appConfig) => checkPatternSupportService(appConfig.data['wazuh.monitoring.pattern'], WAZUH_INDEX_TYPE_MONITORING),
+    validator: (appConfig) =>
+      checkPatternSupportService(
+        appConfig.data['wazuh.monitoring.pattern'],
+        WAZUH_INDEX_TYPE_MONITORING
+      ),
     awaitFor: [],
     shouldCheck: true,
     canRetry: true,
@@ -85,7 +81,11 @@ const checks = {
   patternStatistics: {
     title: 'Check statistics index pattern',
     label: 'Statistics index pattern',
-    validator: (appConfig) => checkPatternSupportService(`${appConfig.data['cron.prefix']}-${appConfig.data['cron.statistics.index.name']}-*`, WAZUH_INDEX_TYPE_STATISTICS),
+    validator: (appConfig) =>
+      checkPatternSupportService(
+        `${appConfig.data['cron.prefix']}-${appConfig.data['cron.statistics.index.name']}-*`,
+        WAZUH_INDEX_TYPE_STATISTICS
+      ),
     awaitFor: [],
     shouldCheck: true,
     canRetry: true,
@@ -93,32 +93,43 @@ const checks = {
   maxBuckets: {
     title: `Check ${PLUGIN_PLATFORM_SETTING_NAME_MAX_BUCKETS} setting`,
     label: `${PLUGIN_PLATFORM_SETTING_NAME_MAX_BUCKETS} setting`,
-    validator: checkPluginPlatformSettings(PLUGIN_PLATFORM_SETTING_NAME_MAX_BUCKETS, WAZUH_PLUGIN_PLATFORM_SETTING_MAX_BUCKETS),
+    validator: checkPluginPlatformSettings(
+      PLUGIN_PLATFORM_SETTING_NAME_MAX_BUCKETS,
+      WAZUH_PLUGIN_PLATFORM_SETTING_MAX_BUCKETS
+    ),
     awaitFor: [],
     canRetry: true,
   },
   metaFields: {
     title: `Check ${PLUGIN_PLATFORM_SETTING_NAME_METAFIELDS} setting`,
     label: `${PLUGIN_PLATFORM_SETTING_NAME_METAFIELDS} setting`,
-    validator: checkPluginPlatformSettings(PLUGIN_PLATFORM_SETTING_NAME_METAFIELDS, WAZUH_PLUGIN_PLATFORM_SETTING_METAFIELDS),
+    validator: checkPluginPlatformSettings(
+      PLUGIN_PLATFORM_SETTING_NAME_METAFIELDS,
+      WAZUH_PLUGIN_PLATFORM_SETTING_METAFIELDS
+    ),
     awaitFor: [],
     canRetry: true,
   },
   timeFilter: {
     title: `Check ${PLUGIN_PLATFORM_SETTING_NAME_TIME_FILTER} setting`,
     label: `${PLUGIN_PLATFORM_SETTING_NAME_TIME_FILTER} setting`,
-    validator: checkPluginPlatformSettings(PLUGIN_PLATFORM_SETTING_NAME_TIME_FILTER, JSON.stringify(WAZUH_PLUGIN_PLATFORM_SETTING_TIME_FILTER), (checkLogger: CheckLogger, options: {defaultAppValue: any}) => {
-      getDataPlugin().query.timefilter.timefilter.setTime(WAZUH_PLUGIN_PLATFORM_SETTING_TIME_FILTER)
-        && checkLogger.action(`Timefilter set to ${JSON.stringify(options.defaultAppValue)}`);
-    }),
+    validator: checkPluginPlatformSettings(
+      PLUGIN_PLATFORM_SETTING_NAME_TIME_FILTER,
+      JSON.stringify(WAZUH_PLUGIN_PLATFORM_SETTING_TIME_FILTER),
+      (checkLogger: CheckLogger, options: { defaultAppValue: any }) => {
+        getDataPlugin().query.timefilter.timefilter.setTime(
+          WAZUH_PLUGIN_PLATFORM_SETTING_TIME_FILTER
+        ) && checkLogger.action(`Timefilter set to ${JSON.stringify(options.defaultAppValue)}`);
+      }
+    ),
     awaitFor: [],
     canRetry: true,
-  }
+  },
 };
 
 function HealthCheckComponent() {
-  const [checkErrors, setCheckErrors] = useState<{[key:string]: []}>({});
-  const [checksReady, setChecksReady] = useState<{[key: string]: boolean}>({});
+  const [checkErrors, setCheckErrors] = useState<{ [key: string]: [] }>({});
+  const [checksReady, setChecksReady] = useState<{ [key: string]: boolean }>({});
   const [isDebugMode, setIsDebugMode] = useState<boolean>(false);
   const appConfig = useAppConfig();
   const checksInitiated = useRef(false);
@@ -126,7 +137,9 @@ function HealthCheckComponent() {
 
   const redirectionPassHealthcheck = () => {
     const params = $rootScope.previousParams || {};
-    const queryString = Object.keys(params).map(key => key + '=' + params[key]).join('&');
+    const queryString = Object.keys(params)
+      .map((key) => key + '=' + params[key])
+      .join('&');
     const url = '/app/wazuh#' + ($rootScope.previousLocation || '') + '?' + queryString;
     window.location.href = getHttp().basePath.prepend(url);
   };
@@ -140,16 +153,15 @@ function HealthCheckComponent() {
 
   useEffect(() => {
     // Redirect to app when all checks are ready
-    Object.keys(checks)
-      .every(check => checksReady[check])
-    && !isDebugMode && (() => setTimeout(redirectionPassHealthcheck, HEALTH_CHECK_REDIRECTION_TIME)
-      )()
+    Object.keys(checks).every((check) => checksReady[check]) &&
+      !isDebugMode &&
+      (() => setTimeout(redirectionPassHealthcheck, HEALTH_CHECK_REDIRECTION_TIME))();
   }, [checksReady]);
 
   useEffect(() => {
     // Check if Health should not redirect automatically (Debug mode)
     setIsDebugMode(window.location.href.includes('debug'));
-  },[]);
+  }, []);
 
   const handleErrors = (checkID, errors, parsed) => {
     const newErrors = parsed
@@ -157,24 +169,27 @@ function HealthCheckComponent() {
           ErrorHandler.handle(error, 'Health Check', { warning: false, silent: true })
         )
       : errors;
-    setCheckErrors((prev) => ({...prev, [checkID]: newErrors}));
+    setCheckErrors((prev) => ({ ...prev, [checkID]: newErrors }));
   };
 
   const cleanErrors = (checkID: string) => {
     delete checkErrors[checkID];
-    setCheckErrors({...checkErrors});
-  }
+    setCheckErrors({ ...checkErrors });
+  };
 
-  const handleCheckReady = (checkID, isReady) => {    
-    setChecksReady(prev =>  ({...prev, [checkID]: isReady}));
-  }
+  const handleCheckReady = (checkID, isReady) => {
+    setChecksReady((prev) => ({ ...prev, [checkID]: isReady }));
+  };
 
-
-  const logoUrl = getHttp().basePath.prepend(appConfig.data['customization.logo.healthcheck'] ? getAssetURL(appConfig.data['customization.logo.healthcheck']) : getThemeAssetURL('logo.svg'));
+  const logoUrl = getHttp().basePath.prepend(
+    appConfig.data['customization.logo.healthcheck']
+      ? getAssetURL(appConfig.data['customization.logo.healthcheck'])
+      : getThemeAssetURL('logo.svg')
+  );
   const thereAreErrors = Object.keys(checkErrors).length > 0;
 
   const renderChecks = () => {
-    const showLogButton = (thereAreErrors || isDebugMode);
+    const showLogButton = thereAreErrors || isDebugMode;
     return Object.keys(checks).map((check, index) => {
       return (
         <CheckResult
@@ -188,7 +203,7 @@ function HealthCheckComponent() {
           handleErrors={handleErrors}
           cleanErrors={cleanErrors}
           isLoading={appConfig.isLoading}
-          handleCheckReady= {handleCheckReady}
+          handleCheckReady={handleCheckReady}
           checksReady={checksReady}
           canRetry={checks[check].canRetry}
         />
@@ -196,21 +211,41 @@ function HealthCheckComponent() {
     });
   };
 
+  const addTagsToUrl = (error) => {
+    const words = error.split(' ');
+    words.forEach((word, index) => {
+      if (word.includes('http://') || word.includes('https://')) {
+        if (word.endsWith('.') || word.endsWith(',')) {
+          words[index] = `<a href="${word.slice(0, -1)}" target="_blank">${word.slice(0, -1)}</a>.`;
+        } else {
+          words[index] = `<a href="${word}" target="_blank">${word}</a>`;
+        }
+      }
+    });
+    return words.join(' ');
+  };
+
   const renderErrors = () => {
-    return Object.keys(checkErrors).map((checkID) => 
+    return Object.keys(checkErrors).map((checkID) =>
       checkErrors[checkID].map((error, index) => (
         <Fragment key={index}>
           <EuiCallOut
-            title={(<>{`[${checks[checkID].label}]`} <span dangerouslySetInnerHTML={{__html: error}}></span></>)}
+            title={
+              <>
+                {`[${checks[checkID].label}]`}{' '}
+                <span dangerouslySetInnerHTML={{ __html: addTagsToUrl(error) }}></span>
+              </>
+            }
             color="danger"
             iconType="alert"
             style={{ textAlign: 'left' }}
-            data-test-subj='callOutError'
+            data-test-subj="callOutError"
           ></EuiCallOut>
+
           <EuiSpacer size="xs" />
         </Fragment>
       ))
-    ) 
+    );
   };
 
   return (
@@ -230,7 +265,7 @@ function HealthCheckComponent() {
       {(thereAreErrors || isDebugMode) && (
         <>
           <EuiSpacer size="xl" />
-          <EuiFlexGroup justifyContent='center'>
+          <EuiFlexGroup justifyContent="center">
             {thereAreErrors && (
               <EuiFlexItem grow={false}>
                 <EuiButton fill href={getHttp().basePath.prepend('/app/wazuh#/settings')}>
@@ -238,7 +273,7 @@ function HealthCheckComponent() {
                 </EuiButton>
               </EuiFlexItem>
             )}
-            {isDebugMode && Object.keys(checks).every(check => checksReady[check]) && (
+            {isDebugMode && Object.keys(checks).every((check) => checksReady[check]) && (
               <EuiFlexItem grow={false}>
                 <EuiButton fill onClick={redirectionPassHealthcheck}>
                   Continue
@@ -247,15 +282,12 @@ function HealthCheckComponent() {
             )}
           </EuiFlexGroup>
         </>
-      )
-      }
+      )}
       <EuiSpacer size="xl" />
     </div>
   );
 }
 
-export const HealthCheck = compose (withErrorBoundary,withReduxProvider) (HealthCheckComponent);
+export const HealthCheck = compose(withErrorBoundary, withReduxProvider)(HealthCheckComponent);
 
 export const HealthCheckTest = HealthCheckComponent;
-
-

--- a/public/components/health-check/container/health-check.container.tsx
+++ b/public/components/health-check/container/health-check.container.tsx
@@ -12,9 +12,17 @@
  *
  */
 
-import { EuiButton, EuiCallOut, EuiDescriptionList, EuiSpacer } from '@elastic/eui';
+import {
+  EuiButton,
+  EuiCallOut,
+  EuiDescriptionList,
+  EuiSpacer,
+} from '@elastic/eui';
 import React, { Fragment, useState, useEffect, useRef } from 'react';
-import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
+import {
+  EuiFlexGroup,
+  EuiFlexItem
+} from '@elastic/eui';
 import { AppState, ErrorHandler } from '../../../react-services';
 import { useAppConfig, useRootScope } from '../../../components/common/hooks';
 import {
@@ -45,7 +53,7 @@ import { compose } from 'redux';
 import { getThemeAssetURL, getAssetURL } from '../../../utils/assets';
 
 const checks = {
-  api: {
+  api: {    
     title: 'Check Wazuh API connection',
     label: 'API connection',
     validator: checkApiService,
@@ -56,7 +64,7 @@ const checks = {
     title: 'Check Wazuh API version',
     label: 'API version',
     validator: checkSetupService,
-    awaitFor: ['api'],
+    awaitFor: ["api"],
   },
   pattern: {
     title: 'Check alerts index pattern',
@@ -69,11 +77,7 @@ const checks = {
   patternMonitoring: {
     title: 'Check monitoring index pattern',
     label: 'Monitoring index pattern',
-    validator: (appConfig) =>
-      checkPatternSupportService(
-        appConfig.data['wazuh.monitoring.pattern'],
-        WAZUH_INDEX_TYPE_MONITORING
-      ),
+    validator: (appConfig) => checkPatternSupportService(appConfig.data['wazuh.monitoring.pattern'], WAZUH_INDEX_TYPE_MONITORING),
     awaitFor: [],
     shouldCheck: true,
     canRetry: true,
@@ -81,11 +85,7 @@ const checks = {
   patternStatistics: {
     title: 'Check statistics index pattern',
     label: 'Statistics index pattern',
-    validator: (appConfig) =>
-      checkPatternSupportService(
-        `${appConfig.data['cron.prefix']}-${appConfig.data['cron.statistics.index.name']}-*`,
-        WAZUH_INDEX_TYPE_STATISTICS
-      ),
+    validator: (appConfig) => checkPatternSupportService(`${appConfig.data['cron.prefix']}-${appConfig.data['cron.statistics.index.name']}-*`, WAZUH_INDEX_TYPE_STATISTICS),
     awaitFor: [],
     shouldCheck: true,
     canRetry: true,
@@ -93,43 +93,32 @@ const checks = {
   maxBuckets: {
     title: `Check ${PLUGIN_PLATFORM_SETTING_NAME_MAX_BUCKETS} setting`,
     label: `${PLUGIN_PLATFORM_SETTING_NAME_MAX_BUCKETS} setting`,
-    validator: checkPluginPlatformSettings(
-      PLUGIN_PLATFORM_SETTING_NAME_MAX_BUCKETS,
-      WAZUH_PLUGIN_PLATFORM_SETTING_MAX_BUCKETS
-    ),
+    validator: checkPluginPlatformSettings(PLUGIN_PLATFORM_SETTING_NAME_MAX_BUCKETS, WAZUH_PLUGIN_PLATFORM_SETTING_MAX_BUCKETS),
     awaitFor: [],
     canRetry: true,
   },
   metaFields: {
     title: `Check ${PLUGIN_PLATFORM_SETTING_NAME_METAFIELDS} setting`,
     label: `${PLUGIN_PLATFORM_SETTING_NAME_METAFIELDS} setting`,
-    validator: checkPluginPlatformSettings(
-      PLUGIN_PLATFORM_SETTING_NAME_METAFIELDS,
-      WAZUH_PLUGIN_PLATFORM_SETTING_METAFIELDS
-    ),
+    validator: checkPluginPlatformSettings(PLUGIN_PLATFORM_SETTING_NAME_METAFIELDS, WAZUH_PLUGIN_PLATFORM_SETTING_METAFIELDS),
     awaitFor: [],
     canRetry: true,
   },
   timeFilter: {
     title: `Check ${PLUGIN_PLATFORM_SETTING_NAME_TIME_FILTER} setting`,
     label: `${PLUGIN_PLATFORM_SETTING_NAME_TIME_FILTER} setting`,
-    validator: checkPluginPlatformSettings(
-      PLUGIN_PLATFORM_SETTING_NAME_TIME_FILTER,
-      JSON.stringify(WAZUH_PLUGIN_PLATFORM_SETTING_TIME_FILTER),
-      (checkLogger: CheckLogger, options: { defaultAppValue: any }) => {
-        getDataPlugin().query.timefilter.timefilter.setTime(
-          WAZUH_PLUGIN_PLATFORM_SETTING_TIME_FILTER
-        ) && checkLogger.action(`Timefilter set to ${JSON.stringify(options.defaultAppValue)}`);
-      }
-    ),
+    validator: checkPluginPlatformSettings(PLUGIN_PLATFORM_SETTING_NAME_TIME_FILTER, JSON.stringify(WAZUH_PLUGIN_PLATFORM_SETTING_TIME_FILTER), (checkLogger: CheckLogger, options: {defaultAppValue: any}) => {
+      getDataPlugin().query.timefilter.timefilter.setTime(WAZUH_PLUGIN_PLATFORM_SETTING_TIME_FILTER)
+        && checkLogger.action(`Timefilter set to ${JSON.stringify(options.defaultAppValue)}`);
+    }),
     awaitFor: [],
     canRetry: true,
-  },
+  }
 };
 
 function HealthCheckComponent() {
-  const [checkErrors, setCheckErrors] = useState<{ [key: string]: [] }>({});
-  const [checksReady, setChecksReady] = useState<{ [key: string]: boolean }>({});
+  const [checkErrors, setCheckErrors] = useState<{[key:string]: []}>({});
+  const [checksReady, setChecksReady] = useState<{[key: string]: boolean}>({});
   const [isDebugMode, setIsDebugMode] = useState<boolean>(false);
   const appConfig = useAppConfig();
   const checksInitiated = useRef(false);
@@ -137,9 +126,7 @@ function HealthCheckComponent() {
 
   const redirectionPassHealthcheck = () => {
     const params = $rootScope.previousParams || {};
-    const queryString = Object.keys(params)
-      .map((key) => key + '=' + params[key])
-      .join('&');
+    const queryString = Object.keys(params).map(key => key + '=' + params[key]).join('&');
     const url = '/app/wazuh#' + ($rootScope.previousLocation || '') + '?' + queryString;
     window.location.href = getHttp().basePath.prepend(url);
   };
@@ -153,15 +140,16 @@ function HealthCheckComponent() {
 
   useEffect(() => {
     // Redirect to app when all checks are ready
-    Object.keys(checks).every((check) => checksReady[check]) &&
-      !isDebugMode &&
-      (() => setTimeout(redirectionPassHealthcheck, HEALTH_CHECK_REDIRECTION_TIME))();
+    Object.keys(checks)
+      .every(check => checksReady[check])
+    && !isDebugMode && (() => setTimeout(redirectionPassHealthcheck, HEALTH_CHECK_REDIRECTION_TIME)
+      )()
   }, [checksReady]);
 
   useEffect(() => {
     // Check if Health should not redirect automatically (Debug mode)
     setIsDebugMode(window.location.href.includes('debug'));
-  }, []);
+  },[]);
 
   const handleErrors = (checkID, errors, parsed) => {
     const newErrors = parsed
@@ -169,27 +157,24 @@ function HealthCheckComponent() {
           ErrorHandler.handle(error, 'Health Check', { warning: false, silent: true })
         )
       : errors;
-    setCheckErrors((prev) => ({ ...prev, [checkID]: newErrors }));
+    setCheckErrors((prev) => ({...prev, [checkID]: newErrors}));
   };
 
   const cleanErrors = (checkID: string) => {
     delete checkErrors[checkID];
-    setCheckErrors({ ...checkErrors });
-  };
+    setCheckErrors({...checkErrors});
+  }
 
-  const handleCheckReady = (checkID, isReady) => {
-    setChecksReady((prev) => ({ ...prev, [checkID]: isReady }));
-  };
+  const handleCheckReady = (checkID, isReady) => {    
+    setChecksReady(prev =>  ({...prev, [checkID]: isReady}));
+  }
 
-  const logoUrl = getHttp().basePath.prepend(
-    appConfig.data['customization.logo.healthcheck']
-      ? getAssetURL(appConfig.data['customization.logo.healthcheck'])
-      : getThemeAssetURL('logo.svg')
-  );
+
+  const logoUrl = getHttp().basePath.prepend(appConfig.data['customization.logo.healthcheck'] ? getAssetURL(appConfig.data['customization.logo.healthcheck']) : getThemeAssetURL('logo.svg'));
   const thereAreErrors = Object.keys(checkErrors).length > 0;
 
   const renderChecks = () => {
-    const showLogButton = thereAreErrors || isDebugMode;
+    const showLogButton = (thereAreErrors || isDebugMode);
     return Object.keys(checks).map((check, index) => {
       return (
         <CheckResult
@@ -203,14 +188,13 @@ function HealthCheckComponent() {
           handleErrors={handleErrors}
           cleanErrors={cleanErrors}
           isLoading={appConfig.isLoading}
-          handleCheckReady={handleCheckReady}
+          handleCheckReady= {handleCheckReady}
           checksReady={checksReady}
           canRetry={checks[check].canRetry}
         />
       );
     });
   };
-
   const addTagsToUrl = (error) => {
     const words = error.split(' ');
     words.forEach((word, index) => {
@@ -224,28 +208,21 @@ function HealthCheckComponent() {
     });
     return words.join(' ');
   };
-
   const renderErrors = () => {
-    return Object.keys(checkErrors).map((checkID) =>
+    return Object.keys(checkErrors).map((checkID) => 
       checkErrors[checkID].map((error, index) => (
         <Fragment key={index}>
           <EuiCallOut
-            title={
-              <>
-                {`[${checks[checkID].label}]`}{' '}
-                <span dangerouslySetInnerHTML={{ __html: addTagsToUrl(error) }}></span>
-              </>
-            }
+            title={(<>{`[${checks[checkID].label}]`} <span dangerouslySetInnerHTML={{__html: addTagsToUrl(error)}}></span></>)}
             color="danger"
             iconType="alert"
             style={{ textAlign: 'left' }}
-            data-test-subj="callOutError"
+            data-test-subj='callOutError'
           ></EuiCallOut>
-
           <EuiSpacer size="xs" />
         </Fragment>
       ))
-    );
+    ) 
   };
 
   return (
@@ -265,7 +242,7 @@ function HealthCheckComponent() {
       {(thereAreErrors || isDebugMode) && (
         <>
           <EuiSpacer size="xl" />
-          <EuiFlexGroup justifyContent="center">
+          <EuiFlexGroup justifyContent='center'>
             {thereAreErrors && (
               <EuiFlexItem grow={false}>
                 <EuiButton fill href={getHttp().basePath.prepend('/app/wazuh#/settings')}>
@@ -273,7 +250,7 @@ function HealthCheckComponent() {
                 </EuiButton>
               </EuiFlexItem>
             )}
-            {isDebugMode && Object.keys(checks).every((check) => checksReady[check]) && (
+            {isDebugMode && Object.keys(checks).every(check => checksReady[check]) && (
               <EuiFlexItem grow={false}>
                 <EuiButton fill onClick={redirectionPassHealthcheck}>
                   Continue
@@ -282,12 +259,15 @@ function HealthCheckComponent() {
             )}
           </EuiFlexGroup>
         </>
-      )}
+      )
+      }
       <EuiSpacer size="xl" />
     </div>
   );
 }
 
-export const HealthCheck = compose(withErrorBoundary, withReduxProvider)(HealthCheckComponent);
+export const HealthCheck = compose (withErrorBoundary,withReduxProvider) (HealthCheckComponent);
 
 export const HealthCheckTest = HealthCheckComponent;
+
+

--- a/public/components/health-check/container/health-check.container.tsx
+++ b/public/components/health-check/container/health-check.container.tsx
@@ -200,7 +200,7 @@ function HealthCheckComponent() {
     words.forEach((word, index) => {
       if (word.includes('http://') || word.includes('https://')) {
         if (word.endsWith('.') || word.endsWith(',')) {
-          words[index] = `<a href="${word.slice(0, -1)}" target="_blank">${word.slice(0, -1)}</a>.`;
+          words[index] = `<a href="${word.slice(0, -1)}" target="_blank">${word.slice(0, -1)}</a>${word.slice(-1)}`;
         } else {
           words[index] = `<a href="${word}" target="_blank">${word}</a>`;
         }

--- a/public/components/health-check/services/check-setup.service.ts
+++ b/public/components/health-check/services/check-setup.service.ts
@@ -14,7 +14,7 @@
 
 import { AppState, GenericRequest, WzRequest } from '../../../react-services';
 import { CheckLogger } from '../types/check_logger';
-import { PLUGIN_PLATFORM_WAZUH_DOCUMENTATION_URL_PATH_TROUBLESHOOTING } from '../../../../common/constants';
+import { PLUGIN_PLATFORM_WAZUH_DOCUMENTATION_URL_PATH_TROUBLESHOOTING, PLUGIN_APP_NAME } from '../../../../common/constants';
 import { webDocumentationLink } from '../../../../common/services/web_documentation';
 
 export const checkSetupService = appInfo => async (checkLogger: CheckLogger) => {
@@ -44,7 +44,7 @@ export const checkSetupService = appInfo => async (checkLogger: CheckLogger) => 
         api.groups.version !== appSplit[0] ||
         api.groups.minor !== appSplit[1]
       ) {
-        checkLogger.error(`Wazuh API and Wazuh App version mismatch. API version: ${apiVersion}. App version: ${setupData.data.data['app-version']}. Check more info about this error on ${webDocumentationLink(PLUGIN_PLATFORM_WAZUH_DOCUMENTATION_URL_PATH_TROUBLESHOOTING)}.`);
+        checkLogger.error(`Wazuh API and ${PLUGIN_APP_NAME} version mismatch. API version: ${apiVersion}. App version: ${setupData.data.data['app-version']}. Check more info about this error on our troubleshooting guide: ${webDocumentationLink(PLUGIN_PLATFORM_WAZUH_DOCUMENTATION_URL_PATH_TROUBLESHOOTING)}.`);
       }
     }
   }

--- a/public/components/health-check/services/check-setup.service.ts
+++ b/public/components/health-check/services/check-setup.service.ts
@@ -44,7 +44,7 @@ export const checkSetupService = appInfo => async (checkLogger: CheckLogger) => 
         api.groups.version !== appSplit[0] ||
         api.groups.minor !== appSplit[1]
       ) {
-        checkLogger.error(`Wazuh API and ${PLUGIN_APP_NAME} version mismatch. API version: ${apiVersion}. App version: ${setupData.data.data['app-version']}. Check more info about this error on our troubleshooting guide: ${webDocumentationLink(PLUGIN_PLATFORM_WAZUH_DOCUMENTATION_URL_PATH_TROUBLESHOOTING)}.`);
+        checkLogger.error(`Wazuh API and ${PLUGIN_APP_NAME} version mismatch. API version: ${apiVersion}. App version: ${setupData.data.data['app-version']}. Read more about this error in our troubleshooting guide: ${webDocumentationLink(PLUGIN_PLATFORM_WAZUH_DOCUMENTATION_URL_PATH_TROUBLESHOOTING)}.`);
       }
     }
   }

--- a/public/components/health-check/services/check-setup.service.ts
+++ b/public/components/health-check/services/check-setup.service.ts
@@ -14,7 +14,7 @@
 
 import { AppState, GenericRequest, WzRequest } from '../../../react-services';
 import { CheckLogger } from '../types/check_logger';
-import { PLUGIN_PLATFORM_WAZUH_DOCUMENTATION_URL_PATH_UPGRADE_PLATFORM } from '../../../../common/constants';
+import { PLUGIN_PLATFORM_WAZUH_DOCUMENTATION_URL_PATH_TROUBLESHOOTING } from '../../../../common/constants';
 import { webDocumentationLink } from '../../../../common/services/web_documentation';
 
 export const checkSetupService = appInfo => async (checkLogger: CheckLogger) => {
@@ -44,7 +44,7 @@ export const checkSetupService = appInfo => async (checkLogger: CheckLogger) => 
         api.groups.version !== appSplit[0] ||
         api.groups.minor !== appSplit[1]
       ) {
-        checkLogger.error(`Wazuh API and Wazuh App version mismatch. API version: ${apiVersion}. App version: ${setupData.data.data['app-version']}. At least, major and minor should match. Check more info about upgrading Wazuh App <a target='_blank' href='${webDocumentationLink(PLUGIN_PLATFORM_WAZUH_DOCUMENTATION_URL_PATH_UPGRADE_PLATFORM)}'>here</a>.`);
+        checkLogger.error(`Wazuh API and Wazuh App version mismatch. API version: ${apiVersion}. App version: ${setupData.data.data['app-version']}. Check more info about this error on ${webDocumentationLink(PLUGIN_PLATFORM_WAZUH_DOCUMENTATION_URL_PATH_TROUBLESHOOTING)}.`);
       }
     }
   }


### PR DESCRIPTION
Solves #4299 
# Important information
On PR https://github.com/wazuh/wazuh-kibana-app/pull/4103, a method was changed to request the API endpoint. Only for testing purposes of this particular issue, it is possible to replace line 50 of `server/lib/api-interceptor.ts` with the following: `method: !!authContext ? 'POST' : 'GET',` to avoid getting an error due to a not allowed method and trigger the desired error.

# Changes made:

- Modified the message displayed when there is a version mismatch between the Wazuh API and the Wazuh App, to make it easier to understand.
- Removed the \<a\> tags on the message. 
- Added `PLUGIN_APP_NAME` constant to make the message match the same structure as in Wazuh Dashboard, for easier modifications in the future. 
- Added `addTagsToUrl` function on `health-check-container.tsx` and modified the displayed error message to use that function. 

## `addTagsToUrl`
This function receives a string and returns it with the next modifications:

- If the string contains a structure `<something> guide: <URL>`, it will modify that part to return `<something> guide` wrapped in \<a\> tags with the href pointing to the URL. 
- If the string contains a URL without `guide:` before it, it will wrap the URL in \<a\> tags.
- If the string doesn't contain any URL, it will return it without modifications.

## Before the changes: 
![image](https://user-images.githubusercontent.com/42900763/190698866-e8376541-0b4b-462e-95f4-f5756a95f9df.png)

## After the changes:
![image](https://user-images.githubusercontent.com/42900763/190698934-48b3948f-4d8f-4ba7-8473-c144f58be133.png)

# Tests
**Scenario**: have an environment with different versions of Wazuh API and Wazuh app, in which the major and minor are not the same.
**When** the user opens the Wazuh plugin
**Then** the health-check confirmation should show an error on `Check Wazuh API Version`
**And** the log message should contain a URL to the Elasticsearch troubleshooting section of Wazuh Documentation.
**And** the log message should not contain any \<a\> tags or HTML structure
**And** the message shown at the bottom should contain a clickable link to the Elasticsearch troubleshooting section of Wazuh Documentation.

**Scenario**: have an environment with different versions of Wazuh API and Wazuh app, in which the major and minor are not the same.
**When** the user forces a health check in debug mode
**Then** the health-check confirmation should show an error on `Check Wazuh API Version`
**And** the log message should contain a URL to the Elasticsearch troubleshooting section of Wazuh Documentation.
**And** the log message should not contain any \<a\> tags or HTML structure
**And** the message shown at the bottom should contain a clickable link to the Elasticsearch troubleshooting section of Wazuh Documentation.