### PR TITLE
Fix errors on closing flyouts in Firefox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,7 +55,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Disabled unmapped fields filter in Security Events alerts table [#4929](https://github.com/wazuh/wazuh-kibana-app/pull/4929)
 - Deploy new agent section: Fixed the way macos versions and architectures were displayed, fixed the way agents were displayed, fixed the way ubuntu versions were displayed. [#4933](https://github.com/wazuh/wazuh-kibana-app/pull/4933)
 - Fixed agent deployment instructions for HP-UX and Solaris. [#4943](https://github.com/wazuh/wazuh-kibana-app/pull/4943)
-- Fixed a bug that caused the flyouts to close when clicking inside them [#4638](https://github.com/wazuh/wazuh-kibana-app/pull/4638)
+- Fixed a bug that caused the flyouts to close when clicking inside them [#4638](https://github.com/wazuh/wazuh-kibana-app/pull/4638) [#5046](https://github.com/wazuh/wazuh-kibana-app/pull/5046)
 - Fixed the manager option in the agent deployment section [#4981](https://github.com/wazuh/wazuh-kibana-app/pull/4981)
 - Fixed commands in the deploy new agent section(most of the commands are missing '-1') [#4962](https://github.com/wazuh/wazuh-kibana-app/pull/4962)
 - Fixed agent installation command for macOS in the deploy new agent section. [#4968](https://github.com/wazuh/wazuh-kibana-app/pull/4968)

--- a/public/components/common/flyouts/wz-flyout.tsx
+++ b/public/components/common/flyouts/wz-flyout.tsx
@@ -11,33 +11,12 @@
  */
 
 import React from 'react';
-import { EuiFlyout, EuiOutsideClickDetector } from '@elastic/eui';
+import { EuiFlyout } from '@elastic/eui';
 
 export const WzFlyout = ({ children, flyoutProps = {}, onClose }) => {
-  const closeFlyout = (ev) => {
-    // Clicking on the flyout or on the flyout selector should not close the flyout.
-    if (
-      ev &&
-      ev.path.some(
-        (element) =>
-          element.classList?.contains('euiFlyout') || element.classList?.contains('euiPanel')
-      )
-    ) {
-      return;
-    }
-    onClose();
-  };
-
   return (
-    <EuiOutsideClickDetector onOutsideClick={closeFlyout}>
-      {/*
-        As the version of Elastic EUI (v34.6.0) has a bug in the EuiOverlayMask component,
-        maskProps is added to avoid the closing of the overlay by the native function, as it contains the bug
-        This bug is fixed in the Elastic EUI version 36.0.0
-      */}
-      <EuiFlyout onClose={onClose} maskProps={{ onClick: () => {} }} {...flyoutProps}>
-        {children}
-      </EuiFlyout>
-    </EuiOutsideClickDetector>
-  );
+    <EuiFlyout onClose={onClose} maskProps={{ onClick: () => {} }} {...flyoutProps} outsideClickCloses={true}>
+      {children}
+    </EuiFlyout>
+  )
 };


### PR DESCRIPTION
### Description
This pull request fixes a problem when closing the flyouts using the Firefox browser.

Previously, we checked if the elements of the `event.path` contains the HTML classes related to the flyouts. The `event.path` is undefined for recent versions of Firefox browser, while others browsers could be defined and work the logic to close the flyout.

The solution removes the EuiOutsideClickDetector component wrapping to EuiFlyout. Now it uses the outsideClickCloses property of EuiFlyout.

The solution must work in all the browsers.
 
### Issues Resolved
Closes #5043

### Evidence
[Provide screenshots or videos to prove this PR solves the issues]

### Test

**For each browser (Google Chrome, Firefox, Safari)**

Tests result template: [pr_5046_template_result_tests.md](https://github.com/wazuh/wazuh-kibana-app/files/10314383/pr_5046_template_result_tests.md)


**Scenario**: Click inside of flyout of Integrity monitoring module should not display any errors in the browser console
**When** The user opens the flyout of the integrity monitoring module
**And** The user clicks inside the flyout
**Then** The browser console should not display any related errors

**Scenario**: Click outside of flyout of Integrity monitoring module should display any errors in the browser console 
**When** The user opens the flyout of the integrity monitoring module
**And** The user clicks outside the flyout
**Then** the flyout should be closed without related errors

**Scenario**: Click inside of flyout of PCI DSS/Controls should not display errors in the browser console
**When** The user opens the flyout of the requirement in PCI DSS/Controls module 
**And** The user clicks inside the flyout
**Then** The browser console should not display any related errors

**Scenario**: Click outside of flyout of PCI DSS/Controls should not display errors in the browser console
**When** The user opens the flyout of the requirement in PCI DSS/Controls module 
**And** The user clicks outside the flyout
**Then** the flyout should be closed without related errors

**Scenario**: Click inside of flyout of GDPR/Controls should not display errors in the browser console
**When** The user opens the flyout of the requirement in GDPR/Controls module 
**And** The user clicks inside the flyout
**Then** The browser console should not display any related errors

**Scenario**: Click outside of flyout of GDPR/Controls should not display errors in the browser console
**When** The user opens the flyout of the requirement in GDPR/Controls module 
**And** The user clicks outside the flyout
**Then** the flyout should be closed without related errors

**Scenario**: Click inside of flyout of HIPAA/Controls should not display errors in the browser console
**When** The user opens the flyout of the requirement in HIPAA/Controls module 
**And** The user clicks inside the flyout
**Then** The browser console should not display related errors

**Scenario**: Click outside of flyout of HIPAA/Controls should not display errors in the browser console
**When** The user opens the flyout of the requirement in HIPAA/Controls module 
**And** The user clicks outside the flyout
**Then** the flyout should be closed without related errors

**Scenario**: Click inside of flyout of NIST 800-53/Controls should not display errors in the browser console
**When** The user opens the flyout of the requirement in NIST 800-53/Controls module 
**And** The user clicks inside the flyout
**Then** The browser console should not display any related errors

**Scenario**: Click outside of flyout of NIST 800-53/Controls should not display errors in the browser console
**When** The user opens the flyout of the requirement in NIST 800-53/Controls module 
**And** The user clicks outside the flyout
**Then** the flyout should be closed without related errors

**Scenario**: Click inside of flyout of TSC/Controls should not display errors in the browser console
**When** The user opens the flyout of the requirement in TSC/Controls module 
**And** The user clicks inside the flyout
**Then** The browser console should not display any related errors

**Scenario**: Click outside of flyout of TSC/Controls should not display errors in the browser console
**When** The user opens the flyout of the requirement in TSC/Controls module 
**And** The user clicks outside the flyout
**Then** the flyout should be closed without related errors

**Scenario**: Click inside of flyout of MITRE ATT&CK/Framework should not display errors in the browser console
**When** The user opens the flyout of the requirement in MITRE ATT&CK/Framework module 
**And** The user clicks inside the flyout
**Then** The browser console should not display any related errors

**Scenario**: Click outside of flyout of MITRE ATT&CK/Framework should not display errors in the browser console
**When** The user opens the flyout of the requirement in MITRE ATT&CK/Framework module 
**And** The user clicks outside the flyout
**Then** the flyout should be closed without related errors

**Scenario**: Click inside of flyout of Security/Users/Create user should not display errors in the browser console
**When** The user opens the flyout of the Security/Users/Create user 
**And** The user clicks inside the flyout
**Then** The browser console should not display any related errors

**Scenario**: Click outside of flyout of Security/Users/Create user should not display errors in the browser console
**When** The user opens the flyout of the Security/Users/Create user
**And** The user clicks outside the flyout
**Then** the flyout should be closed without related errors

**Scenario**: Click outside of flyout of Security/Users/Create user should when there are no saved content should display the confirmation prompt. Cancel confirmation
**When** The user opens the flyout of the Security/Users/Create user
**And** The user clicks outside the flyout
**Then** A confirmation prompt should appear
**And** no related errors are displayed in the browser console
**And** The user clicks on the `Cancel` button
**And** no related errors are displayed in the browser console

**Scenario**: Click outside of flyout of Security/Users/Create user should when there are no saved content should display the confirmation prompt. Accept confirmation
**When** The user opens the flyout of the Security/Users/Create user
**And** The user clicks outside the flyout
**Then** A confirmation prompt should appear
**And** no related errors are displayed in the browser console
**And** The user clicks on the `Aceept` button
**And** no related errors are displayed in the browser console

**Scenario**: Click inside of flyout of Security/Users/Edit user should not display errors in the browser console
**When** The user opens the flyout of the Security/Users/Edit user 
**And** The user clicks inside the flyout
**Then** The browser console should not display any related errors

**Scenario**: Click outside of flyout of Security/Users/Edit user should not display errors in the browser console
**When** The user opens the flyout of the Security/Users/Edit user
**And** The user clicks outside the flyout
**Then** the flyout should be closed without related errors

**Scenario**: Click outside of flyout of Security/Users/Edit user should when there are no saved content should display the confirmation prompt. Cancel confirmation
**When** The user opens the flyout of the Security/Users/Edit user
**And** The user clicks outside the flyout
**Then** A confirmation prompt should appear
**And** no related errors are displayed in the browser console
**And** The user clicks on the `Cancel` button
**And** no related errors are displayed in the browser console

**Scenario**: Click outside of flyout of Security/Users/Edit user should when there are no saved content should display the confirmation prompt. Accept confirmation
**When** The user opens the flyout of the Security/Users/Edit user
**And** The user clicks outside the flyout
**Then** A confirmation prompt should appear
**And** no related errors are displayed in the browser console
**And** The user clicks on the `Cancel` button
**And** no related errors are displayed in the browser console

**Scenario**: Click inside of flyout of Security/Policies/Create policy should not display errors in the browser console
**When** The user opens the flyout of the Security/Policies/Create policy
**And** The user clicks inside the flyout
**Then** The browser console should not display any related errors

**Scenario**: Click outside of flyout of Security/Policies/Create policy should not display errors in the browser console
**When** The user opens the flyout of the Security/Policies/Create policy
**And** The user clicks outside the flyout
**Then** the flyout should be closed without related errors

**Scenario**: Click outside of flyout of Security/Policies/Create policy should when there are no saved content should display the confirmation prompt. Cancel confirmation
**When** The user opens the flyout of the Security/Policies/Create policy
**And** The user clicks outside the flyout
**Then** A confirmation prompt should appear
**And** no related errors are displayed in the browser console
**And** The user clicks on the `Cancel` button
**And** no related errors are displayed in the browser console

**Scenario**: Click outside of flyout of Security/Policies/Create policy should when there are no saved content should display the confirmation prompt. Accept confirmation
**When** The user opens the flyout of the Security/Policies/Create policy
**And** The user clicks outside the flyout
**Then** A confirmation prompt should appear
**And** no related errors are displayed in the browser console
**And** The user clicks on the `Accept` button
**And** no related errors are displayed in the browser console

**Scenario**: Click inside of flyout of Security/Policies/Edit policy should not display errors in the browser console
**When** The user opens the flyout of the Security/Policies/Edit policy
**And** The user clicks inside the flyout
**Then** The browser console should not display any related errors

**Scenario**: Click outside of flyout of Security/Policies/Edit policy should not display errors in the browser console
**When** The user opens the flyout of the Security/Policies/Edit policy
**And** The user clicks outside the flyout
**Then** the flyout should be closed without related errors

**Scenario**: Click outside of flyout of Security/Policies/Edit policy should when there are no saved content should display the confirmation prompt. Cancel confirmation
**When** The user opens the flyout of the Security/Policies/Edit policy
**And** The user clicks outside the flyout
**Then** A confirmation prompt should appear
**And** no related errors are displayed in the browser console
**And** The user clicks on the `Cancel` button
**And** no related errors are displayed in the browser console

**Scenario**: Click outside of flyout of Security/Policies/Edit policy should when there are no saved content should display the confirmation prompt. Accept confirmation
**When** The user opens the flyout of the Security/Policies/Edit policy
**And** The user clicks outside the flyout
**Then** A confirmation prompt should appear
**And** no related errors are displayed in the browser console
**And** The user clicks on the `Accept` button
**And** no related errors are displayed in the browser console

**Scenario**: Click inside of flyout of Security/Roles/Create role should not display errors in the browser console
**When** The user opens the flyout of the Security/Roles/Create role
**And** The user clicks inside the flyout
**Then** The browser console should not display any related errors

**Scenario**: Click outside of flyout of Security/Roles/Create role should not display errors in the browser console
**When** The user opens the flyout of the Security/Roles/Create role
**And** The user clicks outside the flyout
**Then** the flyout should be closed without related errors

**Scenario**: Click outside of flyout of Security/Roles/Create role should when there are no saved content should display the confirmation prompt. Cancel confirmation
**When** The user opens the flyout of the Security/Roles/Create role
**And** The user clicks outside the flyout
**Then** A confirmation prompt should appear
**And** no related errors are displayed in the browser console
**And** The user clicks on the `Cancel` button
**And** no related errors are displayed in the browser console

**Scenario**: Click outside of flyout of Security/Roles/Create role should when there are no saved content should display the confirmation prompt. Accept confirmation
**When** The user opens the flyout of the Security/Roles/Create role
**And** The user clicks outside the flyout
**Then** A confirmation prompt should appear
**And** no related errors are displayed in the browser console
**And** The user clicks on the `Accept` button
**And** no related errors are displayed in the browser console

**Scenario**: Click inside of flyout of Security/Roles/Edit role should not display errors in the browser console
**When** The user opens the flyout of the Security/Roles/Edit role
**And** The user clicks inside the flyout
**Then** The browser console should not display any related errors

**Scenario**: Click outside of flyout of Security/Roles/Edit role should not display errors in the browser console
**When** The user opens the flyout of the Security/Roles/Edit role
**And** The user clicks outside the flyout
**Then** the flyout should be closed without related errors

**Scenario**: Click outside of flyout of Security/Roles/Edit role should when there are no saved content should display the confirmation prompt. Cancel confirmation
**When** The user opens the flyout of the Security/Roles/Edit role
**And** The user clicks outside the flyout
**Then** A confirmation prompt should appear
**And** no related errors are displayed in the browser console
**And** The user clicks on the `Cancel` button
**And** no related errors are displayed in the browser console

**Scenario**: Click outside of flyout of Security/Roles/Edit role should when there are no saved content should display the confirmation prompt. Accept confirmation
**When** The user opens the flyout of the Security/Roles/Edit role
**And** The user clicks outside the flyout
**Then** A confirmation prompt should appear
**And** no related errors are displayed in the browser console
**And** The user clicks on the `Accept` button
**And** no related errors are displayed in the browser console

**Scenario**: Click inside of flyout of Security/Role mapping/Create role mapping should not display errors in the browser console
**When** The user opens the flyout of the Security/Role mapping/Create role mapping
**And** The user clicks inside the flyout
**Then** The browser console should not display any related errors

**Scenario**: Click outside of flyout of Security/Role mapping/Create role mapping should not display errors in the browser console
**When** The user opens the flyout of the Security/Role mapping/Create role mapping
**And** The user clicks outside the flyout
**Then** the flyout should be closed without related errors

**Scenario**: Click outside of flyout of Security/Role mapping/Create role mapping should when there are no saved content should display the confirmation prompt. Cancel confirmation
**When** The user opens the flyout of the Security/Role mapping/Create role mapping
**And** The user clicks outside the flyout
**Then** A confirmation prompt should appear
**And** no related errors are displayed in the browser console
**And** The user clicks on the `Cancel` button
**And** no related errors are displayed in the browser console

**Scenario**: Click outside of flyout of Security/Role mapping/Create role mapping should when there are no saved content should display the confirmation prompt. Accept confirmation
**When** The user opens the flyout of the Security/Role mapping/Create role mapping
**And** The user clicks outside the flyout
**Then** A confirmation prompt should appear
**And** no related errors are displayed in the browser console
**And** The user clicks on the `Accept` button
**And** no related errors are displayed in the browser console

**Scenario**: Click inside of flyout of Security/Role mapping/Edit role mapping should not display errors in the browser console
**When** The user opens the flyout of the Security/Role mapping/Edit role mapping
**And** The user clicks inside the flyout
**Then** The browser console should not display any related errors

**Scenario**: Click outside of flyout of Security/Role mapping/Edit role mapping should not display errors in the browser console
**When** The user opens the flyout of the Security/Role mapping/Edit role mapping
**And** The user clicks outside the flyout
**Then** the flyout should be closed without related errors

**Scenario**: Click outside of flyout of Security/Role mapping/Edit role mapping should when there are no saved content should display the confirmation prompt. Cancel confirmation
**When** The user opens the flyout of the Security/Role mapping/Edit role mapping
**And** The user clicks outside the flyout
**Then** A confirmation prompt should appear
**And** no related errors are displayed in the browser console
**And** The user clicks on the `Cancel` button
**And** no related errors are displayed in the browser console

**Scenario**: Click outside of flyout of Security/Role mapping/Edit role mapping should when there are no saved content should display the confirmation prompt. Accept confirmation
**When** The user opens the flyout of the Security/Role mapping/Edit role mapping
**And** The user clicks outside the flyout
**Then** A confirmation prompt should appear
**And** no related errors are displayed in the browser console
**And** The user clicks on the `Accept` button
**And** no related errors are displayed in the browser console

**Scenario**: Click inside of flyout of rule details in Management/Rules should not display errors in the browser console
**When** The user opens the flyout of rule details in Management/Rules
**And** The user clicks inside the flyout
**Then** The browser console should not display any related errors

**Scenario**: Click outside of flyout of rule details in Management/Rules should not display errors in the browser console
**When** The user opens the flyout of rule details in Management/Rules
**And** The user clicks outside the flyout
**Then** the flyout should be closed without related errors

**Scenario**: Click inside of flyout of decoder details in Management/Decoders should not display errors in the browser console
**When** The user opens the flyout of rule details in Management/Decoders
**And** The user clicks inside the flyout
**Then** The browser console should not display any related errors

**Scenario**: Click outside of flyout of decoder details in Management/Decoders should not display errors in the browser console
**When** The user opens the flyout of rule details in Management/Decoders
**And** The user clicks outside the flyout
**Then** the flyout should be closed without related errors

**Scenario**: Click inside of flyout of Ruleset Test when creating a new rule file in Management/Rules should not display errors in the browser console
**When** The user opens the flyout of Ruleset Test when creating a new rule file in Management/Rules
**And** The user clicks inside the flyout
**Then** The browser console should not display any related errors

**Scenario**: Click outside of flyout of Ruleset Test when creating a new rule file in Management/Rules should not display errors in the browser console
**When** The user opens the flyout of Ruleset Test when creating a new rule file in Management/Rules
**And** The user clicks outside the flyout
**Then** the flyout should be closed without related errors

**Scenario**: Click inside of flyout of Ruleset Test when creating a new decoder file in Management/Decoders should not display errors in the browser console
**When** The user opens the flyout of Ruleset Test when creating a new decoder file in Management/Decoders
**And** The user clicks inside the flyout
**Then** The browser console should not display any related errors

**Scenario**: Click outside of flyout of Ruleset Test when creating a new decoder file in Management/Decoders should not display errors in the browser console
**When** The user opens the flyout of Ruleset Test when creating a new decoder file in Management/Decoders
**And** The user clicks outside the flyout
**Then** the flyout should be closed without related errors

### Check List
- [x] All tests pass
  - [x] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff 
