### PR TITLE
Implement new versioning methodology

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+# Bold font and white color for the console.
+Color_Off='\033[0m
+BWhite=\033[1;37m
+
+# Generate tags for a release automatically.
+# Update the tag.py file before running this script.
+tags:
+	@echo "$(BWhite)- Generating Git tags ...$(Color_Off)"
+	@python3 scripts/tag.py >> tags.log
+

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,11 @@
 # Generate tags for a release automatically.
 # Update the tag.py file before running this script.
-tags:
+
+prebuild:
+	@echo "- Updating project's versions ..."
+	@node scripts/generate-build-version
+
+tags: prebuild
 	@echo "- Generating Git tags ..."
 	@python3 scripts/tag.py
 

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,6 @@
-# Bold font and white color for the console.
-Color_Off='\033[0m
-BWhite=\033[1;37m
-
 # Generate tags for a release automatically.
 # Update the tag.py file before running this script.
 tags:
-	@echo "$(BWhite)- Generating Git tags ...$(Color_Off)"
-	@python3 scripts/tag.py >> tags.log
+	@echo "- Generating Git tags ..."
+	@python3 scripts/tag.py
 

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "4.4.0",
   "revision": "00",
   "stage": "alpha",
+  "commit": "f4f8345",
   "pluginPlatform": {
     "version": "2.4.0"
   },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "wazuh",
   "version": "4.4.0",
   "revision": "4400",
-  "code": "4400",
+  "stage": "alpha",
   "pluginPlatform": {
     "version": "2.4.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wazuh",
   "version": "4.4.0",
-  "revision": "4400",
+  "revision": "00",
   "stage": "alpha",
   "pluginPlatform": {
     "version": "2.4.0"

--- a/public/package.test.ts
+++ b/public/package.test.ts
@@ -1,0 +1,50 @@
+import packageValue from '../package.json';
+
+const isNaN = (currentValue: string) => Number.isNaN(Number(currentValue));
+
+describe('package.json version', () => {
+  it('should have a version', () => {
+    expect(packageValue.version).toBeDefined();
+  });
+  it("Wazuh's revision should be to follow the major.minor.patch.pattern.", () => {
+    const versionSplit = packageValue.version.split('.');
+
+    const versionIsNaN = versionSplit.every(isNaN);
+
+    expect(versionSplit.length).toBe(3);
+    expect(versionIsNaN).toBeFalsy();
+  });
+});
+
+describe('package.json revison', () => {
+  it('should have a revison', () => {
+    expect(packageValue.revision).toBeDefined();
+  });
+  it('the revision should be a 2 digit number.', () => {
+    const revision = packageValue.revision;
+
+    const revisionIsNaN = isNaN(revision);
+
+    expect(revision.length).toBe(2);
+    expect(revisionIsNaN).toBeFalsy();
+  });
+});
+
+describe('package.json stage', () => {
+  it('should have a stage', () => {
+    expect(packageValue.stage).toBeDefined();
+  });
+  it('the state should be one of the defined.', () => {
+    const stateDefined = [
+      'pre-alpha',
+      'alpha',
+      'beta',
+      'release-candidate',
+      'stable',
+    ];
+
+    const stage = packageValue.stage;
+
+    expect(stateDefined).toContain(stage);
+  });
+});

--- a/scripts/tag.py
+++ b/scripts/tag.py
@@ -3,63 +3,106 @@ import logging
 import os
 import subprocess
 
-versionOSD = '2.4.1'
-# major.minor.patch
+# ==================== CONFIGURATION ==================== #
+# Values to modify:
+#  - version
+#  - revision
+#  - stage
+#  - supported_versions & kbn_versions ONLY IF NEEDED (e.g. new Kibana version)
+# ======================================================= #
+
+# Wazuh version: major.minor.patch
 version = '4.4.0'
 # App's revision number (previous rev + 1)
 revision = '00'
-# 'pre-alpha','alpha','beta','release-candidate', 'stable'
+# One of 'pre-alpha', 'alpha', 'beta', 'release-candidate', 'stable'
 stage = 'alpha'
-# Base branch
-branch = f'{".".join( version.split(".")[:2])}-{".".join( versionOSD.split(".")[:2])}-wzd'
+
+# Global variable. Will be set later
+branch = None
+minor = ".".join(version.split('.')[:2])
+
+# Supported versions of Kibana
+kbn_versions = [
+    [f'7.16.{x}' for x in range(0, 4)],
+    [f'7.17.{x}' for x in range(0, 9)]
+]
+
+# Platforms versions
+supported_versions = {
+    'OpenDistro': {
+        'branch': f'{minor}-7.10',
+        'versions': ['7.10.2']
+    },
+    'Kibana': {
+        'branch': f'{minor}-7.16',
+        # Flatten 2D list kbn_versions using lists comprehension
+        'versions': [item for sublist in kbn_versions for item in sublist]
+    },
+    'Wazuh Dashboard': {
+        'branch': f'{minor}-2.4-wzd',
+        'versions': ['2.4.1']
+    }
+}
+
 
 def get_git_revision_short_hash() -> str:
     return subprocess.check_output(['git', 'rev-parse', '--short', branch]).decode('ascii').strip()
 
 
 def update_package_json() -> tuple:
-  logging.info(f'Updating package.json')
-  data, success = {}, True
+    logging.info(f'Updating package.json')
+    data, success = {}, True
 
-  # Read JSON and update keys.
-  with open('package.json', 'r') as f:
-    data, success = json.load(f), False
+    # Read JSON and update keys.
+    with open('package.json', 'r') as f:
+        data, success = json.load(f), False
 
+        # Update file
+        data['commit'] = get_git_revision_short_hash()
+        data['version'] = version
+        data['revision'] = revision
+        data['stage'] = stage
 
-    # Update file
-    data['commit'] = get_git_revision_short_hash()
-    data['version'] = version
-    data['revision'] = revision
-    data['stage'] = stage
+    with open('package.json', 'w') as f:
+        json.dump(data, f, indent=2)
 
-  with open('package.json', 'w') as f:
-    json.dump(data, f, indent=2)
+    return data, success
 
-  return data, success
 
 def setup():
-  logging.info(f'Switching to branch {branch} and removing outdated tags...')
-  os.system(f'git checkout {branch}')
-  os.system('git fetch --prune --prune-tags')
+    logging.info(
+        f'Switching to branch "{branch}" and removing outdated tags...')
+    os.system(f'git checkout {branch}')
+    os.system('git fetch --prune --prune-tags')
 
-def main():
-  logging.info(f'Wazuh version is {version}. App revision is {revision}')
-  tag = f'v{version}-{versionOSD}-wzd'
-  logging.info(f'Generating tag {tag}')
-  update_package_json()
-  os.system(f'git commit -am "Bump {tag}"')
-  os.system(f'git tag -a {tag} -m "Wazuh {version} for Opensearch Dashboards {versionOSD}"')
-  logging.info(f'Pushing tag {tag} to remote.')
-  os.system(f'git push origin {tag}')
-  # Undo latest commit
-  os.system(f'git reset --hard origin/{branch}')
+
+def main(platform: str, versions: list):
+    for v in versions:
+        tag = f'v{version}-{v}-{stage}'
+        logging.info(f'Generating tag "{tag}"')
+        update_package_json()
+        os.system(f'git commit -am "Bump {tag}"')
+        os.system(
+            f'git tag -a {tag} -m "Wazuh {version} for {platform} {v}"')
+        logging.info(f'Pushing tag "{tag}" to remote.')
+        os.system(f'git push origin {tag}')
+        # Undo latest commit
+        os.system(f'git reset --hard origin/{branch}')
+    # Save created tags to file
+    os.system(f'git tag | grep -P -i "^v{version}-.*-{stage}" > tags.txt')
 
 
 if __name__ == '__main__':
-  logging.basicConfig(
-    filename='output.log',
-    level=logging.INFO,
-    format='%(asctime)s %(message)s'
-  )
-  setup()
-  main()
+    logging.basicConfig(
+        filename='output.log',
+        level=logging.INFO,
+        format='%(asctime)s %(message)s'
+    )
+    logging.info(
+        f'Wazuh version is "{version}". App revision is "{revision}". Stage is "{stage}"')
+
+    for platform_name, platform_data in supported_versions.items():
+        branch, versions = platform_data['branch'], platform_data['versions']
+        setup()
+        main(platform_name, versions)

--- a/scripts/tag.py
+++ b/scripts/tag.py
@@ -1,0 +1,65 @@
+import json
+import logging
+import os
+import subprocess
+
+versionOSD = '2.4.1'
+# major.minor.patch
+version = '4.4.0'
+# App's revision number (previous rev + 1)
+revision = '00'
+# 'pre-alpha','alpha','beta','release-candidate', 'stable'
+stage = 'alpha'
+# Base branch
+branch = f'{".".join( version.split(".")[:2])}-{".".join( versionOSD.split(".")[:2])}-wzd'
+
+def get_git_revision_short_hash() -> str:
+    return subprocess.check_output(['git', 'rev-parse', '--short', branch]).decode('ascii').strip()
+
+
+def update_package_json() -> tuple:
+  logging.info(f'Updating package.json')
+  data, success = {}, True
+
+  # Read JSON and update keys.
+  with open('package.json', 'r') as f:
+    data, success = json.load(f), False
+
+
+    # Update file
+    data['commit'] = get_git_revision_short_hash()
+    data['version'] = version
+    data['revision'] = revision
+    data['stage'] = stage
+
+  with open('package.json', 'w') as f:
+    json.dump(data, f, indent=2)
+
+  return data, success
+
+def setup():
+  logging.info(f'Switching to branch {branch} and removing outdated tags...')
+  os.system(f'git checkout {branch}')
+  os.system('git fetch --prune --prune-tags')
+
+def main():
+  logging.info(f'Wazuh version is {version}. App revision is {revision}')
+  tag = f'v{version}-{versionOSD}-wzd'
+  logging.info(f'Generating tag {tag}')
+  update_package_json()
+  os.system(f'git commit -am "Bump {tag}"')
+  os.system(f'git tag -a {tag} -m "Wazuh {version} for Opensearch Dashboards {versionOSD}"')
+  logging.info(f'Pushing tag {tag} to remote.')
+  os.system(f'git push origin {tag}')
+  # Undo latest commit
+  os.system(f'git reset --hard origin/{branch}')
+
+
+if __name__ == '__main__':
+  logging.basicConfig(
+    filename='output.log',
+    level=logging.INFO,
+    format='%(asctime)s %(message)s'
+  )
+  setup()
+  main()


### PR DESCRIPTION
### Description

Some of the `package.json` settings were changed, 
for example: 
- `version`: untouched. Follows the major.minor.patch pattern
- `revision`: represents the build number. It is a number of 2 digits, starting at 00 and increased by one each time a package for the same version is built. This value is reset only when the version changes.
- `stage`: replaces the code property which has no actual use. With this property, we'll represent the stage of development at which the package has been built at: pre-alpha (development), alpha, beta, release-candidate or stable (production).
- `commit`: we'll also include the short SHA of the latest commit included in the package (can also be the SHA of the commit used to tag). With this, we'll be able to have a clear reference of what was included in the package.

Tests were added to corroborate the correctness of these settings.

Also, a script to generate the tags automatically has been added.
 
### Issues Resolved

- #5052 

### Evidence
![image](https://user-images.githubusercontent.com/63758389/210250409-1ee3074f-46c6-4dfd-987f-ca9c87b1adb8.png)
![image](https://user-images.githubusercontent.com/63758389/210250430-a265df8e-d443-4ee9-94ad-7367690b00e7.png)


### Test

Check that the `package.json` contains the settings:
- `version`
- `revision`
- `stage`
- `commit`

Verify that the tests are working and if you change the value of these settings to invalid values, the tests will not work.

`package.test.ts`

### Check List
- [x] All tests pass
  - [x] `yarn test:jest`
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 
