### PR TITLE
Disable synced by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 ### Added
 
 - Added the option to sort by the agents count in the group table. [#4323](https://github.com/wazuh/wazuh-kibana-app/pull/4323)
-- Added agent synchronization status in the agent module. [#3874](https://github.com/wazuh/wazuh-kibana-app/pull/3874)
+- Added agent synchronization status in the agent module. [#3874](https://github.com/wazuh/wazuh-kibana-app/pull/3874) [#5143](https://github.com/wazuh/wazuh-kibana-app/pull/5143)
 - The input name was added and when the user adds a value the variable WAZUH_AGENT_NAME with its value appears in the installation command. [#4739](https://github.com/wazuh/wazuh-kibana-app/pull/4739)
 - Redesign the SCA table from agent's dashboard [#4512](https://github.com/wazuh/wazuh-kibana-app/pull/4512)
 - Enhanced the plugin setting description displayed in the UI and the configuration file. [#4501](https://github.com/wazuh/wazuh-kibana-app/pull/4501)

--- a/common/compliance-requirements/pci-requirements.ts
+++ b/common/compliance-requirements/pci-requirements.ts
@@ -34,7 +34,7 @@ export const pciRequirementsFile = {
   '6.5':
     'Address common coding vulnerabilities in software development processes as follows:Train developers in secure coding techniques, including how to avoid common coding vulnerabilities, and understanding how sensitive data is handled in memory. Develop applications based on secure coding guidelines. ',
   '6.5.1':
-    'Injection flaws, particularly SQL injection. Also consider OS Command Injection, LDAP and XPath injection flaws as well as other injection flaws.',
+    'Injection flaws, particularly SQL injection. Also consider Operating System Command Injection, LDAP and XPath injection flaws as well as other injection flaws.',
   '6.5.2': 'Buffer overflows',
   '6.5.5': 'Improper error handling',
   '6.5.7': 'Cross-site scripting (XSS)',

--- a/common/csv-key-equivalence.ts
+++ b/common/csv-key-equivalence.ts
@@ -25,7 +25,7 @@ export const KeyEquivalence: {[key: string]: string} = {
   'os.uname': 'OS uname',
   status: 'Status',
   group: 'Group',
-  ip: 'IP',
+  ip: 'IP address',
   description: 'Description',
   tag: 'Tag',
   level: 'Level',

--- a/common/csv-key-equivalence.ts
+++ b/common/csv-key-equivalence.ts
@@ -52,7 +52,7 @@ export const KeyEquivalence: {[key: string]: string} = {
   dateAdd: 'Registration date',
   manager: 'Manager',
   lastKeepAlive: 'Last keep alive',
-  os: 'OS',
+  os: 'Operating system',
   path: 'Path',
   details: 'Details',
   position: 'Position',

--- a/public/components/agents/syscollector/components/syscollector-metrics.tsx
+++ b/public/components/agents/syscollector/components/syscollector-metrics.tsx
@@ -39,7 +39,7 @@ export function InventoryMetrics({agent}) {
                     <EuiText>Arch: {syscollector.isLoading ? <EuiLoadingSpinner size="s" /> : <strong>{syscollector.data.os.architecture}</strong>}</EuiText>
                 </EuiFlexItem>
                 <EuiFlexItem grow={false}>
-                    <EuiText>OS: {syscollector.isLoading ? <EuiLoadingSpinner size="s" /> : <strong>{syscollector.data.os.os.name} {syscollector.data.os.os.version}</strong>}</EuiText>
+                    <EuiText>Operating system: {syscollector.isLoading ? <EuiLoadingSpinner size="s" /> : <strong>{syscollector.data.os.os.name} {syscollector.data.os.os.version}</strong>}</EuiText>
                 </EuiFlexItem>
                 <EuiFlexItem grow={true}>
                     <EuiText>CPU: {syscollector.isLoading ? <EuiLoadingSpinner size="s" /> : <strong>{syscollector.data.hardware.cpu.name}</strong>}</EuiText>

--- a/public/components/common/welcome/agents-info.js
+++ b/public/components/common/welcome/agents-info.js
@@ -33,7 +33,7 @@ export class AgentInfo extends Component {
     this.state = {};
   }
 
-  
+
   async componentDidMount() {
     const managerVersion = await WzRequest.apiReq('GET', '/', {});
     this.setState({
@@ -99,7 +99,7 @@ export class AgentInfo extends Component {
     )
   }
 
-  buildStats(items) {    
+  buildStats(items) {
     const checkField = field => {
       return field !== undefined || field ? field : '-';
     };
@@ -157,7 +157,7 @@ export class AgentInfo extends Component {
       arrayStats = [
         { title: agent.id, description: 'ID', style: { minWidth: 30 } },
         { title: agent.status, description: 'Status', style: { minWidth: 130 } },
-        { title: agent.ip, description: 'IP', style: { minWidth: 80 } },
+        { title: agent.ip, description: 'IP address', style: { minWidth: 80 } },
         { title: agent.version, description: 'Version', style: { minWidth: 100 } },
         { title: agent.group, description: 'Groups', style: { minWidth: 150 } },
         { title: agent.name, description: 'Operating system', style: { minWidth: 150 } },

--- a/public/components/management/cluster/node-list.tsx
+++ b/public/components/management/cluster/node-list.tsx
@@ -44,7 +44,7 @@ export const NodeList = withErrorBoundary (class NodeList extends Component {
             },
             {
                 field: 'ip',
-                name: 'IP Address',
+                name: 'IP address',
                 sortable: true,
             },
             {

--- a/public/components/management/cluster/node-list.tsx
+++ b/public/components/management/cluster/node-list.tsx
@@ -44,7 +44,7 @@ export const NodeList = withErrorBoundary (class NodeList extends Component {
             },
             {
                 field: 'ip',
-                name: 'IP',
+                name: 'IP Address',
                 sortable: true,
             },
             {

--- a/public/components/overview/office-panel/config/drilldown-operations-config.tsx
+++ b/public/components/overview/office-panel/config/drilldown-operations-config.tsx
@@ -63,7 +63,7 @@ export const drilldownOperationsConfig = {
                     { field: 'timestamp' },
                     { field: 'rule.description', label: 'Description' },
                     { field: 'data.office365.UserId', label: 'User ID' },
-                    { field: 'data.office365.ClientIP', label: 'Client IP' },
+                    { field: 'data.office365.ClientIP', label: 'Client IP address' },
                     { field: 'rule.level', label: 'Level' },
                     { field: 'rule.id', label: 'Rule ID' },
                   ]}

--- a/public/components/overview/office-panel/config/drilldown-rules-config.tsx
+++ b/public/components/overview/office-panel/config/drilldown-rules-config.tsx
@@ -69,7 +69,7 @@ export const drilldownRulesConfig = {
                     { field: 'timestamp' },
                     { field: 'rule.description', label: 'Description' },
                     { field: 'data.office365.UserId', label: 'User ID' },
-                    { field: 'data.office365.ClientIP', label: 'Client IP' },
+                    { field: 'data.office365.ClientIP', label: 'Client IP address' },
                     { field: 'data.office365.Operation', label: 'Operation' },
                     { field: 'rule.level', label: 'Level' },
                     { field: 'rule.id', label: 'Rule ID' },

--- a/public/components/overview/office-panel/config/drilldown-user-config.tsx
+++ b/public/components/overview/office-panel/config/drilldown-user-config.tsx
@@ -73,7 +73,7 @@ export const drilldownUserConfig = {
                     { field: 'icon' },
                     { field: 'timestamp' },
                     { field: 'rule.description', label: 'Description' },
-                    { field: 'data.office365.ClientIP', label: 'Client IP' },
+                    { field: 'data.office365.ClientIP', label: 'Client IP address' },
                     { field: 'data.office365.Operation', label: 'Operation' },
                     { field: 'rule.level', label: 'Level' },
                     { field: 'rule.id', label: 'Rule ID' },

--- a/public/components/overview/office-panel/config/main-view-config.tsx
+++ b/public/components/overview/office-panel/config/main-view-config.tsx
@@ -41,7 +41,7 @@ export const MainViewConfig = {
               <AggTable
                 tableTitle="Top client IP"
                 aggTerm="data.office365.ClientIP"
-                aggLabel="Client IP"
+                aggLabel="Client IP address"
                 maxRows={5}
                 onRowClick={(field, value) => props.onRowClick(field, value)}
               />

--- a/public/components/overview/office-panel/config/main-view-config.tsx
+++ b/public/components/overview/office-panel/config/main-view-config.tsx
@@ -39,7 +39,7 @@ export const MainViewConfig = {
           component: (props) => (
             <EuiFlexItem grow={props.grow}>
               <AggTable
-                tableTitle="Top client IP"
+                tableTitle="Top client IP address"
                 aggTerm="data.office365.ClientIP"
                 aggLabel="Client IP address"
                 maxRows={5}

--- a/public/components/overview/office-panel/config/module-config.tsx
+++ b/public/components/overview/office-panel/config/module-config.tsx
@@ -38,7 +38,7 @@ export const ModuleConfig = {
   'data.office365.ClientIP': {
     length: () => drilldownIPConfig.rows.reduce((total, row) => total + row.columns.length, 0),
     component: (props) => (
-      <OfficeDrilldown title={'Client IP'} {...{ ...drilldownIPConfig, ...props }} />
+      <OfficeDrilldown title={'Client IP address'} {...{ ...drilldownIPConfig, ...props }} />
     ),
   },
   'data.office365.Operation': {

--- a/public/components/visualize/visualizations.js
+++ b/public/components/visualize/visualizations.js
@@ -235,7 +235,7 @@ export const visualizations = {
         height: 450,
         vis: [
           {
-            title: 'Top 5 Map by source ip',
+            title: 'Top 5 Map by source IP address',
             id: 'Wazuh-App-Overview-GCP-Map-By-SourceIp',
             width: 100
           },

--- a/public/components/visualize/visualizations.js
+++ b/public/components/visualize/visualizations.js
@@ -104,7 +104,7 @@ export const visualizations = {
             width: 40
           },
           {
-            title: 'IP by Users',
+            title: 'IP address by Users',
             id: 'Wazuh-App-Overview-Office-IPs-By-User-Barchart',
             width: 30
           },

--- a/public/components/wz-search-bar/wz-search-bar.test.tsx
+++ b/public/components/wz-search-bar/wz-search-bar.test.tsx
@@ -14,14 +14,14 @@ const suggestions: IWzSuggestItem[] = [
   {
     type: 'q',
     label: 'os.platform',
-    description: 'Filter by OS platform',
+    description: 'Filter by operating system platform',
     operators: ['=', '!='],
     values: async (value) => getSuggestionsFilters('os.platform', value, { q: 'id!=000' }),
   },
   {
     type: 'q',
     label: 'ip',
-    description: 'Filter by agent IP',
+    description: 'Filter by agent IP address',
     operators: ['=', '!='],
     values: async (value) => getSuggestionsFilters('ip', value, { q: 'id!=000' }),
   },

--- a/public/controllers/agent/components/agents-preview.js
+++ b/public/controllers/agent/components/agents-preview.js
@@ -84,8 +84,8 @@ export const AgentsPreview = compose(
       this._isMount = true;
       this.fetchAgentStatusDetailsData();
       if (this.wazuhConfig.getConfig()['wazuh.monitoring.enabled']) {
-        this._isMount && this.setState({ 
-          showAgentsEvolutionVisualization: true 
+        this._isMount && this.setState({
+          showAgentsEvolutionVisualization: true
         });
         const tabVisualizations = new TabVisualizations();
         tabVisualizations.removeAll();
@@ -238,15 +238,6 @@ export const AgentsPreview = compose(
                             description="Agents coverage"
                             className="white-space-nowrap"
                             />
-                        </EuiFlexItem>
-                        <EuiFlexItem className="agents-link-item">
-                          <EuiStat
-                            isLoading={this.state.loadingSummary}
-                            title={`${this.state.agentsSynced}%`}
-                            titleSize='s'
-                            description="Synced agents"
-                            className="white-space-nowrap"
-                          />
                         </EuiFlexItem>
                       </EuiFlexGroup>
                       <EuiFlexGroup className="mt-0">

--- a/public/controllers/agent/components/agents-preview.js
+++ b/public/controllers/agent/components/agents-preview.js
@@ -70,7 +70,6 @@ export const AgentsPreview = compose(
         agentStatusSummary: { active: '-', disconnected: '-', total: '-', pending: '-', never_connected: '-' },
         agentConfiguration: {},
         agentsActiveCoverage: 0,
-        agentsSynced: 0,
       };
       this.wazuhConfig = new WazuhConfig();
       this.agentStatus = UI_ORDER_AGENT_STATUS.map(agentStatus => ({
@@ -120,7 +119,6 @@ export const AgentsPreview = compose(
         agentStatusSummary,
         agentConfiguration,
         agentsActiveCoverage: ((agentStatusSummary.active / agentStatusSummary.total) * 100).toFixed(2),
-        agentsSynced: ((agentConfiguration.synced/agentConfiguration.total)*100).toFixed(2),
       });
     }
 

--- a/public/controllers/agent/components/agents-preview.scss
+++ b/public/controllers/agent/components/agents-preview.scss
@@ -42,6 +42,7 @@
   display: flex;
   align-items: baseline;
   margin: 15px 0px;
+  flex-wrap: wrap;
 }
 
 .columnsSelectedCheckboxs div {

--- a/public/controllers/agent/components/agents-table.js
+++ b/public/controllers/agent/components/agents-table.js
@@ -355,13 +355,13 @@ export const AgentsTable = withErrorBoundary(
         checkField(agent?.os?.version);
 
       return (
-        <span className="euiTableCellContent__text euiTableCellContent--truncateText">
-          <i
+        <EuiFlexGroup gutterSize="none">
+          <EuiFlexItem grow={false} ><i
             className={`fa fa-${icon} AgentsTable__soBadge AgentsTable__soBadge--${icon}`}
             aria-hidden="true"
-          ></i>{' '}
-          {os_name === '- -' ? '-' : os_name}
-        </span>
+          ></i></EuiFlexItem>{' '}
+          <EuiFlexItem>{os_name === '- -' ? '-' : os_name}</EuiFlexItem>
+        </EuiFlexGroup>
       );
     }
 

--- a/public/controllers/agent/components/agents-table.js
+++ b/public/controllers/agent/components/agents-table.js
@@ -81,7 +81,7 @@ export const AgentsTable = withErrorBoundary(
         {
           type: 'q',
           label: 'os.platform',
-          description: 'Filter by OS platform',
+          description: 'Filter by operating system platform',
           operators: ['=', '!='],
           values: async (value) => getAgentFilterValues('os.platform', value, { q: 'id!=000' }),
         },

--- a/public/controllers/agent/components/agents-table.js
+++ b/public/controllers/agent/components/agents-table.js
@@ -467,6 +467,7 @@ export const AgentsTable = withErrorBoundary(
         name: 'ID',
         sortable: true,
         width: '6%',
+        enabledByDefault: true,
       },
       {
         field: 'name',
@@ -474,6 +475,7 @@ export const AgentsTable = withErrorBoundary(
         sortable: true,
         width: '10%',
         truncateText: true,
+        enabledByDefault: true,
       },
       {
         field: 'ip',
@@ -481,6 +483,7 @@ export const AgentsTable = withErrorBoundary(
         width: '8%',
         truncateText: true,
         sortable: true,
+        enabledByDefault: true,
       },
       {
         field: 'group',
@@ -488,6 +491,7 @@ export const AgentsTable = withErrorBoundary(
         width: '14%',
         truncateText: true,
         sortable: true,
+        enabledByDefault: true,
         render: (groups) => (groups !== '-' ? this.renderGroups(groups) : '-'),
       },
       {
@@ -496,6 +500,7 @@ export const AgentsTable = withErrorBoundary(
         sortable: true,
         width: '10%',
         truncateText: true,
+        enabledByDefault: true,
         render: this.addIconPlatformRender,
       },
       {
@@ -504,6 +509,7 @@ export const AgentsTable = withErrorBoundary(
         width: '8%',
         truncateText: true,
         sortable: true,
+        enabledByDefault: true,
       },
       {
         field: 'version',
@@ -511,6 +517,7 @@ export const AgentsTable = withErrorBoundary(
         width: '5%',
         truncateText: true,
         sortable: true,
+        enabledByDefault: true,
       },
       {
         field: 'dateAdd',
@@ -518,6 +525,7 @@ export const AgentsTable = withErrorBoundary(
         width: '8%',
         truncateText: true,
         sortable: true,
+        enabledByDefault: true,
       },
       {
         field: 'lastKeepAlive',
@@ -525,6 +533,7 @@ export const AgentsTable = withErrorBoundary(
         width: '8%',
         truncateText: true,
         sortable: true,
+        enabledByDefault: true,
       },
       {
         field: 'status',
@@ -532,6 +541,7 @@ export const AgentsTable = withErrorBoundary(
         truncateText: true,
         sortable: true,
         width: '10%',
+        enabledByDefault: true,
         render: (status) => <AgentStatus status={status} labelProps={{ className: 'hide-agent-status' }} />,
       },
       {
@@ -540,6 +550,7 @@ export const AgentsTable = withErrorBoundary(
         truncateText: true,
         sortable: true,
         width: '10%',
+        enabledByDefault: false,
         render: (synced) => <AgentSynced synced={synced}/>,
       },
       {
@@ -547,6 +558,7 @@ export const AgentsTable = withErrorBoundary(
         width: '5%',
         field: 'actions',
         name: 'Actions',
+        enabledByDefault: true,
         render: (agent) => this.actionButtonsRender(agent),
       },
     ];
@@ -564,7 +576,9 @@ export const AgentsTable = withErrorBoundary(
         });
         return newSelectedColumns;
       } else {
-        const fieldColumns = this.defaultColumns.map((item) => {
+        const fieldColumns = this.defaultColumns
+        .filter(column=>column.enabledByDefault)
+        .map((item) => {
           return {
             field: item.field,
             name: item.name,
@@ -572,7 +586,7 @@ export const AgentsTable = withErrorBoundary(
           };
         });
         this.setTableColumnsSelected(fieldColumns);
-        return this.defaultColumns;
+        return fieldColumns;
       }
     }
 

--- a/public/controllers/agent/components/agents-table.js
+++ b/public/controllers/agent/components/agents-table.js
@@ -88,7 +88,7 @@ export const AgentsTable = withErrorBoundary(
         {
           type: 'q',
           label: 'ip',
-          description: 'Filter by agent IP',
+          description: 'Filter by agent IP address',
           operators: ['=', '!='],
           values: async (value) => getAgentFilterValues('ip', value, { q: 'id!=000' }),
         },
@@ -220,7 +220,7 @@ export const AgentsTable = withErrorBoundary(
         const selectFieldsList = this.defaultColumns
           .filter(field => field.field != 'actions')
           .map(field => field.field.replace('os_', 'os.')); // "os_name" subfield should be specified as 'os.name'
-        const selectFields = [...selectFieldsList, 'os.uname', 'os.version'].join(','); // Add version and uname fields to render the OS icon and version in the table
+        const selectFields = [...selectFieldsList, 'os.platform', 'os.uname', 'os.version'].join(','); // Add version and uname fields to render the OS icon and version in the table
 
         const rawAgents = await this.props.wzReq('GET', '/agents', { params: { ...this.buildFilter(), select: selectFields } });
         const formatedAgents = (((rawAgents || {}).data || {}).data || {}).affected_items.map(
@@ -342,17 +342,17 @@ export const AgentsTable = withErrorBoundary(
       };
       const os = (agent || {}).os;
 
-      if (((os || {}).uname || '').includes('Linux')) {
+      if ((os?.uname || '').includes('Linux')) {
         icon = 'linux';
-      } else if ((os || {}).platform === 'windows') {
+      } else if (os?.platform === 'windows') {
         icon = 'windows';
-      } else if ((os || {}).platform === 'darwin') {
+      } else if (os?.platform === 'darwin') {
         icon = 'apple';
       }
       const os_name =
-        checkField(((agent || {}).os || {}).name) +
+        checkField(agent?.os?.name) +
         ' ' +
-        checkField(((agent || {}).os || {}).version);
+        checkField(agent?.os?.version);
 
       return (
         <span className="euiTableCellContent__text euiTableCellContent--truncateText">
@@ -466,21 +466,18 @@ export const AgentsTable = withErrorBoundary(
         field: 'id',
         name: 'ID',
         sortable: true,
-        width: '6%',
         show: true,
       },
       {
         field: 'name',
         name: 'Name',
         sortable: true,
-        width: '10%',
         truncateText: true,
         show: true,
       },
       {
         field: 'ip',
-        name: 'IP',
-        width: '8%',
+        name: 'IP address',
         truncateText: true,
         sortable: true,
         show: true,
@@ -488,7 +485,6 @@ export const AgentsTable = withErrorBoundary(
       {
         field: 'group',
         name: 'Group(s)',
-        width: '14%',
         truncateText: true,
         sortable: true,
         show: true,
@@ -496,9 +492,8 @@ export const AgentsTable = withErrorBoundary(
       },
       {
         field: 'os_name',
-        name: 'OS',
+        name: 'Operating system',
         sortable: true,
-        width: '10%',
         truncateText: true,
         show: true,
         render: this.addIconPlatformRender,
@@ -506,7 +501,6 @@ export const AgentsTable = withErrorBoundary(
       {
         field: 'node_name',
         name: 'Cluster node',
-        width: '8%',
         truncateText: true,
         sortable: true,
         show: true,
@@ -514,7 +508,6 @@ export const AgentsTable = withErrorBoundary(
       {
         field: 'version',
         name: 'Version',
-        width: '5%',
         truncateText: true,
         sortable: true,
         show: true,
@@ -522,25 +515,22 @@ export const AgentsTable = withErrorBoundary(
       {
         field: 'dateAdd',
         name: 'Registration date',
-        width: '8%',
         truncateText: true,
         sortable: true,
-        show: true,
+        show: false,
       },
       {
         field: 'lastKeepAlive',
         name: 'Last keep alive',
-        width: '8%',
         truncateText: true,
         sortable: true,
-        show: true,
+        show: false,
       },
       {
         field: 'status',
         name: 'Status',
         truncateText: true,
         sortable: true,
-        width: '10%',
         show: true,
         render: (status) => <AgentStatus status={status} labelProps={{ className: 'hide-agent-status' }} />,
       },
@@ -549,7 +539,6 @@ export const AgentsTable = withErrorBoundary(
         name: 'Synced',
         truncateText: true,
         sortable: true,
-        width: '10%',
         show: false,
         render: (synced) => <AgentSynced synced={synced}/>,
       },
@@ -730,6 +719,7 @@ export const AgentsTable = withErrorBoundary(
         <EuiFlexGroup>
           <EuiFlexItem>
             <EuiBasicTable
+              tableLayout="auto"
               items={agents}
               itemId="id"
               columns={columns}

--- a/public/controllers/agent/components/agents-table.js
+++ b/public/controllers/agent/components/agents-table.js
@@ -467,7 +467,7 @@ export const AgentsTable = withErrorBoundary(
         name: 'ID',
         sortable: true,
         width: '6%',
-        enabledByDefault: true,
+        show: true,
       },
       {
         field: 'name',
@@ -475,7 +475,7 @@ export const AgentsTable = withErrorBoundary(
         sortable: true,
         width: '10%',
         truncateText: true,
-        enabledByDefault: true,
+        show: true,
       },
       {
         field: 'ip',
@@ -483,7 +483,7 @@ export const AgentsTable = withErrorBoundary(
         width: '8%',
         truncateText: true,
         sortable: true,
-        enabledByDefault: true,
+        show: true,
       },
       {
         field: 'group',
@@ -491,7 +491,7 @@ export const AgentsTable = withErrorBoundary(
         width: '14%',
         truncateText: true,
         sortable: true,
-        enabledByDefault: true,
+        show: true,
         render: (groups) => (groups !== '-' ? this.renderGroups(groups) : '-'),
       },
       {
@@ -500,7 +500,7 @@ export const AgentsTable = withErrorBoundary(
         sortable: true,
         width: '10%',
         truncateText: true,
-        enabledByDefault: true,
+        show: true,
         render: this.addIconPlatformRender,
       },
       {
@@ -509,7 +509,7 @@ export const AgentsTable = withErrorBoundary(
         width: '8%',
         truncateText: true,
         sortable: true,
-        enabledByDefault: true,
+        show: true,
       },
       {
         field: 'version',
@@ -517,7 +517,7 @@ export const AgentsTable = withErrorBoundary(
         width: '5%',
         truncateText: true,
         sortable: true,
-        enabledByDefault: true,
+        show: true,
       },
       {
         field: 'dateAdd',
@@ -525,7 +525,7 @@ export const AgentsTable = withErrorBoundary(
         width: '8%',
         truncateText: true,
         sortable: true,
-        enabledByDefault: true,
+        show: true,
       },
       {
         field: 'lastKeepAlive',
@@ -533,7 +533,7 @@ export const AgentsTable = withErrorBoundary(
         width: '8%',
         truncateText: true,
         sortable: true,
-        enabledByDefault: true,
+        show: true,
       },
       {
         field: 'status',
@@ -541,7 +541,7 @@ export const AgentsTable = withErrorBoundary(
         truncateText: true,
         sortable: true,
         width: '10%',
-        enabledByDefault: true,
+        show: true,
         render: (status) => <AgentStatus status={status} labelProps={{ className: 'hide-agent-status' }} />,
       },
       {
@@ -550,7 +550,7 @@ export const AgentsTable = withErrorBoundary(
         truncateText: true,
         sortable: true,
         width: '10%',
-        enabledByDefault: false,
+        show: false,
         render: (synced) => <AgentSynced synced={synced}/>,
       },
       {
@@ -558,7 +558,7 @@ export const AgentsTable = withErrorBoundary(
         width: '5%',
         field: 'actions',
         name: 'Actions',
-        enabledByDefault: true,
+        show: true,
         render: (agent) => this.actionButtonsRender(agent),
       },
     ];
@@ -576,13 +576,11 @@ export const AgentsTable = withErrorBoundary(
         });
         return newSelectedColumns;
       } else {
-        const fieldColumns = this.defaultColumns
-        .filter(column=>column.enabledByDefault)
-        .map((item) => {
+        const fieldColumns = this.defaultColumns.map((item) => {
           return {
             field: item.field,
             name: item.name,
-            show: true,
+            show: item.show,
           };
         });
         this.setTableColumnsSelected(fieldColumns);

--- a/public/controllers/agent/components/agents-table.js
+++ b/public/controllers/agent/components/agents-table.js
@@ -461,6 +461,8 @@ export const AgentsTable = withErrorBoundary(
       window.localStorage.setItem('columnsSelectedTableAgent', JSON.stringify(data));
     }
 
+    // Columns with the property truncateText: true won't wrap the text
+    // This is added to prevent the wrap because of the table-layout: auto
     defaultColumns = [
       {
         field: 'id',
@@ -472,7 +474,6 @@ export const AgentsTable = withErrorBoundary(
         field: 'name',
         name: 'Name',
         sortable: true,
-        truncateText: true,
         show: true,
       },
       {
@@ -485,7 +486,6 @@ export const AgentsTable = withErrorBoundary(
       {
         field: 'group',
         name: 'Group(s)',
-        truncateText: true,
         sortable: true,
         show: true,
         render: (groups) => (groups !== '-' ? this.renderGroups(groups) : '-'),
@@ -494,14 +494,12 @@ export const AgentsTable = withErrorBoundary(
         field: 'os_name',
         name: 'Operating system',
         sortable: true,
-        truncateText: true,
         show: true,
         render: this.addIconPlatformRender,
       },
       {
         field: 'node_name',
         name: 'Cluster node',
-        truncateText: true,
         sortable: true,
         show: true,
       },
@@ -522,7 +520,6 @@ export const AgentsTable = withErrorBoundary(
       {
         field: 'lastKeepAlive',
         name: 'Last keep alive',
-        truncateText: true,
         sortable: true,
         show: false,
       },
@@ -537,10 +534,9 @@ export const AgentsTable = withErrorBoundary(
       {
         field: 'group_config_status',
         name: 'Synced',
-        truncateText: true,
         sortable: true,
         show: false,
-        render: (synced) => <AgentSynced synced={synced}/>,
+        render: (synced) => <AgentSynced synced={synced} />,
       },
       {
         align: 'right',
@@ -673,7 +669,7 @@ export const AgentsTable = withErrorBoundary(
         return {
           'data-test-subj': `row-${id}`,
           className: 'customRowClass',
-          onClick: () => {},
+          onClick: () => { },
         };
       };
 
@@ -702,11 +698,11 @@ export const AgentsTable = withErrorBoundary(
       const pagination =
         totalItems > 15
           ? {
-              pageIndex: pageIndex,
-              pageSize: pageSize,
-              totalItemCount: totalItems,
-              pageSizeOptions: [15, 25, 50, 100],
-            }
+            pageIndex: pageIndex,
+            pageSize: pageSize,
+            totalItemCount: totalItems,
+            pageSizeOptions: [15, 25, 50, 100],
+          }
           : false;
       const sorting = {
         sort: {
@@ -715,6 +711,9 @@ export const AgentsTable = withErrorBoundary(
         },
       };
 
+      // The EuiBasicTable tableLayout is set to "auto" to improve the use of empty space in the component.
+      // Previously the tableLayout is set to "fixed" with percentage width for each column, but the use of space was not optimal.
+      // Important: If all the columns have the truncateText property set to true, the table cannot adjust properly when the viewport size is small.
       return (
         <EuiFlexGroup>
           <EuiFlexItem>
@@ -742,8 +741,8 @@ export const AgentsTable = withErrorBoundary(
       if (filters.length > 0) {
         !auxFilters.includes(group)
           ? this.setState({
-              filters: [...filters, { field: 'q', value: `group=${group}` }],
-            })
+            filters: [...filters, { field: 'q', value: `group=${group}` }],
+          })
           : false;
       } else {
         this.setState({

--- a/public/controllers/agent/components/agents-table.js
+++ b/public/controllers/agent/components/agents-table.js
@@ -479,7 +479,6 @@ export const AgentsTable = withErrorBoundary(
       {
         field: 'ip',
         name: 'IP address',
-        truncateText: true,
         sortable: true,
         show: true,
       },
@@ -506,14 +505,12 @@ export const AgentsTable = withErrorBoundary(
       {
         field: 'version',
         name: 'Version',
-        truncateText: true,
         sortable: true,
         show: true,
       },
       {
         field: 'dateAdd',
         name: 'Registration date',
-        truncateText: true,
         sortable: true,
         show: false,
       },

--- a/public/controllers/agent/components/agents-table.js
+++ b/public/controllers/agent/components/agents-table.js
@@ -712,7 +712,7 @@ export const AgentsTable = withErrorBoundary(
       // Previously the tableLayout is set to "fixed" with percentage width for each column, but the use of space was not optimal.
       // Important: If all the columns have the truncateText property set to true, the table cannot adjust properly when the viewport size is small.
       return (
-        <EuiFlexGroup>
+        <EuiFlexGroup className="wz-overflow-auto">
           <EuiFlexItem>
             <EuiBasicTable
               tableLayout="auto"

--- a/public/controllers/agent/components/agents-table.js
+++ b/public/controllers/agent/components/agents-table.js
@@ -355,7 +355,7 @@ export const AgentsTable = withErrorBoundary(
         checkField(agent?.os?.version);
 
       return (
-        <EuiFlexGroup gutterSize="none">
+        <EuiFlexGroup gutterSize="xs">
           <EuiFlexItem grow={false} ><i
             className={`fa fa-${icon} AgentsTable__soBadge AgentsTable__soBadge--${icon}`}
             aria-hidden="true"

--- a/public/controllers/management/components/management/configuration/configuration-settings.js
+++ b/public/controllers/management/components/management/configuration/configuration-settings.js
@@ -133,7 +133,7 @@ export default [
       {
         name: 'Inventory data',
         description:
-          'Gather relevant information about system OS, hardware, networking and packages',
+          'Gather relevant information about system operating system, hardware, networking and packages',
         goto: 'inventory'
       },
       {

--- a/public/controllers/management/components/management/configuration/global-configuration/global-configuration-remote.js
+++ b/public/controllers/management/components/management/configuration/global-configuration/global-configuration-remote.js
@@ -72,7 +72,7 @@ class WzConfigurationGlobalConfigurationRemote extends Component {
       },
       {
         field: 'local_ip',
-        name: 'Local IP',
+        name: 'Local IP address',
         render: renderValueOrDefault('All interfaces')
       },
       {

--- a/public/controllers/management/components/management/configuration/global-configuration/global-configuration-remote.js
+++ b/public/controllers/management/components/management/configuration/global-configuration/global-configuration-remote.js
@@ -62,12 +62,12 @@ class WzConfigurationGlobalConfigurationRemote extends Component {
       { field: 'ipv6', name: 'IPv6', render: renderValueOrNoValue },
       {
         field: 'allowed-ips',
-        name: 'Allowed IPs',
+        name: 'Allowed IP addresses',
         render: item => renderAllowedDeniedIPs(item, 'allowed')
       },
       {
         field: 'denied-ips',
-        name: 'Denied Ips',
+        name: 'Denied IP addresses',
         render: item => renderAllowedDeniedIPs(item, 'denied')
       },
       {

--- a/public/controllers/management/components/management/configuration/integrations/integrations.js
+++ b/public/controllers/management/components/management/configuration/integrations/integrations.js
@@ -57,7 +57,7 @@ const integrationsSettings = [
   { field: 'group', label: 'Filter alerts by these rule groupst' },
   {
     field: 'event_location',
-    label: 'Filter alerts by location (agent, IP or file)'
+    label: 'Filter alerts by location (agent, IP address or file)'
   },
   { field: 'alert_format', label: 'Used format to write alerts' }
 ];

--- a/public/controllers/management/components/management/groups/group-agents-table.js
+++ b/public/controllers/management/components/management/groups/group-agents-table.js
@@ -165,13 +165,13 @@ class WzGroupAgentsTable extends Component {
       },
       {
         field: 'os.name',
-        name: 'Os name',
+        name: 'Operating system name',
         align: 'left',
         sortable: true,
       },
       {
         field: 'os.version',
-        name: 'Os version',
+        name: 'Operating system version',
         align: 'left',
         sortable: true,
       },

--- a/public/controllers/management/components/management/groups/group-agents-table.js
+++ b/public/controllers/management/components/management/groups/group-agents-table.js
@@ -52,7 +52,7 @@ class WzGroupAgentsTable extends Component {
       {
         type: 'q',
         label: 'os.platform',
-        description: 'Filter by OS platform',
+        description: 'Filter by operating system platform',
         operators: ['=', '!='],
         values: async (value) =>
           getAgentFilterValues('os.platform', value, {
@@ -62,7 +62,7 @@ class WzGroupAgentsTable extends Component {
       {
         type: 'q',
         label: 'ip',
-        description: 'Filter by agent IP',
+        description: 'Filter by agent IP address',
         operators: ['=', '!='],
         values: async (value) =>
           getAgentFilterValues('ip', value, { q: `group=${this.props.state.itemDetail.name}` }),
@@ -153,7 +153,7 @@ class WzGroupAgentsTable extends Component {
       },
       {
         field: 'ip',
-        name: 'Ip',
+        name: 'IP address',
         align: 'left',
         sortable: true,
       },

--- a/public/controllers/management/components/management/status/status-agent-info.js
+++ b/public/controllers/management/components/management/status/status-agent-info.js
@@ -80,7 +80,7 @@ export class WzStatusAgentInfo extends Component {
           <EuiFlexItem style={{...greyStyle}}>{agentStatusLabelByAgentStatus(agentInfo.status)}</EuiFlexItem>
         </EuiFlexGroup>
         <EuiFlexGroup>
-          <EuiFlexItem>IP Address</EuiFlexItem>
+          <EuiFlexItem>IP address</EuiFlexItem>
           <EuiFlexItem style={greyStyle}>{agentInfo.ip}</EuiFlexItem>
         </EuiFlexGroup>
         <EuiFlexGroup>

--- a/public/controllers/management/components/management/status/status-stats.js
+++ b/public/controllers/management/components/management/status/status-stats.js
@@ -32,11 +32,6 @@ export class WzStatusStats extends Component {
       description: 'Agents coverage',
       status: 'coverage'
     })
-    this.agentStatus.push({
-      color: undefined,
-      description: 'Synced agents',
-      status: 'synced'
-    })
   }
 
   componentDidMount() {
@@ -54,13 +49,12 @@ export class WzStatusStats extends Component {
     const metric = {
       [status]: stats?.agentsCount?.[status],
       coverage: `${stats?.agentsCoverage}%`,
-      synced: `${stats?.agentsSynced}%`
     };
     return metric[status];
   }
 
   render() {
-    
+
     return (
       <div>
         <EuiFlexGroup>

--- a/public/controllers/overview/components/overview-actions/agents-selection-table.js
+++ b/public/controllers/overview/components/overview-actions/agents-selection-table.js
@@ -119,8 +119,8 @@ export class AgentSelectionTable extends Component {
     ];
     this.suggestions = [
       { type: 'q', label: 'status', description: 'Filter by agent connection status', operators: ['=', '!=',], values: UI_ORDER_AGENT_STATUS },
-      { type: 'q', label: 'os.platform', description: 'Filter by OS platform', operators: ['=', '!=',], values: async (value) => getAgentFilterValues('os.platform', value, { q: 'id!=000'})},
-      { type: 'q', label: 'ip', description: 'Filter by agent IP', operators: ['=', '!=',], values: async (value) => getAgentFilterValues('ip', value, { q: 'id!=000'})},
+      { type: 'q', label: 'os.platform', description: 'Filter by operating system platform', operators: ['=', '!=',], values: async (value) => getAgentFilterValues('os.platform', value, { q: 'id!=000'})},
+      { type: 'q', label: 'ip', description: 'Filter by agent IP address', operators: ['=', '!=',], values: async (value) => getAgentFilterValues('ip', value, { q: 'id!=000'})},
       { type: 'q', label: 'name', description: 'Filter by agent name', operators: ['=', '!=',], values: async (value) => getAgentFilterValues('name', value, { q: 'id!=000'})},
       { type: 'q', label: 'id', description: 'Filter by agent id', operators: ['=', '!=',], values: async (value) => getAgentFilterValues('id', value, { q: 'id!=000'})},
       { type: 'q', label: 'group', description: 'Filter by agent group', operators: ['=', '!=',], values: async (value) => getAgentFilterValues('group', value, { q: 'id!=000'})},

--- a/public/controllers/overview/components/overview-actions/agents-selection-table.js
+++ b/public/controllers/overview/components/overview-actions/agents-selection-table.js
@@ -97,7 +97,7 @@ export class AgentSelectionTable extends Component {
       },
       {
         id: 'os',
-        label: 'OS',
+        label: 'Operating system',
         alignment: LEFT_ALIGNMENT,
         mobileOptions: {
           show: false,

--- a/public/controllers/overview/components/select-agent.js
+++ b/public/controllers/overview/components/select-agent.js
@@ -170,7 +170,7 @@ export const SelectAgent = withErrorBoundary (class SelectAgent extends Componen
       },
       {
         field: 'ip',
-        name: 'IP',
+        name: 'IP address',
         truncateText: true,
         sortable: true
       },

--- a/public/styles/common.scss
+++ b/public/styles/common.scss
@@ -1561,7 +1561,7 @@ div.euiPopover__panel.euiPopover__panel-isOpen.euiPopover__panel--bottom.wz-menu
         overflow: hidden;
       }
     }
-  } 
+  }
 }
 
 @media (min-width: 1600px) {
@@ -1617,6 +1617,7 @@ div.euiPopover__panel.euiPopover__panel-isOpen.euiPopover__panel--bottom.wz-menu
 
 .icon-box-action {
   display: flex;
+  flex-wrap: wrap;
 }
 
 @media only screen and (max-width: 1200px) {
@@ -1805,4 +1806,8 @@ iframe.width-changed {
     margin-top: 10px;
     display: flex;
     flex-direction: row;
+}
+
+.wz-overflow-auto{
+  overflow: auto;
 }

--- a/public/templates/management/management.html
+++ b/public/templates/management/management.html
@@ -111,7 +111,7 @@
           </span>
           <div class="euiSpacer euiSpacer--m"></div>
           <div layout="row" class="wz-padding-top-10">
-            <span flex="25">IP</span>
+            <span flex="25">IP address</span>
             <span class="color-grey">{{configuration.nodes[0] || '-'}}</span>
           </div>
           <div layout="row" class="wz-padding-top-10">
@@ -226,7 +226,7 @@
               <span class="euiLoadingChart__bar"></span>
               <span class="euiLoadingChart__bar"></span>
               <span class="euiLoadingChart__bar"></span>
-          </span> 
+          </span>
           <md-card-content
             class="wazuh-column"
             ng-class="{'no-opacity-overview-monitoring': !isReady || !rendered }"

--- a/server/controllers/wazuh-reporting.ts
+++ b/server/controllers/wazuh-reporting.ts
@@ -889,7 +889,7 @@ export class WazuhReportingCtrl {
       createDirectoryIfNotExists(path.join(WAZUH_DATA_DOWNLOADS_REPORTS_DIRECTORY_PATH, hashUsername));
 
       log('reporting:createReportsAgentsInventory', `Syscollector report`, 'debug');
-      const sanitizedFilters = filters ? this.sanitizeKibanaFilters(filters, searchBar) : false;
+      const [sanitizedFilters, agentsFilter] = filters ? this.sanitizeKibanaFilters(filters, searchBar) : [false, null];
 
       // Get the agent OS
       let agentOs = '';
@@ -1071,6 +1071,7 @@ export class WazuhReportingCtrl {
           from,
           to,
           sanitizedFilters + ' AND rule.groups: "vulnerability-detector"',
+          agentsFilter,
           indexPatternTitle,
           agentID
         );

--- a/server/controllers/wazuh-reporting.ts
+++ b/server/controllers/wazuh-reporting.ts
@@ -961,14 +961,14 @@ export class WazuhReportingCtrl {
             columns:
               agentOs === 'windows'
                 ? [
-                    { id: 'local_ip', label: 'Local IP' },
+                    { id: 'local_ip', label: 'Local IP address' },
                     { id: 'local_port', label: 'Local port' },
                     { id: 'process', label: 'Process' },
                     { id: 'state', label: 'State' },
                     { id: 'protocol', label: 'Protocol' },
                   ]
                 : [
-                    { id: 'local_ip', label: 'Local IP' },
+                    { id: 'local_ip', label: 'Local IP address' },
                     { id: 'local_port', label: 'Local port' },
                     { id: 'state', label: 'State' },
                     { id: 'protocol', label: 'Protocol' },
@@ -1001,7 +1001,7 @@ export class WazuhReportingCtrl {
             title: 'Network settings',
             columns: [
               { id: 'iface', label: 'Interface' },
-              { id: 'address', label: 'address' },
+              { id: 'address', label: 'Address' },
               { id: 'netmask', label: 'Netmask' },
               { id: 'proto', label: 'Protocol' },
               { id: 'broadcast', label: 'Broadcast' },

--- a/server/integration-files/visualizations/overview/overview-office.ts
+++ b/server/integration-files/visualizations/overview/overview-office.ts
@@ -1175,7 +1175,7 @@ export default [
               otherBucketLabel: 'Others',
               missingBucket: false,
               missingBucketLabel: 'Missing',
-              customLabel: 'Client IP',
+              customLabel: 'Client IP address',
             },
             schema: 'bucket',
           },

--- a/server/lib/reporting/agent-configuration.ts
+++ b/server/lib/reporting/agent-configuration.ts
@@ -163,7 +163,7 @@ export const AgentConfiguration = {
           subtitle: 'Inventory data',
           docuLink: webDocumentationLink('user-manual/reference/ossec-conf/wodle-syscollector.html'),
           desc:
-            'Gather relevant information about system OS, hardware, networking and packages',
+            'Gather relevant information about the operating system, hardware, networking and packages',
           wodle: [{ name: 'syscollector' }],
           labels: [
             {

--- a/server/lib/reporting/extended-information.ts
+++ b/server/lib/reporting/extended-information.ts
@@ -81,7 +81,7 @@ import { getSettingDefaultValue } from '../../../common/services/settings';
           { id: 'ip', label: 'IP address' },
           { id: 'version', label: 'Version' },
           { id: 'manager', label: 'Manager' },
-          { id: 'os', label: 'OS' },
+          { id: 'os', label: 'Operating system' },
           { id: 'dateAdd', label: 'Registration date' },
           { id: 'lastKeepAlive', label: 'Last keep alive' },
         ],

--- a/server/lib/reporting/extended-information.ts
+++ b/server/lib/reporting/extended-information.ts
@@ -714,9 +714,9 @@ export async function extendedInformation(
         },
         {
           endpoint: `/syscollector/${agent}/os`,
-          loggerMessage: `Fetching OS information for agent ${agent}`,
+          loggerMessage: `Fetching operating system information for agent ${agent}`,
           list: {
-            title: { text: 'OS information', style: 'h2' },
+            title: { text: 'Operating system information', style: 'h2' },
           },
           mapResponse: (osData) => [
             osData.sysname,

--- a/server/lib/reporting/extended-information.ts
+++ b/server/lib/reporting/extended-information.ts
@@ -78,7 +78,7 @@ import { getSettingDefaultValue } from '../../../common/services/settings';
         columns: [
           { id: 'id', label: 'ID' },
           { id: 'name', label: 'Name' },
-          { id: 'ip', label: 'IP' },
+          { id: 'ip', label: 'IP address' },
           { id: 'version', label: 'Version' },
           { id: 'manager', label: 'Manager' },
           { id: 'os', label: 'OS' },


### PR DESCRIPTION
### Description
Hi team,

This PR: 

- Disables by default the `Synced` - `Registration Date` - `Last Keep Alive` fields of the Agents table and removes the metric on the top of the view. Even though it is disabled, it still can be enabled by checking the field in the table settings.
- It also changes the text `IP` and the text `OS` to `IP address` and to `Operating system` throughout the app. 
- Improves the Agents table dynamic layout
- Fixes Windows and MacOs operating system icons in the agents table

 
### Issues Resolved
Closes #5141 

### Evidence
![image](https://user-images.githubusercontent.com/9343732/213511691-a30946b6-77f1-4060-9d70-f981883f26af.png)



## Tests

### Synced field - Registration Date - Last Keep Alive

- Register agents in the manager
- Go to Agents overview
- Check the table does not include the `synced` field
- Check the top metrics don't include the `Synced` percentage
- Check the synced field can be enabled in the Agents table

### Replace `OS` to `Operating system` and `IP` to `IP address`

#### Agents table 
![image](https://user-images.githubusercontent.com/9343732/214295490-48ca440a-889e-4ebe-9422-5c16117c874d.png)

#### Agents Inventory PDF report

- Go to an Agent inventory data
- Generate PDF report

![image](https://user-images.githubusercontent.com/9343732/214296022-c5336d69-4891-4e8c-9186-7f1c916b2ede.png)
![image](https://user-images.githubusercontent.com/9343732/214297228-299297b2-7925-4a66-9742-6dcb8e2fb0c5.png)
![image](https://user-images.githubusercontent.com/9343732/214297692-d7c788dc-433f-4ab1-9dd1-6f0755bdd3c0.png)

#### Groups agents table

- Go to Management -> Groups
- Select a group
![image](https://user-images.githubusercontent.com/9343732/214522322-d63abdb9-4eeb-4ced-9758-adb36d562f92.png)

#### Agent overview

- Go to Agents
- Select an agent

![image](https://user-images.githubusercontent.com/9343732/214523324-7d4d89d6-2898-44f8-b3f1-12bff4b3b466.png)


#### Management cluster

- Go to Management -> Cluster
- Click on `Nodes` link

![image](https://user-images.githubusercontent.com/9343732/214524910-3da5d9a3-a513-4599-8420-65551febc399.png)
![image](https://user-images.githubusercontent.com/9343732/214524955-c4d497fd-0db0-4344-9bd0-a676314b6f55.png)


#### Office365 Panel

- Go to Office365 -> Panel
- Click on any Top Client IP Address table row to drill-down

![image](https://user-images.githubusercontent.com/9343732/214525407-72903fd0-2efe-4f83-a16b-67ac4a7c17f4.png)
![image](https://user-images.githubusercontent.com/9343732/214525724-ff359b15-cbbf-439f-a93f-ff73dc4f2e27.png)


#### Global Configuration Remote

- Go to Management -> Configuration
- Click on the Global configuration row
- Click on the Remote tab

![image](https://user-images.githubusercontent.com/9343732/214526481-ed30c63a-b75b-4551-869d-b0fa95263e4b.png)


#### Explore Agent modal

- Go to Security Events
- Click on Explore Agent button

![image](https://user-images.githubusercontent.com/9343732/214526911-7aaf1a95-b8ca-4ee6-a90d-7cb1d82e898d.png)


### Redistribute Agents Table column widths automatically 

- Go to Agents Overview
- Add and remove all available columns to force different widths in the columns
- Check they adjust properly

### Verify all main agents operating system have the proper icon in the table

- Register Linux, Windows and MacOS agents
- Check they have the corresponding icon in the Agents Overview Table

>  **Important**
> To test it properly, delete the preview _**local storage**_ table configuration
>  ![image](https://user-images.githubusercontent.com/9343732/213504621-531845cd-3485-4856-8e62-8b6c16ca1518.png)


## Check List
- [x] All tests pass
  - [x] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 
