### PR TITLE
Show name and number in OS version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,9 +22,14 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Updated and added operating systems, versions, architectures commands of Install and enroll the agent and
 commands of Start the agent in the deploy new agent section [#4458](https://github.com/wazuh/wazuh-kibana-app/pull/4458)
 - Added cluster's IP and protocol as suggestions in the agent deployment wizard. [#4776](https://github.com/wazuh/wazuh-kibana-app/pull/4776)
-- Improved Agents Overview performance [#4363](https://github.com/wazuh/wazuh-kibana-app/pull/4363)
-- Enhance the message shown when a mismatch between Wazuh API and Wazuh APP occurs [#4544](https://github.com/wazuh/wazuh-kibana-app/pull/4544)
-- Changed breadcrumb styling to support OpenSearch dashboard 2.x. [#4649](https://github.com/wazuh/wazuh-kibana-app/pull/4649)
+- Show OS name and OS version in the agent installation wizard. [#4851](https://github.com/wazuh/wazuh-kibana-app/pull/4851)
+
+### Fixed
+
+- Improves Agents Overview performance [#4363](https://github.com/wazuh/wazuh-kibana-app/pull/4363)
+- Improved alerts summary performance [#4376](https://github.com/wazuh/wazuh-kibana-app/pull/4376)
+- The endpoint `/agents/summary/status` response was adapted. [#3874](https://github.com/wazuh/wazuh-kibana-app/pull/3874)
+- Made Agents Overview icons load independently [#4363](https://github.com/wazuh/wazuh-kibana-app/pull/4363)
 - Improved the message displayed when there is a versions mismatch between the Wazuh API and the Wazuh APP [#4529](https://github.com/wazuh/wazuh-kibana-app/pull/4529)
 - Allowed to upload an image for the `customization.logo.*` settings in `Settings/Configuration` [#4504](https://github.com/wazuh/wazuh-kibana-app/pull/4504)
 

--- a/public/controllers/agent/wazuh-config/index.ts
+++ b/public/controllers/agent/wazuh-config/index.ts
@@ -173,7 +173,7 @@ const versionButtonsDebian = [
 const versionButtonFedora = [
   {
     id: '22',
-    label: '22 or later'
+    label: 'Fedora 22 or later'
   }
 ]
 
@@ -206,45 +206,45 @@ const versionButtonsWindows = [
 const versionButtonsSuse = [
   {
     id: 'suse11',
-    label: '11',
+    label: 'SUSE 11',
   },
   {
     id: 'suse12',
-    label: '12',
+    label: 'SUSE 12',
   }
 ];
 
 const versionButtonsMacOS = [
   {
     id: 'sierra',
-    label: 'Sierra',
+    label: 'macOS Sierra',
   },
   {
     id: 'highSierra',
-    label: 'High Sierra',
+    label: 'macOS High Sierra',
   },
   {
     id: 'mojave',
-    label: 'Mojave',
+    label: 'macOS Mojave',
   },
   {
     id: 'catalina',
-    label: 'Catalina',
+    label: 'macOS Catalina',
   },
   {
     id: 'bigSur',
-    label: 'Big Sur',
+    label: 'macOS Big Sur',
   },
   {
     id: 'monterrey',
-    label: 'Monterrey',
+    label: 'macOS Monterrey',
   },
 ];
 
 const versionButtonsOpenSuse = [
   {
     id: 'leap15',
-    label: 'Leap 15 or higher',
+    label: 'OpenSuse Leap 15 or higher',
   }
 ];
 
@@ -262,32 +262,32 @@ const versionButtonsSolaris = [
 const versionButtonsAix = [
   {
     id: '6.1 TL9',
-    label: '6.1 TL9 or higher',
+    label: 'AIX 6.1 TL9 or higher',
   }
 ];
 
 const versionButtonsHPUX = [
   {
     id: '11.31',
-    label: '11.31 or higher',
+    label: 'HP-UX 11.31 or higher',
   }
 ];
 
 const versionButtonsOracleLinux = [
   {
     id: 'oraclelinux5',
-    label: '5',
+    label: 'Oracle Linux 5',
   },
   {
     id: 'oraclelinux6',
-    label: '6 or later',
+    label: 'Oracle Linux 6 or later',
   }
 ];
 
 const versionButtonsRaspbian = [
   {
     id: 'busterorgreater',
-    label: 'Buster or greater',
+    label: 'Raspbian Buster or greater',
   }
 ];
 


### PR DESCRIPTION
### Description

We want to unify the names displayed in operating system versions, as for example in SUSE versions only the number is displayed and on Ubuntu the number plus the OS name is displayed.

### Issues Resolved
https://github.com/wazuh/wazuh-kibana-app/issues/4850

### Evidence

<img width="1792" alt="image" src="https://user-images.githubusercontent.com/99441266/201748745-274bd2cb-765e-4ea1-8abc-a82200cafe46.png">

### Steps to test:
*Go to the Agents tab
*Click on the 'Deploy new agent' button.
*Verify that each version shows the OS name plus the number.

### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff 