### PR TITLE
Fix the agent installation command for macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fixed WAZUH_PROTOCOL param suggestion [#4849](https://github.com/wazuh/wazuh-kibana-app/pull/4849)
 - Raspbian OS, Ubuntu, Amazon Linux and Amazon Linux 2 commands in the wizard deploy agent now change when a different architecture is selected [#4876](https://github.com/wazuh/wazuh-kibana-app/pull/4876) [#4880](https://github.com/wazuh/wazuh-kibana-app/pull/4880)
 - Fixed the way macos versions and architectures were displayed, fixed the way agents were displayed, fixed the way ubuntu versions were displayed. [#4933](https://github.com/wazuh/wazuh-kibana-app/pull/4933)
+- Fixed agent installation command for macOS en la seccion de deploy new agent. [#4968](https://github.com/wazuh/wazuh-kibana-app/pull/4968)
 
 ## Wazuh v4.3.10 - Kibana 7.10.2, 7.16.x, 7.17.x - Revision 4311
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fixed pagination to SCA table [#4653](https://github.com/wazuh/wazuh-kibana-app/issues/4653)
 - Fixed WAZUH_PROTOCOL param suggestion [#4849](https://github.com/wazuh/wazuh-kibana-app/pull/4849)
 - Raspbian OS, Ubuntu, Amazon Linux and Amazon Linux 2 commands in the wizard deploy agent now change when a different architecture is selected [#4876](https://github.com/wazuh/wazuh-kibana-app/pull/4876) [#4880](https://github.com/wazuh/wazuh-kibana-app/pull/4880)
-- Fixed agent installation command for macOS en la seccion de deploy new agent. [#4968](https://github.com/wazuh/wazuh-kibana-app/pull/4968)
+- Fixed agent installation command for macOS in the deploy new agent section. [#4968](https://github.com/wazuh/wazuh-kibana-app/pull/4968)
 - Deploy new agent section: Fixed the way macos versions and architectures were displayed, fixed the way agents were displayed, fixed the way ubuntu versions were displayed. [#4933](https://github.com/wazuh/wazuh-kibana-app/pull/4933)
 
 ## Wazuh v4.3.10 - Kibana 7.10.2, 7.16.x, 7.17.x - Revision 4311

--- a/public/controllers/agent/components/register-agent.js
+++ b/public/controllers/agent/components/register-agent.js
@@ -372,6 +372,14 @@ export const RegisterAgent = withErrorBoundary(
 
     agentNameVariable() {
       let agentName = `WAZUH_AGENT_NAME='${this.state.agentName}' `;
+      if (
+        this.state.selectedOS === 'macos' &&
+        this.state.selectedArchitecture &&
+        this.state.agentName !== ''
+      ) {
+        return agentName.replace(/=/g, ' ');
+      }
+
       if (this.state.selectedArchitecture && this.state.agentName !== '') {
         return agentName;
       } else {


### PR DESCRIPTION
### Description

This PR fixes the agent installation command for macOS

<!--
### Main PR
-->

This pull request is going to be merged into the main branch used for this epic [#4931](https://github.com/wazuh/wazuh-kibana-app/pull/4933)

### Manual Backports

[4.4-2.3-wzd](https://github.com/wazuh/wazuh-kibana-app/pull/4982)
[4.4-7.16 ](https://github.com/wazuh/wazuh-kibana-app/pull/4983)

### Issues Resolved

#4953 

### Evidence

<img width="879" alt="image" src="https://user-images.githubusercontent.com/99441266/205988060-67548d0b-df04-4a65-bb92-3cafea7caff4.png">

### Steps to test

* Click on agents
* Click deploy new agent
* Follow the steps to deploy a new macOS agent
* In the step 'Install and enroll agent' the variables WAZUH_MANAGER, WAZUH_AGENT_GROUP and WAZUH_AGENT_NAME *should not contain a '=' sign.

### Check List
- [x] All tests pass
  - [x] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff 
