### PR TITLE
Fix pre-release environments for kibana 7.10.2

### DIFF
--- a/docker/wazuh-4.3-es/pre.sh
+++ b/docker/wazuh-4.3-es/pre.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 elastic_versions=(
+	"7.10.2"
 	"7.16.0"
 	"7.16.1"
 	"7.16.2"
@@ -12,6 +13,9 @@ elastic_versions=(
 	"7.17.4"
 	"7.17.5"
 	"7.17.6"
+	"7.17.7"
+	"7.17.8"
+	"7.17.9"
 )
 
 wazuh_api_version=(

--- a/docker/wazuh-4.3-es/pre.yml
+++ b/docker/wazuh-4.3-es/pre.yml
@@ -120,7 +120,7 @@ services:
           unzip config/certs/certs.zip -d config/certs;
         fi;
         echo "Setting file permissions"
-        chown -R root:root config/certs;
+        chown -R 1000:1000 config/certs;
         find . -type d -exec chmod 750 \{\} \;;
         find . -type f -exec chmod 640 \{\} \;;
         echo "Waiting for Elasticsearch availability";
@@ -323,4 +323,3 @@ volumes:
   esdata02:
   esdata03:
   kibanadata:
-

--- a/docker/wazuh-4.3-es/rel.sh
+++ b/docker/wazuh-4.3-es/rel.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 elastic_versions=(
+	"7.10.2"
 	"7.16.0"
 	"7.16.1"
 	"7.16.2"
@@ -12,6 +13,9 @@ elastic_versions=(
 	"7.17.4"
 	"7.17.5"
 	"7.17.6"
+	"7.17.7"
+	"7.17.8"
+	"7.17.9"
 )
 
 wazuh_versions=(

--- a/docker/wazuh-4.3-es/rel.yml
+++ b/docker/wazuh-4.3-es/rel.yml
@@ -109,7 +109,7 @@ services:
           unzip config/certs/certs.zip -d config/certs;
         fi;
         echo "Setting file permissions"
-        chown -R root:root config/certs;
+        chown -R 1000:1000 config/certs;
         find . -type d -exec chmod 750 \{\} \;;
         find . -type f -exec chmod 640 \{\} \;;
         echo "Waiting for Elasticsearch availability";


### PR DESCRIPTION
### Description
The pre-release environments in Kibana 7.10.2 were not working. Because of a file permissions problem that caused the container where Kibana was located to stop working.
 
### Evidence
![image](https://user-images.githubusercontent.com/63758389/226683935-a1c2ba2b-bac8-48cb-ab55-0011342834b8.png)

### Test
Try to use the pre-release environment and install wazuh on version 7.10.2 and 7.16.x or 7.17.x.

### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 
