### PR TITLE
Fix PDF header and footer input max row length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Redesign the SCA table from agent's dashboard [#4512](https://github.com/wazuh/wazuh-kibana-app/pull/4512)
 - Enhanced the plugin setting description displayed in the UI and the configuration file. [#4501](https://github.com/wazuh/wazuh-kibana-app/pull/4501)
 - Added validation to the plugin settings in the form of `Settings/Configuration` and the endpoint to update the plugin configuration [#4503](https://github.com/wazuh/wazuh-kibana-app/pull/4503)[#4785](https://github.com/wazuh/wazuh-kibana-app/pull/4785)
-- Added new plugin settings to customize the header and footer on the PDF reports [#4505](https://github.com/wazuh/wazuh-kibana-app/pull/4505)
+- Added new plugin settings to customize the header and footer on the PDF reports [#4505](https://github.com/wazuh/wazuh-kibana-app/pull/4505)[#4798](https://github.com/wazuh/wazuh-kibana-app/pull/4798)
 - Add a new plugin setting to enable or disable the customization [#4507](https://github.com/wazuh/wazuh-kibana-app/pull/4507)
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Redesign the SCA table from agent's dashboard [#4512](https://github.com/wazuh/wazuh-kibana-app/pull/4512)
 - Enhanced the plugin setting description displayed in the UI and the configuration file. [#4501](https://github.com/wazuh/wazuh-kibana-app/pull/4501)
 - Added validation to the plugin settings in the form of `Settings/Configuration` and the endpoint to update the plugin configuration [#4503](https://github.com/wazuh/wazuh-kibana-app/pull/4503)[#4785](https://github.com/wazuh/wazuh-kibana-app/pull/4785)
-- Added new plugin settings to customize the header and footer on the PDF reports [#4505](https://github.com/wazuh/wazuh-kibana-app/pull/4505)[#4798](https://github.com/wazuh/wazuh-kibana-app/pull/4798)
+- Added new plugin settings to customize the header and footer on the PDF reports [#4505](https://github.com/wazuh/wazuh-kibana-app/pull/4505)[#4798](https://github.com/wazuh/wazuh-kibana-app/pull/4798)[#4805](https://github.com/wazuh/wazuh-kibana-app/pull/4805)
 - Add a new plugin setting to enable or disable the customization [#4507](https://github.com/wazuh/wazuh-kibana-app/pull/4507)
 
 ### Changed

--- a/common/constants.ts
+++ b/common/constants.ts
@@ -1117,7 +1117,7 @@ export const PLUGIN_SETTINGS: { [key: string]: TPluginSetting } = {
     defaultValueIfNotSet: REPORTS_PAGE_FOOTER_TEXT,
 		isConfigurableFromFile: true,
 		isConfigurableFromUI: true,
-    options: { maxRows: 2, maxLength: 30 },
+    options: { maxRows: 2, maxLength: 50 },
     validate: function (value) {
       return SettingsValidator.multipleLinesString({
         maxRows: this.options?.maxRows,
@@ -1137,7 +1137,7 @@ export const PLUGIN_SETTINGS: { [key: string]: TPluginSetting } = {
     defaultValueIfNotSet: REPORTS_PAGE_HEADER_TEXT,
     isConfigurableFromFile: true,
     isConfigurableFromUI: true,
-    options: { maxRows: 3, maxLength: 20 },
+    options: { maxRows: 3, maxLength: 40 },
     validate: function (value) {
       return SettingsValidator.multipleLinesString({
         maxRows: this.options?.maxRows,

--- a/common/plugin-settings.test.ts
+++ b/common/plugin-settings.test.ts
@@ -122,12 +122,12 @@ describe('[settings] Input validation', () => {
     ${'customization.reports.footer'}   | ${'Test\nTest'}                            | ${undefined}
     ${'customization.reports.footer'}   | ${'Test\nTest\nTest\nTest\nTest'}          | ${'The string should have less or equal to 2 line/s.'}
     ${'customization.reports.footer'}   | ${'Line with 30 characters       \nTest'}  | ${undefined}
-    ${'customization.reports.footer'}   | ${'Line with 31 characters        \nTest'} | ${"The maximum length of a line is 30 characters."}
+    ${'customization.reports.footer'}   | ${'Testing maximum length of a line of more than 50 characters\nTest'} | ${"The maximum length of a line is 50 characters."}
     ${'customization.reports.header'}   | ${'Test'}                                  | ${undefined}
     ${'customization.reports.header'}   | ${'Test\nTest'}                            | ${undefined}
     ${'customization.reports.header'}   | ${'Test\nTest\nTest\nTest\nTest'}          | ${'The string should have less or equal to 3 line/s.'}
     ${'customization.reports.header'}   | ${'Line with 20 charact\nTest'}            | ${undefined}
-    ${'customization.reports.header'}   | ${'Line with 23 characters\nTest'}         | ${"The maximum length of a line is 20 characters."}
+    ${'customization.reports.header'}   | ${'Testing maximum length of a line of 40 characters\nTest'}         | ${"The maximum length of a line is 40 characters."}
     ${'disabled_roles'}                 | ${['test']}                                | ${undefined}
     ${'disabled_roles'}                 | ${['']}                                    | ${'Value can not be empty.'}
     ${'disabled_roles'}                 | ${['test space']}                          | ${"No whitespaces allowed."}

--- a/server/lib/reporting/printer.ts
+++ b/server/lib/reporting/printer.ts
@@ -62,7 +62,8 @@ const pageConfiguration = ({ pathToLogo, pageHeader, pageFooter }) => ({
         text: pageHeader,
         alignment: 'right',
         margin: [0, 0, 40, 0],
-        color: COLORS.PRIMARY
+        color: COLORS.PRIMARY,
+        width: 'auto'
       }
     ]
   },
@@ -79,7 +80,8 @@ const pageConfiguration = ({ pathToLogo, pageHeader, pageFooter }) => ({
           text: 'Page ' + currentPage.toString() + ' of ' + pageCount,
           alignment: 'right',
           margin: [0, 40, 40, 0],
-          color: COLORS.PRIMARY
+          color: COLORS.PRIMARY,
+          width: 'auto'
         }
       ]
     };

--- a/server/routes/wazuh-utils/wazuh-utils.test.ts
+++ b/server/routes/wazuh-utils/wazuh-utils.test.ts
@@ -304,13 +304,13 @@ hosts:
     ${'customization.reports.footer'}   | ${'Test\nTest'}                            | ${200}             | ${null}
     ${'customization.reports.footer'}   | ${'Test\nTest\nTest\nTest\nTest'}          | ${400}             | ${"[request body.customization.reports.footer]: The string should have less or equal to 2 line/s."}
     ${'customization.reports.footer'}   | ${'Line with 30 characters       \nTest'}  | ${200}             | ${undefined}
-    ${'customization.reports.footer'}   | ${'Line with 31 characters        \nTest'} | ${400}             | ${"[request body.customization.reports.footer]: The maximum length of a line is 30 characters."}
+    ${'customization.reports.footer'}   | ${'Testing the maximum length of a line of 50 characters\nTest'}| ${400}             | ${"[request body.customization.reports.footer]: The maximum length of a line is 50 characters."}
     ${'customization.reports.footer'}   | ${true}                                    | ${400}             | ${'[request body.customization.reports.footer]: expected value of type [string] but got [boolean]'}
     ${'customization.reports.header'}   | ${'Test'}                                  | ${200}             | ${null}
     ${'customization.reports.header'}   | ${'Test\nTest'}                            | ${200}             | ${null}
     ${'customization.reports.header'}   | ${'Test\nTest\nTest\nTest\nTest'}          | ${400}             | ${"[request body.customization.reports.header]: The string should have less or equal to 3 line/s."}
     ${'customization.reports.header'}   | ${'Line with 20 charact\nTest'}            | ${200}             | ${undefined}
-    ${'customization.reports.header'}   | ${'Line with 23 characters\nTest'}         | ${400}             | ${"[request body.customization.reports.header]: The maximum length of a line is 20 characters."}
+    ${'customization.reports.header'}   | ${'Testing maximum length of a line of 40 characters\nTest'}    | ${400}             | ${"[request body.customization.reports.header]: The maximum length of a line is 40 characters."}
     ${'customization.reports.header'}   | ${true}                                    | ${400}             | ${'[request body.customization.reports.header]: expected value of type [string] but got [boolean]'}
     ${'disabled_roles'}                 | ${['test']}                                | ${200}             | ${null}
     ${'disabled_roles'}                 | ${['']}                                    | ${400}             | ${'[request body.disabled_roles.0]: Value can not be empty.'}


### PR DESCRIPTION
### Description
Hi team,
this PR increases the maximum character length of the header and footer PDF report customization. 

### Test

- Go to Settings / Configuration
- Customize a header and check the maximum character length is 40
- Customize a footer and check the maximum character length is 50

### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff 
