### PR TITLE
Header in agent view is rendered correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fixed Wazuh main menu not displayed when navigation menu is locked [#5273](https://github.com/wazuh/wazuh-kibana-app/pull/5273)
 - Fixed Deploy Agent wrong use of connection secure property [#5285](https://github.com/wazuh/wazuh-kibana-app/pull/5285)
 - Fixed events view when search bar language is `lucene` [#5286](https://github.com/wazuh/wazuh-kibana-app/pull/5286)
+- Fixed head rendering in agent view [#5291](https://github.com/wazuh/wazuh-kibana-app/pull/5291)
 
 ### Removed
 

--- a/public/components/common/modules/module.scss
+++ b/public/components/common/modules/module.scss
@@ -35,7 +35,7 @@
     margin-top: 0px;
 }
 
-.wz-module-header-agent-title{    
+.wz-module-header-agent-title{
     margin: 6px 12px!important;
 }
 
@@ -53,16 +53,16 @@
     color: #006BB4;
 }
 
-.wz-module-header-agent h1{    
+.wz-module-header-agent h1{
     font-weight: 400;
 }
 
-.wz-module-header-agent h1 b{    
+.wz-module-header-agent h1 b{
     font-weight: 500;
 }
 
 .wz-module-header-nav-wrapper{
-    margin-top: 49px;    
+    margin-top: 49px;
 }
 
 .wz-module-header-nav .euiTabs{
@@ -121,7 +121,7 @@ discover-app-w .sidebar-container {
         }
         .wz-module-header-agent{
             height: auto;
-            h1{    
+            h1{
                 white-space: nowrap;
                 text-overflow: ellipsis;
                 overflow: hidden;
@@ -130,27 +130,27 @@ discover-app-w .sidebar-container {
         .wz-module-body {
             margin-top: -160px;
         }
-    
+
         .wz-module-header-agent-wrapper, .wz-module-header-nav-wrapper{
             position: relative;
         }
-    
+
         .wz-module-header-nav-wrapper{
             margin-top: 15px;
         }
-    
+
         .wz-module-header-nav {
             padding-bottom: 16px;
         }
-    
+
         .wz-module-body-agent-info > .euiFlexGroup > .euiFlexItem {
             max-width: unset!important;
         }
 
         .wz-module-header-agent-title .euiFlexItem{
-            align-items: flex-start!important;    
+            align-items: flex-start!important;
         }
-        .wz-agent-empty-item .euiFlexItem{
+        .wz-agent-empty-item.euiFlexItem{
             margin-top: 0px!important;
             margin-bottom:0px!important;
         }

--- a/public/components/common/welcome/agents-welcome.js
+++ b/public/components/common/welcome/agents-welcome.js
@@ -316,9 +316,7 @@ class AgentsWelcome extends Component {
                 </EuiPopover>
               </EuiFlexItem>
               }
-              <div className="wz-agent-empty-item">
-              <EuiFlexItem></EuiFlexItem>
-              </div>
+              <EuiFlexItem className="wz-agent-empty-item"></EuiFlexItem>
               <EuiFlexItem grow={false} style={{ marginTop: 7 }}>
                 <EuiButtonEmpty
                   iconType="inspect"


### PR DESCRIPTION
### Description
Removed an unnecessary div and changed a style for components that have the 2 classes together (.wz-agent-empty-item.euiFlexItem).
 
### Issues Resolved
- #5290

### Evidence
![image](https://user-images.githubusercontent.com/63758389/225019824-550b014f-d9ed-40af-9bde-0ea910b23ee7.png)

![image](https://user-images.githubusercontent.com/63758389/225020037-f6b0d295-d24d-4980-b8a4-5a29e3d9d00f.png)


### Test

1. Navigate to 'an agent'
2. View header in different width sizes 

### Check List
- [x] All tests pass
  - [x] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 
