### PR TITLE
Fix cannot read null properties bug in settings section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fixed several typos in the code, by @jctello [#4911](https://github.com/wazuh/wazuh-kibana-app/pull/4911)
 - Fixed the display of more than one protocol in the Global configuration section [#4917](https://github.com/wazuh/wazuh-kibana-app/pull/4917)
 - Handling endpoint response was done when there is no data to show [#4918]https://github.com/wazuh/wazuh-kibana-app/pull/4918
+- Fixed the 2 errors that appeared in console in Settings>Configuration section. [#5135](https://github.com/wazuh/wazuh-kibana-app/pull/5135)
 
 ## Wazuh v4.4.0 - Kibana 7.10.2, 7.16.x, 7.17.x - Revision 4400
 


### PR DESCRIPTION
### Description

Fixed the 2 errors that appeared in console in Settings>Configuration section.
 
### Issues Resolved

#4772 

### Evidence

https://user-images.githubusercontent.com/99441266/212919623-c28a2d46-e47d-4c5c-a2fb-d76318240953.mov

### Test

**Case 1:**

In the Wazuh menu click on Settings>Configuration
Then go to any part of the application and check that no error is displayed in console

**Case 2:**

In the Wazuh menu click on Settings>Configuration
Change some configuration and when you click on save a loading should appear next to the kibana logo. 

https://user-images.githubusercontent.com/99441266/212922249-c5b1cb0a-c774-4d12-9176-35e4a5762020.mov

In opensearch the loading appears in this icon <img width="50" alt="image" src="https://user-images.githubusercontent.com/99441266/212921006-642ef5ed-83ad-4883-b7b0-e5c47a6a339d.png">


### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff 
