### PR TITLE
fix for configuration feature

### DIFF
--- a/test/cypress/cypress/integration/step-definitions/settings/configuration/valida-configuration.when.js
+++ b/test/cypress/cypress/integration/step-definitions/settings/configuration/valida-configuration.when.js
@@ -1,6 +1,6 @@
 import { elementTextIncludes, elementIsVisible, getSelector } from '../../../utils/driver';
 
-import { CONFIGURATION_PAGE as pageName} from '../../../utils/pages-constants';
+import { CONFIGURATION_PAGE as pageName } from '../../../utils/pages-constants';
 const settingTitle = getSelector('settingTitle', pageName);
 const generalPanelTitle = getSelector('generalPanelTitle', pageName);
 const generalPanelIndexPatternName = getSelector('generalPanelIndexPatternName', pageName);
@@ -150,8 +150,8 @@ const texts = require('../../../../fixtures/configuration.panel.text.json');
 
 Then('The app current settings are displayed', () => {
     elementTextIncludes(settingTitle, texts.configurationTitle);
-    elementTextIncludes(settingSubTitle, texts.configurationDescription);
-    
+    (Cypress.env('type') == 'wzd') ? elementTextIncludes(settingSubTitle, 'Configuration file located at /usr/share/wazuh-dashboard/data/wazuh/config/wazuh.yml') : elementTextIncludes(settingSubTitle, texts.configurationDescription);
+
     elementIsVisible(generalPanelTitle);
     elementIsVisible(generalPanelIndexPatternName);
     elementIsVisible(generalPanelIndexPatternDescription);
@@ -300,115 +300,148 @@ Then('The app current settings are displayed', () => {
 
     //check the title, subtitle and label texts
     elementTextIncludes(generalPanelTitle, texts.Panel[0].name);
-    elementTextIncludes(generalPanelIndexPatternName, texts.Panel[0].items[0].title );
-    elementTextIncludes(generalPanelIndexPatternDescription, texts.Panel[0].items[0].subTitle );
+    elementTextIncludes(generalPanelIndexPatternName, texts.Panel[0].items[0].title);
+    elementTextIncludes(generalPanelIndexPatternDescription, texts.Panel[0].items[0].subTitle);
     elementTextIncludes(generalPanelIndexPatternLabel, texts.Panel[0].items[0].label);
-    elementTextIncludes(generalPanelRequestTimeoutName, texts.Panel[0].items[1].title );
-    elementTextIncludes(generalPanelRequestTimeoutDescription, texts.Panel[0].items[1].subTitle );
-    elementTextIncludes(generalPanelRequestLabel, texts.Panel[0].items[1].label );
-    elementTextIncludes(generalPanelIpSelectorName, texts.Panel[0].items[2].title );
-    elementTextIncludes(generalPanelIpSelectorDescription, texts.Panel[0].items[2].subTitle );
-    elementTextIncludes(generalPanelIpSelectorLabel, texts.Panel[0].items[2].label );
-    elementTextIncludes(generalPanelIpIgnoreName, texts.Panel[0].items[3].title );
-    elementTextIncludes(generalPanelIpIgnoreDescription, texts.Panel[0].items[3].subTitle );
-    elementTextIncludes(generalPanelIpIgnoreLabel, texts.Panel[0].items[3].label );
-    elementTextIncludes(generalPanelCronPrefixName, texts.Panel[0].items[4].title );
-    elementTextIncludes(generalPanelCronPrefixDescription, texts.Panel[0].items[4].subTitle );
-    elementTextIncludes(generalPanelCronLabel, texts.Panel[0].items[4].label );
-    elementTextIncludes(generalPanelSamplePrefixName, texts.Panel[0].items[5].title );
-    elementTextIncludes(generalPanelSamplePrefixDescription, texts.Panel[0].items[5].subTitle );
-    elementTextIncludes(generalPanelManagerAlertsPrefixName, texts.Panel[0].items[6].title );
-    elementTextIncludes(generalPanelManagerAlertsPrefixDescription, texts.Panel[0].items[6].subTitle );
-    elementTextIncludes(generalPanelManagerAlertsLabel, texts.Panel[0].items[6].label );
-    elementTextIncludes(generalPanelLogLevelName, texts.Panel[0].items[7].title );
-    elementTextIncludes(generalPanelLogLevelDescription, texts.Panel[0].items[7].subTitle );
-    elementTextIncludes(generalPanelLogLevelLabel, texts.Panel[0].items[7].label );
-    elementTextIncludes(generalPanelEnrollmentName, texts.Panel[0].items[8].title );
-    elementTextIncludes(generalPanelEnrollmentDescription, texts.Panel[0].items[8].subTitle );
-    elementTextIncludes(generalPanelEnrollmentLabel, texts.Panel[0].items[8].label );
+    elementTextIncludes(generalPanelRequestTimeoutName, texts.Panel[0].items[1].title);
+    (Cypress.env('type') == 'wzd') ? elementTextIncludes(generalPanelRequestTimeoutDescription, 'Maximum time, in milliseconds, the app will wait for an API response when making requests to it. It will be ignored if the value is set under 1500 milliseconds.') : elementTextIncludes(generalPanelRequestTimeoutDescription, texts.Panel[0].items[1].subTitle);
+    elementTextIncludes(generalPanelRequestLabel, texts.Panel[0].items[1].label);
+    elementTextIncludes(generalPanelIpSelectorName, texts.Panel[0].items[2].title);
+    (Cypress.env('type') == 'wzd') ? elementTextIncludes(generalPanelIpSelectorDescription, 'Define if the user is allowed to change the selected index pattern directly from the top menu bar.') : elementTextIncludes(generalPanelIpSelectorDescription, texts.Panel[0].items[2].subTitle);
+    elementTextIncludes(generalPanelIpSelectorLabel, texts.Panel[0].items[2].label);
+    elementTextIncludes(generalPanelIpIgnoreName, texts.Panel[0].items[3].title);
+    elementTextIncludes(generalPanelIpIgnoreDescription, texts.Panel[0].items[3].subTitle);
+    elementTextIncludes(generalPanelIpIgnoreLabel, texts.Panel[0].items[3].label);
+    elementTextIncludes(generalPanelCronPrefixName, texts.Panel[0].items[4].title);
+    elementTextIncludes(generalPanelCronPrefixDescription, texts.Panel[0].items[4].subTitle);
+    elementTextIncludes(generalPanelCronLabel, texts.Panel[0].items[4].label);
+    elementTextIncludes(generalPanelSamplePrefixName, texts.Panel[0].items[5].title);
+
+    (Cypress.env('type') == 'wzd') ? elementTextIncludes(generalPanelSamplePrefixDescription, 'Define the index name prefix of sample alerts. It must match the template used by the index pattern to avoid unknown fields in dashboards.') : elementTextIncludes(generalPanelSamplePrefixDescription, texts.Panel[0].items[5].subTitle);
+
+    elementTextIncludes(generalPanelManagerAlertsPrefixName, texts.Panel[0].items[6].title);
+    (Cypress.env('type') == 'wzd') ? elementTextIncludes(generalPanelManagerAlertsPrefixDescription, 'Hide the alerts of the manager in every dashboard.') : elementTextIncludes(generalPanelManagerAlertsPrefixDescription, texts.Panel[0].items[6].subTitle);
+    elementTextIncludes(generalPanelManagerAlertsLabel, texts.Panel[0].items[6].label);
+    elementTextIncludes(generalPanelLogLevelName, texts.Panel[0].items[7].title);
+
+    (Cypress.env('type') == 'wzd') ? elementTextIncludes(generalPanelLogLevelDescription, 'Logging level of the App.') : elementTextIncludes(generalPanelLogLevelDescription, texts.Panel[0].items[7].subTitle);
+
+    elementTextIncludes(generalPanelLogLevelLabel, texts.Panel[0].items[7].label);
+    elementTextIncludes(generalPanelEnrollmentName, texts.Panel[0].items[8].title);
+
+    (Cypress.env('type') == 'wzd') ? elementTextIncludes(generalPanelEnrollmentDescription, 'Specifies the Wazuh registration server, used for the agent enrollment.') : elementTextIncludes(generalPanelEnrollmentDescription, texts.Panel[0].items[8].subTitle);
+
+    elementTextIncludes(generalPanelEnrollmentLabel, texts.Panel[0].items[8].label);
 
 
-    elementTextIncludes(healthCheckPanelTitle, texts.Panel[1].name );
-    elementTextIncludes(healthCheckPanelIndexPatternPrefixName, texts.Panel[1].items[0].title );
-    elementTextIncludes(healthCheckPanelIndexPatternPrefixDescription, texts.Panel[1].items[0].subTitle );
-    elementTextIncludes(healthCheckPanelIndexPatterLabel, texts.Panel[1].items[0].label );
-    elementTextIncludes(healthCheckPanelIndexTemplatePrefixName, texts.Panel[1].items[1].title );
-    elementTextIncludes(healthCheckPanelIndexTemplatePrefixDescription, texts.Panel[1].items[1].subTitle );
-    elementTextIncludes(healthCheckPanelIndexTemplateLabel, texts.Panel[1].items[1].label );
-    elementTextIncludes(healthCheckPanelApiConnectionPrefixName, texts.Panel[1].items[2].title );
-    elementTextIncludes(healthCheckPanelApiConnectionPrefixDescription, texts.Panel[1].items[2].subTitle );
-    elementTextIncludes(healthCheckPanelApiConnectionLabel, texts.Panel[1].items[2].label );
-    elementTextIncludes(healthCheckPanelApiVersionPrefixName, texts.Panel[1].items[3].title );
-    elementTextIncludes(healthCheckPanelApiVersionPrefixDescription, texts.Panel[1].items[3].subTitle );
-    elementTextIncludes(healthCheckPanelApiVersionLabel, texts.Panel[1].items[3].label );
-    elementTextIncludes(healthCheckPanelKnowFieldsPrefixName, texts.Panel[1].items[4].title );
-    elementTextIncludes(healthCheckPanelKnowFieldsPrefixDescription, texts.Panel[1].items[4].subTitle );
-    elementTextIncludes(healthCheckPanelKnowFieldsLabel, texts.Panel[1].items[4].label );
-    elementTextIncludes(healthCheckPanelRemoveMetaFieldsPrefixName, texts.Panel[1].items[5].title );
-    elementTextIncludes(healthCheckPanelRemoveMetaFieldsPrefixDescription, texts.Panel[1].items[5].subTitle );
-    elementTextIncludes(healthCheckPanelRemoveMetaFieldsPrefixLabel, texts.Panel[1].items[5].label );
-    elementTextIncludes(healthCheckPanelSetBucketPrefixName, texts.Panel[1].items[6].title );
-    elementTextIncludes(healthCheckPanelSetBucketPrefixDescription, texts.Panel[1].items[6].subTitle );
-    elementTextIncludes(healthCheckPanelSetBucketLabel, texts.Panel[1].items[6].label );
-    elementTextIncludes(healthCheckPanelSetTimePrefixName, texts.Panel[1].items[7].title );
-    elementTextIncludes(healthCheckPanelSetTimePrefixDescription, texts.Panel[1].items[7].subTitle );
-    elementTextIncludes(healthCheckPanelSetTimeLabel, texts.Panel[1].items[7].label );
+    elementTextIncludes(healthCheckPanelTitle, texts.Panel[1].name);
+    elementTextIncludes(healthCheckPanelIndexPatternPrefixName, texts.Panel[1].items[0].title);
+    elementTextIncludes(healthCheckPanelIndexPatternPrefixDescription, texts.Panel[1].items[0].subTitle);
+    elementTextIncludes(healthCheckPanelIndexPatterLabel, texts.Panel[1].items[0].label);
+    elementTextIncludes(healthCheckPanelIndexTemplatePrefixName, texts.Panel[1].items[1].title);
+    elementTextIncludes(healthCheckPanelIndexTemplatePrefixDescription, texts.Panel[1].items[1].subTitle);
+    elementTextIncludes(healthCheckPanelIndexTemplateLabel, texts.Panel[1].items[1].label);
+    elementTextIncludes(healthCheckPanelApiConnectionPrefixName, texts.Panel[1].items[2].title);
+    elementTextIncludes(healthCheckPanelApiConnectionPrefixDescription, texts.Panel[1].items[2].subTitle);
+    elementTextIncludes(healthCheckPanelApiConnectionLabel, texts.Panel[1].items[2].label);
+    elementTextIncludes(healthCheckPanelApiVersionPrefixName, texts.Panel[1].items[3].title);
+    elementTextIncludes(healthCheckPanelApiVersionPrefixDescription, texts.Panel[1].items[3].subTitle);
+    elementTextIncludes(healthCheckPanelApiVersionLabel, texts.Panel[1].items[3].label);
+    elementTextIncludes(healthCheckPanelKnowFieldsPrefixName, texts.Panel[1].items[4].title);
+    elementTextIncludes(healthCheckPanelKnowFieldsPrefixDescription, texts.Panel[1].items[4].subTitle);
+    elementTextIncludes(healthCheckPanelKnowFieldsLabel, texts.Panel[1].items[4].label);
+    elementTextIncludes(healthCheckPanelRemoveMetaFieldsPrefixName, texts.Panel[1].items[5].title);
 
-    
-    elementTextIncludes(monitoringPanelTitle, texts.Panel[2].name );
+    (Cypress.env('type') == 'wzd') ? elementTextIncludes(healthCheckPanelRemoveMetaFieldsPrefixDescription, 'Change the default value of the Wazuh dashboard metaField configuration') : elementTextIncludes(healthCheckPanelRemoveMetaFieldsPrefixDescription, texts.Panel[1].items[5].subTitle);
 
-    elementTextIncludes(monitoringPanelStatusName, texts.Panel[2].items[0].title );
-    elementTextIncludes(monitoringPanelStatusDescription, texts.Panel[2].items[0].subTitle );
-    elementTextIncludes(monitoringPanelStatusPatterLabel, texts.Panel[2].items[0].label );
-    elementTextIncludes(monitoringPanelFrequencyName, texts.Panel[2].items[1].title );
-    elementTextIncludes(monitoringPanelFrequencyDescription, texts.Panel[2].items[1].subTitle );
-    elementTextIncludes(monitoringPanelFrequencyLabel, texts.Panel[2].items[1].label );
-    elementTextIncludes(monitoringPanelIndexShardsName, texts.Panel[2].items[2].title );
-    elementTextIncludes(monitoringPanelIndexShardsDescription, texts.Panel[2].items[2].subTitle );
-    elementTextIncludes(monitoringPanelIndexShardsLabel, texts.Panel[2].items[2].label );
-    elementTextIncludes(monitoringPanelIndexReplicasName, texts.Panel[2].items[3].title );
-    elementTextIncludes(monitoringPanelIndexReplicasDescription, texts.Panel[2].items[3].subTitle );
-    elementTextIncludes(monitoringPanelPanelIndexReplicasLabel, texts.Panel[2].items[3].label );
-    elementTextIncludes(monitoringPanelIndexCreationName, texts.Panel[2].items[4].title );
-    elementTextIncludes(monitoringPanelIndexCreationDescription, texts.Panel[2].items[4].subTitle );
-    elementTextIncludes(monitoringPanelIndexCreationLabel, texts.Panel[2].items[4].label );
-    elementTextIncludes(monitoringPanelIndexPatternName, texts.Panel[2].items[5].title );
-    elementTextIncludes(monitoringPanelIndexPatternDescription, texts.Panel[2].items[5].subTitle );
-    elementTextIncludes(monitoringPanelIndexPatternLabel, texts.Panel[2].items[5].label );
+    elementTextIncludes(healthCheckPanelRemoveMetaFieldsPrefixLabel, texts.Panel[1].items[5].label);
+    elementTextIncludes(healthCheckPanelSetBucketPrefixName, texts.Panel[1].items[6].title);
 
-    elementTextIncludes(statisticsPanelTitle,                     texts.Panel[3].name );
-    elementTextIncludes(StatisticsPanelStatusName,                texts.Panel[3].items[0].title );
-    elementTextIncludes(StatisticsPanelStatusDescription,         texts.Panel[3].items[0].subTitle );
-    elementTextIncludes(StatisticsPanelStatusPatterLabel,         texts.Panel[3].items[0].label );
-    elementTextIncludes(StatisticsPanelIncludesApisName,          texts.Panel[3].items[1].title );
-    elementTextIncludes(StatisticsPanelIncludesApisDescription,   texts.Panel[3].items[1].subTitle );
-    elementTextIncludes(StatisticsPanelIncludesApisLabel,         texts.Panel[3].items[1].label );
-    elementTextIncludes(StatisticsPanelIndexIntervalName,         texts.Panel[3].items[2].title );
-    elementTextIncludes(StatisticsPanelIndexIntervalDescription,  texts.Panel[3].items[2].subTitle );
-    elementTextIncludes(StatisticsPanelIndexIntervalLabel,        texts.Panel[3].items[2].label );
-    elementTextIncludes(StatisticsPanelIndexNameName,             texts.Panel[3].items[3].title );
-    elementTextIncludes(StatisticsPanelIndexNameDescription,      texts.Panel[3].items[3].subTitle );
-    elementTextIncludes(StatisticsPanelIndexNameLabel,            texts.Panel[3].items[3].label );
-    elementTextIncludes(StatisticsPanelIndexCreationName,         texts.Panel[3].items[4].title );
-    elementTextIncludes(StatisticsPanelIndexCreationDescription,  texts.Panel[3].items[4].subTitle );
-    elementTextIncludes(StatisticsPanelIndexCreationLabel,        texts.Panel[3].items[4].label );
-    elementTextIncludes(StatisticsPanelIndexShardsName,         texts.Panel[3].items[5].title );
-    elementTextIncludes(StatisticsPanelIndexShardsDescription,  texts.Panel[3].items[5].subTitle );
-    elementTextIncludes(StatisticsPanelIndexShardsLabel,        texts.Panel[3].items[5].label );
-    elementTextIncludes(StatisticsPanelIndexReplicasName,           texts.Panel[3].items[6].title );
-    elementTextIncludes(StatisticsPanelIndexReplicasDescription,    texts.Panel[3].items[6].subTitle );
-    elementTextIncludes(StatisticsPanelIndexReplicasLabel,          texts.Panel[3].items[6].label );
-    elementTextIncludes(logoPanelTitle, texts.Panel[4].name );
-    elementTextIncludes(LogosCustomizationPanelLogoAppName, texts.Panel[4].items[0].title );
-    elementTextIncludes(LogosCustomizationPanelLogoAppDescription, texts.Panel[4].items[0].subTitle );
-    elementTextIncludes(LogosCustomizationPanelLogoAppPatterLabel, texts.Panel[4].items[0].label );
-    elementTextIncludes(LogosCustomizationPanelLogosSidebarName, texts.Panel[4].items[1].title );
-    elementTextIncludes(LogosCustomizationPanelLogosSidebarDescription, texts.Panel[4].items[1].subTitle );
-    elementTextIncludes(LogosCustomizationPanelLogosSidebarLabel, texts.Panel[4].items[1].label );
-    elementTextIncludes(LogosCustomizationPanelLogoHealthCheckName, texts.Panel[4].items[2].title );
-    elementTextIncludes(LogosCustomizationPanelLogoHealthCheckDescription, texts.Panel[4].items[2].subTitle );
-    elementTextIncludes(LogosCustomizationPanelLogoHealthCheckLabel, texts.Panel[4].items[2].label );
-    elementTextIncludes(LogosCustomizationPanelLogoReportName, texts.Panel[4].items[3].title );
-    elementTextIncludes(LogosCustomizationPanelLogoReportDescription, texts.Panel[4].items[3].subTitle );
-    elementTextIncludes(LogosCustomizationPanelLogoReportLabel, texts.Panel[4].items[3].label );
+    (Cypress.env('type') == 'wzd') ? elementTextIncludes(healthCheckPanelSetBucketPrefixDescription, 'Change the default value of the Wazuh dashboard max buckets configuration') : elementTextIncludes(healthCheckPanelSetBucketPrefixDescription, texts.Panel[1].items[6].subTitle);
+
+    elementTextIncludes(healthCheckPanelSetBucketLabel, texts.Panel[1].items[6].label);
+    elementTextIncludes(healthCheckPanelSetTimePrefixName, texts.Panel[1].items[7].title);
+
+    (Cypress.env('type') == 'wzd') ? elementTextIncludes(healthCheckPanelSetTimePrefixDescription, 'Change the default value of the Wazuh dashboard timeFilter configuration') : elementTextIncludes(healthCheckPanelSetTimePrefixDescription, texts.Panel[1].items[7].subTitle);
+
+    elementTextIncludes(healthCheckPanelSetTimeLabel, texts.Panel[1].items[7].label);
+
+
+    elementTextIncludes(monitoringPanelTitle, texts.Panel[2].name);
+
+    elementTextIncludes(monitoringPanelStatusName, texts.Panel[2].items[0].title);
+    elementTextIncludes(monitoringPanelStatusDescription, texts.Panel[2].items[0].subTitle);
+    elementTextIncludes(monitoringPanelStatusPatterLabel, texts.Panel[2].items[0].label);
+    elementTextIncludes(monitoringPanelFrequencyName, texts.Panel[2].items[1].title);
+
+    (Cypress.env('type') == 'wzd') ? elementTextIncludes(monitoringPanelFrequencyDescription, 'Frequency, in seconds, of API requests to get the state of the agents and create a new document in the wazuh-monitoring index with this data.') : elementTextIncludes(monitoringPanelFrequencyDescription, texts.Panel[2].items[1].subTitle);
+
+    elementTextIncludes(monitoringPanelFrequencyLabel, texts.Panel[2].items[1].label);
+    elementTextIncludes(monitoringPanelIndexShardsName, texts.Panel[2].items[2].title);
+    elementTextIncludes(monitoringPanelIndexShardsDescription, texts.Panel[2].items[2].subTitle);
+    elementTextIncludes(monitoringPanelIndexShardsLabel, texts.Panel[2].items[2].label);
+    elementTextIncludes(monitoringPanelIndexReplicasName, texts.Panel[2].items[3].title);
+    elementTextIncludes(monitoringPanelIndexReplicasDescription, texts.Panel[2].items[3].subTitle);
+    elementTextIncludes(monitoringPanelPanelIndexReplicasLabel, texts.Panel[2].items[3].label);
+    elementTextIncludes(monitoringPanelIndexCreationName, texts.Panel[2].items[4].title);
+
+    (Cypress.env('type') == 'wzd') ? elementTextIncludes(monitoringPanelIndexCreationDescription, 'Define the interval in which a new wazuh-monitoring index will be created.') : elementTextIncludes(monitoringPanelIndexCreationDescription, texts.Panel[2].items[4].subTitle);
+
+    elementTextIncludes(monitoringPanelIndexCreationLabel, texts.Panel[2].items[4].label);
+    elementTextIncludes(monitoringPanelIndexPatternName, texts.Panel[2].items[5].title);
+
+    (Cypress.env('type') == 'wzd') ? elementTextIncludes(monitoringPanelIndexPatternDescription, 'Default index pattern to use for Wazuh monitoring.') : elementTextIncludes(monitoringPanelIndexPatternDescription, texts.Panel[2].items[5].subTitle);
+
+    elementTextIncludes(monitoringPanelIndexPatternLabel, texts.Panel[2].items[5].label);
+
+    elementTextIncludes(statisticsPanelTitle, texts.Panel[3].name);
+    elementTextIncludes(StatisticsPanelStatusName, texts.Panel[3].items[0].title);
+    elementTextIncludes(StatisticsPanelStatusDescription, texts.Panel[3].items[0].subTitle);
+    elementTextIncludes(StatisticsPanelStatusPatterLabel, texts.Panel[3].items[0].label);
+    elementTextIncludes(StatisticsPanelIncludesApisName, texts.Panel[3].items[1].title);
+
+    (Cypress.env('type') == 'wzd') ? elementTextIncludes(StatisticsPanelIncludesApisDescription, 'Enter the ID of the hosts you want to save data from, leave this empty to run the task on every host.') : elementTextIncludes(StatisticsPanelIncludesApisDescription, texts.Panel[3].items[1].subTitle);
+
+    elementTextIncludes(StatisticsPanelIncludesApisLabel, texts.Panel[3].items[1].label);
+    elementTextIncludes(StatisticsPanelIndexIntervalName, texts.Panel[3].items[2].title);
+    elementTextIncludes(StatisticsPanelIndexIntervalDescription, texts.Panel[3].items[2].subTitle);
+    elementTextIncludes(StatisticsPanelIndexIntervalLabel, texts.Panel[3].items[2].label);
+    elementTextIncludes(StatisticsPanelIndexNameName, texts.Panel[3].items[3].title);
+
+    (Cypress.env('type') == 'wzd') ? elementTextIncludes(StatisticsPanelIndexNameDescription, 'Define the name of the index in which the documents will be saved.') : elementTextIncludes(StatisticsPanelIndexNameDescription, texts.Panel[3].items[3].subTitle);
+
+    elementTextIncludes(StatisticsPanelIndexNameLabel, texts.Panel[3].items[3].label);
+    elementTextIncludes(StatisticsPanelIndexCreationName, texts.Panel[3].items[4].title);
+
+    (Cypress.env('type') == 'wzd') ? elementTextIncludes(StatisticsPanelIndexCreationDescription, 'Define the interval in which a new index will be created.') : elementTextIncludes(StatisticsPanelIndexCreationDescription, texts.Panel[3].items[4].subTitle);
+
+    elementTextIncludes(StatisticsPanelIndexCreationLabel, texts.Panel[3].items[4].label);
+    elementTextIncludes(StatisticsPanelIndexShardsName, texts.Panel[3].items[5].title);
+    elementTextIncludes(StatisticsPanelIndexShardsDescription, texts.Panel[3].items[5].subTitle);
+    elementTextIncludes(StatisticsPanelIndexShardsLabel, texts.Panel[3].items[5].label);
+    elementTextIncludes(StatisticsPanelIndexReplicasName, texts.Panel[3].items[6].title);
+    elementTextIncludes(StatisticsPanelIndexReplicasDescription, texts.Panel[3].items[6].subTitle);
+    elementTextIncludes(StatisticsPanelIndexReplicasLabel, texts.Panel[3].items[6].label);
+    elementTextIncludes(logoPanelTitle, texts.Panel[4].name);
+    elementTextIncludes(LogosCustomizationPanelLogoAppName, texts.Panel[4].items[0].title);
+
+    (Cypress.env('type') == 'wzd') ? elementTextIncludes(LogosCustomizationPanelLogoAppDescription, 'Set the name of the app logo stored at /plugins/wazuh/public/assets/') : elementTextIncludes(LogosCustomizationPanelLogoAppDescription, texts.Panel[4].items[0].subTitle);
+
+
+    elementTextIncludes(LogosCustomizationPanelLogoAppPatterLabel, texts.Panel[4].items[0].label);
+    elementTextIncludes(LogosCustomizationPanelLogosSidebarName, texts.Panel[4].items[1].title);
+
+    (Cypress.env('type') == 'wzd') ? elementTextIncludes(LogosCustomizationPanelLogosSidebarDescription, 'Set the name of the sidebar logo stored at /plugins/wazuh/public/assets') : elementTextIncludes(LogosCustomizationPanelLogosSidebarDescription, texts.Panel[4].items[1].subTitle);
+
+    elementTextIncludes(LogosCustomizationPanelLogosSidebarLabel, texts.Panel[4].items[1].label);
+    elementTextIncludes(LogosCustomizationPanelLogoHealthCheckName, texts.Panel[4].items[2].title);
+
+    (Cypress.env('type') == 'wzd') ? elementTextIncludes(LogosCustomizationPanelLogoHealthCheckDescription, 'Set the name of the health-check logo stored at /plugins/wazuh/public/assets/') : elementTextIncludes(LogosCustomizationPanelLogoHealthCheckDescription, texts.Panel[4].items[2].subTitle);
+
+    elementTextIncludes(LogosCustomizationPanelLogoHealthCheckLabel, texts.Panel[4].items[2].label);
+    elementTextIncludes(LogosCustomizationPanelLogoReportName, texts.Panel[4].items[3].title);
+
+    (Cypress.env('type') == 'wzd') ? elementTextIncludes(LogosCustomizationPanelLogoReportDescription, 'Set the name of the reports logo (.png) stored at /plugins/wazuh/public/assets/') : elementTextIncludes(LogosCustomizationPanelLogoReportDescription, texts.Panel[4].items[3].subTitle);
+
+    elementTextIncludes(LogosCustomizationPanelLogoReportLabel, texts.Panel[4].items[3].label);
 })


### PR DESCRIPTION
Issue #4530 


## Description:

This PR includes the fix for the feature "configuration to the module", this includes changes of the texts description on the setting/configuration page.


one example of the change including
```
(Cypress.env('type') == 'wzd') ? elementTextIncludes(LogosCustomizationPanelLogoReportDescription, 'Set the name of the reports logo (.png) stored at /plugins/wazuh/public/assets/') : elementTextIncludes(LogosCustomizationPanelLogoReportDescription, texts.Panel[4].items[3].subTitle);

```

### Test
<details>
<summary> Feature</summary>

![Screenshot from 2022-09-15 18-04-57](https://user-images.githubusercontent.com/76791841/190509977-a7a340c9-ef8f-435d-973a-398b1d6bd604.png)

</details>
