### PR TITLE
Add multi-line validation parameters in config description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Added agent synchronization status in the agent module. [#3874](https://github.com/wazuh/wazuh-kibana-app/pull/3874)
 - Redesign the SCA table from agent's dashboard [#4512](https://github.com/wazuh/wazuh-kibana-app/pull/4512)
 - Enhanced the plugin setting description displayed in the UI and the configuration file. [#4501](https://github.com/wazuh/wazuh-kibana-app/pull/4501)
-- Added validation to the plugin settings in the form of `Settings/Configuration` and the endpoint to update the plugin configuration [#4503](https://github.com/wazuh/wazuh-kibana-app/pull/4503)
+- Added validation to the plugin settings in the form of `Settings/Configuration` and the endpoint to update the plugin configuration [#4503](https://github.com/wazuh/wazuh-kibana-app/pull/4503)[#4785](https://github.com/wazuh/wazuh-kibana-app/pull/4785)
 - Added new plugin settings to customize the header and footer on the PDF reports [#4505](https://github.com/wazuh/wazuh-kibana-app/pull/4505)
 
 ### Changed

--- a/common/constants.ts
+++ b/common/constants.ts
@@ -359,7 +359,8 @@ export enum SettingCategory {
 };
 
 type TPluginSettingOptionsTextArea = {
-  rowsSize?: number
+  maxRows?: number
+  minRows?: number
   maxLength?: number
 };
 
@@ -1091,11 +1092,11 @@ export const PLUGIN_SETTINGS: { [key: string]: TPluginSetting } = {
     	defaultValueIfNotSet: REPORTS_PAGE_FOOTER_TEXT,
 		isConfigurableFromFile: true,
 		isConfigurableFromUI: true,
-    options: { rowsSize: 2, maxLength: 30 },
+    options: { maxRows: 2, maxLength: 30 },
     validate: function (value) {
       return SettingsValidator.multipleLinesString({
-        max: this.options.rowsSize,
-        maxLength: this.options.maxLength
+        maxRows: this.options?.maxRows,
+        maxLength: this.options?.maxLength
       })(value)
     },
     validateBackend: function (schema) {
@@ -1111,10 +1112,10 @@ export const PLUGIN_SETTINGS: { [key: string]: TPluginSetting } = {
     defaultValueIfNotSet: REPORTS_PAGE_HEADER_TEXT,
     isConfigurableFromFile: true,
     isConfigurableFromUI: true,
-    options: { rowsSize: 3, maxLength: 20 },
+    options: { maxRows: 3, maxLength: 20 },
     validate: function (value) {
       return SettingsValidator.multipleLinesString({
-        max: this.options.rowsSize,
+        maxRows: this.options?.maxRows,
         maxLength: this.options?.maxLength
       })(value)
     },

--- a/common/services/settings-validator.ts
+++ b/common/services/settings-validator.ts
@@ -56,17 +56,17 @@ export class SettingsValidator {
    * @param options
    * @returns
    */
-  static multipleLinesString(options: { min?: number, max?: number, maxLength?: number } = {}) {
+  static multipleLinesString(options: { minRows?: number, maxRows?: number, maxLength?: number } = {}) {
     return function (value: number) {
       const lines = value.split(/\r\n|\r|\n/).length;
       if (typeof options.maxLength !== 'undefined' && value.split('\n').some(line => line.length > options.maxLength)) {
         return `The maximum length of a line is ${options.maxLength} characters.`;
       };
-      if (typeof options.min !== 'undefined' && lines < options.min) {
-        return `The string should have more or ${options.min} line/s.`;
+      if (typeof options.minRows !== 'undefined' && lines < options.minRows) {
+        return `The string should have more or ${options.minRows} line/s.`;
       };
-      if (typeof options.max !== 'undefined' && lines > options.max) {
-        return `The string should have less or equal to ${options.max} line/s.`;
+      if (typeof options.maxRows !== 'undefined' && lines > options.maxRows) {
+        return `The string should have less or equal to ${options.maxRows} line/s.`;
       };
     }
   };

--- a/common/services/settings.ts
+++ b/common/services/settings.ts
@@ -116,6 +116,10 @@ export function groupSettingsByCategory(settings: TPluginSettingWithKey[]){
 		// File size
 		...((options?.file?.size && typeof options.file.size.minBytes !== 'undefined') ? [`Minimum file size: ${formatBytes(options.file.size.minBytes)}.`] : []),
 		...((options?.file?.size && typeof options.file.size.maxBytes !== 'undefined') ? [`Maximum file size: ${formatBytes(options.file.size.maxBytes)}.`] : []),
+		// Multi line text
+		...((options?.maxRows && typeof options.maxRows !== 'undefined' ? [`Maximum amount of lines: ${options.maxRows}.`] : [])),
+		...((options?.minRows && typeof options.minRows !== 'undefined' ? [`Minimum amount of lines: ${options.minRows}.`] : [])),
+		...((options?.maxLength && typeof options.maxLength !== 'undefined' ? [`Maximum lines length is ${options.maxLength} characters.`] : [])),
 	].join(' ');
 };
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,7 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react"
+    "jsx": "react-jsx"
   },
   "include": [
     "public",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,7 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react-jsx"
+    "jsx": "react"
   },
   "include": [
     "public",


### PR DESCRIPTION
### Description
Team,
this PR adds the wazuh.yml multiline settings validations to the configuration description. The goal is to warn the user about the text area validations to prevent errors.
 
### Issues Resolved
Related issue #4446 

![image](https://user-images.githubusercontent.com/9343732/199013971-e70d8e0b-d4eb-4886-b130-7b0ee278bcb8.png)
