### PR TITLE
Fix typos and errors code status replacement in wazuh-api controller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fixed a bug where the Wazuh logo was used instead of the custom one [#4539](https://github.com/wazuh/wazuh-kibana-app/pull/4539)
 - Fixed rendering problems of the `Agent Overview` section in low resolutions [#4516](https://github.com/wazuh/wazuh-kibana-app/pull/4516)
 - Fixed issue when logging out from Wazuh when SAML is enabled [#4595](https://github.com/wazuh/wazuh-kibana-app/issues/4595)
-- Fixed server errors with code 500 when the Wazuh API is not reachable / up. [#4710](https://github.com/wazuh/wazuh-kibana-app/pull/4710)
+- Fixed server errors with code 500 when the Wazuh API is not reachable / up. [#4710](https://github.com/wazuh/wazuh-kibana-app/pull/4710) [#4728](https://github.com/wazuh/wazuh-kibana-app/pull/4728)
 - Fixed pagination to SCA table [#4653](https://github.com/wazuh/wazuh-kibana-app/issues/4653)
 
 ## Wazuh v4.3.9 - Kibana 7.10.2, 7.16.x, 7.17.x - Revision 4310

--- a/server/controllers/wazuh-api.ts
+++ b/server/controllers/wazuh-api.ts
@@ -728,7 +728,7 @@ export class WazuhApiCtrl {
     const idApi = getCookieValueByName(request.headers.cookie, 'wz-api');
     if (idApi !== request.body.id) { // if the current token belongs to a different API id, we relogin to obtain a new token
       return ErrorResponse(
-        'status code HTTP_STATUS_CODES.UNAUTHORIZED',
+        'status code 401',
         HTTP_STATUS_CODES.UNAUTHORIZED,
         HTTP_STATUS_CODES.UNAUTHORIZED,
         response
@@ -935,7 +935,7 @@ export class WazuhApiCtrl {
       log('wazuh-api:getTimeStamp', error.message || error);
       return ErrorResponse(
         error.message || 'Could not fetch wazuh-version registry',
-        HTTP_STATUS_CODES.BAD_REQUEST1,
+        4001,
         HTTP_STATUS_CODES.INTERNAL_SERVER_ERROR,
         response
       );
@@ -963,7 +963,7 @@ export class WazuhApiCtrl {
       log('wazuh-api:setExtensions', error.message || error);
       return ErrorResponse(
         error.message || 'Could not set extensions',
-        HTTP_STATUS_CODES.BAD_REQUEST1,
+        4001,
         HTTP_STATUS_CODES.INTERNAL_SERVER_ERROR,
         response
       );
@@ -991,7 +991,7 @@ export class WazuhApiCtrl {
       log('wazuh-api:getExtensions', error.message || error);
       return ErrorResponse(
         error.message || 'Could not fetch wazuh-version registry',
-        HTTP_STATUS_CODES.BAD_REQUEST1,
+        4001,
         HTTP_STATUS_CODES.INTERNAL_SERVER_ERROR,
         response
       );
@@ -1018,7 +1018,7 @@ export class WazuhApiCtrl {
       log('wazuh-api:getSetupInfo', error.message || error);
       return ErrorResponse(
         `Could not get data from wazuh-version registry due to ${error.message || error}`,
-        HTTP_STATUS_CODES.BAD_REQUEST5,
+        4005,
         HTTP_STATUS_CODES.INTERNAL_SERVER_ERROR,
         response
       );

--- a/server/routes/wazuh-api-http-status.test.ts
+++ b/server/routes/wazuh-api-http-status.test.ts
@@ -1,12 +1,11 @@
 // To launch this file
-// yarn test:jest --testEnvironment node --verbose server/routes/wazuh-api
+// yarn test:jest --testEnvironment node --verbose server/routes/wazuh-api-http-status.test.ts
 import { Router } from '../../../../src/core/server/http/router/router';
 import { HttpServer } from '../../../../src/core/server/http/http_server';
 import { loggingSystemMock } from '../../../../src/core/server/logging/logging_system.mock';
 import { ByteSizeValue } from '@kbn/config-schema';
 import supertest from 'supertest';
 import { WazuhApiRoutes } from './wazuh-api';
-import { WazuhApiCtrl } from '../controllers/wazuh-api';
 import { createDataDirectoryIfNotExists, createDirectoryIfNotExists } from '../lib/filesystem';
 import {
   HTTP_STATUS_CODES,
@@ -32,11 +31,11 @@ const enhanceWithContext = (fn: (...args: any[]) => any) => fn.bind(null, contex
 let server, innerServer;
 
 beforeAll(async () => {
+
   // Create <PLUGIN_PLATFORM_PATH>/data/wazuh directory.
   createDataDirectoryIfNotExists();
   // Create <PLUGIN_PLATFORM_PATH>/data/wazuh/config directory.
   createDirectoryIfNotExists(WAZUH_DATA_CONFIG_DIRECTORY_PATH);
-
   // Create <PLUGIN_PLATFORM_PATH>/data/wazuh/logs directory.
   createDirectoryIfNotExists(WAZUH_DATA_LOGS_DIRECTORY_PATH);
 
@@ -57,9 +56,6 @@ beforeAll(async () => {
   const router = new Router('', logger, enhanceWithContext);
   const { registerRouter, server: innerServerTest, ...rest } = await server.setup(config);
   innerServer = innerServerTest;
-
-  // const spyRouteDecoratorProtectedAdministratorRoleValidToken = jest.spyOn(WazuhApiCtrl.prototype as any, 'routeDecoratorProtectedAdministratorRoleValidToken')
-  // .mockImplementation((handler) => async (...args) => handler(...args));
 
   // Register routes
   WazuhApiRoutes(router);


### PR DESCRIPTION
### Description
Team, this PR fixes typos and error codes that shouldn't be replaced in the pull request _[Replace generic HTTP status codes in the API controller #4710](https://github.com/wazuh/wazuh-kibana-app/pull/4710)_

### Test

- All jest tests should work.
- Testing the previous PR [#4710](https://github.com/wazuh/wazuh-kibana-app/pull/4710) should work

### Check List
- [x] All tests pass
  - [x] `yarn test:jest`
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 
