### PR TITLE
Fix GitHub office365 panel information tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fixed mispelling in the NIST module [#5107](https://github.com/wazuh/wazuh-kibana-app/pull/5107)
 - Fixed Statistic cronjob bulk document insert [#5150](https://github.com/wazuh/wazuh-kibana-app/pull/5150)
 - Fixed the style of the buttons showing more event information in the event view table. [#5137](https://github.com/wazuh/wazuh-kibana-app/pull/5137)
+- Fixed the module information button in Office365 and Github Panel tab to open the nav drawer. [#5167](https://github.com/wazuh/wazuh-kibana-app/pull/5167)
 
 ### Removed
 

--- a/public/components/common/modules/panel/components/module-side-panel.tsx
+++ b/public/components/common/modules/panel/components/module-side-panel.tsx
@@ -22,8 +22,8 @@ export const ModuleSidePanel = ({ navIsDocked = false, children, ...props }) => 
     <EuiCollapsibleNav
       isOpen={navIsOpen}
       isDocked={navIsDocked}
-      showCloseButton={true}
-      maskProps={{ headerZindexLocation: 'below', className: 'wz-no-display' }}
+      ownFocus={false}
+      closeButtonPosition={'inside'}
       button={
         <EuiButtonEmpty
           className={'sidepanel-infoBtnStyle'}
@@ -34,11 +34,6 @@ export const ModuleSidePanel = ({ navIsDocked = false, children, ...props }) => 
       onClose={() => setNavIsOpen(false)}
     >
       <div>
-        <EuiButtonEmpty
-          style={{ position: 'absolute', right: 0 }}
-          onClick={() => setNavIsOpen(!navIsOpen)}
-          iconType={'cross'}
-        />
         <div className={'wz-padding-16'}>{children}</div>
       </div>
     </EuiCollapsibleNav>


### PR DESCRIPTION
### Description

Hi team,
This PR fixes GitHub office365 panel information tab by removing the euiCollapsibleNavbar custom styles and using newer eui v34.6.0 component properties to display the close button inside the container and to remove the overlay.
 
## Important
This fix is for Opensearch 2.4.0 and above. Elasticsearch 7.10.x and 7.16.x branches don't require it.
 
### Issues Resolved
Closes #5164 

### Evidence
![Peek 2023-01-25 17-00](https://user-images.githubusercontent.com/9343732/214616436-1957ef16-89f1-4c49-9ce1-09cab6da0982.gif)


### Test

- Navigate to Modules -> Github / Office365
- Click on the `Panel` tab
- Click on the laft tab with the _`i`_ icon
- Check it opens the drawer

### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff 
