### PR TITLE
4545-fix for "add sample data" and "About" features

### DIFF
--- a/test/cypress/cypress/integration/features/management/settings/sample-data.feature
+++ b/test/cypress/cypress/integration/features/management/settings/sample-data.feature
@@ -8,6 +8,7 @@ Feature: Add/Delete Sample data to modules
   Scenario: Add all sample data
     Given The wazuh admin user is logged
     When The user navigates to Sample data settings
+    And All buttons have add status
     And The user adds sample data for
       | security information            |
       | auditing and policy monitoring  |
@@ -18,6 +19,7 @@ Feature: Add/Delete Sample data to modules
   Scenario: Delete all sample data
       Given The wazuh admin user is logged
       When The user navigates to Sample data settings
+      And All buttons have remove status
       And The user removes sample data for
       | security information            |
       | auditing and policy monitoring  |

--- a/test/cypress/cypress/integration/pageobjects/wzd/settings/api-configuration.page.js
+++ b/test/cypress/cypress/integration/pageobjects/wzd/settings/api-configuration.page.js
@@ -1,5 +1,5 @@
 export const API_CONFIGURATION_PAGE = {
-  checkConnectionButton: 'div:nth-child(2) > span > button',
+  checkConnectionButton: 'tbody tr:nth-child(1) div:nth-child(2) > span > button',
   connectionSuccessToast: '.euiToast--success',
   addNewConnectionButton: 'react-component > div > div > div:nth-child(1) > div:nth-child(2) > button > span',
   addNewConnectionModal: 'react-component > div > div.euiFlexItem.min-guide-width > div',

--- a/test/cypress/cypress/integration/pageobjects/wzd/settings/logs.page.js
+++ b/test/cypress/cypress/integration/pageobjects/wzd/settings/logs.page.js
@@ -1,6 +1,6 @@
 export const LOGS_PAGE = {
   logsTitle: 'div > .euiTitle',
   logsContainer: 'div > .euiCodeBlock',
-  reloadLogsLink: 'div.euiFlexItem > button > span > span',
+  reloadLogsLink: '[name="SettingsLogs"] .euiPanel div.euiFlexItem > button > span > span',
   logsTitleText: 'App log messages',
 };

--- a/test/cypress/cypress/integration/step-definitions/filters/the-user-adds-a-new-filter.when.js
+++ b/test/cypress/cypress/integration/step-definitions/filters/the-user-adds-a-new-filter.when.js
@@ -14,14 +14,11 @@ const filterOperatorListObject = getSelector('filterOperatorListObject', pageNam
 
 
 When('The user adds a new filter', () => {
-  debugger
   //+ Add Filter
   elementIsVisible(addFilterButton);
   clickElement(addFilterButton);
-
   //Card
   elementIsVisible(filterCard);
-
   elementIsVisible(filterSuggestionList);
   fillField(filterSuggestionList,'rule.level');
   forceEnter(filterSuggestionList);
@@ -31,11 +28,9 @@ When('The user adds a new filter', () => {
   elementIsVisible(operatorList);
   elementIsVisible(filterOperatorListObject);
   cy.wait(150);
-  // forceClickElement(SelectedOperatorIs);
   cy.get(SelectedOperatorIs).click({force:true});
   elementIsVisible(filterParams);
   clickElement(filterParams);
   fillField(filterParams,'7')
   clickElement(saveFilterButton);
-
 });

--- a/test/cypress/cypress/integration/step-definitions/settings/navigate-to-settings.when.js
+++ b/test/cypress/cypress/integration/step-definitions/settings/navigate-to-settings.when.js
@@ -8,7 +8,6 @@ const wazuhMenuRight = getSelector('wazuhMenuRight', pageName);
 const wazuhMenuSettingRight = getSelector('wazuhMenuSettingRight', pageName);
 
 When('The user navigates to {} settings', (menuOption) => {
-  debugger
   elementIsVisible(wazuhMenuButton);
   clickElement(wazuhMenuButton);
   elementIsVisible(wazuhMenuLeft);
@@ -16,6 +15,6 @@ When('The user navigates to {} settings', (menuOption) => {
   elementIsVisible(settingsButton);
   clickElement(settingsButton);
   elementIsVisible(wazuhMenuSettingRight);
-  elementIsVisible(getSelector(menuOption, SETTINGS_MENU_LINKS));
-  clickElement(getSelector(menuOption, SETTINGS_MENU_LINKS));
+  cy.wait(800);
+  elementIsVisible(getSelector(menuOption, SETTINGS_MENU_LINKS)).click();
 });

--- a/test/cypress/cypress/integration/step-definitions/settings/sample-data/add-remove-sample-data.when.js
+++ b/test/cypress/cypress/integration/step-definitions/settings/sample-data/add-remove-sample-data.when.js
@@ -1,24 +1,41 @@
-import { clickElement, getSelector, forceClickElement } from '../../../utils/driver';
+import { clickElement, getSelector, forceClickElement, elementIsVisible } from '../../../utils/driver';
 import { SAMPLE_DATA } from '../../../utils/pages-constants';
 let toastLocator = '[data-test-subj="globalToastList"] div button';
 let toastLocatorTitle = '[data-test-subj="globalToastList"] div';
 
-When('The user {} sample data for', (status,types) => {
+When('All buttons have {} status', (status) => {
+  cy.wait(4000);
+  let label = 'Add data';
+  if (status == 'add') label = 'Remove data';
+  for (let i = 1; i <= 3; i++) {
+    elementIsVisible('div:nth-child(' + i + ') > div > div.euiCard__footer > div > div > button')
+    cy.get('div:nth-child(' + i + ') > div > div.euiCard__footer > div > div > button',{timeot:10000})
+    .then($button => {
+      if($button.find(':contains("' + label + '")').length){
+        return cy.get($button).click().wait(10000);
+      }
+    }).then(selector =>{
+      cy.get(selector);
+    })
+  }
+});
+
+When('The user {} sample data for', (status, types) => {
   let titleStatus = 'added'
   let buttonLabel = 'Remove data'
-  if(status != 'adds'){titleStatus =  'removed'; buttonLabel = 'Add data';}
+  if (status != 'adds') { titleStatus = 'removed'; buttonLabel = 'Add data'; }
   types.raw().forEach((sample) => {
     cy.get(getSelector(sample, SAMPLE_DATA), { timeout: 15000 })
     forceClickElement(getSelector(sample, SAMPLE_DATA));
     cy.wait(500);
-    cy.get(getSelector(sample, SAMPLE_DATA), { timeout: 15000 }).should('have.text',buttonLabel)
+    cy.get(getSelector(sample, SAMPLE_DATA), { timeout: 15000 }).should('have.text', buttonLabel)
     cy.get(toastLocatorTitle, { timeout: 15000 })
       .then(($) => {
         const texts = $.map((i, el) => Cypress.$(el).text().replace('A new notification appears').replace('Date range for sample data is now-7 days ago'))
         const paragraphs = texts.get()
         let element = getSelector(sample + ' title', SAMPLE_DATA)
         let titles = Cypress.$(element).text()
-        expect(paragraphs.toString()).to.contains(titles + ' alerts '+ titleStatus)
+        expect(paragraphs.toString()).to.contains(titles + ' alerts ' + titleStatus)
       })
   });
 });

--- a/test/cypress/cypress/integration/step-definitions/settings/wazuh-logs/reload-logs.when.js
+++ b/test/cypress/cypress/integration/step-definitions/settings/wazuh-logs/reload-logs.when.js
@@ -6,4 +6,5 @@ const reloadLogsLink = getSelector('reloadLogsLink', pageName);
 When('The user reloads the logs', () => {
   interceptAs('GET', '/utils/logs', 'apiCheck');
   clickElement(reloadLogsLink);
+  cy.wait(500);
 });


### PR DESCRIPTION
Issue #4545  

## Description:

This PR includes the fix for both features add sample data and About.

fix for About feature:

it was decided to add a wait for the web elements.

Fix for Add Sample Data:
It was decided to add a step to the function, this step fixes the state of the button in the sample data page when the state of the buttons does not have the expected state.

```
And All buttons have add status
```

```
And All buttons have remove status
```

### Test
<details>
<summary> Feature</summary>

![Screenshot from 2022-09-19 12-34-54](https://user-images.githubusercontent.com/76791841/191056180-10ef99bc-96c9-4a0e-aa67-4da820ec8223.png)

</details>

<details>
<summary> Test execution</summary>

![Screenshot from 2022-09-19 11-40-29](https://user-images.githubusercontent.com/76791841/191056275-967e9c3b-f0c4-493a-bb94-c90c564c2eb5.png)
![Screenshot from 2022-09-19 11-35-41](https://user-images.githubusercontent.com/76791841/191056284-1e61bc15-87d5-4696-86f0-c2d1a49feaac.png)
![Screenshot from 2022-09-19 12-13-28](https://user-images.githubusercontent.com/76791841/191056269-f47d6772-53f5-4ad7-8676-bdc013ee6c22.png)




</details>