### PR TITLE
add feature to #4593 rules are displayed after refreshing the page fo…

### DIFF
--- a/test/cypress/cypress/integration/features/management/rules/refresh-rules-page.feature
+++ b/test/cypress/cypress/integration/features/management/rules/refresh-rules-page.feature
@@ -1,0 +1,12 @@
+Feature: Validate refresh option is working fine
+
+  As a kibana user
+  i want to edit a custom rule
+  in order to check if the warning no saving toast is displayed.
+
+@rules
+Scenario: Rules are displayed after refreshing the page
+Given The wazuh admin user is logged
+When The user navigates to rules
+And The user clicks the refresh button
+Then The user should be able to see the rules page

--- a/test/cypress/cypress/integration/pageobjects/wzd/wazuh-menu/rules.page.js
+++ b/test/cypress/cypress/integration/pageobjects/wzd/wazuh-menu/rules.page.js
@@ -13,5 +13,8 @@ export const RULES_PAGE = {
   createNewRulesSelector: '.euiFlexGroup .euiFlexItem .euiButtonEmpty .euiButtonContent .euiButtonEmpty__text:contains("Add new rules file")',
   rulesTitleSelector:'.euiFlexItem .euiFlexGroup .euiFormControlLayout input.euiFieldText',
   saveRulesButtonSelector: '.euiFlexGroup .euiFlexItem button.euiButton span.euiButtonContent span.euiButton__text:contains("Save")',
-  saveRulesMessage: '.euiText span:contains("Changes will not take effect until a restart is performed.")'
+  saveRulesMessage: '.euiText span:contains("Changes will not take effect until a restart is performed.")',
+  refreshButtonSelector: '.euiFlexGroup .euiFlexItem .euiButtonEmpty .euiButtonContent .euiButtonEmpty__text:contains("Refresh")',
+  rulestableSelector: '[name="WzManagement"] table tr',
+  buttonListPageSelector: '[name="WzManagement"] button > span',
 };

--- a/test/cypress/cypress/integration/pageobjects/xpack/wazuh-menu/rules.page.js
+++ b/test/cypress/cypress/integration/pageobjects/xpack/wazuh-menu/rules.page.js
@@ -13,5 +13,8 @@ export const RULES_PAGE = {
   createNewRulesSelector: '.euiFlexGroup .euiFlexItem .euiButtonEmpty .euiButtonContent .euiButtonEmpty__text:contains("Add new rules file")',
   rulesTitleSelector:'.euiFlexItem .euiFlexGroup .euiFormControlLayout input.euiFieldText',
   saveRulesButtonSelector: '.euiFlexGroup .euiFlexItem button.euiButton span.euiButtonContent span.euiButton__text:contains("Save")',
-  saveRulesMessage: '.euiText span:contains("Changes will not take effect until a restart is performed.")'
+  saveRulesMessage: '.euiText span:contains("Changes will not take effect until a restart is performed.")',
+  refreshButtonSelector: '.euiFlexGroup .euiFlexItem .euiButtonEmpty .euiButtonContent .euiButtonEmpty__text:contains("Refresh")',
+  rulestableSelector: '[name="WzManagement"] table tr',
+  buttonListPageSelector: '[name="WzManagement"] button > span',
 };

--- a/test/cypress/cypress/integration/step-definitions/management/rules/the-user-clicks-the-refresh-button-when.js
+++ b/test/cypress/cypress/integration/step-definitions/management/rules/the-user-clicks-the-refresh-button-when.js
@@ -1,0 +1,37 @@
+import { When } from 'cypress-cucumber-preprocessor/steps';
+import { clickElement, elementIsVisible, getSelector } from '../../../utils/driver';
+import { RULES_PAGE as pageName } from '../../../utils/pages-constants';
+const refreshButtonSelector = getSelector('refreshButtonSelector', pageName);
+const titleSelector = getSelector('titleSelector', pageName);
+const rulestableSelector = getSelector('rulestableSelector', pageName);
+const dropdownPaginationSelector = getSelector('dropdownPaginationSelector', pageName);
+const listPagesSelector = getSelector('listPagesSelector', pageName);
+const customRulesButtonSelector = getSelector('customRulesButtonSelector', pageName);
+const createNewRulesSelector = getSelector('createNewRulesSelector', pageName);
+const buttonListPageSelector = getSelector('buttonListPageSelector', pageName);
+
+
+When('The user clicks the refresh button', () => {
+  elementIsVisible(titleSelector);
+  elementIsVisible(rulestableSelector);
+  elementIsVisible(dropdownPaginationSelector);
+  elementIsVisible(listPagesSelector);
+  elementIsVisible(customRulesButtonSelector);
+  elementIsVisible(createNewRulesSelector);
+  elementIsVisible(refreshButtonSelector);
+  elementIsVisible(buttonListPageSelector);
+  cy.get(titleSelector).invoke('text').as('title');
+  cy.get(rulestableSelector).then(($e) =>{
+    cy.wrap($e.length).as('rulesLength');
+  })
+  cy.get(dropdownPaginationSelector).invoke('text').as('paginationRows');
+  cy.get(listPagesSelector).invoke('text').as('paginationPages');
+  cy.get(customRulesButtonSelector).invoke('text').as('customRules');
+  cy.get(createNewRulesSelector).invoke('text').as('createNewRules');
+  cy.get(refreshButtonSelector).invoke('text').as('refreshButton');
+  cy.get(buttonListPageSelector).then(($e) =>{
+    cy.wrap($e.length).as('buttonLength');
+  });
+  clickElement(refreshButtonSelector);
+  cy.wait(1500);
+});

--- a/test/cypress/cypress/integration/step-definitions/management/rules/the-user-should-see-the-rule-page.then.js
+++ b/test/cypress/cypress/integration/step-definitions/management/rules/the-user-should-see-the-rule-page.then.js
@@ -1,0 +1,55 @@
+import { Then } from 'cypress-cucumber-preprocessor/steps';
+import { getSelector } from '../../../utils/driver';
+import { RULES_PAGE as pageName } from '../../../utils/pages-constants';
+const listPagesSelector = getSelector('listPagesSelector', pageName);
+const rulestableSelector = getSelector('rulestableSelector', pageName);
+const titleSelector = getSelector('titleSelector', pageName);
+const dropdownPaginationSelector = getSelector('dropdownPaginationSelector', pageName);
+const customRulesButtonSelector = getSelector('customRulesButtonSelector', pageName);
+const createNewRulesSelector = getSelector('createNewRulesSelector', pageName);
+const refreshButtonSelector = getSelector('refreshButtonSelector', pageName);
+const buttonListPageSelector = getSelector('buttonListPageSelector', pageName);
+
+Then('The user should be able to see the rules page', () => {
+
+  cy.get(titleSelector).then(($title) => {
+    cy.get('@title').then(($e) => {
+      expect($title.text()).to.be.eq($e);
+    })
+  })
+  cy.get(rulestableSelector).then(($rules) => {
+    cy.get('@rulesLength').then(($e) => {
+      expect($rules.length).to.be.eq($e);
+    })
+  })
+  cy.get(dropdownPaginationSelector).then(($pagination) => {
+    cy.get('@paginationRows').then(($e) => {
+      expect($pagination.text()).to.be.eq($e);
+    })
+  })
+  cy.get(listPagesSelector).then(($paginationPages) => {
+    cy.get('@paginationPages').then(($e) => {
+      expect($paginationPages.text()).to.be.eq($e);
+    })
+  })
+  cy.get(customRulesButtonSelector).then(($customRules) => {
+    cy.get('@customRules').then(($e) => {
+      expect($customRules.text()).to.be.eq($e);
+    })
+  })
+  cy.get(createNewRulesSelector).then(($createNewRules) => {
+    cy.get('@createNewRules').then(($e) => {
+      expect($createNewRules.text()).to.be.eq($e);
+    })
+  })
+  cy.get(refreshButtonSelector).then(($refreshButton) => {
+    cy.get('@refreshButton').then(($e) => {
+      expect($refreshButton.text()).to.be.eq($e);
+    })
+  })
+  cy.get(buttonListPageSelector).then(($buttonLength) => {
+    cy.get('@buttonLength').then(($e) => {
+      expect($buttonLength.length).to.be.eq($e);
+    })
+  })
+});


### PR DESCRIPTION
### Description
this PR includes a new test case to validate the element of the Rules page after selecting the refresh button.
 
### Issues Resolved
#4593 

### Evidence
<details>
<summary> test on WZD </summary>

![Screenshot from 2022-09-28 08-26-52](https://user-images.githubusercontent.com/76791841/192825908-61f6a130-8a62-456d-b120-268b5f352521.png)


</details>
<details>
<summary> test on XPACK </summary>

![Screenshot from 2022-09-28 12-35-24](https://user-images.githubusercontent.com/76791841/192825931-7230eb9b-66a5-4b49-a87d-68c10ec21b03.png)


</details>

### Test
Run the feature `cypress/integration/features/management/rules/refresh-rules-page.feature` on wzd and xpack env.

### Check List
- [ ] All tests pass
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.

