### PR TITLE
 Added file saving conditions in File Editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Added powerPC architecture in redhat7, in the section 'Deploy new agent'. [4833](https://github.com/wazuh/wazuh-kibana-app/pull/4833)
 - Added a centralized service to handle the requests [#4831](https://github.com/wazuh/wazuh-kibana-app/pull/4831)
 - Added data-test-subj create policy [#4873](https://github.com/wazuh/wazuh-kibana-app/pull/4873)
+- Added file saving conditions in File Editor [#4970](https://github.com/wazuh/wazuh-kibana-app/pull/4970)
 
 ### Changed
 

--- a/public/controllers/management/components/management/common/file-editor.tsx
+++ b/public/controllers/management/components/management/common/file-editor.tsx
@@ -91,6 +91,12 @@ class WzFileEditor extends Component {
     this._isMounted = true;
   }
 
+  /**
+   * Check if the file content has changed and is not empty
+   */
+  contentHasChanged() {
+    return !!this.state.content.trim() && (this.state.content.trim() !== this.state.initContent.trim());
+  } 
 
   /**
    * Save the new content
@@ -129,7 +135,7 @@ class WzFileEditor extends Component {
 
         let toastMessage;
 
-        if (this.props.state.addingFile != false) {
+        if (this.props.addingFile != false) {
           //remove current invalid file if the file is new.
           await this.resourcesHandler.deleteFile(name);
           toastMessage = 'The new file was deleted.';
@@ -243,7 +249,7 @@ class WzFileEditor extends Component {
           fill
           iconType={isEditable && xmlError ? 'alert' : 'save'}
           isLoading={this.state.isSaving}
-          isDisabled={nameForSaving.length <= 4 || !!(isEditable && xmlError)}
+          isDisabled={nameForSaving.length <= 4 || !!(isEditable && xmlError) || !this.contentHasChanged()}
           onClick={() => this.save(nameForSaving, overwrite)}
         >
           {isEditable && xmlError ? 'XML format error' : 'Save'}


### PR DESCRIPTION
### Description
This PR adds validations in the File Editor.
 
### Issues Resolved
Closes #4946 

### Test

- When the editor hasn't changed the initial content or is empty the "Save" button is disabled

https://user-images.githubusercontent.com/6089438/206179577-c56db1f9-a38b-44f5-a2bb-14f4836b790e.mp4

- When the editor has a valid XML  the "Save" button is enabled.

https://user-images.githubusercontent.com/6089438/206179804-272887db-35c0-496c-9642-1034823d769a.mp4




### Check List
- [x] All tests pass
  - [x] `yarn test:jest`
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 
