### PR TITLE
Fix timepicker close

### DIFF
--- a/public/components/wz-date-picker/components/condensed.tsx
+++ b/public/components/wz-date-picker/components/condensed.tsx
@@ -48,8 +48,8 @@ export function CondensedPicker({ ranges, onTimeChange }) {
     return result;
   }
 
-  const button = (<EuiButtonEmpty 
-    onClick={() => setIsOpen(true)}
+  const button = (<EuiButtonEmpty
+    onClick={() => setIsOpen(!isOpen)}
     iconType="arrowDown"
     iconSide="right">
     {!!customRange


### PR DESCRIPTION
### Description
Fixed the problem that did not allow closing the time picker when the button was clicked again.

The scrolling of the menu when opening the timepicker is specific to EuiPopover as it is happening in all EuiPopovers.
 
### Issues Resolved
- #5300

### Evidence
At the beginning you can see how the timepicker works and at the end you can see that the EuiPopover have the same behaviour.


https://user-images.githubusercontent.com/63758389/228856216-7131839e-8058-48db-83b0-39ca840616fe.mp4


### Test

1. Navigate to Agents
2. Open the time picker
3. Click again in the same spot to close it

### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 
