### PR TITLE
Backport 4851 to 4.4 7.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Updated and added operating systems, versions, architectures commands of Install and enroll the agent and
 commands of Start the agent in the deploy new agent section [#4458](https://github.com/wazuh/wazuh-kibana-app/pull/4458)
 - Makes Agents Overview loading icons independent [#4363](https://github.com/wazuh/wazuh-kibana-app/pull/4363)
+- Added cluster's IP and protocol as suggestions in the agent deployment wizard. [#4776](https://github.com/wazuh/wazuh-kibana-app/pull/4776)
+- Show OS name and OS version in the agent installation wizard. [#4851](https://github.com/wazuh/wazuh-kibana-app/pull/4851)
 
 ### Fixed
 

--- a/public/controllers/agent/wazuh-config/index.ts
+++ b/public/controllers/agent/wazuh-config/index.ts
@@ -173,7 +173,7 @@ const versionButtonsDebian = [
 const versionButtonFedora = [
   {
     id: '22',
-    label: '22 or later'
+    label: 'Fedora 22 or later'
   }
 ]
 
@@ -206,45 +206,45 @@ const versionButtonsWindows = [
 const versionButtonsSuse = [
   {
     id: 'suse11',
-    label: '11',
+    label: 'SUSE 11',
   },
   {
     id: 'suse12',
-    label: '12',
+    label: 'SUSE 12',
   }
 ];
 
 const versionButtonsMacOS = [
   {
     id: 'sierra',
-    label: 'Sierra',
+    label: 'macOS Sierra',
   },
   {
     id: 'highSierra',
-    label: 'High Sierra',
+    label: 'macOS High Sierra',
   },
   {
     id: 'mojave',
-    label: 'Mojave',
+    label: 'macOS Mojave',
   },
   {
     id: 'catalina',
-    label: 'Catalina',
+    label: 'macOS Catalina',
   },
   {
     id: 'bigSur',
-    label: 'Big Sur',
+    label: 'macOS Big Sur',
   },
   {
     id: 'monterrey',
-    label: 'Monterrey',
+    label: 'macOS Monterrey',
   },
 ];
 
 const versionButtonsOpenSuse = [
   {
     id: 'leap15',
-    label: 'Leap 15 or higher',
+    label: 'OpenSuse Leap 15 or higher',
   }
 ];
 
@@ -262,32 +262,32 @@ const versionButtonsSolaris = [
 const versionButtonsAix = [
   {
     id: '6.1 TL9',
-    label: '6.1 TL9 or higher',
+    label: 'AIX 6.1 TL9 or higher',
   }
 ];
 
 const versionButtonsHPUX = [
   {
     id: '11.31',
-    label: '11.31 or higher',
+    label: 'HP-UX 11.31 or higher',
   }
 ];
 
 const versionButtonsOracleLinux = [
   {
     id: 'oraclelinux5',
-    label: '5',
+    label: 'Oracle Linux 5',
   },
   {
     id: 'oraclelinux6',
-    label: '6 or later',
+    label: 'Oracle Linux 6 or later',
   }
 ];
 
 const versionButtonsRaspbian = [
   {
     id: 'busterorgreater',
-    label: 'Buster or greater',
+    label: 'Raspbian Buster or greater',
   }
 ];
 


### PR DESCRIPTION
### Description

We want to unify the names displayed in operating system versions, as for example in SUSE versions only the number is displayed and on Ubuntu the number plus the OS name is displayed.

### Issues Resolved
https://github.com/wazuh/wazuh-kibana-app/issues/4850

### Evidence

<img width="1792" alt="image" src="https://user-images.githubusercontent.com/99441266/201739174-7a62dd35-ab14-4a36-ab7d-4ef6352a03e5.png">

### Steps to test:
*Go to the Agents tab
*Click on the 'Deploy new agent' button.
*Verify that each version shows the OS name plus the number.
