### PR TITLE
Remove duplicated buttons in SCA inventory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fixed rendering problems of the `Agent Overview` section in low resolutions [#4516](https://github.com/wazuh/wazuh-kibana-app/pull/4516)
 - Fixed issue when logging out from Wazuh when SAML is enabled [#4595](https://github.com/wazuh/wazuh-kibana-app/issues/4595)
 - Fixed server errors with code 500 when the Wazuh API is not reachable / up. [#4710](https://github.com/wazuh/wazuh-kibana-app/pull/4710) [#4728](https://github.com/wazuh/wazuh-kibana-app/pull/4728) [#4971](https://github.com/wazuh/wazuh-kibana-app/pull/4971)
-- Fixed pagination to SCA table [#4653](https://github.com/wazuh/wazuh-kibana-app/issues/4653)
+- Fixed pagination to SCA table [#4653](https://github.com/wazuh/wazuh-kibana-app/issues/4653) [#5010](https://github.com/wazuh/wazuh-kibana-app/pull/5010)
 - Fixed WAZUH_PROTOCOL param suggestion [#4849](https://github.com/wazuh/wazuh-kibana-app/pull/4849)
 - Raspbian OS, Ubuntu, Amazon Linux and Amazon Linux 2 commands in the wizard deploy agent now change when a different architecture is selected [#4876](https://github.com/wazuh/wazuh-kibana-app/pull/4876) [#4880](https://github.com/wazuh/wazuh-kibana-app/pull/4880)
 - Fixed a bug that caused the flyouts to close when clicking inside them [#4638](https://github.com/wazuh/wazuh-kibana-app/pull/4638)

--- a/public/components/agents/sca/inventory.tsx
+++ b/public/components/agents/sca/inventory.tsx
@@ -31,7 +31,6 @@ import {
 } from '@elastic/eui';
 import { WzRequest } from '../../../react-services/wz-request';
 import { formatUIDate } from '../../../react-services/time-service';
-import exportCsv from '../../../react-services/wz-csv';
 import { getToasts } from '../../../kibana-services';
 import _ from 'lodash';
 import {
@@ -325,32 +324,6 @@ export class Inventory extends Component<InventoryProps, InventoryState> {
     });
   };
 
-  /**
-   *
-   */
-  async downloadCsv() {
-    try {
-      this.showToast('success', 'Your download should begin automatically...', 3000);
-      await exportCsv(
-        '/sca/' + this.props.agent.id + '/checks/' + this.state.lookingPolicy.policy_id,
-        [],
-        this.state.lookingPolicy.policy_id
-      );
-    } catch (error) {
-      const options: UIErrorLog = {
-        context: `${Inventory.name}.downloadCsv`,
-        level: UI_LOGGER_LEVELS.ERROR as UILogLevel,
-        severity: UI_ERROR_SEVERITIES.BUSINESS as UIErrorSeverity,
-        error: {
-          error: error,
-          message: error.message || error,
-          title: error.name,
-        },
-      };
-      getErrorOrchestrator().handleError(options);
-    }
-  }
-
   buttonStat(text, field, value) {
     return <button onClick={() => this.setState({ filters: [{ field, value }] })}>{text}</button>;
   }
@@ -502,22 +475,6 @@ export class Inventory extends Component<InventoryProps, InventoryState> {
                           </EuiToolTip>
                         </h2>
                       </EuiTitle>
-                    </EuiFlexItem>
-                    <EuiFlexItem grow={false}>
-                      <EuiButtonEmpty
-                        iconType="importAction"
-                        onClick={async () => await this.downloadCsv()}
-                      >
-                        Export formatted
-                      </EuiButtonEmpty>
-                    </EuiFlexItem>
-                    <EuiFlexItem grow={false}>
-                      <EuiButtonEmpty
-                        iconType="refresh"
-                        onClick={() => this.loadScaPolicy(this.state.lookingPolicy.policy_id)}
-                      >
-                        Refresh
-                      </EuiButtonEmpty>
                     </EuiFlexItem>
                   </EuiFlexGroup>
                   <EuiSpacer size="m" />


### PR DESCRIPTION
### Description
This pull request removes unneeded buttons in the SCA inventory section.

The affected buttons are:
- Export formatted
- Refresh

that were displayed on the top of the panel.

With the work in a previous pull request (https://github.com/wazuh/wazuh-kibana-app/pull/4653), these actions are included in the reusable component, but the previous buttons were not removed so they were duplicated.
 
### Issues Resolved
Closes #5011 

### Evidence
The buttons were placed in the highlighted section.
![image](https://user-images.githubusercontent.com/34042064/208445686-dfa61387-2bc6-4a8b-96b4-db21e4eb94f6.png)

### Test
**Scenario 1**: `Export formatted` button should not be duplicated
**Given** data related to Security configuration assessment scan
**When** When the user goes to `Modules/Security configuration assessment`
**And** Select a policy
**Then** the button should be duplicated. It should appear above the table.

**Scenario 2**: `Refresh` button should not be duplicated
**Given** data related to Security configuration assessment scan
**When** When the user goes to `Modules/Security configuration assessment`
**And** Select a policy
**Then** the button should be duplicated. It should appear above the table.

### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff 
