### PR TITLE
Fixed Inventory checks table filters by stats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fixed pagination to SCA table [#4653](https://github.com/wazuh/wazuh-kibana-app/issues/4653)
 - Fixed WAZUH_PROTOCOL param suggestion [#4849](https://github.com/wazuh/wazuh-kibana-app/pull/4849)
 - Raspbian OS, Ubuntu, Amazon Linux and Amazon Linux 2 commands in the wizard deploy agent now change when a different architecture is selected [#4876](https://github.com/wazuh/wazuh-kibana-app/pull/4876) [#4880](https://github.com/wazuh/wazuh-kibana-app/pull/4880)
+- Fixed Inventory checks table filters by stats [#4999](https://github.com/wazuh/wazuh-kibana-app/pull/4999)
 
 ## Wazuh v4.3.10 - Kibana 7.10.2, 7.16.x, 7.17.x - Revision 4311
 

--- a/public/components/agents/sca/inventory.tsx
+++ b/public/components/agents/sca/inventory.tsx
@@ -578,6 +578,7 @@ export class Inventory extends Component<InventoryProps, InventoryState> {
                     <EuiFlexItem>
                       <InventoryPolicyChecksTable
                         agent={this.props.agent}
+                        filters={this.state.filters}
                         lookingPolicy={this.state.lookingPolicy}
                       />
                     </EuiFlexItem>

--- a/public/components/agents/sca/inventory.tsx
+++ b/public/components/agents/sca/inventory.tsx
@@ -544,7 +544,7 @@ export class Inventory extends Component<InventoryProps, InventoryState> {
                       <EuiStat
                         title={this.buttonStat(
                           this.state.lookingPolicy.invalid,
-                          'result',
+                          'status',
                           'not applicable'
                         )}
                         description="Not applicable"

--- a/public/components/agents/sca/inventory/checks-table.tsx
+++ b/public/components/agents/sca/inventory/checks-table.tsx
@@ -8,6 +8,7 @@ import { getFilterValues } from './lib';
 type Props = {
   agent: { [key: string]: any };
   lookingPolicy: { [key: string]: any };
+  filters: any[];
 };
 
 type State = {
@@ -24,12 +25,12 @@ export class InventoryPolicyChecksTable extends Component<Props, State> {
   columnsChecks: any;
   constructor(props) {
     super(props);
-    const { agent, lookingPolicy } = this.props;
+    const { agent, lookingPolicy, filters } = this.props;
     this.state = {
       agent,
       lookingPolicy,
       itemIdToExpandedRowMap: {},
-      filters: [],
+      filters: filters || [],
       pageTableChecks: { pageIndex: 0 },
     };
     this.suggestions = [
@@ -208,7 +209,12 @@ export class InventoryPolicyChecksTable extends Component<Props, State> {
 
   async componentDidMount() {}
 
-  async componentDidUpdate(prevProps, prevState) {}
+  async componentDidUpdate(prevProps) {
+    const { filters } =  this.props
+    if (filters !== prevProps.filters) {
+      this.setState({ filters: filters });
+    }
+  }
 
   componentWillUnmount() {
     this._isMount = false;


### PR DESCRIPTION
### Description

Hi Team, This PR fixes the behavior when the Inventory Stat is clicked.
Closes #4952 

### Test case

- When the Inventory Stat is clicked the Check table must be filtered

https://user-images.githubusercontent.com/6089438/207654344-f8e73ffa-25fa-4881-ab8b-bd0317d80ebb.mp4

### Tests

1. **Scenario** The user can add a filter by clicking on the result count indicator (Pass) of the Security configuration assessment
 policy checks
**Given** SCA data is available
**When** the user is seeing the table of checks of a Security configuration assessment
 policy
**And** the user clicks on any result count indicator
**Then** a filter must be added to the search bar
**And** the table should be filtered by the added filter

2. **Scenario** The user can add a filter by clicking on the result count indicator (Fail) of the Security configuration assessment
 policy checks
**Given** SCA data is available
**When** the user is seeing the table of checks of a Security configuration assessment
 policy
**And** the user clicks on any result count indicator
**Then** a filter must be added to the search bar
**And** the table should be filtered by the added filter

3. **Scenario** The user can add a filter by clicking on the result count indicator (Not applicable) of the Security configuration assessment
 policy checks
**Given** SCA data is available
**When** the user is seeing the table of checks of a Security configuration assessment
 policy
**And** the user clicks on any result count indicator
**Then** a filter must be added to the search bar
**And** the table should be filtered by the added filter

### Check List
- [x] All tests pass
  - [x] `yarn test:jest`
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 
