### PR TITLE
Agents table action buttons style fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 ### Added
 
 - Added the option to sort by the agents count in the group table. [#4323](https://github.com/wazuh/wazuh-kibana-app/pull/4323)
-- Added agent synchronization status in the agent module. [#3874](https://github.com/wazuh/wazuh-kibana-app/pull/3874) [#5143](https://github.com/wazuh/wazuh-kibana-app/pull/5143)
+- Added agent synchronization status in the agent module. [#3874](https://github.com/wazuh/wazuh-kibana-app/pull/3874) [#5143](https://github.com/wazuh/wazuh-kibana-app/pull/5143) [#5177](https://github.com/wazuh/wazuh-kibana-app/pull/5177)
 - The input name was added and when the user adds a value the variable WAZUH_AGENT_NAME with its value appears in the installation command. [#4739](https://github.com/wazuh/wazuh-kibana-app/pull/4739)
 - Redesign the SCA table from agent's dashboard [#4512](https://github.com/wazuh/wazuh-kibana-app/pull/4512)
 - Enhanced the plugin setting description displayed in the UI and the configuration file. [#4501](https://github.com/wazuh/wazuh-kibana-app/pull/4501)

--- a/public/controllers/agent/components/agents-table.js
+++ b/public/controllers/agent/components/agents-table.js
@@ -305,7 +305,7 @@ export const AgentsTable = withErrorBoundary(
 
     actionButtonsRender(agent) {
       return (
-        <div>
+        <div className={'icon-box-action'}>
           <EuiToolTip content="Open summary panel for this agent" position="left">
             <EuiButtonIcon
               onClick={(ev) => {

--- a/public/controllers/agent/components/agents-table.js
+++ b/public/controllers/agent/components/agents-table.js
@@ -305,7 +305,7 @@ export const AgentsTable = withErrorBoundary(
 
     actionButtonsRender(agent) {
       return (
-        <div className={'icon-box-action'}>
+        <div>
           <EuiToolTip content="Open summary panel for this agent" position="left">
             <EuiButtonIcon
               onClick={(ev) => {

--- a/public/styles/common.scss
+++ b/public/styles/common.scss
@@ -1615,6 +1615,10 @@ div.euiPopover__panel.euiPopover__panel-isOpen.euiPopover__panel--bottom.wz-menu
   padding-left: 320px;
 }
 
+.icon-box-action {
+  display: flex;
+}
+
 @media only screen and (max-width: 1200px) {
   .hide-agent-status {
     display: none;

--- a/public/styles/common.scss
+++ b/public/styles/common.scss
@@ -1615,11 +1615,6 @@ div.euiPopover__panel.euiPopover__panel-isOpen.euiPopover__panel--bottom.wz-menu
   padding-left: 320px;
 }
 
-.icon-box-action {
-  display: flex;
-  flex-wrap: wrap;
-}
-
 @media only screen and (max-width: 1200px) {
   .hide-agent-status {
     display: none;


### PR DESCRIPTION
### Description
Hi team,

This PR removes the flex-wrap style from the action buttons of the Agents table. This is to avoid the buttons wrapping unnecessarily in firefox.
 
### Issues Resolved
Related to https://github.com/wazuh/wazuh-kibana-app/issues/5141

### Evidence
![Peek 2023-01-27 17-48](https://user-images.githubusercontent.com/9343732/215145135-53665110-502f-44d4-87ba-7571acd4b85b.gif)



### Test
- Go to Agents Overview
- Change the screen size to see the buttons horizontally and vertically

| Chrome | Firefox | Safari |
| --- | --- | --- |
| :black_circle:  | :black_circle:  | :black_circle:  |

### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff 
