### PR TITLE
Fix logout from Wazuh when SAML is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fixed nested field rendering in security alerts table details [#4428](https://github.com/wazuh/wazuh-kibana-app/pull/4428)
 - Fixed a bug where the Wazuh logo was used instead of the custom one [#4539](https://github.com/wazuh/wazuh-kibana-app/pull/4539)
 - Fixed rendering problems of the `Agent Overview` section in low resolutions [#4516](https://github.com/wazuh/wazuh-kibana-app/pull/4516)
+- Fixed issue when logging out from Wazuh when SAML is enabled [#4595](https://github.com/wazuh/wazuh-kibana-app/issues/4595)
 
 ## Wazuh v4.3.8 - Kibana 7.10.2, 7.16.x, 7.17.x - Revision 4309
 

--- a/public/app.js
+++ b/public/app.js
@@ -111,8 +111,6 @@ app.run(function ($rootElement) {
   // Add plugin help links as extension to plugin platform help menu
   addHelpMenuToAppChrome();
 
-  
-  const urlToLogout = getHttp().basePath.prepend('/logout');
 
   // Bind deleteExistentToken on Log out component.
   $('.euiHeaderSectionItem__button, .euiHeaderSectionItemButton').on('mouseleave', function () {
@@ -123,14 +121,14 @@ app.run(function ($rootElement) {
     // x-pack
     $('a:contains(Log out)').on('click', function (event) {
       // Override href's behaviour and navigate programatically
-      // to '/logout' once the token has been deleted.
+      // to the logout path once the token has been deleted.
       event.preventDefault();
       WzAuthentication.deleteExistentToken()
         .catch((err) => {
           console.error('[ERROR] - User token could not be deprecated - ', err);
         })
         .finally(() => {
-          window.location = urlToLogout;
+          window.location = event.currentTarget.href;
         });
     });
   });


### PR DESCRIPTION
### Description
When SAML is enabled, the logout button inside the Wazuh plugin didn't work properly. That was because there is a function to remove the token before redirecting to logout, and the logout URL is different when SAML is enabled. 

The solucion provided is to get the logout URL programatically from the logout anchor. That way, the issue is resolved and there is no need to modify anything in case that the logout URL changes in the future.
 
### Issues Resolved
https://github.com/wazuh/wazuh-kibana-app/issues/4595

### Evidence
Trying to logout from the Wazuh plugin before the changes: 
![image](https://user-images.githubusercontent.com/42900763/195162369-4573651c-7a2c-4510-976e-4770d9fda103.png)

Trying to logout from the Wazuh plugin after the changes (the user is correctly redirected to the idp login page): 
![image](https://user-images.githubusercontent.com/42900763/195162769-9fbd01d8-4197-4305-80b9-b3d39d3817ce.png)


### Test
Scenario: have an environment with xPack
When the user opens the Wazuh plugin and clicks on log out 
Then the session should be closed and the user redirected to the login page

Scenario: have an environment with OpenDistro
When the user opens the Wazuh plugin and clicks on log out 
Then the session should be closed and the user redirected to the login page

Scenario: have an environment with OpenSearch
When the user opens the Wazuh plugin and clicks on log out 
Then the session should be closed and the user redirected to the login page

Scenario: have an environment with SAML
When the user opens the Wazuh plugin and clicks on log out 
Then the session should be closed and the user redirected to the login page

### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 
