### PR TITLE
Added server address and wazuh protocol definition in Deploy agent section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Added file saving conditions in File Editor [#4970](https://github.com/wazuh/wazuh-kibana-app/pull/4970)
 - Added character validation to avoid invalid agent names in the section 'Deploy new agent'. [#5021](https://github.com/wazuh/wazuh-kibana-app/pull/5021) [#5028](https://github.com/wazuh/wazuh-kibana-app/pull/5028)
 - Added default selected options in Deploy Agent page [#5063](https://github.com/wazuh/wazuh-kibana-app/pull/5063)
-- Added new Server Address component [#5166](https://github.com/wazuh/wazuh-kibana-app/pull/5166)
+- Added new Server Address input in Deploy agent section  [#5166](https://github.com/wazuh/wazuh-kibana-app/pull/5166)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Added file saving conditions in File Editor [#4970](https://github.com/wazuh/wazuh-kibana-app/pull/4970)
 - Added character validation to avoid invalid agent names in the section 'Deploy new agent'. [#5021](https://github.com/wazuh/wazuh-kibana-app/pull/5021) [#5028](https://github.com/wazuh/wazuh-kibana-app/pull/5028)
 - Added default selected options in Deploy Agent page [#5063](https://github.com/wazuh/wazuh-kibana-app/pull/5063)
+- Added new Server Address component [#5166](https://github.com/wazuh/wazuh-kibana-app/pull/5166)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Added file saving conditions in File Editor [#4970](https://github.com/wazuh/wazuh-kibana-app/pull/4970)
 - Added character validation to avoid invalid agent names in the section 'Deploy new agent'. [#5021](https://github.com/wazuh/wazuh-kibana-app/pull/5021) [#5028](https://github.com/wazuh/wazuh-kibana-app/pull/5028)
 - Added default selected options in Deploy Agent page [#5063](https://github.com/wazuh/wazuh-kibana-app/pull/5063)
-- Added new Server Address input in Deploy agent section  [#5166](https://github.com/wazuh/wazuh-kibana-app/pull/5166)
+- Added server address and wazuh protocol definition in Deploy agent section [#5166](https://github.com/wazuh/wazuh-kibana-app/pull/5166)
 
 ### Changed
 

--- a/public/controllers/agent/components/register-agent-service.ts
+++ b/public/controllers/agent/components/register-agent-service.ts
@@ -198,4 +198,16 @@ export const getMasterNode = (
     return nodeIps.filter(nodeIp => nodeIp.nodetype === 'master');
 };
 
+/**
+ * Get the remote configuration from manager
+ * This function get the config from manager mode or cluster mode 
+ */
+export const getMasterRemoteConfiguration = async () => {
+  const nodes = await fetchClusterNodesOptions();
+  const masterNode = getMasterNode(nodes);
+  return await getRemoteConfiguration(masterNode[0].label);      
+}
+
+
+
 export { getConnectionConfig, getRemoteConfiguration };

--- a/public/controllers/agent/components/register-agent.js
+++ b/public/controllers/agent/components/register-agent.js
@@ -200,15 +200,10 @@ export const RegisterAgent = withErrorBoundary(
 
     getRemoteConfig = async () => {
       const remoteConfig = await getMasterRemoteConfiguration();
-      const serverAddress = this.defaultServerAddress || this.configuration['enrollment.dns'] || '';
-      if (serverAddress) {
-        this.setState({ 
-          udpProtocol: false,
-          connectionSecure: true, 
-          serverAddress });
-      }else{
+      if (remoteConfig) {
         this.setState({
           haveUdpProtocol: remoteConfig.isUdp,
+          haveConnectionSecure: remoteConfig.isSecure,
           udpProtocol: remoteConfig.isUdp,
           connectionSecure: remoteConfig.isSecure,
         })
@@ -1665,19 +1660,11 @@ apk add wazuh-agent=${this.state.wazuhVersion}-r1`,
       ];
 
       const onChangeServerAddress = async nodeSelected => {
-        if (!nodeSelected) {
-          this.setState({
-            serverAddress: '',
-            udpProtocol: this.state.haveUdpProtocol,
-            connectionSecure: this.state.haveUdpProtocol ? false : true
-          });
-        } else {
           this.setState({
             serverAddress: nodeSelected,
-            udpProtocol: false,
-            connectionSecure: true,
-          });
-        }
+            udpProtocol: this.state.haveUdpProtocol,
+            connectionSecure: this.state.haveConnectionSecure
+          }); 
       };
 
       const steps = [

--- a/public/controllers/agent/components/register-agent.js
+++ b/public/controllers/agent/components/register-agent.js
@@ -194,14 +194,13 @@ export const RegisterAgent = withErrorBoundary(
     }
 
     getEnrollDNSConfig = () => {
-      let serverAddress = this.configuration['enrollment.dns'] || '';
+      const serverAddress = this.configuration['enrollment.dns'] || '';
       this.setState({ defaultServerAddress: serverAddress });
     };
 
     getRemoteConfig = async () => {
       const remoteConfig = await getMasterRemoteConfiguration();
-      let serverAddress = this.defaultServerAddress || this.configuration['enrollment.dns'] || '';
-      console.log('remote config', remoteConfig);
+      const serverAddress = this.defaultServerAddress || this.configuration['enrollment.dns'] || '';
       if (serverAddress) {
         this.setState({ 
           udpProtocol: false,

--- a/public/controllers/agent/components/register-agent.js
+++ b/public/controllers/agent/components/register-agent.js
@@ -1668,44 +1668,15 @@ apk add wazuh-agent=${this.state.wazuhVersion}-r1`,
         if (!nodeSelected) {
           this.setState({
             serverAddress: '',
-            udpProtocol: false,
-            connectionSecure: null,
+            udpProtocol: this.state.haveUdpProtocol,
+            connectionSecure: this.state.haveUdpProtocol ? false : true
           });
         } else {
-          if (nodeSelected === this.state.defaultServerAddress) {
-            this.setState({
-              serverAddress: nodeSelected,
-              udpProtocol: false,
-              connectionSecure: true,
-            });
-          } else {
-            try {
-              this.setState({
-                serverAddress: nodeSelected,
-                udpProtocol: this.state.haveUdpProtocol,
-                connectionSecure: this.state.haveUdpProtocol ? false : true
-              });
-            } catch (error) {
-              const options = {
-                context: `${RegisterAgent.name}.onChangeServerAddress`,
-                level: UI_LOGGER_LEVELS.ERROR,
-                severity: UI_ERROR_SEVERITIES.BUSINESS,
-                display: true,
-                store: false,
-                error: {
-                  error: error,
-                  message: error.message || error,
-                  title: error.name || error,
-                },
-              };
-              getErrorOrchestrator().handleError(options);
-              this.setState({
-                serverAddress: nodeSelected,
-                udpProtocol: false,
-                connectionSecure: false,
-              });
-            }
-          }
+          this.setState({
+            serverAddress: nodeSelected,
+            udpProtocol: false,
+            connectionSecure: true,
+          });
         }
       };
 

--- a/public/controllers/agent/components/register-agent.js
+++ b/public/controllers/agent/components/register-agent.js
@@ -70,10 +70,9 @@ import {
   versionButtonAlpine,
   architectureButtonsWithPPC64LEAlpine,
 } from '../wazuh-config';
-import ServerAddress from '../register-agent/steps/server-address';
+import WzManagerAddressInput from '../register-agent/steps/wz-manager-address';
 import {
-  getConnectionConfig,
-  fetchClusterNodesOptions,
+  getMasterRemoteConfiguration
 } from './register-agent-service';
 import { PrincipalButtonGroup } from './wz-accordion';
 import RegisterAgentButtonGroup from '../register-agent/register-agent-button-group';
@@ -121,6 +120,7 @@ export const RegisterAgent = withErrorBoundary(
       };
     }
 
+
     async componentDidMount() {
       try {
         this.setState({ loading: true });
@@ -128,6 +128,7 @@ export const RegisterAgent = withErrorBoundary(
         let wazuhPassword = '';
         let hidePasswordInput = false;
         this.getEnrollDNSConfig();
+        await this.getRemoteConfig();
         let authInfo = await this.getAuthInfo();
         const needsPassword = (authInfo.auth || {}).use_password === 'yes';
         if (needsPassword) {
@@ -195,12 +196,26 @@ export const RegisterAgent = withErrorBoundary(
     getEnrollDNSConfig = () => {
       let serverAddress = this.configuration['enrollment.dns'] || '';
       this.setState({ defaultServerAddress: serverAddress });
-      if (serverAddress) {
-        this.setState({ udpProtocol: true });
-      } else {
-        this.setState({ udpProtocol: false });
-      }
     };
+
+    getRemoteConfig = async () => {
+      const remoteConfig = await getMasterRemoteConfiguration();
+      let serverAddress = this.defaultServerAddress || this.configuration['enrollment.dns'] || '';
+      console.log('remote config', remoteConfig);
+      if (serverAddress) {
+        this.setState({ 
+          udpProtocol: false,
+          connectionSecure: true, 
+          serverAddress });
+      }else{
+        this.setState({
+          haveUdpProtocol: remoteConfig.isUdp,
+          udpProtocol: remoteConfig.isUdp,
+          connectionSecure: remoteConfig.isSecure,
+        })
+      }
+    }
+
 
     async getAuthInfo() {
       try {
@@ -375,7 +390,6 @@ export const RegisterAgent = withErrorBoundary(
       let deployment =
         this.state.serverAddress &&
         `WAZUH_MANAGER='${this.state.serverAddress}' `;
-      const protocol = false;
       if (this.state.selectedOS == 'win') {
         deployment += `WAZUH_REGISTRATION_SERVER='${this.state.serverAddress}' `;
       }
@@ -1651,41 +1665,47 @@ apk add wazuh-agent=${this.state.wazuhVersion}-r1`,
         },
       ];
 
-      const onChangeServerAddress = async selectedNodes => {
-        if (selectedNodes.length === 0) {
+      const onChangeServerAddress = async nodeSelected => {
+        if (!nodeSelected) {
           this.setState({
             serverAddress: '',
             udpProtocol: false,
             connectionSecure: null,
           });
         } else {
-          const nodeSelected = selectedNodes[0];
-          try {
-            const remoteConfig = await getConnectionConfig(nodeSelected);
+          if (nodeSelected === this.state.defaultServerAddress) {
             this.setState({
-              serverAddress: remoteConfig.serverAddress,
-              udpProtocol: remoteConfig.udpProtocol,
-              connectionSecure: remoteConfig.connectionSecure,
-            });
-          } catch (error) {
-            const options = {
-              context: `${RegisterAgent.name}.onChangeServerAddress`,
-              level: UI_LOGGER_LEVELS.ERROR,
-              severity: UI_ERROR_SEVERITIES.BUSINESS,
-              display: true,
-              store: false,
-              error: {
-                error: error,
-                message: error.message || error,
-                title: error.name || error,
-              },
-            };
-            getErrorOrchestrator().handleError(options);
-            this.setState({
-              serverAddress: nodeSelected.label,
+              serverAddress: nodeSelected,
               udpProtocol: false,
-              connectionSecure: false,
+              connectionSecure: true,
             });
+          } else {
+            try {
+              this.setState({
+                serverAddress: nodeSelected,
+                udpProtocol: this.state.haveUdpProtocol,
+                connectionSecure: this.state.haveUdpProtocol ? false : true
+              });
+            } catch (error) {
+              const options = {
+                context: `${RegisterAgent.name}.onChangeServerAddress`,
+                level: UI_LOGGER_LEVELS.ERROR,
+                severity: UI_ERROR_SEVERITIES.BUSINESS,
+                display: true,
+                store: false,
+                error: {
+                  error: error,
+                  message: error.message || error,
+                  title: error.name || error,
+                },
+              };
+              getErrorOrchestrator().handleError(options);
+              this.setState({
+                serverAddress: nodeSelected,
+                udpProtocol: false,
+                connectionSecure: false,
+              });
+            }
           }
         }
       };
@@ -2142,10 +2162,9 @@ apk add wazuh-agent=${this.state.wazuhVersion}-r1`,
                 title: 'Wazuh server address',
                 children: (
                   <Fragment>
-                    <ServerAddress
+                    <WzManagerAddressInput
                       defaultValue={this.state.defaultServerAddress}
                       onChange={onChangeServerAddress}
-                      fetchOptions={fetchClusterNodesOptions}
                     />
                   </Fragment>
                 ),

--- a/public/controllers/agent/register-agent/steps/wz-manager-address.tsx
+++ b/public/controllers/agent/register-agent/steps/wz-manager-address.tsx
@@ -1,0 +1,43 @@
+import React, { memo, useCallback, useEffect, useState } from 'react';
+import { EuiText, EuiFieldText } from '@elastic/eui';
+
+type Props = {
+  onChange: (value: string) => void;
+  defaultValue?: string;
+};
+
+const WzManagerAddressInput = (props: Props) => {
+  const { onChange, defaultValue } = props;
+  const [value, setValue] = useState('');
+
+  useEffect(() => {
+    if(defaultValue){
+      setValue(defaultValue);
+      onChange(defaultValue);
+    }
+  },[])
+  /**
+   * Handles the change of the selected node IP
+   * @param value
+   */
+  const handleOnChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const { value } = event.target;
+    onChange(value);
+    setValue(value);
+  };
+  return (
+    <EuiText>
+      <p>
+        This is the address the agent uses to communicate with the Wazuh server.
+        It can be an IP address or a fully qualified domain name (FQDN).
+      </p>
+      <EuiFieldText
+        placeholder='Server Address'
+        onChange={handleOnChange}
+        value={value}
+      />
+    </EuiText>
+  );
+};
+
+export default memo(WzManagerAddressInput);

--- a/public/controllers/agent/register-agent/steps/wz-manager-address.tsx
+++ b/public/controllers/agent/register-agent/steps/wz-manager-address.tsx
@@ -14,6 +14,9 @@ const WzManagerAddressInput = (props: Props) => {
     if(defaultValue){
       setValue(defaultValue);
       onChange(defaultValue);
+    }else{
+      setValue('');
+      onChange('');
     }
   },[])
   /**

--- a/public/controllers/agent/register-agent/steps/wz-manager-address.tsx
+++ b/public/controllers/agent/register-agent/steps/wz-manager-address.tsx
@@ -43,4 +43,4 @@ const WzManagerAddressInput = (props: Props) => {
   );
 };
 
-export default memo(WzManagerAddressInput);
+export default WzManagerAddressInput;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,7 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react"
+    "jsx": "react-jsx"
   },
   "include": [
     "public",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,7 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react-jsx"
+    "jsx": "react"
   },
   "include": [
     "public",


### PR DESCRIPTION
### Description
This PR, adds a new WzServerAddress component for the Deploy Agent section.
The component is a free input.
 
Closes #5138 #5140

## Scope

### Protocol cases

1. When the only available Protocol is `UDP`, the `WAZUH_PROTOCOL` param in the command will show `UDP`.
- On Manager and Cluster mode.

2. When the Protocol available exists `TCP`,   the `WAZUH_PROTOCOL` param in the command will be `TCP` (the param is hidden, and TCP is the default value)
- On Manager and Cluster mode.

### Server address input cases

1. When the user has filled the `enrollment.dns` field in `Management > Configuration`. The server address input must be filled by default with this value.


> ### Annotation
> The protocol and server address input are independent.
> The command protocol param defined depends on only the remote configuration defined in the ossec.conf file.

# Test cases evidence

## Protocol cases

## When the protocol is UDP (Cluster mode)

1. Check the remote config in `Management > Configuration > Global configuration > Remote Tab`
2. Go to Deploy Agent
3. Complete the OS options.
4. The WAZUH_PROTOCOL param must show `UDP`

https://user-images.githubusercontent.com/6089438/214850771-c2d70d93-4532-4e7f-9513-c5d0cb800090.mp4


## When the protocol is TCP (`Cluster mode`)

1. Check the remote config in `Management > Configuration > Global configuration > Remote Tab`
2. Go to Deploy Agent
3. Complete the OS options.
4. The WAZUH_PROTOCOL param must be hidden (when is not defined the protocol is TCP)

https://user-images.githubusercontent.com/6089438/214854292-53f1b4df-97ff-4322-b7a2-fee226febebd.mp4


## When the protocol is UDP (`Manager mode`)

1. Check the remote config in `Management > Configuration > Global configuration > Remote Tab`
2. Go to Deploy Agent
3. Complete the OS options.
4. The WAZUH_PROTOCOL param must show `UDP`

https://user-images.githubusercontent.com/6089438/214857603-09eb998f-3c26-4521-bb67-121a2a53165a.mp4


## When the protocol is TCP (`Manager mode`)

1. Check the remote config in `Management > Configuration > Global configuration > Remote Tab`
2. Go to Deploy Agent
3. Complete the OS options.
4. The WAZUH_PROTOCOL param must be hidden (when is not defined the protocol is TCP)

https://user-images.githubusercontent.com/6089438/214855167-d2a34f17-296c-4739-8005-ff42134f0544.mp4

### Check List
- [x] All tests pass
  - [x] `yarn test:jest`
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 
