### PR TITLE
[Backport 2.4] Fix github agents visualizations id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fixed vulnerabilities default last scan date formatter [#4975](https://github.com/wazuh/wazuh-kibana-app/pull/4975)
 - A solaris command has been fixed [5035](https://github.com/wazuh/wazuh-kibana-app/pull/5035)
 - Fixed commands: Aix, OpenSUSE, Alpine, Suse11, Fedora, HP, Oracle Linux 5, Amazon Linux 2, Centos5. Changed the word 'or higher' in buttons to '+'.Fixed validations for Hp, Solaris and Alpine. [5045](https://github.com/wazuh/wazuh-kibana-app/pull/5045)
+- Fixed error in Github module PDF report. [5069](https://github.com/wazuh/wazuh-kibana-app/pull/5069)
 
 ### Removed
 

--- a/public/components/visualize/agent-visualizations.js
+++ b/public/components/visualize/agent-visualizations.js
@@ -660,12 +660,12 @@ export const agentVisualizations = {
         vis: [
           {
             title: 'Alerts evolution by organization',
-            id: 'Wazuh-App-Overview-GitHub-Alerts-Evolution-By-Organization',
+            id: 'Wazuh-App-Agents-GitHub-Alerts-Evolution-By-Organization',
             width: 60
           },
           {
             title: 'Top 5 organizations by alerts',
-            id: 'Wazuh-App-Overview-GitHub-Top-5-Organizations-By-Alerts',
+            id: 'Wazuh-App-Agents-GitHub-Top-5-Organizations-By-Alerts',
             width: 40
           }
         ]
@@ -675,12 +675,12 @@ export const agentVisualizations = {
         vis: [
           {
             title: 'Top alerts by action type and organization',
-            id: 'Wazuh-App-Overview-GitHub-Alert-Action-Type-By-Organization',
+            id: 'Wazuh-App-Agents-GitHub-Alert-Action-Type-By-Organization',
             width: 40
           },
           {
             title: 'Users with more alerts',
-            id: 'Wazuh-App-Overview-GitHub-Users-With-More-Alerts',
+            id: 'Wazuh-App-Agents-GitHub-Users-With-More-Alerts',
             width: 60
           }
         ]

--- a/server/integration-files/visualizations/agents/agents-github.ts
+++ b/server/integration-files/visualizations/agents/agents-github.ts
@@ -12,7 +12,7 @@
 
 export default [
   {
-    _id: 'Wazuh-App-Overview-GitHub-Alerts-Evolution-By-Organization',
+    _id: 'Wazuh-App-Agents-GitHub-Alerts-Evolution-By-Organization',
     _source: {
       title: 'Alerts evolution by organization',
       visState: JSON.stringify({
@@ -152,7 +152,7 @@ export default [
     _type: 'visualization',
   },
   {
-    _id: 'Wazuh-App-Overview-GitHub-Top-5-Organizations-By-Alerts',
+    _id: 'Wazuh-App-Agents-GitHub-Top-5-Organizations-By-Alerts',
     _source: {
       title: 'Top 5 organizations by alerts',
       visState: JSON.stringify({
@@ -207,7 +207,7 @@ export default [
     _type: 'visualization',
   },
   {
-    _id: 'Wazuh-App-Overview-GitHub-Users-With-More-Alerts',
+    _id: 'Wazuh-App-Agents-GitHub-Users-With-More-Alerts',
     _source: {
       title: 'Users with more alerts',
       visState: JSON.stringify({
@@ -341,7 +341,7 @@ export default [
     _type: 'visualization',
   },
   {
-    _id: 'Wazuh-App-Overview-GitHub-Alert-Action-Type-By-Organization',
+    _id: 'Wazuh-App-Agents-GitHub-Alert-Action-Type-By-Organization',
     _source: {
       title: 'Top alerts by alert action type and organization',
       visState: JSON.stringify({
@@ -412,7 +412,7 @@ export default [
     _type: 'visualization',
   },
   {
-    _id: 'Wazuh-App-Overview-GitHub-Alert-Summary',
+    _id: 'Wazuh-App-Agents-GitHub-Alert-Summary',
     _source: {
       title: 'Alerts summary',
       visState: JSON.stringify({


### PR DESCRIPTION
### Description
Team,
 
this PR fixes an exception when selecting an agent or removing a pinned agent and later generating a PDF report in the dashboard.
The problem was that the agents visualizations had exactly the same HTML ID as the overview visualizations, therefore when angularJS updated the state it didn't create a new instance of the visualization component.


### Issues Resolved
Closes #5065 

### Evidence
![Peek 2023-01-04 17-38](https://user-images.githubusercontent.com/9343732/210604536-ca88e10a-1b88-4d19-a9da-08726f1d6f45.gif)


### Test
**Scenario**: Loading Github dashboard for the first time and generating a PDF report should not produce any errors
**When** The user loads Github dashboard
**And** The user clicks Generate report
**Then** a toast with a report successful message should pop up

**Scenario**: Loading Github dashboard then changing the pinned agent state and generating a PDF report should not produce any errors
**When** The user loads Github dashboard
**And** The user clicks Explore agent
**And** The user selects an agent
**And** The user clicks Generate report
**Then** a toast with a report successful message should pop up

**Scenario**: Loading Github dashboard then changing the pinned agent state and generating a PDF report should not produce any errors
**When** The user loads Github dashboard
**And** The user removes a pinned agent
**And** The user clicks Generate report
**Then** a toast with a report successful message should pop up

### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff 
