### PR TITLE
[Backport 7.16] Add `os.uname` and `os.version` fields to agents table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 
 - Changed the HTTP verb from `GET` to `POST` in the requests to login to the Wazuh API [#4103](https://github.com/wazuh/wazuh-kibana-app/pull/4103)
 - Improved alerts summary performance [#4376](https://github.com/wazuh/wazuh-kibana-app/pull/4376)
-- Improved Agents Overview performance [#4363](https://github.com/wazuh/wazuh-kibana-app/pull/4363) [#4996](https://github.com/wazuh/wazuh-kibana-app/pull/4996)
+- Improved Agents Overview performance [#4363](https://github.com/wazuh/wazuh-kibana-app/pull/4363) [#4996](https://github.com/wazuh/wazuh-kibana-app/pull/4996) [#5076](https://github.com/wazuh/wazuh-kibana-app/pull/5076)
 - Improved the message displayed when there is a versions mismatch between the Wazuh API and the Wazuh APP [#4529](https://github.com/wazuh/wazuh-kibana-app/pull/4529) [#4964](https://github.com/wazuh/wazuh-kibana-app/pull/4964)
 - Independently load each dashboard from the `Agents Overview` page [#4363](https://github.com/wazuh/wazuh-kibana-app/pull/4363)
 - The endpoint `/agents/summary/status` response was adapted. [#3874](https://github.com/wazuh/wazuh-kibana-app/pull/3874)

--- a/public/controllers/agent/components/agents-table.js
+++ b/public/controllers/agent/components/agents-table.js
@@ -217,11 +217,12 @@ export const AgentsTable = withErrorBoundary(
     async getItems() {
       try {
         this._isMount && this.setState({ isLoading: true });
-        const fields = this.defaultColumns
+        const selectFieldsList = this.defaultColumns
           .filter(field => field.field != 'actions')
-          .map(field => field.field.replace('os_', 'os.')) // "os_name" subfield should be specified as 'os.name'
-          .join(',');
-        const rawAgents = await this.props.wzReq('GET', '/agents', { params: { ...this.buildFilter(), select: fields } });
+          .map(field => field.field.replace('os_', 'os.')); // "os_name" subfield should be specified as 'os.name'
+        const selectFields = [...selectFieldsList, 'os.uname', 'os.version'].join(','); // Add version and uname fields to render the OS icon and version in the table
+
+        const rawAgents = await this.props.wzReq('GET', '/agents', { params: { ...this.buildFilter(), select: selectFields } });
         const formatedAgents = (((rawAgents || {}).data || {}).data || {}).affected_items.map(
           this.formatAgent.bind(this)
         );


### PR DESCRIPTION
### Description
Team,
this PR adds os.uname and os.version fields to the required /agents request for the agents overview table. With this information the table can render the agent OS icon and the agent OS version in the OS column
 
### Issues Resolved
Closes #5073 

Related to https://github.com/wazuh/wazuh-kibana-app/pull/4363

### Evidence
![image](https://user-images.githubusercontent.com/9343732/210769040-aa02164e-5338-4af7-87fd-f9803242497a.png)


### Test
Register Linux / Windows agents in the manager
Check the agent OS icon and version are shown

### Check List
- [x] All tests pass
  - [x] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 
