### PR TITLE
change function to get the path programatically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fixed persistence of the plugin registry file between updates [#4359](https://github.com/wazuh/wazuh-kibana-app/pull/4359)
 - Fixed searchbar error on SCA Inventory table [#4367](https://github.com/wazuh/wazuh-kibana-app/pull/4367)
 - Fixed a routes loop when reinstalling Wazuh indexer [#4373](https://github.com/wazuh/wazuh-kibana-app/pull/4373)
+- Fixed issue when logging out from Wazuh when SAML is enabled [#4815](https://github.com/wazuh/wazuh-kibana-app/issues/4815)
 
 # Removed
 

--- a/public/app.js
+++ b/public/app.js
@@ -111,9 +111,6 @@ app.run(function ($rootElement) {
   // Add plugin help links as extension to plugin platform help menu
   addHelpMenuToAppChrome();
 
-  
-  const urlToLogout = getHttp().basePath.prepend('/logout');
-
   // Bind deleteExistentToken on Log out component.
   $('.euiHeaderSectionItem__button, .euiHeaderSectionItemButton').on('mouseleave', function () {
     // opendistro
@@ -123,14 +120,14 @@ app.run(function ($rootElement) {
     // x-pack
     $('a:contains(Log out)').on('click', function (event) {
       // Override href's behaviour and navigate programatically
-      // to '/logout' once the token has been deleted.
+      // to the logout path once the token has been deleted.
       event.preventDefault();
       WzAuthentication.deleteExistentToken()
         .catch((err) => {
           console.error('[ERROR] - User token could not be deprecated - ', err);
         })
         .finally(() => {
-          window.location = urlToLogout;
+          window.location = event.currentTarget.href;        
         });
     });
   });


### PR DESCRIPTION
### Description

When SAML is enabled, the logout button inside the Wazuh plugin didn't work properly. That was because there is a function to remove the token before redirecting to logout, and the logout URL is different when SAML is enabled.

The solucion provided is to get the logout URL programatically from the logout anchor. That way, the issue is resolved and there is no need to modify anything in case that the logout URL changes in the future.

### Issues Resolved
https://github.com/wazuh/wazuh-kibana-app/issues/4595

### Evidence
Trying to log out from the Wazuh plugin before the changes:
![image](https://user-images.githubusercontent.com/42900763/200335059-4c9c4e77-31c6-4568-99c4-2a561cb71318.png)

Trying to log out from the Wazuh plugin after the changes (the user is correctly redirected to the idp login page):
![image](https://user-images.githubusercontent.com/42900763/200335150-d696f9bf-e064-4bff-a89a-99f25ef33847.png)

### Test
Scenario: have an environment with xPack
When the user opens the Wazuh plugin and clicks on log out
Then the session should be closed and the user redirected to the login page

Scenario: have an environment with OpenDistro
When the user opens the Wazuh plugin and clicks on log out
Then the session should be closed and the user redirected to the login page

Scenario: have an environment with OpenSearch
When the user opens the Wazuh plugin and clicks on log out
Then the session should be closed and the user redirected to the login page

Scenario: have an environment with SAML
When the user opens the Wazuh plugin and clicks on log out
Then the session should be closed and the user redirected to the login page

### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff 
