### PR TITLE
Fix button styling in event view 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fixed menu content panel is displayed in the wrong place. [5092](https://github.com/wazuh/wazuh-kibana-app/pull/5092)
 - Fixed greyed and disabled menu section names [#5101](https://github.com/wazuh/wazuh-kibana-app/pull/5101)
 - Fixed mispelling in the NIST module [#5107](https://github.com/wazuh/wazuh-kibana-app/pull/5107)
+- Fixed the style of the buttons showing more event information in the event view table. [#5137](https://github.com/wazuh/wazuh-kibana-app/pull/5137)
 
 ### Removed
 

--- a/public/kibana-integrations/discover/application/angular/doc_table/components/table_row/_open.scss
+++ b/public/kibana-integrations/discover/application/angular/doc_table/components/table_row/_open.scss
@@ -12,3 +12,18 @@
   width: 14px; /* 1 */
   height: 14px;
 }
+
+.euiButtonIcon.euiButtonIcon--open {
+  box-shadow: none;
+  min-height: 24px;
+  min-width: 24px;
+  line-height: 0;
+  transition: all 250ms ease-in-out 0s;
+  border: none;
+  background-color: transparent;
+
+  &:hover,
+  &:focus {
+    box-shadow: none;
+  }
+}

--- a/public/kibana-integrations/discover/application/angular/doc_table/components/table_row/open.html
+++ b/public/kibana-integrations/discover/application/angular/doc_table/components/table_row/open.html
@@ -1,6 +1,6 @@
 <td ng-click="toggleRow()" data-test-subj="docTableExpandToggleColumn" class="kbnDocTableCell__toggleDetails">
   <button
-    class="euiButtonIcon euiButtonIcon--text"
+    class="euiButtonIcon euiButtonIcon--text euiButtonIcon--open euiButtonIcon--auto"
     aria-expanded="{{!!open}}"
     aria-label="{{ ::'discover.docTable.tableRow.toggleRowDetailsButtonAriaLabel' | i18n: {defaultMessage: 'Toggle row details'} }}"
   >


### PR DESCRIPTION
### Description
Changed the styles of the button that shows more information of each row of the table in events so that it has the same styles as the button that appears in discover.
 
### Issues Resolved
- #5136

### Evidence

#### Wazuh

![image](https://user-images.githubusercontent.com/63758389/213176511-1a86fd17-1198-486c-afb9-b135ed7ec82c.png)

![image](https://user-images.githubusercontent.com/63758389/213176585-cdcfc204-5f59-4570-8de5-21f0d807c8fa.png)


#### Discover

![image](https://user-images.githubusercontent.com/63758389/213176732-8c3835b0-275a-4c44-92a9-dac8bd495e12.png)

![image](https://user-images.githubusercontent.com/63758389/213176831-e4f9ea57-24be-4ae6-bc84-86bd4b048645.png)

### Test

**Scenario 1** The button should have the same appearance as the button that appears in Discover when the information is not displayed.
**When** the user navigates to a module/events
**Then** should see the button like the one shown in Discover

**Scenario 2** The button should have the same appearance as the button that appears in Discover when after clicking to see the information.
**When** the user navigates to a module/events and click to see the information
**Then** should see the button like the one shown in Discover

### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 
