### PR TITLE
feature search by parameters And , Or

### DIFF
--- a/test/cypress/cypress/integration/features/filters/Search-by-parameters.feature
+++ b/test/cypress/cypress/integration/features/filters/Search-by-parameters.feature
@@ -1,0 +1,32 @@
+Feature: Search by parameters
+
+    As a Wazuh user
+    I want to pin a filter
+    in order to aplly it across the modules
+    Background:
+        Given The wazuh admin user is logged
+        And The sample data is loaded
+
+    Scenario Outline: Search by parameters with AND
+        When The user goes to <Module Name>
+        And The user types a particular search <key> on the search bar
+        Then The query is accepted and the results should be displayed
+        Examples:
+            | Module Name          | key                                              |
+            | Security Events      | cluster.name : "wazuh" and rule.level : "3"      |
+            | Integrity Monitoring | cluster.name : "wazuh" and agent.id : "001"      |
+            | NIST                 | cluster.name : "wazuh" and agent.name : "Ubuntu" |
+            | TSC                  | cluster.name : "wazuh" and agent.name : "Ubuntu" |
+            | PCIDSS               | cluster.name : "wazuh" and agent.name : "Ubuntu" |
+
+    Scenario Outline: Search by parameters with OR
+        When The user goes to <Module Name>
+        And The user types a particular search <key> on the search bar
+        Then The query is accepted and the results should be displayed
+        Examples:
+            | Module Name          | key                                             |
+            | Security Events      | cluster.name : "wazuh" or rule.level : "3"      |
+            | Integrity Monitoring | cluster.name : "wazuh" or agent.id : "001"      |
+            | NIST                 | cluster.name : "wazuh" or agent.name : "Ubuntu" |
+            | TSC                  | cluster.name : "wazuh" or agent.name : "Ubuntu" |
+            | PCIDSS               | cluster.name : "wazuh" or agent.name : "Ubuntu" |

--- a/test/cypress/cypress/integration/features/filters/pin-filter-from-dashboard-to-events.feature
+++ b/test/cypress/cypress/integration/features/filters/pin-filter-from-dashboard-to-events.feature
@@ -27,4 +27,3 @@ Feature: Pin filter - from dashboard to event page
       | TSC                  |
       | Policy Monitoring    |
       | PCIDSS               |
-      

--- a/test/cypress/cypress/integration/pageobjects/wzd/filters/filters.page.js
+++ b/test/cypress/cypress/integration/pageobjects/wzd/filters/filters.page.js
@@ -13,5 +13,7 @@ export const FILTERS_PAGE = {
   pinnedFilter: '[data-test-subj="filter filter-enabled filter-key-rule.level filter-value-7 filter-pinned "]',
   eventsButton: '//*[contains(@class,"euiTabs")]//*[contains(text(),"Events")]',
   removeFilterButton: '//*[contains(@class,"euiContextMenuPanel")]//*[contains(text(),"Delete")]',
-  operatorList: '.euiPanel[data-test-subj="comboBoxOptionsList filterOperatorList-optionsList"] .euiComboBoxOptionsList__rowWrap'
+  operatorList: '.euiPanel[data-test-subj="comboBoxOptionsList filterOperatorList-optionsList"] .euiComboBoxOptionsList__rowWrap',
+  searchInputSelector: '[role="combobox"] [data-test-subj="queryInput"]',
+  noResultMessage: '#moduleDashboard .euiCallOut--warning span'
 };

--- a/test/cypress/cypress/integration/step-definitions/filters/The-user-types-particular-search.when.js
+++ b/test/cypress/cypress/integration/step-definitions/filters/The-user-types-particular-search.when.js
@@ -1,0 +1,10 @@
+import { When } from 'cypress-cucumber-preprocessor/steps';
+import { fillField, elementIsVisible, getSelector, forceEnter} from '../../utils/driver';
+import { FILTERS_PAGE as pageName} from '../../utils/pages-constants';
+const searchInputSelector = getSelector('searchInputSelector', pageName);
+
+When('The user types a particular search {} on the search bar', (key) => {
+    elementIsVisible(searchInputSelector);
+    fillField(searchInputSelector, key);
+    forceEnter(searchInputSelector);
+});

--- a/test/cypress/cypress/integration/step-definitions/filters/the-query-is-accepted.then.js
+++ b/test/cypress/cypress/integration/step-definitions/filters/the-query-is-accepted.then.js
@@ -1,0 +1,8 @@
+import { Then } from "cypress-cucumber-preprocessor/steps";
+import { elementIsNotVisible, getSelector } from '../../utils/driver';
+import { FILTERS_PAGE as pageName} from '../../utils/pages-constants';
+const noResultMessage = getSelector('noResultMessage', pageName);
+
+Then('The query is accepted and the results should be displayed', () => {
+    elementIsNotVisible(noResultMessage)
+})

--- a/test/cypress/cypress/integration/step-definitions/settings/The-wazuh-admin-user-is-logged.given.js
+++ b/test/cypress/cypress/integration/step-definitions/settings/The-wazuh-admin-user-is-logged.given.js
@@ -1,10 +1,29 @@
 import { Given } from 'cypress-cucumber-preprocessor/steps';
-import { navigate, elementIsVisible, getSelector } from '../../utils/driver';
+import { navigate, elementIsVisible, getSelector, getCookiesFromBrowser } from '../../utils/driver';
 import { WAZUH_MENU_PAGE as pageName} from '../../utils/pages-constants';
 const wazuhMenuButton = getSelector('wazuhMenuButton', pageName);
+let urlsList = ['https://localhost:5601/elastic/samplealerts/security','https://localhost:5601/elastic/samplealerts/auditing-policy-monitoring','https://localhost:5601/elastic/samplealerts/threat-detection'];
+let urlBodys = [{"alertCount": 27000,"index": "wazuh-alerts-4.x-sample-security"},{"alertCount": 12000,"index": "wazuh-alerts-4.x-sample-auditing-policy-monitoring"},{"alertCount": 15000,"index": "wazuh-alerts-4.x-sample-threat-detection"}]
 
 Given('The wazuh admin user is logged',  () => {
     if (Cypress.env('type') != 'wzd') {
     navigate("app/wazuh");}else{navigate("/")}
     elementIsVisible(wazuhMenuButton);
+})
+
+Given('The sample data is loaded', () => {
+    cy.readFile('cookies.json').then((cookies) => {
+        let headersFormat = {"content-type":"application/json; charset=utf-8","Cookie": getCookiesFromBrowser(cookies),"Accept":"application/json, text/plain, */*","Accept-Encoding":"gzip, deflate, br","osd-xsrf":"kibana"};
+        for(let i = 0; i < urlsList.length; i++){
+            cy.request({
+                method: 'POST',
+                url: urlsList[i],
+                headers: headersFormat,
+                body: urlBodys[i]
+            }).should((response) => {
+                expect(response.status).to.eq(200)
+            })
+        }
+
+    })
 })

--- a/test/cypress/cypress/integration/utils/driver.js
+++ b/test/cypress/cypress/integration/utils/driver.js
@@ -149,3 +149,20 @@ export const xpathCheckInformationElement=  (webLocator, optionsNames, optionLen
       expect(optionsNames, 'has expected [' + optionsNames + '] text in each paragraph [' + paragraphs + ']').to.contains(paragraphs)
     })
 }
+
+
+export const getCookiesFromBrowser = (values) => {
+  return values.filter(item=>['wz-token', 'wz-user', 'wz-api', 'security_authentication'].includes(item.name))
+  .map(item=>{
+      return `${item.name}:${item.value}`
+  }).join(';');
+}
+
+export const retrieveInformation = (url,method,headers,bodyPost) => {
+  return cy.request({
+    method: method,
+    url: url,
+    headers: headers,
+    body: bodyPost
+  }).as('response');
+}


### PR DESCRIPTION
### Description
this PR adds a feature to increase coverage in some modules for search by filter with parameters AND, OR

Feature

```
Feature: Search by parameters

    As a Wazuh user
    I want to pin a filter
    in order to aplly it across the modules
    Background:
        Given The wazuh admin user is logged
        And The sample data is loaded

    Scenario Outline: Search by parameters with AND
        When The user goes to <Module Name>
        And The user types a particular search <key> on the search bar
        Then The query is accepted and the results should be displayed
        Examples:
            | Module Name          | key                                              |
            | Security Events      | cluster.name : "wazuh" and rule.level : "3"      |
            | Integrity Monitoring | cluster.name : "wazuh" and agent.id : "001"      |
            | NIST                 | cluster.name : "wazuh" and agent.name : "Ubuntu" |
            | TSC                  | cluster.name : "wazuh" and agent.name : "Ubuntu" |
            | PCIDSS               | cluster.name : "wazuh" and agent.name : "Ubuntu" |

    Scenario Outline: Search by parameters with OR
        When The user goes to <Module Name>
        And The user types a particular search <key> on the search bar
        Then The query is accepted and the results should be displayed
        Examples:
            | Module Name          | key                                             |
            | Security Events      | cluster.name : "wazuh" or rule.level : "3"      |
            | Integrity Monitoring | cluster.name : "wazuh" or agent.id : "001"      |
            | NIST                 | cluster.name : "wazuh" or agent.name : "Ubuntu" |
            | TSC                  | cluster.name : "wazuh" or agent.name : "Ubuntu" |
            | PCIDSS               | cluster.name : "wazuh" or agent.name : "Ubuntu" |
```

### Feature Implemented 

In order to implement both features, we need to include a pre-step after the user is logged step and the request is executed to activate the sample data.
The activation of the sample data allows us to use the search with filters and we will have results to be able to validate them

<summary> code </summary>

```
import { Given } from 'cypress-cucumber-preprocessor/steps';
import { navigate, elementIsVisible, getSelector, getCookiesFromBrowser } from '../../utils/driver';
import { WAZUH_MENU_PAGE as pageName} from '../../utils/pages-constants';
const wazuhMenuButton = getSelector('wazuhMenuButton', pageName);
let urlsList = ['https://localhost:5601/elastic/samplealerts/security','https://localhost:5601/elastic/samplealerts/auditing-policy-monitoring','https://localhost:5601/elastic/samplealerts/threat-detection'];
let urlBodys = [{"alertCount": 27000,"index": "wazuh-alerts-4.x-sample-security"},{"alertCount": 12000,"index": "wazuh-alerts-4.x-sample-auditing-policy-monitoring"},{"alertCount": 15000,"index": "wazuh-alerts-4.x-sample-threat-detection"}]

Given('The wazuh admin user is logged',  () => {
    if (Cypress.env('type') != 'wzd') {
    navigate("app/wazuh");}else{navigate("/")}
    elementIsVisible(wazuhMenuButton);
})

Given('The sample data is loaded', () => {
    cy.readFile('cookies.json').then((cookies) => {
        let headersFormat = {"content-type":"application/json; charset=utf-8","Cookie": getCookiesFromBrowser(cookies),"Accept":"application/json, text/plain, */*","Accept-Encoding":"gzip, deflate, br","osd-xsrf":"kibana"};
        for(let i = 0; i < urlsList.length; i++){
            cy.request({
                method: 'POST',
                url: urlsList[i],
                headers: headersFormat,
                body: urlBodys[i]
            }).should((response) => {
                expect(response.status).to.eq(200)
            })
        }

    })
})
```


The requests must include the cookie in the header, with a special format for these to be successful.

<summary> code  by @asteriscos  </summary>

```
export const getCookiesFromBrowser = (values) => {
  return values.filter(item=>['wz-token', 'wz-user', 'wz-api', 'security_authentication'].includes(item.name))
  .map(item=>{
      return `${item.name}:${item.value}`
  }).join(';');
}
```



<details>
<summary> draft evidencie </summary>

![2022-10-19_12-44](https://user-images.githubusercontent.com/76791841/196746666-e20de2a0-204c-4d8a-8aeb-278f40c3718b.png)

![2022-10-19_12-46](https://user-images.githubusercontent.com/76791841/196746683-8fdbb34d-7a50-4653-bb8e-46eacccba857.png)

</details>



### Issues Resolved
#4709 

### Evidence

<details>

![2022-10-19_16-47](https://user-images.githubusercontent.com/76791841/196793321-9864eff9-624d-404e-9ac8-1cf22716bf5f.png)


<?details>

### Test
[Provide instructions to test this PR]

### Check List
- [ ] All tests pass
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.

