### PR TITLE
Serialize cronjob doc and remove type property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,7 +66,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Deploy new agent section: Fixed the way macos versions and architectures were displayed, fixed the way agents were displayed, fixed the way ubuntu versions were displayed. [#4933](https://github.com/wazuh/wazuh-kibana-app/pull/4933)
 - Fixed agent deployment instructions for HP-UX and Solaris. [#4943](https://github.com/wazuh/wazuh-kibana-app/pull/4943)
 - Fixed Inventory checks table filters by stats [#4999](https://github.com/wazuh/wazuh-kibana-app/pull/4999)
-- Fixed agent graph in opensearch dashboard [#4942] (https://github.com/wazuh/wazuh-kibana-app/pull/4942)
+- Fixed agent graph in opensearch dashboard [#4942](https://github.com/wazuh/wazuh-kibana-app/pull/4942)
 - Fixed commands in the deploy new agent section(most of the commands are missing '-1') [#4962](https://github.com/wazuh/wazuh-kibana-app/pull/4962)
 - Fixed agent installation command for macOS in the deploy new agent section. [#4968](https://github.com/wazuh/wazuh-kibana-app/pull/4968)
 - Fixed commands in the deploy new agent section(most of the commands are missing '-1') [#4984](https://github.com/wazuh/wazuh-kibana-app/pull/4984)
@@ -79,6 +79,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fixed menu content panel is displayed in the wrong place. [5092](https://github.com/wazuh/wazuh-kibana-app/pull/5092)
 - Fixed greyed and disabled menu section names [#5101](https://github.com/wazuh/wazuh-kibana-app/pull/5101)
 - Fixed mispelling in the NIST module [#5107](https://github.com/wazuh/wazuh-kibana-app/pull/5107)
+- Fixed Statistic cronjob bulk document insert [#5150](https://github.com/wazuh/wazuh-kibana-app/pull/5150)
 
 ### Removed
 

--- a/server/start/cron-scheduler/save-document.ts
+++ b/server/start/cron-scheduler/save-document.ts
@@ -76,15 +76,11 @@ export class SaveDocument {
   private createDocument(doc, index, mapping: string): BulkIndexDocumentsParams {
     const createDocumentObject: BulkIndexDocumentsParams = {
       index,
-      type: '_doc',
-      body: doc.flatMap(item => [{
-        index: { _index: index }
-      },
-      {
+      body: doc.map(item => `{"index": { "_index": "${index}" }}\n${JSON.stringify({
         ...this.buildData(item, mapping),
         timestamp: new Date(Date.now()).toISOString()
-      }
-      ])
+      })}\n`)
+      .join('')
     };
     log(this.logPath, `Document object: ${JSON.stringify(createDocumentObject)}`, 'debug');
     return createDocumentObject;


### PR DESCRIPTION
### Description
Hi team,
this PR fixes the statistics cronjob request body to fix the `"mapper_parsing_exception"`. It seems the opensearch dependency that executes the bulk doc insert has changed.

https://github.com/opensearch-project/OpenSearch-Dashboards/blob/1.2.0/package.json#L121
https://github.com/opensearch-project/OpenSearch-Dashboards/blob/2.4.1/package.json#L133
 
### Issues Resolved
Closes https://github.com/wazuh/wazuh-automation/issues/1020

### Evidence
#### Discover
![image](https://user-images.githubusercontent.com/9343732/213742004-5fe1969b-9aa1-4278-a1a9-e1f3b0b75cd4.png)

#### Statistics
![image](https://user-images.githubusercontent.com/9343732/213741905-6a540f63-5a92-4bd2-8c0c-2daf95e206d4.png)

### Test

- Verify the Statistics information is indexed in Cluster mode ON and OFF

| Cluster Mode ON | Cluster Mode OFF |
| --- |  --- |
|:black_circle:|:black_circle:|

### Check List
- [x] All tests pass
  - [x] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 
