### PR TITLE
Change default last scan date formatter

### DIFF
--- a/public/components/agents/vuls/inventory.tsx
+++ b/public/components/agents/vuls/inventory.tsx
@@ -33,7 +33,7 @@ import {
   VisualizationBasicWidget,
 } from '../../common/charts/visualizations/basic';
 import { WzStat } from '../../wz-stat';
-import { formatUIDate } from '../../../react-services/time-service';
+import { beautifyDate } from './inventory/lib';
 
 interface Aggregation {
   title: number;
@@ -104,11 +104,6 @@ export class Inventory extends Component {
     this.colorsVisualizationVulnerabilitiesSummaryData = euiPaletteColorBlind();
   }
 
-  // when vulnerability module is not configured
-  // its meant to render nothing when such date is received
-  beautifyDate(date?: string) {
-    return date && !['1970-01-01T00:00:00Z', '-'].includes(date) ? formatUIDate(date) : '-';
-  }
 
   async componentDidMount() {
     this._isMount = true;
@@ -234,8 +229,8 @@ export class Inventory extends Component {
     if (isLoading) {
       return this.loadingInventory();
     }
-    const last_full_scan = this.beautifyDate(vulnerabilityLastScan.last_full_scan);
-    const last_partial_scan = this.beautifyDate(vulnerabilityLastScan.last_partial_scan);
+    const last_full_scan = beautifyDate(vulnerabilityLastScan.last_full_scan);
+    const last_partial_scan = beautifyDate(vulnerabilityLastScan.last_partial_scan);
 
     const table = this.renderTable();
     return (

--- a/public/components/agents/vuls/inventory/detail.tsx
+++ b/public/components/agents/vuls/inventory/detail.tsx
@@ -36,7 +36,7 @@ import { AppNavigate } from '../../../../react-services/app-navigate';
 import { TruncateHorizontalComponents } from '../../../common/util';
 import { getDataPlugin, getUiSettings } from '../../../../kibana-services';
 import { FilterManager } from '../../../../../../../src/plugins/data/public/';
-import { formatUIDate } from '../../../../react-services/time-service';
+import { beautifyDate } from './lib/';
 export class Details extends Component {
   props!: {
     currentItem: {
@@ -132,28 +132,28 @@ export class Details extends Component {
         name: 'Last full scan',
         icon: 'clock',
         link: false,
-        transformValue: this.beautifyDate
+        transformValue: beautifyDate
       },
       {
         field: 'last_partial_scan',
         name: 'Last partial scan',
         icon: 'clock',
         link: false,
-        transformValue: this.beautifyDate
+        transformValue: beautifyDate
       },
       {
         field: 'published',
         name: 'Published',
         icon: 'clock',
         link: false,
-        transformValue: this.beautifyDate
+        transformValue: beautifyDate
       },
       {
         field: 'updated',
         name: 'Updated',
         icon: 'clock',
         link: false,
-        transformValue: this.beautifyDate
+        transformValue: beautifyDate
       },
       {
         field: 'external_references',
@@ -165,12 +165,7 @@ export class Details extends Component {
     ];
   }
 
-  // This method was created because Wazuh API returns 1970-01-01T00:00:00Z dates or undefined ones
-  // when vulnerability module is not configured
-  // its meant to render nothing when such date is received
-  beautifyDate(date?: string) {
-    return date && !['1970-01-01T00:00:00Z', '-'].includes(date) ? formatUIDate(date) : '-';
-  }
+
 
   viewInEvents = (ev) => {
     const { cve } = this.props.currentItem;

--- a/public/components/agents/vuls/inventory/lib/index.ts
+++ b/public/components/agents/vuls/inventory/lib/index.ts
@@ -1,1 +1,2 @@
 export * from './api-requests';
+export * from './utils';

--- a/public/components/agents/vuls/inventory/lib/utils.ts
+++ b/public/components/agents/vuls/inventory/lib/utils.ts
@@ -1,0 +1,10 @@
+import { formatUIDate } from '../../../../../react-services/time-service';
+
+// This method was created because Wazuh API returns 1970-01-01T00:00:00Z dates or undefined ones
+// when vulnerability module is not configured
+// its meant to render nothing when such date is received
+export function beautifyDate(date?: string) {
+  return date &&
+    (!['-'].includes(date) && !date.startsWith('1970')) ?
+    formatUIDate(date) : '-';
+}


### PR DESCRIPTION
### Description
Hi team,
this PR changes de default last scan date parser to be able to catch dates returned by Wazuh API when no vulnerabilities scan has been made. It prepares the parser to format any date string starting with `1970` _(default last scan date in the API response)_.

Default last scan response example:
```
{
    "data": {
        "affected_items": [
            {
                "last_full_scan": "1970-01-01T00:00:00+00:00",
                "last_partial_scan": "1970-01-01T00:00:00+00:00"
            }
        ],
        "total_affected_items": 1,
        "total_failed_items": 0,
        "failed_items": []
    },
    "message": "Last vulnerability scans of the agent were returned",
    "error": 0
}
 ```
 
### Issues Resolved
Closes https://github.com/wazuh/wazuh-kibana-app/issues/4959

### Evidence
![image](https://user-images.githubusercontent.com/9343732/206703835-cf9b45d8-50e3-43a4-a492-06efb0fcdc06.png)


### Test

- Set up a new environment without any vulnerabilities scan
- Go to Vulnerabilities / Inventory
- See the default dates as `-` 

### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff 
