### PR TITLE
fix for misspelling on features 4648

### DIFF
--- a/test/cypress/cypress/integration/features/management/rules/validate-paginator.feature
+++ b/test/cypress/cypress/integration/features/management/rules/validate-paginator.feature
@@ -7,13 +7,13 @@ Feature: Validate paginator on Rule page
     Background: the user navigate to the Rules page
         Given The wazuh admin user is logged
         When The user navigates to rules
-        Then The user see that the rule list is paginated
+        Then The user sees that the rule list is paginated
 
     Scenario: Rules are displayed when user clicks the first page
         When The user clicks on the second page button
         And A new set of rules it's displayed
         And The user clicks on the first page button
-        Then The first page of rules it displayed
+        Then The first page of rules is displayed
 
     Scenario: Rules are displayed - Select a previous page
         When The user clicks on the second page button

--- a/test/cypress/cypress/integration/features/management/rules/validate-paginator.feature
+++ b/test/cypress/cypress/integration/features/management/rules/validate-paginator.feature
@@ -11,7 +11,7 @@ Feature: Validate paginator on Rule page
 
     Scenario: Rules are displayed when user clicks the first page
         When The user clicks on the second page button
-        And A new set of rules it's displayed
+        And A new set of rules is displayed
         And The user clicks on the first page button
         Then The first page of rules is displayed
 

--- a/test/cypress/cypress/integration/step-definitions/management/rules/a-new-set-of-rules-displayed.when.js
+++ b/test/cypress/cypress/integration/step-definitions/management/rules/a-new-set-of-rules-displayed.when.js
@@ -4,7 +4,7 @@ import { RULES_PAGE as pageName } from '../../../utils/pages-constants';
 const paginatorSelector = getSelector('paginatorSelector', pageName);
 
 
-When('A new set of rules is displayed', () => {
+When('A new set of rules it\'s displayed', () => {
     cy.wait(2500);
     elementIsVisible(paginatorSelector);
 });

--- a/test/cypress/cypress/integration/step-definitions/management/rules/a-new-set-of-rules-displayed.when.js
+++ b/test/cypress/cypress/integration/step-definitions/management/rules/a-new-set-of-rules-displayed.when.js
@@ -4,7 +4,7 @@ import { RULES_PAGE as pageName } from '../../../utils/pages-constants';
 const paginatorSelector = getSelector('paginatorSelector', pageName);
 
 
-When('A new set of rules it\'s displayed', () => {
+When('A new set of rules is displayed', () => {
     cy.wait(2500);
     elementIsVisible(paginatorSelector);
 });


### PR DESCRIPTION
### Description
Some Features are failing on the test suite execution because of misspellings on steps features.

<details>
<summary>tes case fail</summary>

![2022-10-14_10-02](https://user-images.githubusercontent.com/76791841/195858414-3206651b-d98d-4fad-829c-09b93c27c18a.png)


</details>

### Issues Resolved
#4648 

### Evidence
<details>

![2022-10-14_10-17](https://user-images.githubusercontent.com/76791841/195858225-57d75e7c-50e0-4990-aae7-702aa018e1cd.png)


</details>

