### PR TITLE
Add length validation to agent name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Added extra steps message and new command for windows xp and windows server 2008, added alpine agent with all its steps. [#4933](https://github.com/wazuh/wazuh-kibana-app/pull/4933)
 - Deploy new agent section: Added link for additional steps to alpine os. [#4933](https://github.com/wazuh/wazuh-kibana-app/pull/4933)
 - Added file saving conditions in File Editor [#4970](https://github.com/wazuh/wazuh-kibana-app/pull/4970)
-- Added character validation to avoid invalid agent names in the section 'Deploy new agent'. [#5021](https://github.com/wazuh/wazuh-kibana-app/pull/5021)[#5028](https://github.com/wazuh/wazuh-kibana-app/pull/5028)
+- Added character validation to avoid invalid agent names in the section 'Deploy new agent'. [#5021](https://github.com/wazuh/wazuh-kibana-app/pull/5021) [#5028](https://github.com/wazuh/wazuh-kibana-app/pull/5028)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Added a centralized service to handle the requests [#4831](https://github.com/wazuh/wazuh-kibana-app/pull/4831)
 - Added data-test-subj create policy [#4873](https://github.com/wazuh/wazuh-kibana-app/pull/4873)
 - Added file saving conditions in File Editor [#4970](https://github.com/wazuh/wazuh-kibana-app/pull/4970)
-- Added character validation to avoid invalid agent names in the section 'Deploy new agent'. [#5021](https://github.com/wazuh/wazuh-kibana-app/pull/5021)
+- Added character validation to avoid invalid agent names in the section 'Deploy new agent'. [#5021](https://github.com/wazuh/wazuh-kibana-app/pull/5021)[#5028](https://github.com/wazuh/wazuh-kibana-app/pull/5028)
 
 ### Changed
 

--- a/public/controllers/agent/components/register-agent.js
+++ b/public/controllers/agent/components/register-agent.js
@@ -298,18 +298,15 @@ export const RegisterAgent = withErrorBoundary(
 
     setAgentName(event) {
       const validation = /^[a-z0-9-_.]+$/i;
-      this.setState({ agentName: event.target.value });
       if (validation.test(event.target.value) || event.target.value.length <= 0) {
-        this.setState({ agentNameError: false });
-        this.setState({ badCharacters: [] });
+        this.setState({ agentName: event.target.value, agentNameError: false, badCharacters: [] });
       } else {
         let badCharacters = event.target.value.split('').map(char =>
           char.replace(validation, '')).join('');
         badCharacters = badCharacters.split('').map(char =>
           char.replace(/\s/, 'whitespace'));
         const characters = [...new Set(badCharacters)];
-        this.setState({ badCharacters: characters });
-        this.setState({ agentNameError: true });
+        this.setState({ agentName: event.target.value, badCharacters: characters, agentNameError: true });
       }
     }
 

--- a/public/controllers/agent/components/register-agent.js
+++ b/public/controllers/agent/components/register-agent.js
@@ -298,15 +298,24 @@ export const RegisterAgent = withErrorBoundary(
 
     setAgentName(event) {
       const validation = /^[a-z0-9-_.]+$/i;
-      if (validation.test(event.target.value) || event.target.value.length <= 0) {
-        this.setState({ agentName: event.target.value, agentNameError: false, badCharacters: [] });
+      if ((validation.test(event.target.value) && event.target.value.length >= 2)
+        || event.target.value.length <= 0) {
+        this.setState({
+          agentName: event.target.value,
+          agentNameError: false,
+          badCharacters: []
+        });
       } else {
         let badCharacters = event.target.value.split('').map(char =>
           char.replace(validation, '')).join('');
         badCharacters = badCharacters.split('').map(char =>
           char.replace(/\s/, 'whitespace'));
         const characters = [...new Set(badCharacters)];
-        this.setState({ agentName: event.target.value, badCharacters: characters, agentNameError: true });
+        this.setState({
+          agentName: event.target.value,
+          badCharacters: characters,
+          agentNameError: true
+        });
       }
     }
 
@@ -874,7 +883,8 @@ export const RegisterAgent = withErrorBoundary(
         <EuiForm>
           <EuiFormRow
             isInvalid={this.state.agentNameError}
-            error={[`The character${this.state.badCharacters.length <= 1 ? ('') : ('s')}
+            error={[this.state.badCharacters.length < 1 ? 'The minimum length is 2 characters.' :
+              `The character${this.state.badCharacters.length <= 1 ? ('') : ('s')}
             ${this.state.badCharacters.map(char => ` "${char}"`)}
             ${this.state.badCharacters.length <= 1 ? ('is') : ('are')}
             not valid. Allowed characters are A-Z, a-z, ".", "-", "_"`]}>


### PR DESCRIPTION
### Description
This PR aims to add length validation to the agent name, in order to avoid entering incorrect names that may cause errors in different places of the app.
 
### Issues Resolved
https://github.com/wazuh/wazuh-kibana-app/issues/4927

### Evidence
![image](https://user-images.githubusercontent.com/42900763/208961701-65e83bc7-84f7-4d8f-88d7-d4bbf83ae091.png)
![image](https://user-images.githubusercontent.com/42900763/208961237-c5d1ff4b-2ead-4300-aadb-be3850bc7744.png)
![image](https://user-images.githubusercontent.com/42900763/208961255-7297a238-80fa-41a2-935e-2b49d25132ec.png)

### Test
Scenario: have a Wazuh environment and navigate to agents/deploy new agent
When the users enter a name shorter than 2 characters
Then it should show an error telling that, and not show the deploy commands

Scenario: have a Wazuh environment and navigate to agents/deploy new agent
When the users doesn't enter any name 
Then it should not show any errors and should show the deploy commands.

### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff 
