### PR TITLE
backport-4933-to-4.4-7.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Added powerPC architecture in redhat7, in the section 'Deploy new agent'. [4833](https://github.com/wazuh/wazuh-kibana-app/pull/4833)
 - Added a centralized service to handle the requests [#4831](https://github.com/wazuh/wazuh-kibana-app/pull/4831)
 - Added data-test-subj create policy [#4873](https://github.com/wazuh/wazuh-kibana-app/pull/4873)
+- Added extra steps message and new command for windows xp and windows server 2008, added alpine agent with all its steps. [#4933](https://github.com/wazuh/wazuh-kibana-app/pull/4933)
+- Deploy new agent section: Added link for additional steps to alpine os. [#4933](https://github.com/wazuh/wazuh-kibana-app/pull/4933)
 - Added file saving conditions in File Editor [#4970](https://github.com/wazuh/wazuh-kibana-app/pull/4970)
 
 ### Changed
@@ -50,6 +52,11 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fixed WAZUH_PROTOCOL param suggestion [#4849](https://github.com/wazuh/wazuh-kibana-app/pull/4849)
 - Raspbian OS, Ubuntu, Amazon Linux and Amazon Linux 2 commands in the wizard deploy agent now change when a different architecture is selected [#4876](https://github.com/wazuh/wazuh-kibana-app/pull/4876) [#4880](https://github.com/wazuh/wazuh-kibana-app/pull/4880)
 - Fixed the agents wizard OS styles and their versions. [#4832](https://github.com/wazuh/wazuh-kibana-app/pull/4832) [#4838](https://github.com/wazuh/wazuh-kibana-app/pull/4838)
+- Fixed the manager option in the agent deployment section [#4981](https://github.com/wazuh/wazuh-kibana-app/pull/4981)
+- Fixed commands in the deploy new agent section(most of the commands are missing '-1') [#4962](https://github.com/wazuh/wazuh-kibana-app/pull/4962)
+- Fixed agent installation command for macOS in the deploy new agent section. [#4968](https://github.com/wazuh/wazuh-kibana-app/pull/4968)
+- Deploy new agent section: Fixed the way macos versions and architectures were displayed, fixed the way agents were displayed, fixed the way ubuntu versions were displayed. [#4933](https://github.com/wazuh/wazuh-kibana-app/pull/4933)
+- Fixed agent deployment instructions for HP-UX and Solaris. [#4943](https://github.com/wazuh/wazuh-kibana-app/pull/4943)
 - Fixed Inventory checks table filters by stats [#4999](https://github.com/wazuh/wazuh-kibana-app/pull/4999)
 - Fixed agent installation command for macOS in the deploy new agent section. [#4983](https://github.com/wazuh/wazuh-kibana-app/pull/4983)
 - Fixed commands in the deploy new agent section(most of the commands are missing '-1') [#4962](https://github.com/wazuh/wazuh-kibana-app/pull/4962)

--- a/public/controllers/agent/components/wz-accordion.tsx
+++ b/public/controllers/agent/components/wz-accordion.tsx
@@ -1,0 +1,59 @@
+import React, { useState } from 'react';
+import {
+  EuiPanel,
+  EuiSpacer,
+  EuiAccordion,
+  EuiButtonGroup,
+  htmlIdGenerator,
+} from '@elastic/eui';
+import { osButtons } from '../wazuh-config';
+
+export const PrincipalButtonGroup = ({
+  legend,
+  options,
+  idSelected,
+  onChange,
+}) => {
+  return (
+    <>
+      <EuiButtonGroup
+        color='primary'
+        legend={legend}
+        options={options}
+        idSelected={idSelected}
+        onChange={onChange}
+        className={'osButtonsStyle'}
+      />
+      <EuiSpacer size='l' />
+      <WzAccordion>
+        <EuiButtonGroup
+          color='primary'
+          legend={legend}
+          options={osButtons}
+          idSelected={idSelected}
+          onChange={onChange}
+          className={'osButtonsStyle'}
+        />
+      </WzAccordion>
+    </>
+  );
+};
+
+export const WzAccordion = ({ children }) => {
+  const [isAccordionOpen, setIsAccordionOpen] = useState(false);
+  const rightArrowAccordionId = htmlIdGenerator('wz-accordion')();
+  return (
+    <EuiAccordion
+      id={rightArrowAccordionId}
+      arrowDisplay='left'
+      buttonContent={isAccordionOpen ? 'Show less' : 'Show more'}
+      onToggle={(isOpen: boolean) => setIsAccordionOpen(isOpen)}
+      className={'action-btn-td'}
+    >
+      <EuiSpacer size='l' />
+      <EuiPanel className={'wz-border-none'} color='subdued'>
+        {children}
+      </EuiPanel>
+    </EuiAccordion>
+  );
+};

--- a/public/controllers/agent/wazuh-config/index.ts
+++ b/public/controllers/agent/wazuh-config/index.ts
@@ -40,12 +40,11 @@ const architectureButtonsWithPPC64LE = [
   },
 ];
 
-
 const architectureButtonsi386 = [
   {
     id: 'i386',
     label: 'i386',
-  }
+  },
 ];
 
 const architecturei386Andx86_64 = [
@@ -67,19 +66,15 @@ const architectureButtonsSolaris = [
   {
     id: 'sparc',
     label: 'SPARC',
-  }
+  },
 ];
 
 const architectureButtonsMacos = [
   {
-    id: 'intel',
-    label: 'Intel'
+    id: 'intel/applesilicon',
+    label: 'Intel/Apple Silicon',
   },
-  {
-    id: 'applesilicon',
-    label: 'Apple Silicon'
-  }
-]
+];
 
 const architectureButtonsOpenSuse = [
   {
@@ -89,21 +84,21 @@ const architectureButtonsOpenSuse = [
   {
     id: 'ARM64',
     label: 'ARM64',
-  }
+  },
 ];
 
 const architectureButtonsAix = [
   {
     id: 'powerpc',
     label: 'PowerPC',
-  }
+  },
 ];
 
 const architectureButtonsHpUx = [
   {
     id: 'itanium2',
     label: 'Itanium2',
-  }
+  },
 ];
 
 const versionButtonAmazonLinux = [
@@ -118,8 +113,8 @@ const versionButtonAmazonLinux = [
   {
     id: 'amazonlinux2022',
     label: 'Amazon Linux 2022',
-  }
-]
+  },
+];
 
 const versionButtonsRedHat = [
   {
@@ -167,15 +162,15 @@ const versionButtonsDebian = [
   {
     id: 'debian10',
     label: 'Debian 10 or higher',
-  }
+  },
 ];
 
 const versionButtonFedora = [
   {
     id: '22',
-    label: 'Fedora 22 or later'
-  }
-]
+    label: 'Fedora 22 or higher',
+  },
+];
 
 const versionButtonsUbuntu = [
   {
@@ -184,12 +179,8 @@ const versionButtonsUbuntu = [
   },
   {
     id: 'ubuntu15',
-    label: 'Ubuntu 15',
+    label: 'Ubuntu 15 or higher',
   },
-  {
-    id: 'ubuntu16',
-    label: 'Ubuntu 16 or higher',
-  }
 ];
 
 const versionButtonsWindows = [
@@ -198,9 +189,13 @@ const versionButtonsWindows = [
     label: 'Windows XP',
   },
   {
-    id: 'windows8',
-    label: 'Windows 8 or higher',
-  }
+    id: 'windowsserver2008',
+    label: 'Windows Server 2008',
+  },
+  {
+    id: 'windows7',
+    label: 'Windows 7 or higher',
+  },
 ];
 
 const versionButtonsSuse = [
@@ -211,36 +206,13 @@ const versionButtonsSuse = [
   {
     id: 'suse12',
     label: 'SUSE 12',
-  }
+  },
 ];
 
 const versionButtonsMacOS = [
   {
     id: 'sierra',
-    label: 'macOS Sierra',
-  },
-  {
-    id: 'highSierra',
-    label: 'macOS High Sierra',
-  },
-  {
-    id: 'mojave',
-    label: 'macOS Mojave',
-  },
-  {
-    id: 'catalina',
-    label: 'macOS Catalina',
-  },
-  {
-    id: 'bigSur',
-    label: 'macOS Big Sur',
-  },
-  {
-    id: 'monterrey',
-    label: 'macOS Monterrey',
-  },
-  { id: 'ventura',
-    label: 'macOS Ventura',
+    label: 'macOS Sierra or higher',
   },
 ];
 
@@ -248,7 +220,7 @@ const versionButtonsOpenSuse = [
   {
     id: 'leap15',
     label: 'OpenSuse Leap 15 or higher',
-  }
+  },
 ];
 
 const versionButtonsSolaris = [
@@ -259,21 +231,21 @@ const versionButtonsSolaris = [
   {
     id: 'solaris11',
     label: 'Solaris 11',
-  }
+  },
 ];
 
 const versionButtonsAix = [
   {
     id: '6.1 TL9',
     label: 'AIX 6.1 TL9 or higher',
-  }
+  },
 ];
 
 const versionButtonsHPUX = [
   {
     id: '11.31',
     label: 'HP-UX 11.31 or higher',
-  }
+  },
 ];
 
 const versionButtonsOracleLinux = [
@@ -283,22 +255,29 @@ const versionButtonsOracleLinux = [
   },
   {
     id: 'oraclelinux6',
-    label: 'Oracle Linux 6 or later',
-  }
+    label: 'Oracle Linux 6 or higher',
+  },
 ];
 
 const versionButtonsRaspbian = [
   {
     id: 'busterorgreater',
     label: 'Raspbian Buster or greater',
-  }
+  },
+];
+
+const versionButtonAlpine = [
+  {
+    id: '3.12.12',
+    label: '3.12.12 or higher',
+  },
 ];
 
 /**
  * Order the OS Buttons Alphabetically by label
- * @param a 
- * @param b 
- * @returns 
+ * @param a
+ * @param b
+ * @returns
  */
 const orderOSAlphabetically = (a, b) => {
   if (a.label.toUpperCase() < b.label.toUpperCase()) {
@@ -308,9 +287,9 @@ const orderOSAlphabetically = (a, b) => {
     return 1;
   }
   return 0;
-}
+};
 
-const osButtons = [
+const osPrincipalButtons = [
   {
     id: 'rpm',
     label: 'Red Hat Enterprise Linux',
@@ -318,10 +297,6 @@ const osButtons = [
   {
     id: 'cent',
     label: 'CentOS',
-  },
-  {
-    id: 'deb',
-    label: 'Debian',
   },
   {
     id: 'ubu',
@@ -335,6 +310,13 @@ const osButtons = [
     id: 'macos',
     label: 'macOS',
   },
+];
+
+const osButtons = [
+  {
+    id: 'deb',
+    label: 'Debian',
+  },
   {
     id: 'open',
     label: 'OpenSuse',
@@ -347,30 +329,62 @@ const osButtons = [
     id: 'aix',
     label: 'AIX',
   },
-  {  
+  {
     id: 'hp',
     label: 'HP-UX',
   },
-  {  
+  {
     id: 'amazonlinux',
     label: 'Amazon Linux',
   },
-  {  
+  {
     id: 'fedora',
     label: 'Fedora',
   },
-  {  
+  {
     id: 'oraclelinux',
     label: 'Oracle Linux',
   },
-  {  
+  {
     id: 'suse',
     label: 'SUSE',
   },
-  {  
+  {
     id: 'raspbian',
     label: 'Raspbian OS',
   },
+  {
+    id: 'alpine',
+    label: 'Alpine',
+  },
 ].sort(orderOSAlphabetically);
 
-export { architectureButtons, architecturei386Andx86_64, versionButtonsRaspbian, versionButtonsSuse, architectureButtonsWithPPC64LE, versionButtonsOracleLinux, versionButtonFedora, versionButtonsRedHat, versionButtonsCentos, architectureButtonsMacos, osButtons, versionButtonsDebian, versionButtonsUbuntu, versionButtonAmazonLinux, versionButtonsWindows, versionButtonsMacOS, versionButtonsOpenSuse, versionButtonsSolaris, versionButtonsAix, versionButtonsHPUX, architectureButtonsi386, architectureButtonsSolaris, architectureButtonsAix, architectureButtonsHpUx, architectureButtonsOpenSuse };
+export {
+  architectureButtons,
+  architecturei386Andx86_64,
+  versionButtonsRaspbian,
+  versionButtonsSuse,
+  architectureButtonsWithPPC64LE,
+  versionButtonsOracleLinux,
+  versionButtonFedora,
+  versionButtonsRedHat,
+  versionButtonsCentos,
+  versionButtonAlpine,
+  architectureButtonsMacos,
+  osButtons,
+  osPrincipalButtons,
+  versionButtonsDebian,
+  versionButtonsUbuntu,
+  versionButtonAmazonLinux,
+  versionButtonsWindows,
+  versionButtonsMacOS,
+  versionButtonsOpenSuse,
+  versionButtonsSolaris,
+  versionButtonsAix,
+  versionButtonsHPUX,
+  architectureButtonsi386,
+  architectureButtonsSolaris,
+  architectureButtonsAix,
+  architectureButtonsHpUx,
+  architectureButtonsOpenSuse,
+};

--- a/public/styles/component.scss
+++ b/public/styles/component.scss
@@ -16,106 +16,122 @@
 
 /* Custom nav bar styles */
 
-.wz-nav-bar .md-nav-bar{
-    height: auto !important;
+.wz-nav-bar .md-nav-bar {
+  height: auto !important;
 }
 
 .wz-nav-item button,
 .wz-no-padding {
-    padding: 0 5px!important;
+  padding: 0 5px !important;
 }
 
 .wz-nav-item button.md-primary {
-    color: rgb(0, 121, 165) !important;
-    background: #f5fafb !important;
-    border-bottom: 2px solid #006BB4;
+  color: rgb(0, 121, 165) !important;
+  background: #f5fafb !important;
+  border-bottom: 2px solid #006bb4;
 }
 
 .wz-nav-item button.md-unselected {
-    color: rgba(0, 0, 0, 0.87) !important;
+  color: rgba(0, 0, 0, 0.87) !important;
 }
 
 .wz-nav-bar md-nav-ink-bar {
-    color: rgb(0, 121, 165) !important;
-    background: rgb(0, 121, 165) !important;
+  color: rgb(0, 121, 165) !important;
+  background: rgb(0, 121, 165) !important;
 }
 
 .wz-nav-bar md-nav-ink-bar._md-left,
 .wz-nav-bar md-nav-ink-bar._md-right {
-    transition: none !important;
+  transition: none !important;
 }
 
 /* Custom tooltip styles */
 
 .wz-tooltip {
-    background-color: rgba(0,0,0,0.87) !important;
-    color: #FFF !important;
+  background-color: rgba(0, 0, 0, 0.87) !important;
+  color: #fff !important;
 }
 
 /* Custom switch styles */
 
 .wz-switch {
-    margin: 0 !important;
+  margin: 0 !important;
 }
 
 /* Custom chips styles */
 
 .wz-chips .md-chips {
-    box-shadow: none !important;
-    padding-bottom: 0;
+  box-shadow: none !important;
+  padding-bottom: 0;
 }
 
 .wz-chip {
-    font-size: 12px;
-    color: white;
-    background-color: #006BB4;
-    height: 26px !important;
-    line-height: 26px !important;
-    margin: 0 8px 0 0 !important;
+  font-size: 12px;
+  color: white;
+  background-color: #006bb4;
+  height: 26px !important;
+  line-height: 26px !important;
+  margin: 0 8px 0 0 !important;
 }
-
 
 .sca-chart-widget {
-    margin: 0 auto;
-    //width:350px;
-    margin-top:50px;
-    background-color: #222D3A;
-    border-radius: 5px;
-    box-shadow: 0px 0px 1px 0px #06060d;
-
+  margin: 0 auto;
+  //width:350px;
+  margin-top: 50px;
+  background-color: #222d3a;
+  border-radius: 5px;
+  box-shadow: 0px 0px 1px 0px #06060d;
 }
 
-.sca-chart-header{
-    background-color: #29384D;
-    height:40px;
-    color:#929DAF;
-    text-align: center;
-    line-height: 40px;
-    border-top-left-radius: 7px;
-    border-top-right-radius: 7px;
-    font-weight: 400;
-    font-size: 1.5em;
-    text-shadow: 1px 1px #06060d;
+.sca-chart-header {
+  background-color: #29384d;
+  height: 40px;
+  color: #929daf;
+  text-align: center;
+  line-height: 40px;
+  border-top-left-radius: 7px;
+  border-top-right-radius: 7px;
+  font-weight: 400;
+  font-size: 1.5em;
+  text-shadow: 1px 1px #06060d;
 }
 
-.sca-chart{
-    padding:12px;
+.sca-chart {
+  padding: 12px;
 }
 
 .sca-chart-shadow {
-    -webkit-filter: drop-shadow( 0px 3px 3px rgba(0,0,0,.5) );
-    filter: drop-shadow( 0px 3px 3px rgba(0,0,0,.5) );
+  -webkit-filter: drop-shadow(0px 3px 3px rgba(0, 0, 0, 0.5));
+  filter: drop-shadow(0px 3px 3px rgba(0, 0, 0, 0.5));
 }
 
 kbn-dis doc-table .kbnDocViewer__warning {
-    display: none;
+  display: none;
 }
 
 /* Custom Breadcrumb styles*/
 .header__breadcrumbsWithExtensionContainer .euiHeaderBreadcrumbs {
-    flex-grow: 1;
-    margin-right: 12px;
+  flex-grow: 1;
+  margin-right: 12px;
 }
 .header__breadcrumbsWithExtensionContainer .header__breadcrumbsAppendExtension {
-    flex-grow: 0;
+  flex-grow: 0;
+}
+
+.osButtonsStyle {
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  grid-gap: 10px;
+}
+
+.osButtonsStyleMac {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  grid-gap: 10px;
+}
+
+.message {
+  margin-top: 10px;
+  display: flex;
+  flex-direction: row;
 }


### PR DESCRIPTION
### Description

- Fixed the way macOS versions and architectures were displayed.
- Fixed the way agents were displayed.
- Fixed the way Ubuntu versions were displayed.
- Added extra steps message and new command for Windows XP and Windows Server 2008
- Added Alpine agent with all its steps.
- Windows command fixed
- CI/CD has [updated](https://github.com/wazuh/wazuh-packages/issues/1625#issuecomment-1357808349) all installation commands, we have also updated them in our code.
 
### Issues Resolved

#4931 