### PR TITLE
4550-feature/fix for enable modules Virus Total in Xpack

### DIFF
--- a/test/cypress/cypress/integration/step-definitions/settings/navigate-to-settings.when.js
+++ b/test/cypress/cypress/integration/step-definitions/settings/navigate-to-settings.when.js
@@ -15,6 +15,11 @@ When('The user navigates to {} settings', (menuOption) => {
   elementIsVisible(settingsButton);
   clickElement(settingsButton);
   elementIsVisible(wazuhMenuSettingRight);
-  cy.wait(800);
-  elementIsVisible(getSelector(menuOption, SETTINGS_MENU_LINKS)).click();
+  if (Cypress.env('type') == 'wzd') {
+    cy.wait(1000);
+    elementIsVisible(getSelector(menuOption, SETTINGS_MENU_LINKS)).click()
+  } else {
+    elementIsVisible(getSelector(menuOption, SETTINGS_MENU_LINKS));
+    clickElement(getSelector(menuOption, SETTINGS_MENU_LINKS));
+  };
 });


### PR DESCRIPTION
Issue #4550 

## Description:

This PR includes the fix for enabling Virus Total Module.

It includes an if statement logical block for WZD


before:

```
cy.wait(1000);
  elementIsVisible(getSelector(menuOption, SETTINGS_MENU_LINKS)).click();
```

After:

```
  if (Cypress.env('type') == 'wzd') {
    cy.wait(1000);
    elementIsVisible(getSelector(menuOption, SETTINGS_MENU_LINKS)).click()
  } else {
    elementIsVisible(getSelector(menuOption, SETTINGS_MENU_LINKS));
    clickElement(getSelector(menuOption, SETTINGS_MENU_LINKS));
  };
```

Test 
<details>

<summary>Test execution</summary>

![Screenshot from 2022-09-20 11-01-21](https://user-images.githubusercontent.com/76791841/191283981-191d1935-8c71-43f8-acff-a76ce46eea0c.png)
![Screenshot from 2022-09-20 10-57-42](https://user-images.githubusercontent.com/76791841/191283993-2a1118c6-ff35-4e69-937d-f23c9b16341b.png)
![Screenshot from 2022-09-20 10-47-44](https://user-images.githubusercontent.com/76791841/191283998-a4c9599a-9c9d-439f-8cdc-4e416aabf05c.png)

</details>