### PR TITLE
Fix Alerts Summary table truncated results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 ### Changed
 
 - Changed the HTTP verb from `GET` to `POST` in the requests to login to the Wazuh API [#4103](https://github.com/wazuh/wazuh-kibana-app/pull/4103)
-- Improved alerts summary performance [#4376](https://github.com/wazuh/wazuh-kibana-app/pull/4376) [#5071](https://github.com/wazuh/wazuh-kibana-app/pull/5071)
+- Improved alerts summary performance [#4376](https://github.com/wazuh/wazuh-kibana-app/pull/4376) [#5071](https://github.com/wazuh/wazuh-kibana-app/pull/5071) [#5131](https://github.com/wazuh/wazuh-kibana-app/pull/5131)
 - Improved Agents Overview performance [#4363](https://github.com/wazuh/wazuh-kibana-app/pull/4363) [#5076](https://github.com/wazuh/wazuh-kibana-app/pull/5076)
 - Improved the message displayed when there is a versions mismatch between the Wazuh API and the Wazuh APP [#4529](https://github.com/wazuh/wazuh-kibana-app/pull/4529) [#4964](https://github.com/wazuh/wazuh-kibana-app/pull/4964)
 - Independently load each dashboard from the `Agents Overview` page [#4363](https://github.com/wazuh/wazuh-kibana-app/pull/4363)

--- a/server/controllers/wazuh-reporting.ts
+++ b/server/controllers/wazuh-reporting.ts
@@ -341,7 +341,7 @@ export class WazuhReportingCtrl {
       }
 
       //add authorized agents
-      if (agentsFilter) {
+      if (agentsFilter?.agentsText) {
         printer.addAgentsFilters(agentsFilter.agentsText);
       }
 

--- a/server/controllers/wazuh-reporting.ts
+++ b/server/controllers/wazuh-reporting.ts
@@ -30,6 +30,11 @@ import {
 import { createDirectoryIfNotExists, createDataDirectoryIfNotExists } from '../lib/filesystem';
 import { agentStatusLabelByAgentStatus } from '../../common/services/wz_agent_status';
 
+interface AgentsFilter {
+  query: any;
+  agentsText: string;
+}
+
 export class WazuhReportingCtrl {
   constructor() {}
   /**
@@ -37,7 +42,7 @@ export class WazuhReportingCtrl {
    * @param {String} filters E.g: cluster.name: wazuh AND rule.groups: vulnerability
    * @param {String} searchBar search term
    */
-  private sanitizeKibanaFilters(filters: any, searchBar?: string): [string, string] {
+  private sanitizeKibanaFilters(filters: any, searchBar?: string): [string, AgentsFilter] {
     log('reporting:sanitizeKibanaFilters', `Started to sanitize filters`, 'info');
     log(
       'reporting:sanitizeKibanaFilters',
@@ -46,12 +51,14 @@ export class WazuhReportingCtrl {
     );
     let str = '';
 
-    const agentsFilter: any = [];
+    const agentsFilter: AgentsFilter = { query: {}, agentsText: '' };
+    const agentsList: string[] = [];
 
     //separate agents filter
     filters = filters.filter((filter) => {
       if (filter.meta.controlledBy === AUTHORIZED_AGENTS) {
-        agentsFilter.push(filter);
+        agentsFilter.query = filter.query;
+        agentsList.push(filter);
         return false;
       }
       return filter;
@@ -81,15 +88,15 @@ export class WazuhReportingCtrl {
       str += ` AND (${ searchBar})`;
     }
 
-    const agentsFilterStr = agentsFilter.map((filter) => filter.meta.value).join(',');
+    agentsFilter.agentsText = agentsList.map((filter) => filter.meta.value).join(',');
 
     log(
       'reporting:sanitizeKibanaFilters',
-      `str: ${str}, agentsFilterStr: ${agentsFilterStr}`,
+      `str: ${str}, agentsFilterStr: ${agentsFilter.agentsText}`,
       'debug'
     );
 
-    return [str, agentsFilterStr];
+    return [str, agentsFilter];
   }
 
   /**
@@ -305,7 +312,7 @@ export class WazuhReportingCtrl {
 
       const [sanitizedFilters, agentsFilter] = filters
         ? this.sanitizeKibanaFilters(filters, searchBar)
-        : [false, false];
+        : [false, null];
 
       if (time && sanitizedFilters) {
         printer.addTimeRangeAndFilters(from, to, sanitizedFilters, browserTimezone);
@@ -321,6 +328,7 @@ export class WazuhReportingCtrl {
           new Date(from).getTime(),
           new Date(to).getTime(),
           sanitizedFilters,
+          agentsFilter,
           indexPatternTitle,
           agents
         );
@@ -334,7 +342,7 @@ export class WazuhReportingCtrl {
 
       //add authorized agents
       if (agentsFilter) {
-        printer.addAgentsFilters(agentsFilter);
+        printer.addAgentsFilters(agentsFilter.agentsText);
       }
 
       await printer.print(context.wazuhEndpointParams.pathFilename);

--- a/server/lib/reporting/audit-request.ts
+++ b/server/lib/reporting/audit-request.ts
@@ -26,12 +26,13 @@ export const getTop3AgentsSudoNonSuccessful = async (
   gte,
   lte,
   filters,
+  allowedAgentsFilter,
   pattern = getSettingDefaultValue('pattern')
 ) => {
   try {
     const base = {};
 
-    Object.assign(base, Base(pattern, filters, gte, lte));
+    Object.assign(base, Base(pattern, filters, gte, lte, allowedAgentsFilter));
 
     Object.assign(base.aggs, {
       '3': {
@@ -93,12 +94,13 @@ export const getTop3AgentsFailedSyscalls = async (
   gte,
   lte,
   filters,
+  allowedAgentsFilter,
   pattern = getSettingDefaultValue('pattern')
 ) => {
   try {
     const base = {};
 
-    Object.assign(base, Base(pattern, filters, gte, lte));
+    Object.assign(base, Base(pattern, filters, gte, lte, allowedAgentsFilter));
 
     Object.assign(base.aggs, {
       '3': {
@@ -138,7 +140,7 @@ export const getTop3AgentsFailedSyscalls = async (
     const { buckets } = response.body.aggregations['3'];
 
     return buckets.map(bucket => {
-      try{
+      try {
         const agent = bucket.key;
         const syscall = {
           id: bucket['4'].buckets[0].key,
@@ -150,7 +152,7 @@ export const getTop3AgentsFailedSyscalls = async (
           agent,
           syscall
         };
-      }catch(error){
+      } catch (error) {
         return undefined;
       }
     }).filter(bucket => bucket);
@@ -172,12 +174,13 @@ export const getTopFailedSyscalls = async (
   gte,
   lte,
   filters,
+  allowedAgentsFilter,
   pattern = getSettingDefaultValue('pattern')
 ) => {
   try {
     const base = {};
 
-    Object.assign(base, Base(pattern, filters, gte, lte));
+    Object.assign(base, Base(pattern, filters, gte, lte, allowedAgentsFilter));
 
     Object.assign(base.aggs, {
       '2': {

--- a/server/lib/reporting/base-query.ts
+++ b/server/lib/reporting/base-query.ts
@@ -9,10 +9,10 @@
  *
  * Find more information about this on the LICENSE file.
  */
-export function Base(pattern: string, filters: any, gte: number, lte: number) {
-  return {
+export function Base(pattern: string, filters: any, gte: number, lte: number, allowedAgentsFilter: any = null) {
+  const base = {
     // index: pattern,
-    
+
     from: 0,
     size: 500,
     aggs: {},
@@ -42,4 +42,12 @@ export function Base(pattern: string, filters: any, gte: number, lte: number) {
       }
     }
   };
+
+  //Add allowed agents filter
+  if(allowedAgentsFilter?.query?.bool){
+    base.query.bool.minimum_should_match = allowedAgentsFilter.query.bool.minimum_should_match;
+    base.query.bool.should = allowedAgentsFilter.query.bool.should;
+  }
+
+  return base;
 }

--- a/server/lib/reporting/extended-information.ts
+++ b/server/lib/reporting/extended-information.ts
@@ -133,6 +133,7 @@ export async function extendedInformation(
   from,
   to,
   filters,
+  allowedAgentsFilter,
   pattern = getSettingDefaultValue('pattern'),
   agent = null
 ) {
@@ -174,6 +175,7 @@ export async function extendedInformation(
                 to,
                 vulnerabilitiesLevel,
                 filters,
+                allowedAgentsFilter,
                 pattern
               );
               return count
@@ -200,6 +202,7 @@ export async function extendedInformation(
         to,
         'Low',
         filters,
+        allowedAgentsFilter,
         pattern
       );
       const mediumRank = await VulnerabilityRequest.topAgentCount(
@@ -208,6 +211,7 @@ export async function extendedInformation(
         to,
         'Medium',
         filters,
+        allowedAgentsFilter,
         pattern
       );
       const highRank = await VulnerabilityRequest.topAgentCount(
@@ -216,6 +220,7 @@ export async function extendedInformation(
         to,
         'High',
         filters,
+        allowedAgentsFilter,
         pattern
       );
       const criticalRank = await VulnerabilityRequest.topAgentCount(
@@ -224,6 +229,7 @@ export async function extendedInformation(
         to,
         'Critical',
         filters,
+        allowedAgentsFilter,
         pattern
       );
       log(
@@ -272,7 +278,7 @@ export async function extendedInformation(
         'Fetching overview vulnerability detector top 3 CVEs',
         'debug'
       );
-      const cveRank = await VulnerabilityRequest.topCVECount(context, from, to, filters, pattern);
+      const cveRank = await VulnerabilityRequest.topCVECount(context, from, to, filters, allowedAgentsFilter, pattern);
       log(
         'reporting:extendedInformation',
         'Adding overview vulnerability detector top 3 CVEs',
@@ -294,7 +300,7 @@ export async function extendedInformation(
     if (section === 'overview' && tab === 'general') {
       log('reporting:extendedInformation', 'Fetching top 3 agents with level 15 alerts', 'debug');
 
-      const level15Rank = await OverviewRequest.topLevel15(context, from, to, filters, pattern);
+      const level15Rank = await OverviewRequest.topLevel15(context, from, to, filters, allowedAgentsFilter, pattern);
 
       log('reporting:extendedInformation', 'Adding top 3 agents with level 15 alerts', 'debug');
       if (level15Rank.length) {
@@ -314,6 +320,7 @@ export async function extendedInformation(
         from,
         to,
         filters,
+        allowedAgentsFilter,
         pattern
       );
       log('reporting:extendedInformation', 'Adding most common rootkits', 'debug');
@@ -344,6 +351,7 @@ export async function extendedInformation(
         from,
         to,
         filters,
+        allowedAgentsFilter,
         pattern
       );
       hiddenPids &&
@@ -362,6 +370,7 @@ export async function extendedInformation(
         from,
         to,
         filters,
+        allowedAgentsFilter,
         pattern
       );
       hiddenPorts &&
@@ -385,6 +394,7 @@ export async function extendedInformation(
         from,
         to,
         filters,
+        allowedAgentsFilter,
         pattern
       );
       printer.addContentWithNewLine({
@@ -397,6 +407,7 @@ export async function extendedInformation(
           from,
           to,
           filters,
+          allowedAgentsFilter,
           item,
           pattern
         );
@@ -429,6 +440,7 @@ export async function extendedInformation(
         from,
         to,
         filters,
+        allowedAgentsFilter,
         pattern
       );
       printer.addContentWithNewLine({
@@ -441,6 +453,7 @@ export async function extendedInformation(
           from,
           to,
           filters,
+          allowedAgentsFilter,
           item,
           pattern
         );
@@ -473,6 +486,7 @@ export async function extendedInformation(
         from,
         to,
         filters,
+        allowedAgentsFilter,
         pattern
       );
       printer.addContentWithNewLine({
@@ -485,6 +499,7 @@ export async function extendedInformation(
           from,
           to,
           filters,
+          allowedAgentsFilter,
           item,
           pattern
         );
@@ -522,6 +537,7 @@ export async function extendedInformation(
         from,
         to,
         filters,
+        allowedAgentsFilter,
         pattern
       );
       if (auditAgentsNonSuccess && auditAgentsNonSuccess.length) {
@@ -536,6 +552,7 @@ export async function extendedInformation(
         from,
         to,
         filters,
+        allowedAgentsFilter,
         pattern
       );
       if (auditAgentsFailedSyscall && auditAgentsFailedSyscall.length) {
@@ -561,7 +578,7 @@ export async function extendedInformation(
     //--- OVERVIEW - FIM
     if (section === 'overview' && tab === 'fim') {
       log('reporting:extendedInformation', 'Fetching top 3 rules for FIM', 'debug');
-      const rules = await SyscheckRequest.top3Rules(context, from, to, filters, pattern);
+      const rules = await SyscheckRequest.top3Rules(context, from, to, filters, allowedAgentsFilter, pattern);
 
       if (rules && rules.length) {
         printer.addContentWithNewLine({ text: 'Top 3 FIM rules', style: 'h2' }).addSimpleTable({
@@ -578,7 +595,7 @@ export async function extendedInformation(
       }
 
       log('reporting:extendedInformation', 'Fetching top 3 agents for FIM', 'debug');
-      const agents = await SyscheckRequest.top3agents(context, from, to, filters, pattern);
+      const agents = await SyscheckRequest.top3agents(context, from, to, filters, allowedAgentsFilter, pattern);
 
       if (agents && agents.length) {
         printer.addContentWithNewLine({
@@ -602,6 +619,7 @@ export async function extendedInformation(
         from,
         to,
         filters,
+        allowedAgentsFilter,
         pattern
       );
       auditFailedSyscall &&
@@ -655,6 +673,7 @@ export async function extendedInformation(
         from,
         to,
         filters,
+        allowedAgentsFilter,
         pattern
       );
 
@@ -675,6 +694,7 @@ export async function extendedInformation(
         from,
         to,
         filters,
+        allowedAgentsFilter,
         pattern
       );
 
@@ -783,6 +803,7 @@ export async function extendedInformation(
                 to,
                 vulnerabilitiesLevel,
                 filters,
+                allowedAgentsFilter,
                 pattern
               );
             } catch (error) {
@@ -814,6 +835,7 @@ export async function extendedInformation(
         to,
         'Critical',
         filters,
+        allowedAgentsFilter,
         pattern
       );
       if (topCriticalPackages && topCriticalPackages.length) {
@@ -843,6 +865,7 @@ export async function extendedInformation(
         to,
         'High',
         filters,
+        allowedAgentsFilter,
         pattern
       );
       if (topHighPackages && topHighPackages.length) {
@@ -876,6 +899,7 @@ export async function extendedInformation(
           from,
           to,
           filters,
+          allowedAgentsFilter,
           summaryTable,
           pattern
         );

--- a/server/lib/reporting/gdpr-request.ts
+++ b/server/lib/reporting/gdpr-request.ts
@@ -25,6 +25,7 @@ export const topGDPRRequirements = async (
   gte,
   lte,
   filters,
+  allowedAgentsFilter,
   pattern = getSettingDefaultValue('pattern')
 ) => {
   if (filters.includes('rule.gdpr: exists')) {
@@ -35,7 +36,7 @@ export const topGDPRRequirements = async (
   try {
     const base = {};
 
-    Object.assign(base, Base(pattern, filters, gte, lte));
+    Object.assign(base, Base(pattern, filters, gte, lte, allowedAgentsFilter));
 
     Object.assign(base.aggs, {
       '2': {
@@ -81,6 +82,7 @@ export const getRulesByRequirement = async (
   gte,
   lte,
   filters,
+  allowedAgentsFilter,
   requirement,
   pattern = getSettingDefaultValue('pattern')
 ) => {
@@ -92,7 +94,7 @@ export const getRulesByRequirement = async (
   try {
     const base = {};
 
-    Object.assign(base, Base(pattern, filters, gte, lte));
+    Object.assign(base, Base(pattern, filters, gte, lte, allowedAgentsFilter));
 
     Object.assign(base.aggs, {
       '2': {

--- a/server/lib/reporting/overview-request.ts
+++ b/server/lib/reporting/overview-request.ts
@@ -20,11 +20,11 @@ import { getSettingDefaultValue } from '../../../common/services/settings';
  * @param {String} filters E.g: cluster.name: wazuh AND rule.groups: vulnerability
  * @returns {Array<String>} E.g:['000','130','300']
  */
-export const topLevel15 = async (context, gte, lte, filters, pattern = getSettingDefaultValue('pattern')) => {
+export const topLevel15 = async (context, gte, lte, filters, allowedAgentsFilter, pattern = getSettingDefaultValue('pattern')) => {
   try {
     const base = {};
 
-    Object.assign(base, Base(pattern, filters, gte, lte));
+    Object.assign(base, Base(pattern, filters, gte, lte, allowedAgentsFilter));
 
     Object.assign(base.aggs, {
       '2': {

--- a/server/lib/reporting/pci-request.ts
+++ b/server/lib/reporting/pci-request.ts
@@ -25,6 +25,7 @@ export const topPCIRequirements = async (
   gte,
   lte,
   filters,
+  allowedAgentsFilter,
   pattern = getSettingDefaultValue('pattern')
 ) => {
   if (filters.includes('rule.pci_dss: exists')) {
@@ -34,7 +35,7 @@ export const topPCIRequirements = async (
   try {
     const base = {};
 
-    Object.assign(base, Base(pattern, filters, gte, lte));
+    Object.assign(base, Base(pattern, filters, gte, lte, allowedAgentsFilter));
 
     Object.assign(base.aggs, {
       '2': {
@@ -95,6 +96,7 @@ export const getRulesByRequirement = async (
   gte,
   lte,
   filters,
+  allowedAgentsFilter,
   requirement,
   pattern = getSettingDefaultValue('pattern')
 ) => {
@@ -105,7 +107,7 @@ export const getRulesByRequirement = async (
   try {
     const base = {};
 
-    Object.assign(base, Base(pattern, filters, gte, lte));
+    Object.assign(base, Base(pattern, filters, gte, lte, allowedAgentsFilter));
 
     Object.assign(base.aggs, {
       '2': {

--- a/server/lib/reporting/rootcheck-request.ts
+++ b/server/lib/reporting/rootcheck-request.ts
@@ -25,13 +25,14 @@ export const top5RootkitsDetected = async (
   gte,
   lte,
   filters,
+  allowedAgentsFilter,
   pattern = getSettingDefaultValue('pattern'),
   size = 5
 ) => {
   try {
     const base = {};
 
-    Object.assign(base, Base(pattern, filters, gte, lte));
+    Object.assign(base, Base(pattern, filters, gte, lte, allowedAgentsFilter));
 
     Object.assign(base.aggs, {
       '2': {
@@ -80,12 +81,13 @@ export const agentsWithHiddenPids = async (
   gte,
   lte,
   filters,
+  allowedAgentsFilter,
   pattern = getSettingDefaultValue('pattern')
 ) => {
   try {
     const base = {};
 
-    Object.assign(base, Base(pattern, filters, gte, lte));
+    Object.assign(base, Base(pattern, filters, gte, lte, allowedAgentsFilter));
 
     Object.assign(base.aggs, {
       '1': {
@@ -129,12 +131,13 @@ export const agentsWithHiddenPorts = async(
   gte,
   lte,
   filters,
+  allowedAgentsFilter,
   pattern = getSettingDefaultValue('pattern')
 ) => {
   try {
     const base = {};
 
-    Object.assign(base, Base(pattern, filters, gte, lte));
+    Object.assign(base, Base(pattern, filters, gte, lte, allowedAgentsFilter));
 
     Object.assign(base.aggs, {
       '1': {

--- a/server/lib/reporting/summary-table.ts
+++ b/server/lib/reporting/summary-table.ts
@@ -23,6 +23,7 @@ export default class SummaryTable {
     gte,
     lte,
     filters,
+    allowedAgentsFilter,
     summarySetup: SummarySetup,
     pattern = getSettingDefaultValue('pattern')
   ) {
@@ -35,7 +36,7 @@ export default class SummaryTable {
     this._rows = [];
     this._title = summarySetup.title;
 
-    Object.assign(this._base, Base(pattern, filters, gte, lte));
+    Object.assign(this._base, Base(pattern, filters, gte, lte, allowedAgentsFilter));
 
     this._parseSummarySetup(summarySetup);
 

--- a/server/lib/reporting/syscheck-request.ts
+++ b/server/lib/reporting/syscheck-request.ts
@@ -26,12 +26,13 @@ export const top3agents = async (
   gte,
   lte,
   filters,
+  allowedAgentsFilter,
   pattern = getSettingDefaultValue('pattern')
 ) => {
   try {
     const base = {};
 
-    Object.assign(base, Base(pattern, filters, gte, lte));
+    Object.assign(base, Base(pattern, filters, gte, lte, allowedAgentsFilter));
 
     Object.assign(base.aggs, {
       '2': {
@@ -78,12 +79,13 @@ export const top3Rules = async (
   gte,
   lte,
   filters,
+  allowedAgentsFilter,
   pattern = getSettingDefaultValue('pattern')
 ) => {
   try {
     const base = {};
 
-    Object.assign(base, Base(pattern, filters, gte, lte));
+    Object.assign(base, Base(pattern, filters, gte, lte, allowedAgentsFilter));
 
     Object.assign(base.aggs, {
       '2': {
@@ -137,12 +139,13 @@ export const lastTenDeletedFiles = async (
   gte,
   lte,
   filters,
+  allowedAgentsFilter,
   pattern = getSettingDefaultValue('pattern')
 ) => {
   try {
     const base = {};
 
-    Object.assign(base, Base(pattern, filters, gte, lte));
+    Object.assign(base, Base(pattern, filters, gte, lte, allowedAgentsFilter));
 
     Object.assign(base.aggs, {
       '2': {
@@ -190,12 +193,13 @@ export const lastTenModifiedFiles = async (
   gte,
   lte,
   filters,
+  allowedAgentsFilter,
   pattern = getSettingDefaultValue('pattern')
 ) => {
   try {
     const base = {};
 
-    Object.assign(base, Base(pattern, filters, gte, lte));
+    Object.assign(base, Base(pattern, filters, gte, lte, allowedAgentsFilter));
 
     Object.assign(base.aggs, {
       '2': {

--- a/server/lib/reporting/tsc-request.ts
+++ b/server/lib/reporting/tsc-request.ts
@@ -25,6 +25,7 @@ export const topTSCRequirements = async (
   gte,
   lte,
   filters,
+  allowedAgentsFilter,
   pattern = getSettingDefaultValue('pattern')
 ) => {
   if (filters.includes('rule.tsc: exists')) {
@@ -34,7 +35,7 @@ export const topTSCRequirements = async (
   try {
     const base = {};
 
-    Object.assign(base, Base(pattern, filters, gte, lte));
+    Object.assign(base, Base(pattern, filters, gte, lte, allowedAgentsFilter));
 
     Object.assign(base.aggs, {
       '2': {
@@ -95,6 +96,7 @@ export const getRulesByRequirement = async (
   gte,
   lte,
   filters,
+  allowedAgentsFilter,
   requirement,
   pattern = getSettingDefaultValue('pattern')
 ) => {
@@ -105,7 +107,7 @@ export const getRulesByRequirement = async (
   try {
     const base = {};
 
-    Object.assign(base, Base(pattern, filters, gte, lte));
+    Object.assign(base, Base(pattern, filters, gte, lte, allowedAgentsFilter));
 
     Object.assign(base.aggs, {
       '2': {

--- a/server/lib/reporting/vulnerability-request.ts
+++ b/server/lib/reporting/vulnerability-request.ts
@@ -27,12 +27,13 @@ export const topAgentCount = async (
   lte,
   severity,
   filters,
+  allowedAgentsFilter,
   pattern = getSettingDefaultValue('pattern')
 ) => {
   try {
     const base = {};
 
-    Object.assign(base, Base(pattern, filters, gte, lte));
+    Object.assign(base, Base(pattern, filters, gte, lte, allowedAgentsFilter));
 
     Object.assign(base.aggs, {
       '2': {
@@ -79,12 +80,13 @@ export const topCVECount = async (
   gte,
   lte,
   filters,
+  allowedAgentsFilter,
   pattern = getSettingDefaultValue('pattern')
 ) => {
   try {
     const base = {};
 
-    Object.assign(base, Base(pattern, filters, gte, lte));
+    Object.assign(base, Base(pattern, filters, gte, lte, allowedAgentsFilter));
 
     Object.assign(base.aggs, {
       '2': {
@@ -125,12 +127,13 @@ export const uniqueSeverityCount = async (
   lte,
   severity,
   filters,
+  allowedAgentsFilter,
   pattern = getSettingDefaultValue('pattern')
 ) => {
   try {
     const base = {};
 
-    Object.assign(base, Base(pattern, filters, gte, lte));
+    Object.assign(base, Base(pattern, filters, gte, lte, allowedAgentsFilter));
 
     Object.assign(base.aggs, {
       '1': {
@@ -170,12 +173,13 @@ export const topPackages = async (
   lte,
   severity,
   filters,
+  allowedAgentsFilter,
   pattern = getSettingDefaultValue('pattern')
 ) => {
   try {
     const base = {};
 
-    Object.assign(base, Base(pattern, filters, gte, lte));
+    Object.assign(base, Base(pattern, filters, gte, lte, allowedAgentsFilter));
 
     Object.assign(base.aggs, {
       '2': {
@@ -219,12 +223,13 @@ export const topPackagesWithCVE = async (
   lte,
   severity,
   filters,
+  allowedAgentsFilter,
   pattern = getSettingDefaultValue('pattern')
 ) => {
   try {
     const base = {};
 
-    Object.assign(base, Base(pattern, filters, gte, lte));
+    Object.assign(base, Base(pattern, filters, gte, lte, allowedAgentsFilter));
 
     Object.assign(base.aggs, {
       '2': {


### PR DESCRIPTION
### Description
Team,

this PR fixes the query result of the PDF report _Alerts Summary Table_ to avoid truncating the number of rows. The parsing algorithm wasn't iterating all the bucket combinations, therefore it returned only the first combination of buckets. Now it iterates al possible combinations of the aggregation buckets and returns all possible results.

Note: We also found server-side functions truncate and sort indexer queries. The issue is described in the issue https://github.com/wazuh/wazuh-kibana-app/issues/5134
 
### Issues Resolved
Closes #5130 

### Evidence
![image](https://user-images.githubusercontent.com/9343732/212708445-2227ad72-389a-4b4d-9f9b-1c57e651131e.png)


### Test

- Generate a report of each module with and without a pinned agent.
  - The rendered Alerts Summary table should be consistent with the rest of the visualizations and the available alerts in the reported Module Dashboard
- Setup the Allow agents restriction filter and verify it applies to the report table.

#### Check allowed Agents

| Module | Allowed agents filtered |
| --- |  --- |
| Security events | :black_circle: |


#### Security Information Management

| Module | With pinned agent | Without agent | 
| --- |  --- | --- |
| Security events | :black_circle: | :black_circle: |
| Integrity monitoring | :black_circle: | :black_circle: |
| Office 365 | :black_circle: | :black_circle: |
| Amazon AWS | :black_circle: | :black_circle: |
| Google Cloud Platform | :black_circle: | :black_circle: |
| GitHub | :black_circle: | :black_circle: |


#### Auditing and Policy Monitoring


| Module | With pinned agent | Without agent | 
| --- |  --- | --- |
| Policy monitoring | :black_circle: | :black_circle: |
| Security configuration assessment | :black_circle: | :black_circle: |
| System auditing | :black_circle: | :black_circle: |
| OpenSCAP | :black_circle: | :black_circle: |
| CIS-CAT | :black_circle: | :black_circle: |


#### Threat Detection and Response


| Module | With pinned agent | Without agent | 
| --- |  --- | --- |
| Vulnerabilities | :black_circle: | :black_circle: |
| MITRE ATT&CK | :black_circle: | :black_circle: |
| VirusTotal | :black_circle: | :black_circle: |
| Osquery | :black_circle: | :black_circle: |
| Docker listener | :black_circle: | :black_circle: |


#### Regulatory Compliance


| Module | With pinned agent | Without agent | 
| --- |  --- | --- | 
| PCI DSS | :black_circle: | :black_circle: |
| NIST 800-53 | :black_circle: | :black_circle: |
| GDPR | :black_circle: | :black_circle: |
| HIPAA | :black_circle: | :black_circle: |
| TSC | :black_circle: | :black_circle: |


### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff 
