### PR TITLE
Fix backport 5137 to 4.4 7.16 - change button text color

### DIFF
--- a/public/kibana-integrations/discover/application/angular/doc_table/components/table_row/open.html
+++ b/public/kibana-integrations/discover/application/angular/doc_table/components/table_row/open.html
@@ -4,8 +4,8 @@
     aria-expanded="{{!!open}}"
     aria-label="{{ ::'discover.docTable.tableRow.toggleRowDetailsButtonAriaLabel' | i18n: {defaultMessage: 'Toggle row details'} }}">
     <span class="euiButtonContent euiButtonEmpty__content">
-        <icon ng-if="open" type="'arrowDown'" size="'s'"></icon>
-        <icon ng-if="!open" type="'arrowRight'" size="'s'"></icon>
+        <icon ng-if="open" type="'arrowDown'" size="'s'" color="'text'"></icon>
+        <icon ng-if="!open" type="'arrowRight'" size="'s'" color="'text'"></icon>
     </span>
   </button>
 </td>


### PR DESCRIPTION
### Description
Team,
 
 this PR changes the color of the `>` button in the `Security events` / `Events` rows. The button style should match the Kibana Discover plugin.
 
 **Important:** This must only be applied to the 7.16.x dev branch.
 
Related Pull request #5184 

### Evidence

**Security events**
![image](https://user-images.githubusercontent.com/9343732/215757665-4b732c6a-1ab1-4745-8d8c-899ad77dc8fc.png)

**Discover**
![image](https://user-images.githubusercontent.com/9343732/215757836-d94d8265-d141-45d7-ab8f-73b138d68fb7.png)


### Test
- Verify the color of the `>` button in the `Security events` / `Events` rows. 
- Check it matches the Kibana Discover plugin row button style.

### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff 
