### PR TITLE
Nested fields error in Security Alerts table and Events tab row details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 ### Fixed
 
 - Fixed nested fields filtering in dashboards tables and KPIs [#4425](https://github.com/wazuh/wazuh-kibana-app/pull/4425)
-- Fixed nested field rendering in security alerts table details [#4428](https://github.com/wazuh/wazuh-kibana-app/pull/4428)
+- Fixed nested field rendering in security alerts table details [#4428](https://github.com/wazuh/wazuh-kibana-app/pull/4428) [#4925](https://github.com/wazuh/wazuh-kibana-app/pull/4925)
 - Fixed a bug where the Wazuh logo was used instead of the custom one [#4539](https://github.com/wazuh/wazuh-kibana-app/pull/4539)
 - Fixed rendering problems of the `Agent Overview` section in low resolutions [#4516](https://github.com/wazuh/wazuh-kibana-app/pull/4516)
 - Fixed issue when logging out from Wazuh when SAML is enabled [#4595](https://github.com/wazuh/wazuh-kibana-app/issues/4595)

--- a/public/components/common/modules/discover/discover.tsx
+++ b/public/components/common/modules/discover/discover.tsx
@@ -44,7 +44,7 @@ import {
   EuiToolTip,
 } from '@elastic/eui';
 import {
-  IIndexPattern,
+  DataView,
   TimeRange,
   Query,
   buildPhraseFilter,
@@ -96,7 +96,7 @@ export const Discover = compose(
       columns: string[];
       hover: string;
     };
-    indexPattern!: IIndexPattern;
+    indexPattern!: DataView;
     props!: {
       implicitFilters: object[];
       initialFilters: object[];
@@ -261,23 +261,7 @@ export const Discover = compose(
     }
 
     async getIndexPattern() {
-      this.indexPattern = {
-        ...(await this.PluginPlatformServices.indexPatterns.get(AppState.getCurrentPattern())),
-      };
-      const fields: IFieldType[] = [];
-      Object.keys(this.indexPattern.fields).forEach((item) => {
-        if (isNaN(item)) {
-          fields.push(this.indexPattern.fields[item]);
-        } else if (
-          this.props.includeFilters &&
-          this.indexPattern.fields[item].name.includes(this.props.includeFilters)
-        ) {
-          fields.unshift(this.indexPattern.fields[item]);
-        } else {
-          fields.push(this.indexPattern.fields[item]);
-        }
-      });
-      this.indexPattern.fields = fields;
+      this.indexPattern = await this.PluginPlatformServices.indexPatterns.get(AppState.getCurrentPattern());
     }
 
     hideCreateCustomLabel = () => {

--- a/public/components/common/modules/discover/row-details.tsx
+++ b/public/components/common/modules/discover/row-details.tsx
@@ -37,6 +37,7 @@ import './discover.scss';
 import { EuiFlexItem } from '@elastic/eui';
 import { WzRequest } from '../../../../react-services/wz-request';
 import WzTextWithTooltipTruncated from '../../../../components/common/wz-text-with-tooltip-if-truncated';
+import { formatHit } from '../../../../kibana-integrations/lib/format_hit';
 
 const capitalize = str => str[0].toUpperCase() + str.slice(1);
 
@@ -107,7 +108,7 @@ export class RowDetails extends Component {
           } else {
             return 0;
           };
-        })        
+        })
         .reduce((product, [key, value]) => {
           let fullPath = addDelimiter(head, key)
           return isObject(value) ?
@@ -229,7 +230,7 @@ export class RowDetails extends Component {
           cells.push(keyCell);
 
           const formattedValue = Array.isArray(value) ? this.renderArrayValue(value) : value.toString();
-          
+
           // If the field is an array of objects, show the collapse button to show the nested fields
           const showCollapseButton = Array.isArray(value) && arrayContainsObjects(value);
 
@@ -244,7 +245,7 @@ export class RowDetails extends Component {
             className={valueClassName}
             style={{ borderTop: 0, borderBottom: 0, padding: 0, margin: 0 }}
             key={key + "2"}>
-            { showCollapseButton && (
+            {showCollapseButton && (
               <DocViewTableRowBtnCollapse onClick={this.onToggleCollapse} isCollapsed={this.state.isCollapsed} />
             )}
             <div
@@ -271,7 +272,7 @@ export class RowDetails extends Component {
         }); //map
         rows = [...rows, ...tmpRows]
       }//if
-    } //for 
+    } //for
 
 
     return rows;
@@ -280,8 +281,9 @@ export class RowDetails extends Component {
   // Render the row value column supporting nested fields
   renderArrayValue = (value) => {
     if (arrayContainsObjects(value)) {
-      const formatted = this.props?.indexPattern?.formatHit({ _index: value }, 'html')?._index;
-      return trimAngularSpan(String(formatted));
+      // For compatibility resaons between Kibana 7.10 and 7.16.x we need to normalize the formatHit
+      const formatHitValue = (formatHit({ _index: value }, this.props?.indexPattern, 'html')?._index)
+      return trimAngularSpan(String(formatHitValue));
     }
     else {
       return value.join(', ')
@@ -440,7 +442,7 @@ export class RowDetails extends Component {
         </ul>
       );
     } else {
-    
+
       return value.toString();
     }
   }
@@ -542,7 +544,7 @@ export class RowDetails extends Component {
               extraAction={
                 <a href={`#/manager/rules?tab=rules&redirectRule=${id}`} target="_blank" style={{ paddingTop: 5 }}>
                   <EuiIcon type="popout" color='primary' />&nbsp;
-                    View in Rules
+                  View in Rules
                 </a>
               }
               paddingSize="none"

--- a/public/components/common/modules/discover/row-details.tsx
+++ b/public/components/common/modules/discover/row-details.tsx
@@ -281,7 +281,7 @@ export class RowDetails extends Component {
   // Render the row value column supporting nested fields
   renderArrayValue = (value) => {
     if (arrayContainsObjects(value)) {
-      // For compatibility resaons between Kibana 7.10 and 7.16.x we need to normalize the formatHit
+      // For compatibility reasons between Kibana 7.10 and 7.16.x we need to normalize the formatHit
       const formatHitValue = (formatHit({ _index: value }, this.props?.indexPattern, 'html')?._index)
       return trimAngularSpan(String(formatHitValue));
     }

--- a/public/kibana-integrations/lib/format_hit.ts
+++ b/public/kibana-integrations/lib/format_hit.ts
@@ -36,8 +36,6 @@ const convert = (
   indexPattern: any,
   type: 'html' | 'text' = 'html'
 ): string => {
-  let format = { convert: () => val };
-
   // Get the field definition by name
   const field = indexPattern.fields.getByName(fieldName);
 
@@ -47,7 +45,7 @@ const convert = (
         .convert(val, type, { field, hit, indexPattern })
       : val;// If the field is not known, just return the value as it is.
   } else {
-    format = indexPattern.getFormatterForField(field);
+    const format = indexPattern.getFormatterForField(field);
     return format.convert(val, type, { field, hit, indexPattern });
   }
 }

--- a/public/kibana-integrations/lib/format_hit.ts
+++ b/public/kibana-integrations/lib/format_hit.ts
@@ -1,12 +1,12 @@
 import _ from 'lodash';
 
 // Utility functions extracted from Kibana 7.10.2 and adapted to use in Kibana >= 7.16
-export const formatField = function(hit: Record<string, any>, fieldName: string, indexPattern: any){
+export const formatField = function (hit: Record<string, any>, fieldName: string, indexPattern: any) {
   const val = fieldName === '_source' ? hit._source : indexPattern.flattenHit(hit)[fieldName];
   return convert(hit, val, fieldName, indexPattern);
 }
 
-export const formatHit = function(hit: Record<string, any>, indexPattern: any, type: string = 'html') {
+export const formatHit = function (hit: Record<string, any>, indexPattern: any, type: string = 'html') {
   if (type === 'text') {
     const flattened = indexPattern.flattenHit(hit);
     const result: Record<string, any> = {};
@@ -36,10 +36,18 @@ const convert = (
   indexPattern: any,
   type: 'html' | 'text' = 'html'
 ): string => {
+  let format = { convert: () => val };
+
+  // Get the field definition by name
   const field = indexPattern.fields.getByName(fieldName);
-  if(!field){
-    return val
-  };
-  const format = indexPattern.getFormatterForField(field);
-  return format.convert(val, type, { field, hit, indexPattern });
+
+  if (!field) {
+    return Array.isArray(val) ?
+      indexPattern.getFormatterForField('_index')// If the field is a nested field it has to be formatted whether it is known or not
+        .convert(val, type, { field, hit, indexPattern })
+      : val;// If the field is not known, just return the value as it is.
+  } else {
+    format = indexPattern.getFormatterForField(field);
+    return format.convert(val, type, { field, hit, indexPattern });
+  }
 }


### PR DESCRIPTION
### Description
The Security Alerts table is unable to parse and render properly nested fields. It displays an array of objects as a single line array string without interpreting the object.
 
### Issues Resolved
Related issue https://github.com/wazuh/wazuh-kibana-app/issues/4429
Related PR for Kibana 7.10 https://github.com/wazuh/wazuh-kibana-app/pull/4428

Closes https://github.com/wazuh/wazuh-kibana-app/issues/4906 issue found in 7.16.x tests

### Evidence
#### Events tab
![image](https://user-images.githubusercontent.com/9343732/204038675-82e0b606-3796-4455-84e9-be6f70c42e76.png)
#### Security Events Dashboard
![image](https://user-images.githubusercontent.com/9343732/204038897-2b7dfdad-d09f-46a0-bb20-0ef1cef07064.png)


### Test
- Load AWS alerts with nested fields

- Go to Security Events / Events
- Search for an alert with nested fields
- Open the row details in the table and check the field is shown properly
- Go to Security Events / Dashboard
- Search for an alert with nested fields
- Open the row details in the Alerts table and check the field is shown properly


### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff 
