### PR TITLE
Fix a crash in the vulnerability details flyout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fixed the style of the buttons showing more event information in the event view table. [#5137](https://github.com/wazuh/wazuh-kibana-app/pull/5137)
 - Fixed Inventory module for solaris agents [#5144](https://github.com/wazuh/wazuh-kibana-app/pull/5144)
 - Fixed the module information button in Office365 and Github Panel tab to open the nav drawer. [#5167](https://github.com/wazuh/wazuh-kibana-app/pull/5167)
+- Fixed a UI crash due to `external_references` field could be missing in some vulnerability data [#5200](https://github.com/wazuh/wazuh-kibana-app/pull/5200)
 
 ### Removed
 

--- a/public/components/agents/vuls/inventory/detail.tsx
+++ b/public/components/agents/vuls/inventory/detail.tsx
@@ -327,8 +327,8 @@ export class Details extends Component {
     );
   }
 
-  renderExternalReferences(references) {
-    return (
+  renderExternalReferences(references: string[]) {
+    return references.length ? (
       <EuiAccordion
         id='modules_vulnerabilities_inventory_flyout_details_references'
         paddingSize='none'
@@ -361,7 +361,7 @@ export class Details extends Component {
           }))}
         />
       </EuiAccordion>
-    );
+    ) : "-";
   }
 
   updateTotalHits = total => {

--- a/public/components/agents/vuls/inventory/table.tsx
+++ b/public/components/agents/vuls/inventory/table.tsx
@@ -245,6 +245,15 @@ export class InventoryTable extends Component {
         endpoint={`/vulnerability/${this.props.agent.id}?${selectFields}`}
         isExpandable={true}
         rowProps={getRowProps}
+        mapResponseItem={(item) => ({
+          ...item,
+          // Some vulnerability data could not contain the external_references field.
+          // This causes the rendering of them can crash when opening the flyout with the details.
+          // So, we ensure the fields are defined with the expected data structure.
+          external_references: Array.isArray(item?.external_references) 
+            ? item?.external_references
+            : []
+        })}
         error={error}
         downloadCsv={true}
         filters={filters}


### PR DESCRIPTION
### Description
This pull request fixes a UI crash when opening the details of a vulnerability that has no the `external_references` field.

The changes ensure the field is defined and is an array.

If there is data related to external references, then a `-` will be displayed
 
### Issues Resolved
#5199

### Evidence
![image](https://user-images.githubusercontent.com/34042064/217298092-f9d25c29-6f91-47b7-820b-18efd0b3d224.png)

### Test

## UI

| Test |
| --- |
| See the References of a vulnerability that has one or more references, it should display the accordion with the references. |
| See the References of a vulnerability that has no references, it should display a `-`. |
| See the References of a vulnerability that the references are not defined, it should display a `-`. |

[crash-vulnerability-data-no-external-references.md](https://github.com/wazuh/wazuh-kibana-app/files/10677157/crash-vulnerability-data-no-external-references.md)

Imposter patch that adds some vulnerability data without the `external_references` field (called `Custom` and `Custom2`).
[pr-5199-imposter.txt](https://github.com/wazuh/wazuh-kibana-app/files/10677348/pr-5199-imposter.txt)

### Check List
- [x] All tests pass
  - [x] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 
