### PR TITLE
Add test feature: rules are displayed after refreshing the page using a filtered label

### DIFF
--- a/test/cypress/cypress/integration/features/management/rules/filter-rules-si-displayed-after-refresh.feature
+++ b/test/cypress/cypress/integration/features/management/rules/filter-rules-si-displayed-after-refresh.feature
@@ -1,0 +1,16 @@
+Feature: Validate Filter Rule refresh option is working fine
+
+    As a wazuh user
+    i want to see the Rules pages
+    in order to manage them
+
+    @rules
+    Scenario Outline: Filter Rule are displayed after refreshing the page
+        Given The wazuh admin user is logged
+        When The user navigates to rules
+        And The user search a rule by Level <condition>
+        And The user clicks the refresh button
+        Then The filtered label <condition> is still visible
+        Examples:
+            | condition |
+            | 2         |

--- a/test/cypress/cypress/integration/step-definitions/management/rules/the-filtered-label-is-still-visible-then.js
+++ b/test/cypress/cypress/integration/step-definitions/management/rules/the-filtered-label-is-still-visible-then.js
@@ -1,0 +1,11 @@
+import { Then } from 'cypress-cucumber-preprocessor/steps';
+import { elementIsVisible, getSelector, getElement } from '../../../utils/driver';
+import { RULES_PAGE as pageName} from '../../../utils/pages-constants';
+const filterLabelSelector = getSelector('filterLabelSelector', pageName);
+
+Then('The filtered label {} is still visible', (condition) => {
+    elementIsVisible(filterLabelSelector);
+    getElement(filterLabelSelector).then(($el) => {
+        expect($el.text()).to.equal("level: "+condition);
+    })
+});

--- a/test/cypress/cypress/integration/step-definitions/management/rules/the-user-clicks-the-refresh-button-when.js
+++ b/test/cypress/cypress/integration/step-definitions/management/rules/the-user-clicks-the-refresh-button-when.js
@@ -22,7 +22,8 @@ When('The user clicks the refresh button', () => {
   elementIsVisible(buttonListPageSelector);
   cy.get(titleSelector).invoke('text').as('title');
   cy.get(rulestableSelector).then(($e) =>{
-    cy.wrap($e.length).as('rulesLength');
+    const agentId = $e.text();
+    cy.wrap(agentId).as('rulesLength');
   })
   cy.get(dropdownPaginationSelector).invoke('text').as('paginationRows');
   cy.get(listPagesSelector).invoke('text').as('paginationPages');


### PR DESCRIPTION
### Description
Added Feature to increase coverage for Rule module. This feature checks the rules result displayed filtered by a user per level

### Issues Resolved
#4636 

### Evidence
<details>
<summary> test execution</summary>

![Screenshot from 2022-10-03 16-59-22](https://user-images.githubusercontent.com/76791841/193667961-9449ef4e-d942-49a3-9eb4-8db43cb84137.png)


</details>
### Test
[Provide instructions to test this PR]

### Check List
- [ ] All tests pass
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.

