### PR TITLE
Fix the GitHub and Office 365 module visibility configuration were not kept when changing the plugin

### DIFF
--- a/common/constants.ts
+++ b/common/constants.ts
@@ -502,7 +502,7 @@ export const PLUGIN_SETTINGS_CATEGORIES: { [category: number]: TPluginSettingCat
   },
   [SettingCategory.STATISTICS]: {
     title: 'Task:Statistics',
-    description: "Options related to the daemons manager monitoring job and their storage in indexes..",
+    description: "Options related to the daemons manager monitoring job and their storage in indexes.",
     renderOrder: SettingCategory.STATISTICS,
   },
   [SettingCategory.CUSTOMIZATION]: {
@@ -1380,7 +1380,7 @@ export const PLUGIN_SETTINGS: { [key: string]: TPluginSetting } = {
 		},
   },
   "extensions.hipaa": {
-    title: "Hipaa",
+    title: "HIPAA",
     description: "Enable or disable the HIPAA tab on Overview and Agents.",
     category: SettingCategory.EXTENSIONS,
     type: EpluginSettingType.switch,

--- a/common/constants.ts
+++ b/common/constants.ts
@@ -1355,6 +1355,30 @@ export const PLUGIN_SETTINGS: { [key: string]: TPluginSetting } = {
 			return schema.boolean();
 		},
   },
+  "extensions.github": {
+    title: "GitHub",
+    description: "Enable or disable the GitHub tab on Overview and Agents.",
+    category: SettingCategory.EXTENSIONS,
+    type: EpluginSettingType.switch,
+    defaultValue: false,
+    isConfigurableFromFile: true,
+    isConfigurableFromUI: false,
+    options: {
+      switch: {
+        values: {
+          disabled: { label: 'false', value: false },
+          enabled: { label: 'true', value: true },
+        }
+      }
+    },
+    uiFormTransformChangedInputValue: function (value: boolean | string): boolean {
+      return Boolean(value);
+    },
+    validate: SettingsValidator.isBoolean,
+		validateBackend: function(schema){
+			return schema.boolean();
+		},
+  },
   "extensions.hipaa": {
     title: "Hipaa",
     description: "Enable or disable the HIPAA tab on Overview and Agents.",
@@ -1385,6 +1409,30 @@ export const PLUGIN_SETTINGS: { [key: string]: TPluginSetting } = {
     category: SettingCategory.EXTENSIONS,
     type: EpluginSettingType.switch,
     defaultValue: true,
+    isConfigurableFromFile: true,
+    isConfigurableFromUI: false,
+    options: {
+      switch: {
+        values: {
+          disabled: { label: 'false', value: false },
+          enabled: { label: 'true', value: true },
+        }
+      }
+    },
+    uiFormTransformChangedInputValue: function (value: boolean | string): boolean {
+      return Boolean(value);
+    },
+    validate: SettingsValidator.isBoolean,
+		validateBackend: function(schema){
+			return schema.boolean();
+		},
+  },
+  "extensions.office": {
+    title: "Office 365",
+    description: "Enable or disable the Office 365 tab on Overview and Agents.",
+    category: SettingCategory.EXTENSIONS,
+    type: EpluginSettingType.switch,
+    defaultValue: false,
     isConfigurableFromFile: true,
     isConfigurableFromUI: false,
     options: {

--- a/server/start/initialize/index.test.ts
+++ b/server/start/initialize/index.test.ts
@@ -338,9 +338,7 @@ describe("[initialize] `wazuh-registry.json` created", () => {
       if ( Object.keys(contentRegistryFile.hosts).length ){
         Object.entries(contentRegistryFile.hosts).forEach(([hostID, hostData]) => {
           if(hostData.extensions){
-            Object.entries(hostData.extensions).forEach(([extensionID, extensionEnabled]) => {
-              expect(extensionEnabled).toBe(contentRegistryExpected.hosts[hostID].extensions[extensionID])
-            });
+            expect(hostData.extensions).toEqual(contentRegistryExpected.hosts[hostID].extensions);
           };
         });
       };


### PR DESCRIPTION
### Description
This pull request fixes a problem when the visibility of GitHub and Office 365 modules are not kept when changing/upgrading the plugin.

Changes:
- Fix the problem related to migration of extension/modules visibility configuration for the API hosts
- Enhance related tests
- Fix typos

### Issues Resolved
https://github.com/wazuh/wazuh-kibana-app/issues/5367

### Evidence
[Provide screenshots or videos to prove this PR solves the issues]

### Test
[Provide instructions to test this PR]

### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff 
