### PR TITLE
Add custom formatter

### DIFF
--- a/public/apps/field-format-test.ts
+++ b/public/apps/field-format-test.ts
@@ -1,0 +1,21 @@
+import { FieldFormat } from '../../../../src/plugins/data/common/'
+import { HtmlContextTypeConvert } from '../../../../src/plugins/data/common/';
+import { OSD_FIELD_TYPES } from '../../../../src/plugins/data/common/';
+import { template } from 'lodash';
+
+const convertTemplate = template('<span style="<%- style %>"><%- val %></span>');
+
+export class CustomFieldFormat extends FieldFormat {
+  static id = 'WAZUH-CUSTOM-FORMAT';
+  static title = 'Wazuh custom format';
+  static fieldType = [OSD_FIELD_TYPES.NUMBER, OSD_FIELD_TYPES.STRING];
+
+
+  htmlConvert: HtmlContextTypeConvert = (val) => {
+
+    let style = '';
+    style += `color: #F00;`;
+    style += `background-color: #CCC;`;
+    return convertTemplate({ val, style });
+  };
+}

--- a/public/plugin.ts
+++ b/public/plugin.ts
@@ -31,6 +31,7 @@ import { getThemeAssetURL, getAssetURL } from './utils/assets';
 import store from './redux/store';
 import { updateAppConfig } from './redux/actions/appConfigActions';
 import { initializeInterceptor, unregisterInterceptor } from './services/request-handler';
+import { CustomFieldFormat } from './apps/field-format-test';
 
 const SIDEBAR_LOGO = 'customization.logo.sidebar';
 const innerAngularName = 'app/wazuh';
@@ -43,6 +44,9 @@ export class WazuhPlugin implements Plugin<WazuhSetup, WazuhStart, WazuhSetupPlu
   private hideTelemetryBanner?: () => void;
   public async setup(core: CoreSetup, plugins: WazuhSetupPlugins): WazuhSetup {
     const UI_THEME = core.uiSettings.get('theme:darkMode') ? 'dark' : 'light';
+
+    // Register custom field format
+    plugins.data.fieldFormats.register([CustomFieldFormat]);
 
     // Get custom logos configuration to start up the app with the correct logos
     let logosInitialState = {};


### PR DESCRIPTION
### Description
Hi team,
thi PR is an example of a custom field formatter. It has the basic feature of changing the styles of a field. The custom field formatter has to return a string, which can be in HTML format.
 
### Issues Resolved
Closes #5228 
Epic #4810 


![image](https://user-images.githubusercontent.com/9343732/221157157-320b5364-3dd6-4e39-8681-0e36e2a6279b.png)

## How to test it

The custom formatter will register automatically, so what we have to do is enable it in the index pattern configuration.

- Go to Stack Management -> Index patterns

![image](https://user-images.githubusercontent.com/9343732/221166873-97af29b6-2353-4a7e-9f45-f0b47378c784.png)

- Select the desired index-pattern and look for the field which has to be formatted.

![image](https://user-images.githubusercontent.com/9343732/221167178-de29cebe-ed74-488e-b59b-3b9a9f8e9710.png)


- Click on the Edit (_pencil_) button and select the custom field formatter. In this particular case _Wazuh custom format_

![image](https://user-images.githubusercontent.com/9343732/221167406-6a1f21d0-05ec-44db-9c90-44b9038b0d82.png)


Finally, you should be able to see the formatted field in any of the table views available, such as the Discover plugin or a regular table.

![image](https://user-images.githubusercontent.com/9343732/221167657-aabfe474-1fc7-434a-b5ab-3d5c5ea6d838.png)


![image](https://user-images.githubusercontent.com/9343732/221168276-1953ed8f-b365-4171-92b2-2bf3b032d22b.png)

