### PR TITLE
Change link to Malware detection documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the Wazuh app project will be documented in this file.
 
+## Wazuh v4.4.1 - OpenSearch Dashboards 2.6.0 - Revision 00
+
+### Changed
+
+- Changed the anomaly and malware detection link to the malware detection link. [#5329](https://github.com/wazuh/wazuh-kibana-app/pull/5329)
+
 ## Wazuh v4.4.0 - OpenSearch Dashboards 2.4.0 - Revision 06
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@ All notable changes to the Wazuh app project will be documented in this file.
 
 ## Wazuh v4.4.1 - OpenSearch Dashboards 2.6.0 - Revision 00
 
-### Changed
+### Fixed
 
-- Changed the anomaly and malware detection link to the malware detection link. [#5329](https://github.com/wazuh/wazuh-kibana-app/pull/5329)
+- Fixed the `Anomaly and malware detection` link. [#5329](https://github.com/wazuh/wazuh-kibana-app/pull/5329)
 
 ## Wazuh v4.4.0 - OpenSearch Dashboards 2.4.0 - Revision 06
 

--- a/public/controllers/management/components/management/configuration/policy-monitoring/help-links.js
+++ b/public/controllers/management/components/management/configuration/policy-monitoring/help-links.js
@@ -14,8 +14,8 @@ import { webDocumentationLink } from "../../../../../../../common/services/web_d
 
 export default [
   {
-    text: 'Anomaly and malware detection',
-    href: webDocumentationLink('user-manual/capabilities/anomalies-detection/index.html')
+    text: 'Malware detection',
+    href: webDocumentationLink('user-manual/capabilities/malware-detection/index.html')
   },
   {
     text: 'Monitoring security policies',


### PR DESCRIPTION
### Description
Anomaly and malware detection link changed to malware detection link. Due to documentation changes in this [PR](https://github.com/wazuh/wazuh-documentation/pull/5944)
 
### Issues Resolved
- #5318

### Evidence

![image](https://user-images.githubusercontent.com/63758389/228280222-77680871-8279-4ae5-858c-6a44bc83928b.png)


### Test

1. Navigate to management/configuration/policy monitoring/system audit
2. Click on image ![image](https://user-images.githubusercontent.com/63758389/227267718-afe190b4-05ac-4d8e-b3d8-3480de25e135.png)
3. The button is now called `Malware detection` and the href has to be `user-manual/capabilities/malware-detection/index`.


### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 
