### PR TITLE
Delete CP command for reports on Cypress

### DIFF
--- a/.github/workflows/cypress-basic.yml
+++ b/.github/workflows/cypress-basic.yml
@@ -86,7 +86,6 @@ jobs:
        run: |
          cd ${{ env.PATH_TEMPLATE }}
          docker exec $(docker-compose ps -q cypress) bash -c " . /home/automation/nvm/nvm.sh && nvm use && npm run cypress:report"        
-         docker exec $(docker-compose ps -q cypress) bash -c "cp -R /home/automation/wazuh-cypress/cypress/* /home/automation/wazuh-cypress/cypress-slack"        
      - name: Step 09 - Archive reports
        uses: actions/upload-artifact@v2
        with:

--- a/.github/workflows/cypress-odfe.yml
+++ b/.github/workflows/cypress-odfe.yml
@@ -92,7 +92,6 @@ jobs:
        run: |
          cd ${{ env.PATH_TEMPLATE }}
          docker exec $(docker-compose ps -q cypress) bash -c " . /home/automation/nvm/nvm.sh && nvm use && npm run cypress:report"        
-         docker exec $(docker-compose ps -q cypress) bash -c "cp -R /home/automation/wazuh-cypress/cypress/* /home/automation/wazuh-cypress/cypress-slack"        
      - name: Step 09 - Archive reports
        uses: actions/upload-artifact@v2
        with:

--- a/.github/workflows/cypress-wzd.yml
+++ b/.github/workflows/cypress-wzd.yml
@@ -83,7 +83,6 @@ jobs:
        run: |
          cd ${{ env.PATH_TEMPLATE }}
          docker exec $(docker-compose ps -q cypress) bash -c " . /home/automation/nvm/nvm.sh && nvm use && npm run cypress:report"        
-         docker exec $(docker-compose ps -q cypress) bash -c "cp -R /home/automation/wazuh-cypress/cypress/* /home/automation/wazuh-cypress/cypress-slack"        
      - name: Step 09 - Archive reports
        uses: actions/upload-artifact@v2
        with:

--- a/.github/workflows/cypress-xpack.yml
+++ b/.github/workflows/cypress-xpack.yml
@@ -87,7 +87,6 @@ jobs:
        run: |
          cd ${{ env.PATH_TEMPLATE }}
          docker exec $(docker-compose ps -q cypress) bash -c " . /home/automation/nvm/nvm.sh && nvm use && npm run cypress:report"        
-         docker exec $(docker-compose ps -q cypress) bash -c "cp -R /home/automation/wazuh-cypress/cypress/* /home/automation/wazuh-cypress/cypress-slack"        
      - name: Step 09 - Archive reports
        uses: actions/upload-artifact@v2
        with:


### PR DESCRIPTION
### Description

Hello team in this PR I remove one of the commands that copies the reports from cypress to send them to slack. These reports are not necessary to send them to slack, since we can access them from the actions.

### Issues Resolved
- Closes #4603 
