### PR TITLE
Change RexExp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 
 ### Changed
 
--
+- Changed of regular expression in RBAC. [#5201](https://github.com/wazuh/wazuh-kibana-app/pull/5201)
 
 ### Fixed
 

--- a/public/react-services/wz-user-permissions.ts
+++ b/public/react-services/wz-user-permissions.ts
@@ -21,7 +21,7 @@ export class WzUserPermissions{
         const missingOrPermissions = WzUserPermissions.checkMissingUserPermissions(permission, userPermissions);
         return Array.isArray(missingOrPermissions) ? missingOrPermissions.length === permission.length : missingOrPermissions;
       }
-      
+
       const isGenericResource = (permission.resource.match(':\\*') || []).index === permission.resource.length - 2
 
       const actionName = typeof permission === 'string' ? permission : permission.action;
@@ -48,8 +48,8 @@ export class WzUserPermissions{
       const simplePermission = (resource: string) => {
         return (
           ![actionResource, actionResourceAll].includes(resource) &&
-          (resource.match(actionResource.replace('*', '\\*')) ||
-            resource.match(actionResourceAll.replace('*', '\*')))
+          (resource.match(actionResource.replace(/\*/g, '.+')) ||
+            resource.match(actionResourceAll.replace(/\*/g, '.+')))
         );
       };
 
@@ -102,10 +102,10 @@ export class WzUserPermissions{
       return userPermissions[actionName][actionResource]
         ? notAllowInWazuhPermissions(actionResource)
         : Object.keys(userPermissions[actionName]).some((resource) => {
-            return resource.match(actionResourceAll.replace('*', '\\*')) !== null;
+            return resource.match(actionResourceAll.replace(/\*/g, '.+')) !== null;
           })
         ? Object.keys(userPermissions[actionName]).some((resource) => {
-            if (resource.match(actionResourceAll.replace('*', '\\*'))) {
+            if (resource.match(actionResourceAll.replace(/\*/g, '.+'))) {
               return notAllowInWazuhPermissions(resource);
             }
           })


### PR DESCRIPTION
### Description
Regular expression change to detect if you have permission to perform actions, In some cases it was checked if it was a literal string and in others it was not. Now if the required permission has the character "*" verify that it has some value. 
 
### Issues Resolved
- #5037

### Evidence
![image](https://user-images.githubusercontent.com/63758389/217601744-3db48590-5b6c-4d0b-bb29-ab2aacb54488.png)

### Test

Case 1

Run test `yarn run test:jest wz-user`

Case 2

Log in with a user with full permissions and see if the application works as expected.

Caso 3

Log in with a user with reduced permissions and check if the application works as expected.

### Check List
- [x] All tests pass
  - [x] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 
