### PR TITLE
Add validation to agent name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,11 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Added a new plugin setting to enable or disable the customization [#4507](https://github.com/wazuh/wazuh-kibana-app/pull/4507)
 - Added the ability to upload an image for the `customization.logo.*` settings in `Settings/Configuration` [#4504](https://github.com/wazuh/wazuh-kibana-app/pull/4504)
 - Added macOS version to wizard deploy agent [#4867](https://github.com/wazuh/wazuh-kibana-app/pull/4867)
-- Added powerPC architecture in redhat7, in the section 'Deploy new agent'. [4833](https://github.com/wazuh/wazuh-kibana-app/pull/4833)
+- Added powerPC architecture in redhat7, in the section 'Deploy new agent'. [#4833](https://github.com/wazuh/wazuh-kibana-app/pull/4833)
 - Added a centralized service to handle the requests [#4831](https://github.com/wazuh/wazuh-kibana-app/pull/4831)
 - Added data-test-subj create policy [#4873](https://github.com/wazuh/wazuh-kibana-app/pull/4873)
 - Added file saving conditions in File Editor [#4970](https://github.com/wazuh/wazuh-kibana-app/pull/4970)
+- Added character validation to avoid invalid agent names in the section 'Deploy new agent'. [#5021](https://github.com/wazuh/wazuh-kibana-app/pull/5021)
 
 ### Changed
 

--- a/public/controllers/agent/components/register-agent.js
+++ b/public/controllers/agent/components/register-agent.js
@@ -34,6 +34,9 @@ import {
   EuiIcon,
   EuiSwitch,
   EuiLink,
+  EuiFormRow,
+  EuiFormControlLayout,
+  EuiForm
 } from '@elastic/eui';
 import { WzRequest } from '../../../react-services/wz-request';
 import { withErrorBoundary } from '../../../components/common/hocs';
@@ -92,6 +95,8 @@ export const RegisterAgent = withErrorBoundary(
         wazuhVersion: '',
         serverAddress: '',
         agentName: '',
+        agentNameError: false,
+        badCharacters: [],
         wazuhPassword: '',
         groups: [],
         selectedGroup: [],
@@ -293,10 +298,18 @@ export const RegisterAgent = withErrorBoundary(
 
     setAgentName(event) {
       this.setState({ agentName: event.target.value });
-    }
-
-    setAgentName(event) {
-      this.setState({ agentName: event.target.value });
+      if (/^[a-z0-9-_.]+$/i.test(event.target.value) || event.target.value.length <= 0) {
+        this.setState({ agentNameError: false });
+        this.setState({ badCharacters: [] });
+      } else {
+        let badCharacters = event.target.value.split('').map(char =>
+          char.replace(/^[a-z0-9-_.]+$/i, '')).join('');
+        badCharacters = badCharacters.split('').map(char =>
+          char.replace(/\s/, 'whitespace'));
+        const characters = [...new Set(badCharacters)];
+        this.setState({ badCharacters: characters });
+        this.setState({ agentNameError: true });
+      }
     }
 
     setGroupName(selectedGroup) {
@@ -385,7 +398,7 @@ export const RegisterAgent = withErrorBoundary(
 
     resolveRPMPackage() {
       switch (
-        `${this.state.selectedVersion}-${this.state.selectedArchitecture}`
+      `${this.state.selectedVersion}-${this.state.selectedArchitecture}`
       ) {
         case 'redhat5-i386':
           return `https://packages.wazuh.com/4.x/yum5/i386/wazuh-agent-${this.state.wazuhVersion}${this.addToVersion}.el5.i386.rpm`;
@@ -416,7 +429,7 @@ export const RegisterAgent = withErrorBoundary(
 
     resolveAlpinePackage() {
       switch (
-        `${this.state.selectedVersion}-${this.state.selectedArchitecture}`
+      `${this.state.selectedVersion}-${this.state.selectedArchitecture}`
       ) {
         case '3.12.12-i386':
           return `https://packages.wazuh.com/key/alpine-devel%40wazuh.com-633d7457.rsa.pub && \echo "https://packages.wazuh.com/4.x/alpine/v3.12/main"`;
@@ -435,7 +448,7 @@ export const RegisterAgent = withErrorBoundary(
 
     resolveORACLELINUXPackage() {
       switch (
-        `${this.state.selectedVersion}-${this.state.selectedArchitecture}`
+      `${this.state.selectedVersion}-${this.state.selectedArchitecture}`
       ) {
         case 'oraclelinux5-i386':
           return `https://packages.wazuh.com/4.x/yum/wazuh-agent-${this.state.wazuhVersion}${this.addToVersion}.i386.rpm`;
@@ -462,7 +475,7 @@ export const RegisterAgent = withErrorBoundary(
 
     resolveCENTPackage() {
       switch (
-        `${this.state.selectedVersion}-${this.state.selectedArchitecture}`
+      `${this.state.selectedVersion}-${this.state.selectedArchitecture}`
       ) {
         case 'centos5-i386':
           return `https://packages.wazuh.com/4.x/yum/i386/wazuh-agent-${this.state.wazuhVersion}${this.addToVersion}.el5.i386.rpm`;
@@ -493,7 +506,7 @@ export const RegisterAgent = withErrorBoundary(
 
     resolveSUSEPackage() {
       switch (
-        `${this.state.selectedVersion}-${this.state.selectedArchitecture}`
+      `${this.state.selectedVersion}-${this.state.selectedArchitecture}`
       ) {
         case 'suse11-i386':
           return `https://packages.wazuh.com/4.x/yum/wazuh-agent-${this.state.wazuhVersion}${this.addToVersion}.i386.rpm`;
@@ -516,7 +529,7 @@ export const RegisterAgent = withErrorBoundary(
 
     resolveFEDORAPachage() {
       switch (
-        `${this.state.selectedVersion}-${this.state.selectedArchitecture}`
+      `${this.state.selectedVersion}-${this.state.selectedArchitecture}`
       ) {
         case '22-i386':
           return `https://packages.wazuh.com/4.x/yum/i386/wazuh-agent-${this.state.wazuhVersion}${this.addToVersion}.el5.i386.rpm`;
@@ -535,7 +548,7 @@ export const RegisterAgent = withErrorBoundary(
 
     resolveAMAZONLPackage() {
       switch (
-        `${this.state.selectedVersion}-${this.state.selectedArchitecture}`
+      `${this.state.selectedVersion}-${this.state.selectedArchitecture}`
       ) {
         case 'amazonlinux1-i386':
           return `https://packages.wazuh.com/4.x/yum/wazuh-agent-${this.state.wazuhVersion}${this.addToVersion}.i386.rpm`;
@@ -589,7 +602,7 @@ export const RegisterAgent = withErrorBoundary(
 
     resolveRASPBIANPackage() {
       switch (
-        `${this.state.selectedVersion}-${this.state.selectedArchitecture}`
+      `${this.state.selectedVersion}-${this.state.selectedArchitecture}`
       ) {
         case 'busterorgreater-i386':
           return `https://packages.wazuh.com/4.x/apt/pool/main/w/wazuh-agent/wazuh-agent_${this.state.wazuhVersion}${this.addToVersion}_i386.deb`;
@@ -608,7 +621,7 @@ export const RegisterAgent = withErrorBoundary(
 
     resolveUBUNTUPackage() {
       switch (
-        `${this.state.selectedVersion}-${this.state.selectedArchitecture}`
+      `${this.state.selectedVersion}-${this.state.selectedArchitecture}`
       ) {
         case 'ubuntu14-i386':
           return `https://packages.wazuh.com/4.x/apt/pool/main/w/wazuh-agent/wazuh-agent_${this.state.wazuhVersion}${this.addToVersion}_i386.deb`;
@@ -633,7 +646,7 @@ export const RegisterAgent = withErrorBoundary(
 
     resolveOPENSUSEPackage() {
       switch (
-        `${this.state.selectedVersion}-${this.state.selectedArchitecture}`
+      `${this.state.selectedVersion}-${this.state.selectedArchitecture}`
       ) {
         case 'leap15-x86_64':
           return `https://packages.wazuh.com/4.x/yum/i386/wazuh-agent-${this.state.wazuhVersion}${this.addToVersion}.x86_64.rpm`;
@@ -646,7 +659,7 @@ export const RegisterAgent = withErrorBoundary(
 
     resolveSOLARISPackage() {
       switch (
-        `${this.state.selectedVersion}-${this.state.selectedArchitecture}`
+      `${this.state.selectedVersion}-${this.state.selectedArchitecture}`
       ) {
         case 'solaris10-i386':
           return `https://packages.wazuh.com/4.x/solaris/i386/10/wazuh-agent-${this.state.wazuhVersion}-sol10-i386.pkg`;
@@ -663,7 +676,7 @@ export const RegisterAgent = withErrorBoundary(
 
     resolveAIXPackage() {
       switch (
-        `${this.state.selectedVersion}-${this.state.selectedArchitecture}`
+      `${this.state.selectedVersion}-${this.state.selectedArchitecture}`
       ) {
         case '6.1 TL9-powerpc':
           return `https://packages.wazuh.com/4.x/yum/i386/wazuh-agent-${this.state.wazuhVersion}${this.addToVersion}.aix.ppc.rpm`;
@@ -674,7 +687,7 @@ export const RegisterAgent = withErrorBoundary(
 
     resolveHPPackage() {
       switch (
-        `${this.state.selectedVersion}-${this.state.selectedArchitecture}`
+      `${this.state.selectedVersion}-${this.state.selectedArchitecture}`
       ) {
         case '11.31-itanium2':
           return `https://packages.wazuh.com/4.x/yum/i386/wazuh-agent-${this.state.wazuhVersion}${this.addToVersion}-hpux-11v3-ia64.tar`;
@@ -860,11 +873,20 @@ export const RegisterAgent = withErrorBoundary(
       const missingOSSelection = this.checkMissingOSSelection();
 
       const agentName = (
-        <EuiFieldText
-          placeholder='Name agent'
-          value={this.state.agentName}
-          onChange={event => this.setAgentName(event)}
-        />
+        <EuiForm>
+          <EuiFormRow
+            isInvalid={this.state.agentNameError}
+            error={[`The character${this.state.badCharacters.length <= 1 ? ('') : ('s')}
+            ${this.state.badCharacters.map(char => ` "${char}"`)}
+            ${this.state.badCharacters.length <= 1 ? ('is') : ('are')}
+            not valid. Allowed characters are A-Z, a-z, ".", "-", "_"`]}>
+            <EuiFieldText
+              isInvalid={this.state.agentNameError}
+              placeholder='Name agent'
+              value={this.state.agentName}
+              onChange={event => this.setAgentName(event)} />
+          </EuiFormRow>
+        </EuiForm >
       );
       const groupInput = (
         <>
@@ -911,47 +933,34 @@ export const RegisterAgent = withErrorBoundary(
       const customTexts = {
         rpmText: `sudo ${this.optionalDeploymentVariables()}${this.agentNameVariable()}yum install -y ${this.optionalPackages()}`,
         centText: `sudo ${this.optionalDeploymentVariables()}${this.agentNameVariable()}yum install -y ${this.optionalPackages()}`,
-        debText: `curl -so wazuh-agent-${
-          this.state.wazuhVersion
-        }.deb ${this.optionalPackages()} && sudo ${this.optionalDeploymentVariables()}${this.agentNameVariable()}dpkg -i ./wazuh-agent-${
-          this.state.wazuhVersion
-        }.deb`,
-        ubuText: `curl -so wazuh-agent-${
-          this.state.wazuhVersion
-        }.deb ${this.optionalPackages()} && sudo ${this.optionalDeploymentVariables()}${this.agentNameVariable()}dpkg -i ./wazuh-agent-${
-          this.state.wazuhVersion
-        }.deb`,
-        macosText: `curl -so wazuh-agent-${
-          this.state.wazuhVersion
-        }.pkg https://packages.wazuh.com/4.x/macos/wazuh-agent-${
-          this.state.wazuhVersion
-        }-1.pkg && sudo launchctl setenv ${this.optionalDeploymentVariables()}${this.agentNameVariable()}&& sudo installer -pkg ./wazuh-agent-${
-          this.state.wazuhVersion
-        }.pkg -target /`,
-        winText: `Invoke-WebRequest -Uri https://packages.wazuh.com/4.x/windows/wazuh-agent-${
-          this.state.wazuhVersion
-        }-1.msi -OutFile \${env:tmp}\\wazuh-agent-${
-          this.state.wazuhVersion
-        }.msi; msiexec.exe /i \${env:tmp}\\wazuh-agent-${
-          this.state.wazuhVersion
-        }.msi /q ${this.optionalDeploymentVariables()}${this.agentNameVariable()}`,
+        debText: `curl -so wazuh-agent-${this.state.wazuhVersion
+          }.deb ${this.optionalPackages()} && sudo ${this.optionalDeploymentVariables()}${this.agentNameVariable()}dpkg -i ./wazuh-agent-${this.state.wazuhVersion
+          }.deb`,
+        ubuText: `curl -so wazuh-agent-${this.state.wazuhVersion
+          }.deb ${this.optionalPackages()} && sudo ${this.optionalDeploymentVariables()}${this.agentNameVariable()}dpkg -i ./wazuh-agent-${this.state.wazuhVersion
+          }.deb`,
+        macosText: `curl -so wazuh-agent-${this.state.wazuhVersion
+          }.pkg https://packages.wazuh.com/4.x/macos/wazuh-agent-${this.state.wazuhVersion
+          }-1.pkg && sudo launchctl setenv ${this.optionalDeploymentVariables()}${this.agentNameVariable()}&& sudo installer -pkg ./wazuh-agent-${this.state.wazuhVersion
+          }.pkg -target /`,
+        winText: `Invoke-WebRequest -Uri https://packages.wazuh.com/4.x/windows/wazuh-agent-${this.state.wazuhVersion
+          }-1.msi -OutFile \${env:tmp}\\wazuh-agent-${this.state.wazuhVersion
+          }.msi; msiexec.exe /i \${env:tmp}\\wazuh-agent-${this.state.wazuhVersion
+          }.msi /q ${this.optionalDeploymentVariables()}${this.agentNameVariable()}`,
         openText: `sudo rpm --import https://packages.wazuh.com/key/GPG-KEY-WAZUH && sudo ${this.optionalDeploymentVariables()}${this.agentNameVariable()} zypper install -y ${this.optionalPackages()}`,
-        solText: `sudo curl -so ${this.optionalPackages()} && sudo ${this.agentNameVariable()}&& ${
-          this.state.selectedVersion == 'solaris11'
-            ? 'pkg install -g wazuh-agent.p5p wazuh-agent'
-            : 'pkgadd -d wazuh-agent.pkg'
-        }`,
+        solText: `sudo curl -so ${this.optionalPackages()} && sudo ${this.agentNameVariable()}&& ${this.state.selectedVersion == 'solaris11'
+          ? 'pkg install -g wazuh-agent.p5p wazuh-agent'
+          : 'pkgadd -d wazuh-agent.pkg'
+          }`,
         aixText: `sudo ${this.optionalDeploymentVariables()}${this.agentNameVariable()}rpm -ivh ${this.optionalPackages()}`,
         hpText: `cd / && sudo curl -so ${this.optionalPackages()} && sudo ${this.agentNameVariable()}groupadd wazuh && sudo useradd -G wazuh wazuh && sudo tar -xvf wazuh-agent.tar`,
         amazonlinuxText: `sudo ${this.optionalDeploymentVariables()}${this.agentNameVariable()}yum install -y ${this.optionalPackages()}`,
         fedoraText: `sudo ${this.optionalDeploymentVariables()}${this.agentNameVariable()}yum install -y ${this.optionalPackages()}`,
         oraclelinuxText: `sudo ${this.optionalDeploymentVariables()}${this.agentNameVariable()}yum install -y ${this.optionalPackages()}`,
         suseText: `sudo ${this.optionalDeploymentVariables()}${this.agentNameVariable()}yum install -y ${this.optionalPackages()}`,
-        raspbianText: `curl -so wazuh-agent-${
-          this.state.wazuhVersion
-        }.deb ${this.optionalPackages()} && sudo ${this.optionalDeploymentVariables()}${this.agentNameVariable()}dpkg -i ./wazuh-agent-${
-          this.state.wazuhVersion
-        }.deb`,
+        raspbianText: `curl -so wazuh-agent-${this.state.wazuhVersion
+          }.deb ${this.optionalPackages()} && sudo ${this.optionalDeploymentVariables()}${this.agentNameVariable()}dpkg -i ./wazuh-agent-${this.state.wazuhVersion
+          }.deb`,
       };
 
       const field = `${this.state.selectedOS}Text`;
@@ -1323,7 +1332,7 @@ export const RegisterAgent = withErrorBoundary(
               className={'osButtonsStyle'}
             />
             {this.state.selectedVersion == 'solaris10' ||
-            this.state.selectedVersion == 'solaris11' ? (
+              this.state.selectedVersion == 'solaris11' ? (
               <EuiCallOut
                 color='warning'
                 className='message'
@@ -1481,412 +1490,412 @@ export const RegisterAgent = withErrorBoundary(
         },
         ...(this.state.selectedOS == 'rpm'
           ? [
-              {
-                title: 'Choose the version',
-                children:
-                  this.state.selectedVersion == 'redhat5' ||
+            {
+              title: 'Choose the version',
+              children:
+                this.state.selectedVersion == 'redhat5' ||
                   this.state.selectedVersion == 'redhat6'
-                    ? buttonGroupWithMessage(
-                        'Choose the version',
-                        versionButtonsRedHat,
-                        this.state.selectedVersion,
-                        version => this.setVersion(version),
-                      )
-                    : buttonGroup(
-                        'Choose the version',
-                        versionButtonsRedHat,
-                        this.state.selectedVersion,
-                        version => this.setVersion(version),
-                      ),
-              },
-            ]
+                  ? buttonGroupWithMessage(
+                    'Choose the version',
+                    versionButtonsRedHat,
+                    this.state.selectedVersion,
+                    version => this.setVersion(version),
+                  )
+                  : buttonGroup(
+                    'Choose the version',
+                    versionButtonsRedHat,
+                    this.state.selectedVersion,
+                    version => this.setVersion(version),
+                  ),
+            },
+          ]
           : []),
         ...(this.state.selectedOS == 'oraclelinux'
           ? [
-              {
-                title: 'Choose the version',
-                children: buttonGroup(
-                  'Choose the version',
-                  versionButtonsOracleLinux,
-                  this.state.selectedVersion,
-                  version => this.setVersion(version),
-                ),
-              },
-            ]
+            {
+              title: 'Choose the version',
+              children: buttonGroup(
+                'Choose the version',
+                versionButtonsOracleLinux,
+                this.state.selectedVersion,
+                version => this.setVersion(version),
+              ),
+            },
+          ]
           : []),
         ...(this.state.selectedOS == 'raspbian'
           ? [
-              {
-                title: 'Choose the version',
-                children: buttonGroup(
-                  'Choose the version',
-                  versionButtonsRaspbian,
-                  this.state.selectedVersion,
-                  version => this.setVersion(version),
-                ),
-              },
-            ]
+            {
+              title: 'Choose the version',
+              children: buttonGroup(
+                'Choose the version',
+                versionButtonsRaspbian,
+                this.state.selectedVersion,
+                version => this.setVersion(version),
+              ),
+            },
+          ]
           : []),
         ...(this.state.selectedOS == 'amazonlinux'
           ? [
-              {
-                title: 'Choose the version',
-                children: buttonGroup(
-                  'Choose the version',
-                  versionButtonAmazonLinux,
-                  this.state.selectedVersion,
-                  version => this.setVersion(version),
-                ),
-              },
-            ]
+            {
+              title: 'Choose the version',
+              children: buttonGroup(
+                'Choose the version',
+                versionButtonAmazonLinux,
+                this.state.selectedVersion,
+                version => this.setVersion(version),
+              ),
+            },
+          ]
           : []),
         ...(this.state.selectedOS == 'cent'
           ? [
-              {
-                title: 'Choose the version',
-                children:
-                  this.state.selectedVersion == 'centos5' ||
+            {
+              title: 'Choose the version',
+              children:
+                this.state.selectedVersion == 'centos5' ||
                   this.state.selectedVersion == 'centos6'
-                    ? buttonGroupWithMessage(
-                        'Choose the version',
-                        versionButtonsCentos,
-                        this.state.selectedVersion,
-                        version => this.setVersion(version),
-                      )
-                    : buttonGroup(
-                        'Choose the version',
-                        versionButtonsCentos,
-                        this.state.selectedVersion,
-                        version => this.setVersion(version),
-                      ),
-              },
-            ]
+                  ? buttonGroupWithMessage(
+                    'Choose the version',
+                    versionButtonsCentos,
+                    this.state.selectedVersion,
+                    version => this.setVersion(version),
+                  )
+                  : buttonGroup(
+                    'Choose the version',
+                    versionButtonsCentos,
+                    this.state.selectedVersion,
+                    version => this.setVersion(version),
+                  ),
+            },
+          ]
           : []),
         ...(this.state.selectedOS == 'fedora'
           ? [
-              {
-                title: 'Choose the version',
-                children: buttonGroup(
-                  'Choose the version',
-                  versionButtonFedora,
-                  this.state.selectedVersion,
-                  version => this.setVersion(version),
-                ),
-              },
-            ]
+            {
+              title: 'Choose the version',
+              children: buttonGroup(
+                'Choose the version',
+                versionButtonFedora,
+                this.state.selectedVersion,
+                version => this.setVersion(version),
+              ),
+            },
+          ]
           : []),
         ...(this.state.selectedOS == 'deb'
           ? [
-              {
-                title: 'Choose the version',
-                children:
-                  this.state.selectedVersion == 'debian7' ||
+            {
+              title: 'Choose the version',
+              children:
+                this.state.selectedVersion == 'debian7' ||
                   this.state.selectedVersion == 'debian8' ||
                   this.state.selectedVersion == 'debian9' ||
                   this.state.selectedVersion == 'debian10'
-                    ? buttonGroupWithMessage(
-                        'Choose the version',
-                        versionButtonsDebian,
-                        this.state.selectedVersion,
-                        version => this.setVersion(version),
-                      )
-                    : buttonGroup(
-                        'Choose the version',
-                        versionButtonsDebian,
-                        this.state.selectedVersion,
-                        version => this.setVersion(version),
-                      ),
-              },
-            ]
+                  ? buttonGroupWithMessage(
+                    'Choose the version',
+                    versionButtonsDebian,
+                    this.state.selectedVersion,
+                    version => this.setVersion(version),
+                  )
+                  : buttonGroup(
+                    'Choose the version',
+                    versionButtonsDebian,
+                    this.state.selectedVersion,
+                    version => this.setVersion(version),
+                  ),
+            },
+          ]
           : []),
         ...(this.state.selectedOS == 'ubu'
           ? [
-              {
-                title: 'Choose the version',
-                children:
-                  this.state.selectedVersion == 'ubuntu14'
-                    ? buttonGroupWithMessage(
-                        'Choose the version',
-                        versionButtonsUbuntu,
-                        this.state.selectedVersion,
-                        version => this.setVersion(version),
-                      )
-                    : buttonGroup(
-                        'Choose the version',
-                        versionButtonsUbuntu,
-                        this.state.selectedVersion,
-                        version => this.setVersion(version),
-                      ),
-              },
-            ]
+            {
+              title: 'Choose the version',
+              children:
+                this.state.selectedVersion == 'ubuntu14'
+                  ? buttonGroupWithMessage(
+                    'Choose the version',
+                    versionButtonsUbuntu,
+                    this.state.selectedVersion,
+                    version => this.setVersion(version),
+                  )
+                  : buttonGroup(
+                    'Choose the version',
+                    versionButtonsUbuntu,
+                    this.state.selectedVersion,
+                    version => this.setVersion(version),
+                  ),
+            },
+          ]
           : []),
         ...(this.state.selectedOS == 'win'
           ? [
-              {
-                title: 'Choose the version',
-                children:
-                  this.state.selectedVersion == 'windowsxp'
-                    ? buttonGroupWithMessage(
-                        'Choose the version',
-                        versionButtonsWindows,
-                        this.state.selectedVersion,
-                        version => this.setVersion(version),
-                      )
-                    : buttonGroup(
-                        'Choose the version',
-                        versionButtonsWindows,
-                        this.state.selectedVersion,
-                        version => this.setVersion(version),
-                      ),
-              },
-            ]
+            {
+              title: 'Choose the version',
+              children:
+                this.state.selectedVersion == 'windowsxp'
+                  ? buttonGroupWithMessage(
+                    'Choose the version',
+                    versionButtonsWindows,
+                    this.state.selectedVersion,
+                    version => this.setVersion(version),
+                  )
+                  : buttonGroup(
+                    'Choose the version',
+                    versionButtonsWindows,
+                    this.state.selectedVersion,
+                    version => this.setVersion(version),
+                  ),
+            },
+          ]
           : []),
         ...(this.state.selectedOS == 'macos'
           ? [
-              {
-                title: 'Choose the version',
-                children: selectedVersionMac(
-                  'Choose the version',
-                  versionButtonsMacOS,
-                  this.state.selectedVersion,
-                  version => this.setVersion(version),
-                ),
-              },
-            ]
+            {
+              title: 'Choose the version',
+              children: selectedVersionMac(
+                'Choose the version',
+                versionButtonsMacOS,
+                this.state.selectedVersion,
+                version => this.setVersion(version),
+              ),
+            },
+          ]
           : []),
         ...(this.state.selectedOS == 'suse'
           ? [
-              {
-                title: 'Choose the version',
-                children: selectedVersionMac(
-                  'Choose the version',
-                  versionButtonsSuse,
-                  this.state.selectedVersion,
-                  version => this.setVersion(version),
-                ),
-              },
-            ]
+            {
+              title: 'Choose the version',
+              children: selectedVersionMac(
+                'Choose the version',
+                versionButtonsSuse,
+                this.state.selectedVersion,
+                version => this.setVersion(version),
+              ),
+            },
+          ]
           : []),
         ...(this.state.selectedOS == 'open'
           ? [
-              {
-                title: 'Choose the version',
-                children: buttonGroup(
-                  'Choose the version',
-                  versionButtonsOpenSuse,
-                  this.state.selectedVersion,
-                  version => this.setVersion(version),
-                ),
-              },
-            ]
+            {
+              title: 'Choose the version',
+              children: buttonGroup(
+                'Choose the version',
+                versionButtonsOpenSuse,
+                this.state.selectedVersion,
+                version => this.setVersion(version),
+              ),
+            },
+          ]
           : []),
         ...(this.state.selectedOS == 'sol'
           ? [
-              {
-                title: 'Choose the version',
-                children:
-                  this.state.selectedVersion == 'solaris10' ||
+            {
+              title: 'Choose the version',
+              children:
+                this.state.selectedVersion == 'solaris10' ||
                   this.state.selectedVersion == 'solaris11'
-                    ? buttonGroupWithMessage(
-                        'Choose the version',
-                        versionButtonsSolaris,
-                        this.state.selectedVersion,
-                        version => this.setVersion(version),
-                      )
-                    : buttonGroup(
-                        'Choose the version',
-                        versionButtonsSolaris,
-                        this.state.selectedVersion,
-                        version => this.setVersion(version),
-                      ),
-              },
-            ]
+                  ? buttonGroupWithMessage(
+                    'Choose the version',
+                    versionButtonsSolaris,
+                    this.state.selectedVersion,
+                    version => this.setVersion(version),
+                  )
+                  : buttonGroup(
+                    'Choose the version',
+                    versionButtonsSolaris,
+                    this.state.selectedVersion,
+                    version => this.setVersion(version),
+                  ),
+            },
+          ]
           : []),
         ...(this.state.selectedOS == 'aix'
           ? [
-              {
-                title: 'Choose the version',
-                children:
-                  this.state.selectedVersion == '6.1 TL9'
-                    ? buttonGroupWithMessage(
-                        'Choose the version',
-                        versionButtonsAix,
-                        this.state.selectedVersion,
-                        version => this.setVersion(version),
-                      )
-                    : buttonGroup(
-                        'Choose the version',
-                        versionButtonsAix,
-                        this.state.selectedVersion,
-                        version => this.setVersion(version),
-                      ),
-              },
-            ]
+            {
+              title: 'Choose the version',
+              children:
+                this.state.selectedVersion == '6.1 TL9'
+                  ? buttonGroupWithMessage(
+                    'Choose the version',
+                    versionButtonsAix,
+                    this.state.selectedVersion,
+                    version => this.setVersion(version),
+                  )
+                  : buttonGroup(
+                    'Choose the version',
+                    versionButtonsAix,
+                    this.state.selectedVersion,
+                    version => this.setVersion(version),
+                  ),
+            },
+          ]
           : []),
         ...(this.state.selectedOS == 'hp'
           ? [
-              {
-                title: 'Choose the version',
-                children:
-                  this.state.selectedVersion == '11.31'
-                    ? buttonGroupWithMessage(
-                        'Choose the version',
-                        versionButtonsHPUX,
-                        this.state.selectedVersion,
-                        version => this.setVersion(version),
-                      )
-                    : buttonGroup(
-                        'Choose the version',
-                        versionButtonsHPUX,
-                        this.state.selectedVersion,
-                        version => this.setVersion(version),
-                      ),
-              },
-            ]
+            {
+              title: 'Choose the version',
+              children:
+                this.state.selectedVersion == '11.31'
+                  ? buttonGroupWithMessage(
+                    'Choose the version',
+                    versionButtonsHPUX,
+                    this.state.selectedVersion,
+                    version => this.setVersion(version),
+                  )
+                  : buttonGroup(
+                    'Choose the version',
+                    versionButtonsHPUX,
+                    this.state.selectedVersion,
+                    version => this.setVersion(version),
+                  ),
+            },
+          ]
           : []),
         ...(this.state.selectedVersion == 'centos5' ||
-        this.state.selectedVersion == 'redhat5' ||
-        this.state.selectedVersion == 'oraclelinux5' ||
-        this.state.selectedVersion == 'suse11'
+          this.state.selectedVersion == 'redhat5' ||
+          this.state.selectedVersion == 'oraclelinux5' ||
+          this.state.selectedVersion == 'suse11'
           ? [
-              {
-                title: 'Choose the architecture',
-                children: buttonGroup(
-                  'Choose the architecture',
-                  architecturei386Andx86_64,
-                  this.state.selectedArchitecture,
-                  architecture => this.setArchitecture(architecture),
-                ),
-              },
-            ]
+            {
+              title: 'Choose the architecture',
+              children: buttonGroup(
+                'Choose the architecture',
+                architecturei386Andx86_64,
+                this.state.selectedArchitecture,
+                architecture => this.setArchitecture(architecture),
+              ),
+            },
+          ]
           : []),
         ...(this.state.selectedVersion == 'leap15'
           ? [
-              {
-                title: 'Choose the architecture',
-                children: buttonGroup(
-                  'Choose the architecture',
-                  architectureButtonsOpenSuse,
-                  this.state.selectedArchitecture,
-                  architecture => this.setArchitecture(architecture),
-                ),
-              },
-            ]
+            {
+              title: 'Choose the architecture',
+              children: buttonGroup(
+                'Choose the architecture',
+                architectureButtonsOpenSuse,
+                this.state.selectedArchitecture,
+                architecture => this.setArchitecture(architecture),
+              ),
+            },
+          ]
           : []),
         ...(this.state.selectedVersion == 'centos6' ||
-        this.state.selectedVersion == 'oraclelinux6' ||
-        this.state.selectedVersion == 'amazonlinux1' ||
-        this.state.selectedVersion == 'redhat6' ||
-        this.state.selectedVersion == 'amazonlinux2022' ||
-        this.state.selectedVersion == 'debian7' ||
-        this.state.selectedVersion == 'debian8' ||
-        this.state.selectedVersion == 'ubuntu14' ||
-        this.state.selectedVersion == 'ubuntu15' ||
-        this.state.selectedVersion == 'ubuntu16'
+          this.state.selectedVersion == 'oraclelinux6' ||
+          this.state.selectedVersion == 'amazonlinux1' ||
+          this.state.selectedVersion == 'redhat6' ||
+          this.state.selectedVersion == 'amazonlinux2022' ||
+          this.state.selectedVersion == 'debian7' ||
+          this.state.selectedVersion == 'debian8' ||
+          this.state.selectedVersion == 'ubuntu14' ||
+          this.state.selectedVersion == 'ubuntu15' ||
+          this.state.selectedVersion == 'ubuntu16'
           ? [
-              {
-                title: 'Choose the architecture',
-                children: buttonGroup(
-                  'Choose the architecture',
-                  architectureButtons,
-                  this.state.selectedArchitecture,
-                  architecture => this.setArchitecture(architecture),
-                ),
-              },
-            ]
+            {
+              title: 'Choose the architecture',
+              children: buttonGroup(
+                'Choose the architecture',
+                architectureButtons,
+                this.state.selectedArchitecture,
+                architecture => this.setArchitecture(architecture),
+              ),
+            },
+          ]
           : []),
         ...(this.state.selectedVersion == 'centos7' ||
-        this.state.selectedVersion == 'redhat7' ||
-        this.state.selectedVersion == 'amazonlinux2' ||
-        this.state.selectedVersion == 'suse12' ||
-        this.state.selectedVersion == '22' ||
-        this.state.selectedVersion == 'debian9' ||
-        this.state.selectedVersion == 'debian10' ||
-        this.state.selectedVersion == 'busterorgreater'
+          this.state.selectedVersion == 'redhat7' ||
+          this.state.selectedVersion == 'amazonlinux2' ||
+          this.state.selectedVersion == 'suse12' ||
+          this.state.selectedVersion == '22' ||
+          this.state.selectedVersion == 'debian9' ||
+          this.state.selectedVersion == 'debian10' ||
+          this.state.selectedVersion == 'busterorgreater'
           ? [
-              {
-                title: 'Choose the architecture',
-                children: buttonGroup(
-                  'Choose the architecture',
-                  architectureButtonsWithPPC64LE,
-                  this.state.selectedArchitecture,
-                  architecture => this.setArchitecture(architecture),
-                ),
-              },
-            ]
+            {
+              title: 'Choose the architecture',
+              children: buttonGroup(
+                'Choose the architecture',
+                architectureButtonsWithPPC64LE,
+                this.state.selectedArchitecture,
+                architecture => this.setArchitecture(architecture),
+              ),
+            },
+          ]
           : []),
         ...(this.state.selectedVersion == 'windowsxp' ||
-        this.state.selectedVersion == 'windows8'
+          this.state.selectedVersion == 'windows8'
           ? [
-              {
-                title: 'Choose the architecture',
-                children: buttonGroup(
-                  'Choose the architecture',
-                  architectureButtonsi386,
-                  this.state.selectedArchitecture,
-                  architecture => this.setArchitecture(architecture),
-                ),
-              },
-            ]
+            {
+              title: 'Choose the architecture',
+              children: buttonGroup(
+                'Choose the architecture',
+                architectureButtonsi386,
+                this.state.selectedArchitecture,
+                architecture => this.setArchitecture(architecture),
+              ),
+            },
+          ]
           : []),
         ...(this.state.selectedVersion == 'sierra' ||
-        this.state.selectedVersion == 'highSierra' ||
-        this.state.selectedVersion == 'mojave' ||
-        this.state.selectedVersion == 'catalina' ||
-        this.state.selectedVersion == 'bigSur' ||
-        this.state.selectedVersion == 'monterrey' ||
-        this.state.selectedVersion == 'ventura'
+          this.state.selectedVersion == 'highSierra' ||
+          this.state.selectedVersion == 'mojave' ||
+          this.state.selectedVersion == 'catalina' ||
+          this.state.selectedVersion == 'bigSur' ||
+          this.state.selectedVersion == 'monterrey' ||
+          this.state.selectedVersion == 'ventura'
           ? [
-              {
-                title: 'Choose the architecture',
-                children: buttonGroup(
-                  'Choose the architecture',
-                  architectureButtonsMacos,
-                  this.state.selectedArchitecture,
-                  architecture => this.setArchitecture(architecture),
-                ),
-              },
-            ]
+            {
+              title: 'Choose the architecture',
+              children: buttonGroup(
+                'Choose the architecture',
+                architectureButtonsMacos,
+                this.state.selectedArchitecture,
+                architecture => this.setArchitecture(architecture),
+              ),
+            },
+          ]
           : []),
         ...(this.state.selectedVersion == 'solaris10' ||
-        this.state.selectedVersion == 'solaris11'
+          this.state.selectedVersion == 'solaris11'
           ? [
-              {
-                title: 'Choose the architecture',
-                children: buttonGroup(
-                  'Choose the architecture',
-                  architectureButtonsSolaris,
-                  this.state.selectedArchitecture,
-                  architecture => this.setArchitecture(architecture),
-                ),
-              },
-            ]
+            {
+              title: 'Choose the architecture',
+              children: buttonGroup(
+                'Choose the architecture',
+                architectureButtonsSolaris,
+                this.state.selectedArchitecture,
+                architecture => this.setArchitecture(architecture),
+              ),
+            },
+          ]
           : []),
         ...(this.state.selectedVersion == '6.1 TL9'
           ? [
-              {
-                title: 'Choose the architecture',
-                children: buttonGroup(
-                  'Choose the architecture',
-                  architectureButtonsAix,
-                  this.state.selectedArchitecture,
-                  architecture => this.setArchitecture(architecture),
-                ),
-              },
-            ]
+            {
+              title: 'Choose the architecture',
+              children: buttonGroup(
+                'Choose the architecture',
+                architectureButtonsAix,
+                this.state.selectedArchitecture,
+                architecture => this.setArchitecture(architecture),
+              ),
+            },
+          ]
           : []),
         ...(this.state.selectedVersion == '11.31'
           ? [
-              {
-                title: 'Choose the architecture',
-                children: buttonGroup(
-                  'Choose the architecture',
-                  architectureButtonsHpUx,
-                  this.state.selectedArchitecture,
-                  architecture => this.setArchitecture(architecture),
-                ),
-              },
-            ]
+            {
+              title: 'Choose the architecture',
+              children: buttonGroup(
+                'Choose the architecture',
+                architectureButtonsHpUx,
+                this.state.selectedArchitecture,
+                architecture => this.setArchitecture(architecture),
+              ),
+            },
+          ]
           : []),
         {
           title: 'Wazuh server address',
@@ -1902,11 +1911,11 @@ export const RegisterAgent = withErrorBoundary(
         },
         ...(!(!this.state.needsPassword || this.state.hidePasswordInput)
           ? [
-              {
-                title: 'Wazuh password',
-                children: <Fragment>{passwordInput}</Fragment>,
-              },
-            ]
+            {
+              title: 'Wazuh password',
+              children: <Fragment>{passwordInput}</Fragment>,
+            },
+          ]
           : []),
         {
           title: 'Assign a name and a group to the agent',
@@ -1922,6 +1931,12 @@ export const RegisterAgent = withErrorBoundary(
           title: 'Install and enroll the agent',
           children: this.state.gotErrorRegistrationServiceInfo ? (
             calloutErrorRegistrationServiceInfo
+          ) : this.state.agentNameError ? (
+            <EuiCallOut
+              color='danger'
+              title={`There are fields with errors. Please verify them.`}
+              iconType='alert'
+            />
           ) : missingOSSelection.length ? (
             <EuiCallOut
               color='warning'
@@ -1933,37 +1948,41 @@ export const RegisterAgent = withErrorBoundary(
           ),
         },
         ...(this.state.selectedOS == 'rpm' ||
-        this.state.selectedOS == 'cent' ||
-        this.state.selectedOS == 'suse' ||
-        this.state.selectedOS == 'fedora' ||
-        this.state.selectedOS == 'oraclelinux' ||
-        this.state.selectedOS == 'amazonlinux' ||
-        this.state.selectedOS == 'deb' ||
-        this.state.selectedOS == 'raspbian' ||
-        this.state.selectedOS == 'ubu' ||
-        this.state.selectedOS == 'win' ||
-        this.state.selectedOS == 'macos' ||
-        this.state.selectedOS == 'open' ||
-        this.state.selectedOS == 'sol' ||
-        this.state.selectedOS == 'aix' ||
-        this.state.selectedOS == 'hp'
+          this.state.selectedOS == 'cent' ||
+          this.state.selectedOS == 'suse' ||
+          this.state.selectedOS == 'fedora' ||
+          this.state.selectedOS == 'oraclelinux' ||
+          this.state.selectedOS == 'amazonlinux' ||
+          this.state.selectedOS == 'deb' ||
+          this.state.selectedOS == 'raspbian' ||
+          this.state.selectedOS == 'ubu' ||
+          this.state.selectedOS == 'win' ||
+          this.state.selectedOS == 'macos' ||
+          this.state.selectedOS == 'open' ||
+          this.state.selectedOS == 'sol' ||
+          this.state.selectedOS == 'aix' ||
+          this.state.selectedOS == 'hp'
           ? [
-              {
-                title: 'Start the agent',
-                children: this.state.gotErrorRegistrationServiceInfo ? (
-                  calloutErrorRegistrationServiceInfo
-                ) : missingOSSelection.length ? (
-                  <EuiCallOut
-                    color='warning'
-                    title={`Please select the ${missingOSSelection.join(
-                      ', ',
-                    )}.`}
-                    iconType='iInCircle'
-                  />
-                ) : (
-                  <EuiTabbedContent
-                    tabs={
-                      this.state.selectedVersion == 'redhat7' ||
+            {
+              title: 'Start the agent',
+              children: this.state.gotErrorRegistrationServiceInfo ? (
+                calloutErrorRegistrationServiceInfo
+              ) : this.state.agentNameError ? (
+                <EuiCallOut
+                  color='danger'
+                  title={`There are fields with errors. Please verify them.`}
+                  iconType='alert'
+                />
+              ) : missingOSSelection.length ? (
+                <EuiCallOut
+                  color='warning'
+                  title={`Please select the ${missingOSSelection.join(', ')}.`}
+                  iconType='iInCircle'
+                />
+              ) : (
+                <EuiTabbedContent
+                  tabs={
+                    this.state.selectedVersion == 'redhat7' ||
                       this.state.selectedVersion == 'amazonlinux2022' ||
                       this.state.selectedVersion == 'centos7' ||
                       this.state.selectedVersion == 'suse11' ||
@@ -1978,9 +1997,9 @@ export const RegisterAgent = withErrorBoundary(
                       this.state.selectedVersion === 'ubuntu15' ||
                       this.state.selectedVersion === 'ubuntu16' ||
                       this.state.selectedVersion === 'leap15'
-                        ? tabSystemD
-                        : this.state.selectedVersion == 'windowsxp' ||
-                          this.state.selectedVersion == 'windows8'
+                      ? tabSystemD
+                      : this.state.selectedVersion == 'windowsxp' ||
+                        this.state.selectedVersion == 'windows8'
                         ? tabNet
                         : this.state.selectedVersion == 'sierra' ||
                           this.state.selectedVersion == 'highSierra' ||
@@ -1989,66 +2008,66 @@ export const RegisterAgent = withErrorBoundary(
                           this.state.selectedVersion == 'bigSur' ||
                           this.state.selectedVersion == 'monterrey' ||
                           this.state.selectedVersion == 'ventura'
-                        ? tabWazuhControlMacos
-                        : this.state.selectedVersion == 'solaris10' ||
-                          this.state.selectedVersion == 'solaris11' ||
-                          this.state.selectedVersion == '6.1 TL9' ||
-                          this.state.selectedVersion == '11.31'
-                        ? tabWazuhControl
-                        : tabSysV
-                    }
-                    selectedTab={this.selectedSYS}
-                    onTabClick={onTabClick}
-                  />
-                ),
-              },
-            ]
+                          ? tabWazuhControlMacos
+                          : this.state.selectedVersion == 'solaris10' ||
+                            this.state.selectedVersion == 'solaris11' ||
+                            this.state.selectedVersion == '6.1 TL9' ||
+                            this.state.selectedVersion == '11.31'
+                            ? tabWazuhControl
+                            : tabSysV
+                  }
+                  selectedTab={this.selectedSYS}
+                  onTabClick={onTabClick}
+                />
+              ),
+            },
+          ]
           : []),
 
         ...(!missingOSSelection.length &&
-        this.state.selectedOS !== 'rpm' &&
-        this.state.selectedOS !== 'deb' &&
-        this.state.selectedOS !== 'cent' &&
-        this.state.selectedOS !== 'ubu' &&
-        this.state.selectedOS !== 'win' &&
-        this.state.selectedOS !== 'macos' &&
-        this.state.selectedOS !== 'open' &&
-        this.state.selectedOS !== 'sol' &&
-        this.state.selectedOS !== 'aix' &&
-        this.state.selectedOS !== 'hp' &&
-        this.state.selectedOS !== 'amazonlinux' &&
-        this.state.selectedOS !== 'fedora' &&
-        this.state.selectedOS !== 'oraclelinux' &&
-        this.state.selectedOS !== 'suse' &&
-        this.state.selectedOS !== 'raspbian' &&
-        restartAgentCommand
+          this.state.selectedOS !== 'rpm' &&
+          this.state.selectedOS !== 'deb' &&
+          this.state.selectedOS !== 'cent' &&
+          this.state.selectedOS !== 'ubu' &&
+          this.state.selectedOS !== 'win' &&
+          this.state.selectedOS !== 'macos' &&
+          this.state.selectedOS !== 'open' &&
+          this.state.selectedOS !== 'sol' &&
+          this.state.selectedOS !== 'aix' &&
+          this.state.selectedOS !== 'hp' &&
+          this.state.selectedOS !== 'amazonlinux' &&
+          this.state.selectedOS !== 'fedora' &&
+          this.state.selectedOS !== 'oraclelinux' &&
+          this.state.selectedOS !== 'suse' &&
+          this.state.selectedOS !== 'raspbian' &&
+          restartAgentCommand
           ? [
-              {
-                title: 'Start the agent',
-                children: this.state.gotErrorRegistrationServiceInfo ? (
-                  calloutErrorRegistrationServiceInfo
-                ) : (
-                  <EuiFlexGroup direction='column'>
-                    <EuiText>
-                      <div className='copy-codeblock-wrapper'>
-                        <EuiCodeBlock style={codeBlock} language={language}>
-                          {restartAgentCommand}
-                        </EuiCodeBlock>
-                        <EuiCopy textToCopy={restartAgentCommand}>
-                          {copy => (
-                            <div className='copy-overlay' onClick={copy}>
-                              <p>
-                                <EuiIcon type='copy' /> Copy command
-                              </p>
-                            </div>
-                          )}
-                        </EuiCopy>
-                      </div>
-                    </EuiText>
-                  </EuiFlexGroup>
-                ),
-              },
-            ]
+            {
+              title: 'Start the agent',
+              children: this.state.gotErrorRegistrationServiceInfo ? (
+                calloutErrorRegistrationServiceInfo
+              ) : (
+                <EuiFlexGroup direction='column'>
+                  <EuiText>
+                    <div className='copy-codeblock-wrapper'>
+                      <EuiCodeBlock style={codeBlock} language={language}>
+                        {restartAgentCommand}
+                      </EuiCodeBlock>
+                      <EuiCopy textToCopy={restartAgentCommand}>
+                        {copy => (
+                          <div className='copy-overlay' onClick={copy}>
+                            <p>
+                              <EuiIcon type='copy' /> Copy command
+                            </p>
+                          </div>
+                        )}
+                      </EuiCopy>
+                    </div>
+                  </EuiText>
+                </EuiFlexGroup>
+              ),
+            },
+          ]
           : []),
       ];
 

--- a/public/controllers/agent/components/register-agent.js
+++ b/public/controllers/agent/components/register-agent.js
@@ -297,13 +297,14 @@ export const RegisterAgent = withErrorBoundary(
     }
 
     setAgentName(event) {
+      const validation = /^[a-z0-9-_.]+$/i;
       this.setState({ agentName: event.target.value });
-      if (/^[a-z0-9-_.]+$/i.test(event.target.value) || event.target.value.length <= 0) {
+      if (validation.test(event.target.value) || event.target.value.length <= 0) {
         this.setState({ agentNameError: false });
         this.setState({ badCharacters: [] });
       } else {
         let badCharacters = event.target.value.split('').map(char =>
-          char.replace(/^[a-z0-9-_.]+$/i, '')).join('');
+          char.replace(validation, '')).join('');
         badCharacters = badCharacters.split('').map(char =>
           char.replace(/\s/, 'whitespace'));
         const characters = [...new Set(badCharacters)];


### PR DESCRIPTION
# Description
This PR aims to add a validation to the agent name, in order to avoid entering incorrect names that may cause errors in different places of the app.

# Issues Resolved
https://github.com/wazuh/wazuh-kibana-app/issues/4927

# Evidence 
![image](https://user-images.githubusercontent.com/42900763/208713567-559e1747-664e-475a-b00c-c708624fb5a6.png)
![image](https://user-images.githubusercontent.com/42900763/208713590-9ea5a5a3-c1cf-4ee0-a96a-eeeeba2cc4f6.png)
![image](https://user-images.githubusercontent.com/42900763/208713598-5f69c6b7-8d62-4274-94c8-a72e90950d14.png)

# Test
**Scenario:** have a Wazuh environment and navigate to agents/deploy new agent
**When** the users enter a name with [invalid characters](https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/client.html#agent-name)
**Then** it should show an error telling that, and not show the deploy commands

### Check List
- [x] All tests pass
  - [x] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff 