### PR TITLE
[Backport 7.16] Fix default last scan date formatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fixed WAZUH_PROTOCOL param suggestion [#4849](https://github.com/wazuh/wazuh-kibana-app/pull/4849)
 - Raspbian OS, Ubuntu, Amazon Linux and Amazon Linux 2 commands in the wizard deploy agent now change when a different architecture is selected [#4876](https://github.com/wazuh/wazuh-kibana-app/pull/4876) [#4880](https://github.com/wazuh/wazuh-kibana-app/pull/4880)
 - Fixed the agents wizard OS styles and their versions. [#4832](https://github.com/wazuh/wazuh-kibana-app/pull/4832) [#4838](https://github.com/wazuh/wazuh-kibana-app/pull/4838)
+- Fixed vulnerabilities default last scan date formatter [#4975](https://github.com/wazuh/wazuh-kibana-app/pull/4975)
 
 ## Wazuh v4.3.10 - Kibana 7.10.2, 7.16.x, 7.17.x - Revision 4311
 

--- a/public/components/agents/vuls/inventory.tsx
+++ b/public/components/agents/vuls/inventory.tsx
@@ -33,7 +33,7 @@ import {
   VisualizationBasicWidget,
 } from '../../common/charts/visualizations/basic';
 import { WzStat } from '../../wz-stat';
-import { formatUIDate } from '../../../react-services/time-service';
+import { beautifyDate } from './inventory/lib';
 
 interface Aggregation {
   title: number;
@@ -102,12 +102,6 @@ export class Inventory extends Component {
       this
     );
     this.colorsVisualizationVulnerabilitiesSummaryData = euiPaletteColorBlind();
-  }
-
-  // when vulnerability module is not configured
-  // its meant to render nothing when such date is received
-  beautifyDate(date?: string) {
-    return date && !['1970-01-01T00:00:00Z', '-'].includes(date) ? formatUIDate(date) : '-';
   }
 
   async componentDidMount() {
@@ -234,8 +228,8 @@ export class Inventory extends Component {
     if (isLoading) {
       return this.loadingInventory();
     }
-    const last_full_scan = this.beautifyDate(vulnerabilityLastScan.last_full_scan);
-    const last_partial_scan = this.beautifyDate(vulnerabilityLastScan.last_partial_scan);
+    const last_full_scan = beautifyDate(vulnerabilityLastScan.last_full_scan);
+    const last_partial_scan = beautifyDate(vulnerabilityLastScan.last_partial_scan);
 
     const table = this.renderTable();
     return (

--- a/public/components/agents/vuls/inventory/detail.tsx
+++ b/public/components/agents/vuls/inventory/detail.tsx
@@ -36,7 +36,7 @@ import { AppNavigate } from '../../../../react-services/app-navigate';
 import { TruncateHorizontalComponents } from '../../../common/util';
 import { getDataPlugin, getUiSettings } from '../../../../kibana-services';
 import { FilterManager } from '../../../../../../../src/plugins/data/public/';
-import { formatUIDate } from '../../../../react-services/time-service';
+import { beautifyDate } from './lib';
 export class Details extends Component {
   props!: {
     currentItem: {
@@ -132,28 +132,28 @@ export class Details extends Component {
         name: 'Last full scan',
         icon: 'clock',
         link: false,
-        transformValue: this.beautifyDate
+        transformValue: beautifyDate
       },
       {
         field: 'last_partial_scan',
         name: 'Last partial scan',
         icon: 'clock',
         link: false,
-        transformValue: this.beautifyDate
+        transformValue: beautifyDate
       },
       {
         field: 'published',
         name: 'Published',
         icon: 'clock',
         link: false,
-        transformValue: this.beautifyDate
+        transformValue: beautifyDate
       },
       {
         field: 'updated',
         name: 'Updated',
         icon: 'clock',
         link: false,
-        transformValue: this.beautifyDate
+        transformValue: beautifyDate
       },
       {
         field: 'external_references',
@@ -163,13 +163,6 @@ export class Details extends Component {
         transformValue: this.renderExternalReferences
       },
     ];
-  }
-
-  // This method was created because Wazuh API returns 1970-01-01T00:00:00Z dates or undefined ones
-  // when vulnerability module is not configured
-  // its meant to render nothing when such date is received
-  beautifyDate(date?: string) {
-    return date && !['1970-01-01T00:00:00Z', '-'].includes(date) ? formatUIDate(date) : '-';
   }
 
   viewInEvents = (ev) => {

--- a/public/components/agents/vuls/inventory/lib/index.ts
+++ b/public/components/agents/vuls/inventory/lib/index.ts
@@ -1,1 +1,2 @@
 export * from './api-requests';
+export * from './utils';

--- a/public/components/agents/vuls/inventory/lib/utils.ts
+++ b/public/components/agents/vuls/inventory/lib/utils.ts
@@ -1,0 +1,10 @@
+import { formatUIDate } from '../../../../../react-services/time-service';
+
+// This method was created because Wazuh API returns 1970-01-01T00:00:00Z dates or undefined ones
+// when vulnerability module is not configured
+// its meant to render nothing when such date is received
+export function beautifyDate(date?: string) {
+  return date &&
+    (!['-'].includes(date) && !date.startsWith('1970')) ?
+    formatUIDate(date) : '-';
+}


### PR DESCRIPTION
### Description
Hi team,
this PR changes de default last scan date parser to be able to catch dates returned by Wazuh API when no vulnerabilities scan has been made. It prepares the parser to format any date string starting with `1970` _(default last scan date in the API response)_.

Default last scan response example:
```
{
    "data": {
        "affected_items": [
            {
                "last_full_scan": "1970-01-01T00:00:00+00:00",
                "last_partial_scan": "1970-01-01T00:00:00+00:00"
            }
        ],
        "total_affected_items": 1,
        "total_failed_items": 0,
        "failed_items": []
    },
    "message": "Last vulnerability scans of the agent were returned",
    "error": 0
}
 ```
 
### Issues Resolved
Closes https://github.com/wazuh/wazuh-kibana-app/issues/4959

### Evidence
![image](https://user-images.githubusercontent.com/9343732/206716754-18ee5c19-00e3-4ee5-9ade-b322a3aea802.png)


### Test

- Set up a new environment without any vulnerabilities scan
- Go to Vulnerabilities / Inventory
- See the default dates as `-` 

### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff 
