### PR TITLE
[Backport 4.4-7.10] Fix error when clicking on the multiple agent selector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - A solaris command has been fixed [5035](https://github.com/wazuh/wazuh-kibana-app/pull/5035)
 - Fixed commands: Aix, OpenSUSE, Alpine, Suse11, Fedora, HP, Oracle Linux 5, Amazon Linux 2, Centos5. Changed the word 'or higher' in buttons to '+'.Fixed validations for Hp, Solaris and Alpine. [5045](https://github.com/wazuh/wazuh-kibana-app/pull/5045)
 - Fixed error in Github module PDF report. [5069](https://github.com/wazuh/wazuh-kibana-app/pull/5069)
+- Fixed error when clicking on the selectors of agents in the group agents management [#5094](https://github.com/wazuh/wazuh-kibana-app/pull/5094)
 
 ### Removed
 

--- a/public/components/management/groups/multiple-agent-selector.tsx
+++ b/public/components/management/groups/multiple-agent-selector.tsx
@@ -396,7 +396,7 @@ export const MultipleAgentSelector = withErrorBoundary(
     };
 
     unselectElementsOfSelectByID(containerID) {
-      document.getElementById(containerID).options.forEach((option) => {
+      Array.from(document.getElementById(containerID).options).forEach((option) => {
         option.selected = false;
       });
     }


### PR DESCRIPTION
### Description
This pull request fixes a console error displayed when clicking in the multiple agent selector to manage the agents in a group
 
### Issues Resolved
Closes #5091

### Evidence
[Provide screenshots or videos to prove this PR solves the issues]

### Test

**Scenario 1** Clicking on the multiple selector (Available agents) of the group agents management doesn't display any error in the console of the browser dev tools
**Given** a group without agents
**When** the user goes to Manage agents
**And** clicking on selector of the Available agentsCurrent agents in the group panel
**Then** it should not appear an error in the console of the browser dev tools

**Scenario 2** Clicking on the multiple selector (Current agents in the group) of the group agents management doesn't display any error in the console of the browser dev tools
**Given** a group without agents
**When** the user goes to Manage agents
**And** clicking on selector of the Current agents in the group panel
**Then** it should not appear an error in the console of the browser dev tools

### Check List
- [x] All tests pass
  - [x] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 
