### PR TITLE
Fix possessive 'it's' in the Vulnerability dashboard

### DIFF
--- a/public/components/agents/vuls/main.tsx
+++ b/public/components/agents/vuls/main.tsx
@@ -16,7 +16,7 @@ export const MainVuls = compose(
   withGuard(
     (props) => !((props.currentAgentData && props.currentAgentData.id) && props.agent),
     () => (
-      <PromptNoSelectedAgent body="You need to select an agent to see it's vulnerabilities." />
+      <PromptNoSelectedAgent body="You need to select an agent to see its vulnerabilities." />
     )
   ),
   withUserAuthorizationPrompt((props) => {


### PR DESCRIPTION
### Description
This PR fixes a typo that is shown when accessing the Vulnerabilities dashboard without having an agent selected. 

Currently it incorrectly has the `it's` contraction where the `its` possessive should be used instead.

This is a trivial PR that should not require a long review period.

### Test
[Provide instructions to test this PR]

### Check List
- [x] All tests pass
  - [x] `yarn test:jest`
- [x] Commits are signed per the DCO using --signoff 
