### PR TITLE
Added export logs validation when is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,6 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Added powerPC architecture in redhat7, in the section 'Deploy new agent'. [4833](https://github.com/wazuh/wazuh-kibana-app/pull/4833)
 - Added a centralized service to handle the requests [#4831](https://github.com/wazuh/wazuh-kibana-app/pull/4831)
 - Added data-test-subj create policy [#4873](https://github.com/wazuh/wazuh-kibana-app/pull/4873)
-- Added export logs validation when is empty [#4972](https://github.com/wazuh/wazuh-kibana-app/pull/4972)
 
 ### Changed
 
@@ -33,6 +32,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Added cluster's IP and protocol as suggestions in the agent deployment wizard. [#4776](https://github.com/wazuh/wazuh-kibana-app/pull/4776)
 - Show OS name and OS version in the agent installation wizard. [#4851](https://github.com/wazuh/wazuh-kibana-app/pull/4851)
 - Changed the endpoint that updates the plugin configuration to support multiple settings. [#4501](https://github.com/wazuh/wazuh-kibana-app/pull/4501)
+- The button to export the app logs is now disabled when there are no results, instead of showing a error toast [#4972](https://github.com/wazuh/wazuh-kibana-app/pull/4972)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Added powerPC architecture in redhat7, in the section 'Deploy new agent'. [4833](https://github.com/wazuh/wazuh-kibana-app/pull/4833)
 - Added a centralized service to handle the requests [#4831](https://github.com/wazuh/wazuh-kibana-app/pull/4831)
 - Added data-test-subj create policy [#4873](https://github.com/wazuh/wazuh-kibana-app/pull/4873)
+- Added export logs validation when is empty [#4972](https://github.com/wazuh/wazuh-kibana-app/pull/4972)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Added cluster's IP and protocol as suggestions in the agent deployment wizard. [#4776](https://github.com/wazuh/wazuh-kibana-app/pull/4776)
 - Show OS name and OS version in the agent installation wizard. [#4851](https://github.com/wazuh/wazuh-kibana-app/pull/4851)
 - Changed the endpoint that updates the plugin configuration to support multiple settings. [#4501](https://github.com/wazuh/wazuh-kibana-app/pull/4501)
-- The button to export the app logs is now disabled when there are no results, instead of showing a error toast [#4972](https://github.com/wazuh/wazuh-kibana-app/pull/4972)
+- The button to export the app logs is now disabled when there are no results, instead of showing an error toast [#4972](https://github.com/wazuh/wazuh-kibana-app/pull/4972)
 
 ### Fixed
 

--- a/public/controllers/management/components/management/mg-logs/logs.js
+++ b/public/controllers/management/components/management/mg-logs/logs.js
@@ -413,6 +413,7 @@ export default compose(
                     iconType="importAction"
                     onClick={this.exportFormatted}
                     isLoading={this.state.generatingCsv}
+                    isDisabled={!this.state.logsList}
                   >
                     Export formatted
                   </EuiButtonEmpty>


### PR DESCRIPTION
### Description
This PR adds a validation in the "Export formatted" button when the logs are empty.
 
### Issues Resolved
Closes #4948 

### Evidence
- When the logs are empty the "Export formatted" button must be disabled.

https://user-images.githubusercontent.com/6089438/206191509-1141916e-2eb3-44b1-b0a6-4a56daf47fb3.mp4



### Check List
- [x] All tests pass
  - [x] `yarn test:jest`
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 
