### PR TITLE
Create pull_request_template.md

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,19 @@
+### Description
+[Describe what this change achieves]
+ 
+### Issues Resolved
+[List any issues this PR will resolve]
+
+### Evidence
+[Provide screenshots or videos to prove this PR solves the issues]
+
+### Test
+[Provide instructions to test this PR]
+
+### Check List
+- [ ] All tests pass
+  - [ ] `yarn test:jest`
+- [ ] New functionality includes testing.
+- [ ] New functionality has been documented.
+- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
+- [ ] Commits are signed per the DCO using --signoff 


### PR DESCRIPTION
This PR adds a [Pull Request template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository) to our repository.

This template is used only if the template is present in the branch that opens the pull request, so this might not work for most of the pull requests for 4.4.0.

I'm adding backport to the development branches to mitigate this situation.