### PR TITLE
Disable expanded header in Wazuh Dashboard

### DIFF
--- a/docker/osd-dev/config/2.x/osd/opensearch_dashboards.yml
+++ b/docker/osd-dev/config/2.x/osd/opensearch_dashboards.yml
@@ -17,3 +17,6 @@ opensearch.ssl.certificateAuthorities: ["/home/node/kbn/certs/ca.pem"]
 uiSettings.overrides.defaultRoute: /app/wazuh
 opensearch.username: "kibanaserver"
 opensearch.password: "kibanaserver"
+opensearchDashboards.branding:
+  useExpandedHeader: false
+

--- a/public/components/wz-menu/wz-menu.scss
+++ b/public/components/wz-menu/wz-menu.scss
@@ -90,7 +90,6 @@ wz-menu {
 
 .wz-menu-popover{
     position: fixed;
-    top: 105px !important;
     left: 96px !important;
     border-radius: 0px 0px 4px 0px;
     max-height: unset!important;


### PR DESCRIPTION
### Description

This pull requests disables the expanded header (black top bar) by adding this configuration to the `opensearch_dashboards.yml` file
```
opensearchDashboards.branding:
  useExpandedHeader: false
```


### Evidence
With `useExpandedHeader: false`

![image](https://user-images.githubusercontent.com/63758389/209867281-07fc0b88-6b3b-4407-9535-c6b2b7ab6da0.png)

Without `useExpandedHeader: false`

![image](https://user-images.githubusercontent.com/63758389/209867488-9d185694-3922-4b1a-88cc-f5fa0b7cc239.png)


### Test
Start environments and see that the black header has disappeared.

### Check List
- [x] All tests pass
  - [x] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 
