### PR TITLE
Fix typo in API getAppLogos endpoint catch log

### DIFF
--- a/server/controllers/wazuh-api.ts
+++ b/server/controllers/wazuh-api.ts
@@ -1097,7 +1097,7 @@ export class WazuhApiCtrl {
         }
       });
     } catch (error) {
-      log('wazuh-api:isWazuhDisabled', error.message || error);
+      log('wazuh-api:getAppLogos', error.message || error);
       return ErrorResponse(error.message || error, 3035, 500, response);
     }
     


### PR DESCRIPTION
### Description
Hi team, this PR fixes a typo in `getAppLogos` endpoint controller. This will avoid mis-interpreting an error in case an exception is logged.

Related to [#4539](https://github.com/wazuh/wazuh-kibana-app/pull/4539/files#diff-b5c6c40e187d24bd680f9885b7ec2a1d09d7faaf1e32e6954c78a03efb6d5306R1100)