### PR TITLE
[Backport 4.4-7.16] Disable unmapped fields filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fixed pagination to SCA table [#4653](https://github.com/wazuh/wazuh-kibana-app/issues/4653)
 - Fixed WAZUH_PROTOCOL param suggestion [#4849](https://github.com/wazuh/wazuh-kibana-app/pull/4849)
 - Raspbian OS, Ubuntu, Amazon Linux and Amazon Linux 2 commands in the wizard deploy agent now change when a different architecture is selected [#4876](https://github.com/wazuh/wazuh-kibana-app/pull/4876) [#4880](https://github.com/wazuh/wazuh-kibana-app/pull/4880)
+- Disabled unmapped fields filter in Security Events alerts table [#4929](https://github.com/wazuh/wazuh-kibana-app/pull/4929)
 - Fixed the agents wizard OS styles and their versions. [#4832](https://github.com/wazuh/wazuh-kibana-app/pull/4832) [#4838](https://github.com/wazuh/wazuh-kibana-app/pull/4838)
 - Fixed agent installation command for macOS in the deploy new agent section. [#4983](https://github.com/wazuh/wazuh-kibana-app/pull/4983)
 - Fixed vulnerabilities default last scan date formatter [#4975](https://github.com/wazuh/wazuh-kibana-app/pull/4975)

--- a/public/components/common/modules/discover/discover.tsx
+++ b/public/components/common/modules/discover/discover.tsx
@@ -264,20 +264,6 @@ export const Discover = compose(
       this.indexPattern = {
         ...(await this.PluginPlatformServices.indexPatterns.get(AppState.getCurrentPattern())),
       };
-      const fields: IFieldType[] = [];
-      Object.keys(this.indexPattern.fields).forEach((item) => {
-        if (isNaN(item)) {
-          fields.push(this.indexPattern.fields[item]);
-        } else if (
-          this.props.includeFilters &&
-          this.indexPattern.fields[item].name.includes(this.props.includeFilters)
-        ) {
-          fields.unshift(this.indexPattern.fields[item]);
-        } else {
-          fields.push(this.indexPattern.fields[item]);
-        }
-      });
-      this.indexPattern.fields = fields;
     }
 
     hideCreateCustomLabel = () => {

--- a/public/components/common/modules/discover/row-details.tsx
+++ b/public/components/common/modules/discover/row-details.tsx
@@ -107,7 +107,7 @@ export class RowDetails extends Component {
           } else {
             return 0;
           };
-        })        
+        })
         .reduce((product, [key, value]) => {
           let fullPath = addDelimiter(head, key)
           return isObject(value) ?
@@ -175,6 +175,7 @@ export class RowDetails extends Component {
         const tmpRows = itemPaths.map((item) => {
           const key = isString(field) ? item : fieldsToShow[i] + "." + item; // = agent + . + id = agent.id
           const value = isString(field) ? field : this.getChildFromPath(this.props.item[fieldsToShow[i]], item);
+          const hasFieldMapping = this.props?.indexPattern?.fields?.getByName(key)?.filterable;// if the field is mapped the filter can be added and removed
           const filter = {};
           filter[key] = value;
           const cells: any[] = [];
@@ -185,8 +186,9 @@ export class RowDetails extends Component {
             {(this.state.hover === key &&
               <EuiFlexGroup style={{ height: 35 }}>
                 <EuiFlexItem grow={false} style={{ marginRight: 0, marginTop: 8 }}>
-                  <EuiToolTip position="top" content={`Filter for value`}>
+                  <EuiToolTip position="top" content={hasFieldMapping ? 'Filter for value' : 'Unindexed fields can not be searched'}>
                     <EuiButtonIcon
+                      disabled={!hasFieldMapping}
                       onClick={() => this.props.addFilter(filter)}
                       iconType="magnifyWithPlus"
                       aria-label="Filter"
@@ -195,8 +197,9 @@ export class RowDetails extends Component {
                   </EuiToolTip>
                 </EuiFlexItem>
                 <EuiFlexItem grow={false} style={{ marginRight: 0, marginLeft: 0, marginTop: 8 }}>
-                  <EuiToolTip position="top" content={`Filter out value`}>
+                  <EuiToolTip position="top" content={hasFieldMapping ? 'Filter for value' : 'Unindexed fields can not be searched'}>
                     <EuiButtonIcon
+                      disabled={!hasFieldMapping}
                       onClick={() => this.props.addFilterOut(filter)}
                       iconType="magnifyWithMinus"
                       aria-label="Filter"
@@ -229,7 +232,7 @@ export class RowDetails extends Component {
           cells.push(keyCell);
 
           const formattedValue = Array.isArray(value) ? this.renderArrayValue(value) : value.toString();
-          
+
           // If the field is an array of objects, show the collapse button to show the nested fields
           const showCollapseButton = Array.isArray(value) && arrayContainsObjects(value);
 
@@ -271,7 +274,7 @@ export class RowDetails extends Component {
         }); //map
         rows = [...rows, ...tmpRows]
       }//if
-    } //for 
+    } //for
 
 
     return rows;
@@ -440,7 +443,7 @@ export class RowDetails extends Component {
         </ul>
       );
     } else {
-    
+
       return value.toString();
     }
   }


### PR DESCRIPTION
### Description
Team,
this PR disables filter buttons of unmapped fields in the Security Events table. 

Prevents filtering errors when clicking unmapped fields filters:

![Screenshot from 2022-11-28 19-26-20](https://user-images.githubusercontent.com/9343732/204353036-c9f76cfb-3201-4c53-9b7b-8db69dda1a59.png)


![Screenshot from 2022-11-28 19-25-20](https://user-images.githubusercontent.com/9343732/204353054-4b54bf27-b6d6-4167-9c65-1588a1cbf959.png)



### Issues Resolved
Closes https://github.com/wazuh/wazuh-kibana-app/issues/4932
Related issue https://github.com/wazuh/wazuh-kibana-app/issues/4429

### Evidence
![Peek 2022-11-28 18-32](https://user-images.githubusercontent.com/9343732/204351493-27076c5a-8ad9-4c8b-a820-963c32bbd4fb.gif)


### Test

- Add alerts with unmapped fields. 
<details>
<summary>Example alert</summary>

```json
{"timestamp":"2022-08-31T16:13:21.285+0000","rule":{"level":3,"description":"AWS Cloudtrail: gefv2.amazonaws.com - UpdateWebACL.","id":"80202","firedtimes":1,"mail":false,"groups":["amazon","aws","aws_cloudtrail"],"gdpr":["IV_35.7.d"],"hipaa":["164.312.b"],"nist_800_53":["AU.6"],"pci_dss":["10.6.1"],"tsc":["CC7.2","CC7.3"]},"agent":{"id":"000","name":"wazuh_manager_filebeat_sources_cmake-v4.3.7-7.10.2"},"manager":{"name":"wazuh_manager_filebeat_sources_cmake-v4.3.7-7.10.2"},"id":"1661184801.1137630","cluster":{"name":"wazuh","node":"master-node"},"decoder":{"name":"json"},"data":{"integration":"aws","aws":{"log_info":{"log_file":"AWSLogs/166157441623/CloudTrail/us-west-1/2022/08/17/166157441623_CloudTrail_us-west-1_20220817T0000Z_HASDoKlxgfdkdIOa.json.txt","s3bucket":"wazuh-aws-wodle-waf"},"eventVersion":"1.08","userIdentity":{"type":"AssumedRole","principalId":"asdf@asdf.com","arn":"-","accountId":"166157441623","accessKeyId":"-","sessionContext":{"sessionIssuer":{"type":"Role","principalId":"-","arn":"-"},"attributes":{"creationDate":"2022-07-05T16:49:18Z","mfaAuthenticated":"false"}}},"eventTime":"2022-07-05T18:20:27Z","eventSource":"gefv2.amazonaws.com","eventName":"UpdateWebACL","awsRegion":"us-west-2","sourceIPAddress":"AWS Internal","userAgent":"AWS Internal","requestParameters":{"name":"ec-web-acl","scope":"REGIONAL","id":"xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx","description":"ec-web-acl","rules":[{"name":"X-Application-ID","priority":0,"statement":{"byteMatchStatement":{"searchString":{"hb":[115,121,110,116,104,101,116,105,99],"offset":0,"isReadOnly":false,"bigEndian":true,"nativeByteOrder":false,"mark":-1,"position":0,"limit":9,"capacity":9,"address":0},"fieldToMatch":{"singleHeader":{"name":"x-application-id"}},"textTransformations":[{"priority":0,"type":"LOWERCASE"}],"positionalConstraint":"CONTAINS"}},"action":{"count":{}},"ruleLabels":[{"name":"RulesCustom:Application:Synthetic"}],"visibilityConfig":{"sampledRequestsEnabled":true,"cloudWatchMetricsEnabled":true,"metricName":"X-Application-ID"}},{"name":"MS-Internos","priority":1,"statement":{"andStatement":{"statements":[{"sizeConstraintStatement":{"fieldToMatch":{"singleHeader":{"name":"x-application-id"}},"comparisonOperator":"GE","size":0,"textTransformations":[{"priority":0,"type":"LOWERCASE"}]}},{"notStatement":{"statement":{"byteMatchStatement":{"searchString":{"hb":[115,121,110,116,104,101,116,105,99],"offset":0,"isReadOnly":false,"bigEndian":true,"nativeByteOrder":false,"mark":-1,"position":0,"limit":9,"capacity":9,"address":0},"fieldToMatch":{"singleHeader":{"name":"x-application-id"}},"textTransformations":[{"priority":0,"type":"LOWERCASE"}],"positionalConstraint":"CONTAINS"}}}}]}},"action":{"count":{}},"visibilityConfig":{"sampledRequestsEnabled":true,"cloudWatchMetricsEnabled":true,"metricName":"MS-Internos"}},{"name":"blueteam-rules","priority":2,"statement":{"ruleGroupReferenceStatement":{"aRN":"arn:aws:gefv2:us-west-2:166157441623:regional/rulegroup/blueteam/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"}},"overrideAction":{"none":{}},"visibilityConfig":{"sampledRequestsEnabled":true,"cloudWatchMetricsEnabled":true,"metricName":"blueteam-rules"}},{"name":"MS-ECOM-PARTNER","priority":3,"statement":{"byteMatchStatement":{"searchString":{"hb":[47,101,99,111,109,45,112,97,114,116,110,101,114,115,47],"offset":0,"isReadOnly":false,"bigEndian":true,"nativeByteOrder":false,"mark":-1,"position":0,"limit":15,"capacity":15,"address":0},"fieldToMatch":{"uriPath":{}},"textTransformations":[{"priority":0,"type":"LOWERCASE"}],"positionalConstraint":"CONTAINS"}},"action":{"count":{}},"visibilityConfig":{"sampledRequestsEnabled":true,"cloudWatchMetricsEnabled":true,"metricName":"MS-ECOM-PARTNER"}},{"name":"RL_ALL","priority":4,"statement":{"rateBasedStatement":{"limit":1000,"aggregateKeyType":"FORWARDED_IP","forwardedIPConfig":{"headerName":"X-Forwarded-For","fallbackBehavior":"MATCH"}}},"action":{"count":{}},"ruleLabels":[{"name":"CustomRules:RateLimitMS"}],"visibilityConfig":{"sampledRequestsEnabled":true,"cloudWatchMetricsEnabled":true,"metricName":"HttpFlood"}},{"name":"Request_From_Country","priority":5,"statement":{"andStatement":{"statements":[{"notStatement":{"statement":{"geoMatchStatement":{"countryCodes":["AR","BR","CL","CO","CR","EC","MX","PE","UY","US"],"forwardedIPConfig":{"headerName":"X-Forwarded-For","fallbackBehavior":"MATCH"}}}}},{"byteMatchStatement":{"searchString":{"hb":[47,114,101,115,116,97,117,114,97,110,116,115,45,98,117,115,47],"offset":0,"isReadOnly":false,"bigEndian":true,"nativeByteOrder":false,"mark":-1,"position":0,"limit":17,"capacity":17,"address":0},"fieldToMatch":{"uriPath":{}},"textTransformations":[{"priority":0,"type":"LOWERCASE"}],"positionalConstraint":"CONTAINS"}}]}},"action":{"block":{}},"visibilityConfig":{"sampledRequestsEnabled":true,"cloudWatchMetricsEnabled":true,"metricName":"Request_From_Country"}},{"name":"rl-es-proxy","priority":6,"statement":{"rateBasedStatement":{"limit":750,"aggregateKeyType":"FORWARDED_IP","scopeDownStatement":{"byteMatchStatement":{"searchString":{"hb":[47,97,112,105,47,101,115,45,112,114,111,120,121,47,115,101,97,114,99,104,47,118,50,47,112,114,111,100,117,99,116,115],"offset":0,"isReadOnly":false,"bigEndian":true,"nativeByteOrder":false,"mark":-1,"position":0,"limit":32,"capacity":32,"address":0},"fieldToMatch":{"uriPath":{}},"textTransformations":[{"priority":0,"type":"LOWERCASE"}],"positionalConstraint":"STARTS_WITH"}},"forwardedIPConfig":{"headerName":"X-Forwarded-For","fallbackBehavior":"MATCH"}}},"action":{"block":{}},"visibilityConfig":{"sampledRequestsEnabled":true,"cloudWatchMetricsEnabled":true,"metricName":"rl-elasticsearch-proxy"}},{"name":"restaurant-bus-rl","priority":7,"statement":{"rateBasedStatement":{"limit":350,"aggregateKeyType":"FORWARDED_IP","scopeDownStatement":{"regexPatternSetReferenceStatement":{"aRN":"arn:aws:gefv2:us-west-2:166157441623:regional/regexpatternset/toppings-rl/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx","fieldToMatch":{"uriPath":{}},"textTransformations":[{"priority":0,"type":"LOWERCASE"}]}},"forwardedIPConfig":{"headerName":"X-Forwarded-For","fallbackBehavior":"MATCH"}}},"action":{"block":{}},"visibilityConfig":{"sampledRequestsEnabled":true,"cloudWatchMetricsEnabled":true,"metricName":"restaurant-bus-rl"}}],"visibilityConfig":{"sampledRequestsEnabled":"true","cloudWatchMetricsEnabled":"true","metricName":"ec-web-acl"},"lockToken":"xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"},"responseElements":{"nextLockToken":"xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"},"requestID":"xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx","eventID":"xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx","readOnly":"false","eventType":"AwsApiCall","apiVersion":"2019-04-23","managementEvent":"true","recipientAccountId":"166157441623","eventCategory":"Management","sessionCredentialFromConsole":"true","source":"cloudtrail","aws_account_id":"166157441623"}},"location":"Wazuh-AWS"}
```

If you are using a Wazuh manager with Filebeat you can append this alert to the `alerts.json` file and this will send it to Elasticsearch.
</details>

- Open the details of the alert in the Security Alerts table
- Click the magnifier glass icon to filter by the unmapped field

### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff 
