### PR TITLE
Fix events view when search bar language is lucene

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fixed the module information button in Office365 and Github Panel tab to open the nav drawer. [#5167](https://github.com/wazuh/wazuh-kibana-app/pull/5167)
 - Fixed a UI crash due to `external_references` field could be missing in some vulnerability data [#5200](https://github.com/wazuh/wazuh-kibana-app/pull/5200)
 - Fixed Wazuh main menu not displayed when navigation menu is locked [#5273](https://github.com/wazuh/wazuh-kibana-app/pull/5273)
+- Fixed events view when search bar language is `lucene` [#5286](https://github.com/wazuh/wazuh-kibana-app/pull/5286)
 
 ### Removed
 

--- a/public/kibana-integrations/discover/application/angular/directives/no_results.js
+++ b/public/kibana-integrations/discover/application/angular/directives/no_results.js
@@ -157,7 +157,7 @@ export class DiscoverNoResults extends Component {
             <p>
               <FormattedMessage
                 id="discover.noResults.searchExamples.howTosearchForWebServerLogsDescription"
-                defaultMessage="The search bar at the top uses Elasticsearch&rsquo;s support for Lucene {queryStringSyntaxLink}.
+                defaultMessage="The search bar at the top uses OpenSearch&rsquo;s support for Lucene {queryStringSyntaxLink}.
                 Here are some examples of how you can search for web server logs that have been parsed into a few fields."
                 values={{
                   queryStringSyntaxLink: (

--- a/public/kibana-integrations/discover/application/angular/directives/no_results.js
+++ b/public/kibana-integrations/discover/application/angular/directives/no_results.js
@@ -163,7 +163,7 @@ export class DiscoverNoResults extends Component {
                   queryStringSyntaxLink: (
                     <EuiLink
                       target="_blank"
-                      href={getServices().docLinks.links.query.luceneQuerySyntax}
+                      href={getServices().docLinks.links.opensearch.queryDSL.base}
                     >
                       <FormattedMessage
                         id="discover.noResults.searchExamples.queryStringSyntaxLinkText"


### PR DESCRIPTION
### Description
This change is only for "OpenSearch dashboards", it changes code that was related to Elasticsearch in the OpenSearch Dashboards branch.
 
### Issues Resolved
- #5284 

### Evidence

![image](https://user-images.githubusercontent.com/63758389/224727918-2649a691-f7ac-49a9-9674-3fbdf9cf79d5.png)

![image](https://user-images.githubusercontent.com/63758389/224728061-6dca19bd-5d13-49fb-8c53-a955b5dbeca6.png)

![image](https://user-images.githubusercontent.com/63758389/224728144-292dc508-41ad-463d-98fc-7b802365cf78.png)


### Test

#### Preconditions

Navigate to 'Security events'
Click on 'Syntax options from search bar'
Change 'OpenSearch Dashboards Query Language' to 'off'

Test 1

Click on Events without data
The view "no results" has to be rendered 

Test 2

Click on Events with data
The table has to be rendered 

Test 1

Click on Events and do a search
The table has to be rendered with the search data.

### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 
