### PR TITLE
[Backport 7.10]Change link to Malware detection documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the Wazuh app project will be documented in this file.
 
+## Wazuh v4.4.1 - Kibana 7.10.2, 7.16.x, 7.17.x - Revision 00
+
+### Fixed
+
+- Fixed the `Anomaly and malware detection` link. [#5329](https://github.com/wazuh/wazuh-kibana-app/pull/5329)
+
 ## Wazuh v4.4.0 - Kibana 7.10.2, 7.16.x, 7.17.x - Revision 06
 
 ### Added

--- a/public/controllers/management/components/management/configuration/policy-monitoring/help-links.js
+++ b/public/controllers/management/components/management/configuration/policy-monitoring/help-links.js
@@ -14,8 +14,8 @@ import { webDocumentationLink } from "../../../../../../../common/services/web_d
 
 export default [
   {
-    text: 'Anomaly and malware detection',
-    href: webDocumentationLink('user-manual/capabilities/anomalies-detection/index.html')
+    text: 'Malware detection',
+    href: webDocumentationLink('user-manual/capabilities/malware-detection/index.html')
   },
   {
     text: 'Monitoring security policies',


### PR DESCRIPTION
Backport https://github.com/wazuh/wazuh-kibana-app/commit/ed9e44e87f092b2965b46ce988aa00d92d701b43 from https://github.com/wazuh/wazuh-kibana-app/pull/5329.