### PR TITLE
Fixed WAZUH_PROTOCOL param suggestion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ commands of Start the agent in the deploy new agent section [#4458](https://gith
 - Improved the message displayed when there is a versions mismatch between the Wazuh API and the Wazuh APP [#4529](https://github.com/wazuh/wazuh-kibana-app/pull/4529)
 - Changed the endpoint that updates the plugin configuration to support multiple settings. [#4501](https://github.com/wazuh/wazuh-kibana-app/pull/4501)
 - Allowed to upload an image for the `customization.logo.*` settings in `Settings/Configuration` [#4504](https://github.com/wazuh/wazuh-kibana-app/pull/4504)
+- Fixed WAZUH_PROTOCOL param suggestion [#4849](https://github.com/wazuh/wazuh-kibana-app/pull/4849)
 
 ### Fixed
 

--- a/public/controllers/agent/components/register-agent-service.test.ts
+++ b/public/controllers/agent/components/register-agent-service.test.ts
@@ -188,7 +188,7 @@ describe('Register agent service', () => {
       jest.clearAllMocks();
     })
 
-    it('should return UDP when the server address is typed manually (custom)', async () => {
+    it('should return IS NOT UDP when the server address is typed manually (custom)', async () => {
       const nodeSelected: ServerAddressOptions = {
         label: 'node-selected',
         value: 'node-selected',
@@ -225,11 +225,11 @@ describe('Register agent service', () => {
       WzRequest.apiReq = jest.fn().mockResolvedValueOnce(mockedResponse);
       
       const config = await RegisterAgentService.getConnectionConfig(nodeSelected, 'default-dns-address');
-      expect(config.udpProtocol).toEqual(true);
+      expect(config.udpProtocol).toEqual(false);
       expect(config.serverAddress).toBe('default-dns-address');
     })
 
-    it('should return UDP when the server address is received like default server address dns (custom)', async () => {
+    it('should return IS NOT UDP when the server address is received like default server address dns (custom)', async () => {
       const nodeSelected: ServerAddressOptions = {
         label: 'node-selected',
         value: 'node-selected',
@@ -265,8 +265,8 @@ describe('Register agent service', () => {
       };
       WzRequest.apiReq = jest.fn().mockResolvedValueOnce(mockedResponse);
       
-      const config = await RegisterAgentService.getConnectionConfig(nodeSelected);
-      expect(config.udpProtocol).toEqual(true);
+      const config = await RegisterAgentService.getConnectionConfig(nodeSelected, 'custom-server-address');
+      expect(config.udpProtocol).toEqual(false);
     })
   })
 });

--- a/public/controllers/agent/components/register-agent-service.ts
+++ b/public/controllers/agent/components/register-agent-service.ts
@@ -83,10 +83,10 @@ async function getConnectionConfig(nodeSelected: ServerAddressOptions, defaultSe
       const remoteConfig = await getRemoteConfiguration(nodeName);
       return { serverAddress: remoteConfig.name, udpProtocol: remoteConfig.isUdp, connectionSecure: remoteConfig.haveSecureConnection };
     }else{
-      return { serverAddress: nodeName, udpProtocol: true, connectionSecure: true };
+      return { serverAddress: nodeName, udpProtocol: false, connectionSecure: true };
     }
   }else{
-    return { serverAddress: defaultServerAddress, udpProtocol: true, connectionSecure: true };
+    return { serverAddress: defaultServerAddress, udpProtocol: false, connectionSecure: true };
   }
 }
 


### PR DESCRIPTION
### Description
Fixed wrong WAZUH_PROTOCOL suggestion when the user has `enrollment.DNS configuration and set a custom IP typing in the server Address Combobox

### Updated unit tests
 
![image](https://user-images.githubusercontent.com/6089438/201379429-fb5e1b60-ada0-449d-ad61-8fe3f70d1806.png)

![image](https://user-images.githubusercontent.com/6089438/201379717-9fa9af85-f49d-4c8b-8cb3-aa8c0bff829b.png)


Closes #4318