### PR TITLE
Fix visual error in "About" section

### DIFF
--- a/public/templates/settings/settings.html
+++ b/public/templates/settings/settings.html
@@ -1,31 +1,55 @@
 <!-- head -->
 <div ng-cloak ng-controller="settingsController as ctrl">
   <div ng-show="ctrl.load" style="padding: 16px">
-    <react-component name="EuiProgress" props="{size: 'xs', color: 'primary'}"></react-component>
+    <react-component
+      name="EuiProgress"
+      props="{size: 'xs', color: 'primary'}"
+    ></react-component>
   </div>
 
   <div
     ng-if="!ctrl.load && ctrl.settingsTabsProps && !ctrl.apiIsDown && ctrl.apiTableProps.apiEntries.length"
     class="wz-margin-top-16 md-margin-h"
   >
-    <react-component name="Tabs" props="ctrl.settingsTabsProps"></react-component>
+    <react-component
+      name="Tabs"
+      props="ctrl.settingsTabsProps"
+    ></react-component>
   </div>
   <!-- end head -->
   <!-- api -->
   <div ng-if="ctrl.tab === 'api' && !ctrl.load">
     <!-- API table section-->
     <div ng-if="ctrl.apiEntries.length && !ctrl.addingApi && !ctrl.apiIsDown">
-      <react-component name="ApiTable" props="ctrl.apiTableProps"></react-component>
+      <react-component
+        name="ApiTable"
+        props="ctrl.apiTableProps"
+      ></react-component>
     </div>
 
     <!-- Add API section-->
-    <div layout="row" layout-padding ng-if="!ctrl.apiEntries.length || ctrl.addingApi">
-      <react-component flex name="AddApi" props="ctrl.addApiProps"></react-component>
+    <div
+      layout="row"
+      layout-padding
+      ng-if="!ctrl.apiEntries.length || ctrl.addingApi"
+    >
+      <react-component
+        flex
+        name="AddApi"
+        props="ctrl.addApiProps"
+      ></react-component>
     </div>
 
     <!-- API is down section-->
-    <div layout="column" layout-padding ng-if="ctrl.apiIsDown && !ctrl.addingApi">
-      <react-component name="ApiIsDown" props="ctrl.apiIsDownProps"></react-component>
+    <div
+      layout="column"
+      layout-padding
+      ng-if="ctrl.apiIsDown && !ctrl.addingApi"
+    >
+      <react-component
+        name="ApiIsDown"
+        props="ctrl.apiIsDownProps"
+      ></react-component>
     </div>
   </div>
   <!-- End API configuration card section -->
@@ -45,7 +69,10 @@
   <!-- end configuration -->
   <!-- logs -->
   <div ng-if="ctrl.tab === 'logs' && !ctrl.load">
-    <react-component name="SettingsLogs" props="ctrl.settingsLogsProps"></react-component>
+    <react-component
+      name="SettingsLogs"
+      props="ctrl.settingsLogsProps"
+    ></react-component>
   </div>
   <!-- end logs -->
   <!-- miscellaneous -->
@@ -55,19 +82,23 @@
   <!-- end miscellaneous -->
   <!-- about -->
   <div ng-if="ctrl.tab === 'about' && !ctrl.load">
-    <div class="euiPage euiPageBody">
+    <div class="euiPage euiPanel--paddingMedium euiPageBody">
       <!-- App information section -->
       <div ng-if="!ctrl.load">
         <div class="euiCallOut euiCallOut--primary" style="display: flex">
           <div class="wz-text-truncatable" flex>
-            App version: <span class="wz-text-bold">{{ctrl.appInfo["app-version"]}}</span>
+            App version:
+            <span class="wz-text-bold">{{ctrl.appInfo["app-version"]}}</span>
           </div>
           <div class="wz-text-truncatable" flex>
-            App revision: <span class="wz-text-bold">{{ctrl.appInfo["revision"]}}</span>
+            App revision:
+            <span class="wz-text-bold">{{ctrl.appInfo["revision"]}}</span>
           </div>
           <div class="wz-text-truncatable" flex>
             Install date:
-            <span class="wz-text-bold">{{ctrl.appInfo["installationDate"] | date : "medium"}}</span>
+            <span class="wz-text-bold"
+              >{{ctrl.appInfo["installationDate"] | date : "medium"}}</span
+            >
           </div>
         </div>
       </div>
@@ -96,10 +127,11 @@
             <div class="euiSpacer euiSpacer--l"></div>
             <div class="euiText euiText--medium">
               <p>
-                {{ctrl.pluginAppName}} provides management and monitoring capabilities, giving users
-                control over the Wazuh infrastructure. You can monitor your agents
-                status and configuration, query and visualize your alert data and monitor manager
-                rules and configuration.
+                {{ctrl.pluginAppName}} provides management and monitoring
+                capabilities, giving users control over the Wazuh
+                infrastructure. You can monitor your agents status and
+                configuration, query and visualize your alert data and monitor
+                manager rules and configuration.
               </p>
             </div>
           </div>
@@ -121,7 +153,10 @@
             </div>
             <div class="euiSpacer euiSpacer--m"></div>
             <div class="euiText euiText--medium">
-              <p>Enjoy your Wazuh experience and please don't hesitate to give us your feedback.</p>
+              <p>
+                Enjoy your Wazuh experience and please don't hesitate to give us
+                your feedback.
+              </p>
             </div>
             <div class="euiSpacer euiSpacer--l"></div>
             <div layout="row" class="layout-align-center-center" flex>


### PR DESCRIPTION
### Description
This PR aims to solve a visual error presented in the `About` section
 
### Issues Resolved
#5336 

### Evidence
Before:
![imagen](https://user-images.githubusercontent.com/42900763/228680707-5ea899cc-3010-4bc3-9154-98d894b3f21d.png)

After:
![imagen](https://user-images.githubusercontent.com/42900763/228680623-f78abb45-b91b-4c31-bb41-5b2e9e255a25.png)


### Test
Navigate to Settings/About and confirm that the `Welcome to the Wazuh dashboard` and `Community` containers, and the blue bar that contains the `App version`, `App revision` and `Install date` on top of them doesn't reach the horizontal end of the screen in any of the sides

### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff 
