### PR TITLE
[Backport 4.4-7.16] Fix vulnerabilities in dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,9 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Show OS name and OS version in the agent installation wizard. [#4851](https://github.com/wazuh/wazuh-kibana-app/pull/4851)
 - Changed the endpoint that updates the plugin configuration to support multiple settings. [#4501](https://github.com/wazuh/wazuh-kibana-app/pull/4501)
 - The button to export the app logs is now disabled when there are no results, instead of showing an error toast [#4972](https://github.com/wazuh/wazuh-kibana-app/pull/4972)
+- Updated the `winston` dependency to `3.5.1` [#4985](https://github.com/wazuh/wazuh-kibana-app/pull/4985)
+- Updated the `pdfmake` dependency to `0.2.6` [#4985](https://github.com/wazuh/wazuh-kibana-app/pull/4985)
+- The button to export the app logs is now disabled when there are no results, instead of showing an error toast [#4992](https://github.com/wazuh/wazuh-kibana-app/pull/4992)
 
 ### Fixed
 
@@ -50,6 +53,10 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fixed agent installation command for macOS in the deploy new agent section. [#4983](https://github.com/wazuh/wazuh-kibana-app/pull/4983)
 - Fixed commands in the deploy new agent section(most of the commands are missing '-1') [#4962](https://github.com/wazuh/wazuh-kibana-app/pull/4962)
 - Fixed vulnerabilities default last scan date formatter [#4975](https://github.com/wazuh/wazuh-kibana-app/pull/4975)
+
+### Removed
+
+- Removed the `angular-chart.js` dependency [#4985](https://github.com/wazuh/wazuh-kibana-app/pull/4985)
 
 ## Wazuh v4.3.10 - Kibana 7.10.2, 7.16.x, 7.17.x - Revision 4311
 

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "angular": "^1.8.0",
     "angular-aria": "^1.8.0",
     "angular-animate": "1.7.8",
-    "angular-chart.js": "1.1.1",
     "angular-elastic": "^2.5.1",
     "angular-material": "1.1.18",
     "angular-recursion": "^1.0.5",
@@ -65,7 +64,7 @@
     "needle": "^2.0.1",
     "ngreact": "^0.5.1",
     "node-cron": "^1.1.2",
-    "pdfmake": "0.1.65",
+    "pdfmake": "0.2.6",
     "pug-loader": "^2.4.0",
     "querystring-browser": "1.0.4",
     "react-codemirror": "^1.0.0",
@@ -73,7 +72,7 @@
     "read-last-lines": "^1.7.2",
     "timsort": "^0.3.0",
     "typescript": "^4.4.2",
-    "winston": "3.0.0"
+    "winston": "3.5.1"
   },
   "devDependencies": {
     "@types/node-cron": "^2.0.3",

--- a/public/app.js
+++ b/public/app.js
@@ -20,9 +20,6 @@ require('./utils/dom-to-image.js');
 // EUI React components wrapper
 import './components';
 
-// angular-charts.js
-import 'angular-chart.js';
-
 // Font Awesome, plugin platform framework and others
 import './utils/fontawesome/scss/font-awesome.scss';
 

--- a/public/get_inner_angular.ts
+++ b/public/get_inner_angular.ts
@@ -89,7 +89,6 @@ export function initializeInnerAngularModule(name = 'app/wazuh', navigation: Nav
       'ngRoute',
       'react',
       'ngMaterial',
-      'chart.js',
       'ui.bootstrap',
       'app/discover',
     ])

--- a/public/kibana-integrations/kibana-discover.js
+++ b/public/kibana-integrations/kibana-discover.js
@@ -17,7 +17,6 @@
  * under the License.
  */
 
-import discoverTemplate from '../templates/discover/discover.html';
 import store from '../redux/store';
 import { updateVis } from '../redux/actions/visualizationsActions';
 import { getAngularModule, getCore, getDiscoverModule, getPlugins, getToasts } from '../kibana-services';
@@ -40,7 +39,7 @@ getAngularModule().directive('kbnDis', [
     return {
       restrict: 'E',
       scope: {},
-      template: indexTemplateLegacy//discoverTemplate,
+      template: indexTemplateLegacy
     };
   }
 ]);

--- a/server/routes/wazuh-reporting.test.ts
+++ b/server/routes/wazuh-reporting.test.ts
@@ -181,11 +181,11 @@ describe('[endpoint] PUT /utils/configuration', () => {
   // If any of the parameters is changed this variable should be updated with the new md5
   it.each`
   footer              | header                                | responseStatusCode | expectedMD5                           | tab
-  ${null}             | ${null}                               | ${200}             | ${'9fbdebb41c6c4fe09841fc94a14de174'} | ${'pm'}
-  ${'Custom\nFooter'} | ${'info@company.com\nFake Avenue 123'}| ${200}             | ${'f01f3aa26436cca6c92e7c45da72efce'} | ${'general'}
-  ${''}               | ${''}                                 | ${200}             | ${'fa6c0527535b314aaf50d27e98fda093'} | ${'fim'}
-  ${'Custom Footer'}  | ${null}                               | ${200}             | ${'e4aba02dcb618387a4da4103ce833238'} | ${'aws'}
-  ${null}             | ${'Custom Header'}                    | ${200}             | ${'102c342384edd4796a02045e28f970cd'} | ${'gcp'}
+  ${null}             | ${null}                               | ${200}             | ${'7b6fa0e2a5911880d17168800c173f89'} | ${'pm'}
+  ${'Custom\nFooter'} | ${'info@company.com\nFake Avenue 123'}| ${200}             | ${'51b268066bb5107e5eb0a9d791a89d0c'} | ${'general'}
+  ${''}               | ${''}                                 | ${200}             | ${'23d5e0eedce38dc6df9e98e898628f68'} | ${'fim'}
+  ${'Custom Footer'}  | ${null}                               | ${200}             | ${'2b16be2ea88d3891cda7acb6075826d9'} | ${'aws'}
+  ${null}             | ${'Custom Header'}                    | ${200}             | ${'91e30564f157942718afdd97db3b4ddf'} | ${'gcp'}
 `(`Set custom report header and footer - Verify PDF output`, async ({footer, header, responseStatusCode, expectedMD5, tab}) => {
 
       // Mock PDF report parameters


### PR DESCRIPTION
### Description
This pull request fixes some problems related to dependency vulnerabilities:

- Remove `angular-chart.js` dependency and unused code
- Upgrade `winston` to `3.5.1`
- Upgrade `pdfmake` to `0.2.6`
 
### Issues Resolved
Closes #4956

### Evidence
[Provide screenshots or videos to prove this PR solves the issues]

### Test
1. **Scenario** Plugin logs should be generated without problems
**Given** a new environment without plugin logs stored in the filesystem
**When** the plugin starts
**Then** it should exist the plugin logs files with some logs

2. **Scenario** The PDF reports can be generated correctly - Modules without selected agent
**When** the user exports to PDF a Dashboard. For example, `Security events` and no agent is selected
**Then** the PDF should be generated correctly.
**And** the logo should appear
**And** the default header should appear
**And** the default footer should appear
**And** the visualizations and summary table should appear

3. **Scenario** The PDF reports can be generated correctly - Modules with selected agent
**When** the user exports to PDF a Dashboard. For example, `Security events` and any agent is selected
**Then** the PDF should be generated correctly.
**And** the logo should appear
**And** the default header should appear
**And** the default footer should appear
**And** the visualizations and summary table should appear

3. **Scenario** The PDF reports can be generated correctly - Agent configuration
**When** the user exports to PDF an agent configuration
**Then** the PDF should be generated correctly.
**And** the logo should appear
**And** the default header should appear
**And** the default footer should appear
**And** the data should appear

4. **Scenario** The PDF reports can be generated correctly - Agent inventory
**When** the user exports to PDF an agent configuration
**Then** the PDF should be generated correctly.
**And** the logo should appear
**And** the default header should appear
**And** the default footer should appear
**And** the data should appear

5. **Scenario** The PDF reports can be generated correctly - Group configuration
**When** the user exports to PDF an agent configuration
**Then** the PDF should be generated correctly.
**And** the logo should appear
**And** the default header should appear
**And** the default footer should appear
**And** the data should appear

### Check List
- [x] All tests pass
  - [x] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff 
