### PR TITLE
Fix styles in deploy new agent section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ commands of Start the agent in the deploy new agent section [#4458](https://gith
 - Improved the message displayed when there is a versions mismatch between the Wazuh API and the Wazuh APP [#4529](https://github.com/wazuh/wazuh-kibana-app/pull/4529)
 - Changed the endpoint that updates the plugin configuration to support multiple settings. [#4501](https://github.com/wazuh/wazuh-kibana-app/pull/4501)
 - Allowed to upload an image for the `customization.logo.*` settings in `Settings/Configuration` [#4504](https://github.com/wazuh/wazuh-kibana-app/pull/4504)
+- Fixed the OS styles and their versions. [#4830](https://github.com/wazuh/wazuh-kibana-app/pull/4830)
 
 ### Removed
 

--- a/public/controllers/agent/components/register-agent.js
+++ b/public/controllers/agent/components/register-agent.js
@@ -324,6 +324,8 @@ export const RegisterAgent = withErrorBoundary(
           return `https://packages.wazuh.com/4.x/yum/wazuh-agent-${this.state.wazuhVersion}-1.x86_64.rpm`;
         case 'redhat7-armhf':
           return `https://packages.wazuh.com/4.x/yum/wazuh-agent-${this.state.wazuhVersion}-1.armv7hl.rpm`;
+        case 'redhat7-powerpc':
+          return `https://packages.wazuh.com/4.x/yum/wazuh-agent-${this.state.wazuhVersion}.ppc64le.rpm`;
         default:
           return `https://packages.wazuh.com/4.x/yum/wazuh-agent-${this.state.wazuhVersion}-1.x86_64.rpm`;
       }
@@ -1037,7 +1039,8 @@ export const RegisterAgent = withErrorBoundary(
             options={options}
             idSelected={idSelected}
             onChange={onChange}
-            className={'osButtonsStyle'} />
+            className={'flex'}
+            />
         )
       }
 
@@ -1050,7 +1053,7 @@ export const RegisterAgent = withErrorBoundary(
               options={options}
               idSelected={idSelected}
               onChange={onChange}
-              className={'osButtonsStyle'}
+              className={'flex'}
             />
             {this.state.selectedVersion == 'solaris10' || this.state.selectedVersion == 'solaris11' ? <EuiCallOut color="warning" className='message' iconType="iInCircle" title={
               <span>
@@ -1267,7 +1270,7 @@ export const RegisterAgent = withErrorBoundary(
             },
           ]
           : []),
-        ...(this.state.selectedVersion == 'centos6' || this.state.selectedVersion == 'oraclelinux6' || this.state.selectedVersion == 'amazonlinux1' || this.state.selectedVersion == 'redhat6' || this.state.selectedVersion == 'redhat7' || this.state.selectedVersion == 'amazonlinux2022' || this.state.selectedVersion == 'debian7' || this.state.selectedVersion == 'debian8' || this.state.selectedVersion == 'ubuntu14' || this.state.selectedVersion == 'ubuntu15' || this.state.selectedVersion == 'ubuntu16'
+        ...(this.state.selectedVersion == 'centos6' || this.state.selectedVersion == 'oraclelinux6' || this.state.selectedVersion == 'amazonlinux1' || this.state.selectedVersion == 'redhat6' || this.state.selectedVersion == 'amazonlinux2022' || this.state.selectedVersion == 'debian7' || this.state.selectedVersion == 'debian8' || this.state.selectedVersion == 'ubuntu14' || this.state.selectedVersion == 'ubuntu15' || this.state.selectedVersion == 'ubuntu16'
           ? [
             {
               title: 'Choose the architecture',
@@ -1277,7 +1280,7 @@ export const RegisterAgent = withErrorBoundary(
             },
           ]
           : []),
-        ...(this.state.selectedVersion == 'centos7' || this.state.selectedVersion == 'amazonlinux2' || this.state.selectedVersion == 'suse12' || this.state.selectedVersion == '22' || this.state.selectedVersion == 'debian9' || this.state.selectedVersion == 'debian10' || this.state.selectedVersion == 'busterorgreater'
+        ...(this.state.selectedVersion == 'centos7' || this.state.selectedVersion == 'redhat7' || this.state.selectedVersion == 'amazonlinux2' || this.state.selectedVersion == 'suse12' || this.state.selectedVersion == '22' || this.state.selectedVersion == 'debian9' || this.state.selectedVersion == 'debian10' || this.state.selectedVersion == 'busterorgreater'
           ? [
             {
               title: 'Choose the architecture',

--- a/public/controllers/agent/components/register-agent.js
+++ b/public/controllers/agent/components/register-agent.js
@@ -1087,8 +1087,7 @@ export const RegisterAgent = withErrorBoundary(
             legend={legend}
             options={options}
             idSelected={idSelected}
-            onChange={onChange}
-            className={'osButtonsStyleMac'} />
+            onChange={onChange} />
         )
       }
 

--- a/public/styles/component.scss
+++ b/public/styles/component.scss
@@ -120,20 +120,25 @@ kbn-dis doc-table .kbnDocViewer__warning {
     flex-grow: 0;
 }
 
-.osButtonsStyle {
-    display: grid;
-    grid-template-columns: repeat(5, 1fr);
-    grid-gap: 10px;
-}
-
-.osButtonsStyleMac {
-    display: grid;
-    grid-template-columns: repeat(3, 1fr);
-    grid-gap: 10px;
-}
-
 .message {
     margin-top: 10px;
     display: flex;
     flex-direction: row;
+}
+
+.euiButtonGroup__buttons {
+    display: grid;
+    grid-template-columns: repeat(5, 1fr);
+    grid-gap: 10px;
+    padding: 0 3px;
+}
+
+.flex {
+    display: flex;
+}
+
+.euiButtonGroup--small {
+    &.euiButtonGroupButton:not(:first-child) {
+    margin-left: 0;
+    }
 }

--- a/public/styles/component.scss
+++ b/public/styles/component.scss
@@ -131,14 +131,19 @@ kbn-dis doc-table .kbnDocViewer__warning {
     grid-template-columns: repeat(5, 1fr);
     grid-gap: 10px;
     padding: 0 3px;
+    box-shadow: none;
 }
 
 .flex {
     display: flex;
 }
 
-.euiButtonGroup--small {
-    &.euiButtonGroupButton:not(:first-child) {
-    margin-left: 0;
-    }
+
+.euiButtonGroup--medium .euiButtonGroupButton:not(:first-child), .euiButtonGroup--small .euiButtonGroupButton:not(:first-child) {
+    margin-left: 0 !important;
+
 }
+
+// .euiButtonGroupButton:not(:first-child) {
+//     margin-left: 0;
+// }

--- a/public/styles/component.scss
+++ b/public/styles/component.scss
@@ -138,12 +138,7 @@ kbn-dis doc-table .kbnDocViewer__warning {
     display: flex;
 }
 
-
 .euiButtonGroup--medium .euiButtonGroupButton:not(:first-child), .euiButtonGroup--small .euiButtonGroupButton:not(:first-child) {
     margin-left: 0 !important;
 
 }
-
-// .euiButtonGroupButton:not(:first-child) {
-//     margin-left: 0;
-// }


### PR DESCRIPTION
### Description

In Wazuh info, in the 'Deploy new agent' section, the OS and versions were not displayed correctly.
 
### Evidence

This is what Wazuh Info used to look like:

![image (10)](https://user-images.githubusercontent.com/99441266/200640423-a60b267c-ec55-4454-abf4-e3aa8e3b48cc.png)

This is what it looks like now: 

![image](https://user-images.githubusercontent.com/99441266/200645528-62631007-1fcc-403d-abbd-26a06acb7b2b.png)

### Steps to test:
*Go to the Agents tab
*Click on the 'Deploy new agent' button.
*Verify that the styles are displayed correctly.
