### PR TITLE
Make checks inside Pattern check services

### DIFF
--- a/public/components/health-check/container/health-check.container.tsx
+++ b/public/components/health-check/container/health-check.container.tsx
@@ -90,33 +90,6 @@ const checks = {
     shouldCheck: true,
     canRetry: true,
   },
-  maxBuckets: {
-    title: `Check ${PLUGIN_PLATFORM_SETTING_NAME_MAX_BUCKETS} setting`,
-    label: `${PLUGIN_PLATFORM_SETTING_NAME_MAX_BUCKETS} setting`,
-    validator: checkPluginPlatformSettings(PLUGIN_PLATFORM_SETTING_NAME_MAX_BUCKETS, WAZUH_PLUGIN_PLATFORM_SETTING_MAX_BUCKETS),
-    awaitFor: [],
-    canRetry: true,
-  },
-  metaFields: {
-    title: `Check ${PLUGIN_PLATFORM_SETTING_NAME_METAFIELDS} setting`,
-    label: `${PLUGIN_PLATFORM_SETTING_NAME_METAFIELDS} setting`,
-    validator: checkPluginPlatformSettings(PLUGIN_PLATFORM_SETTING_NAME_METAFIELDS, WAZUH_PLUGIN_PLATFORM_SETTING_METAFIELDS),
-    awaitFor: [],
-    canRetry: true,
-  },
-  timeFilter: {
-    title: `Check ${PLUGIN_PLATFORM_SETTING_NAME_TIME_FILTER} setting`,
-    label: `${PLUGIN_PLATFORM_SETTING_NAME_TIME_FILTER} setting`,
-    validator: checkPluginPlatformSettings(
-      PLUGIN_PLATFORM_SETTING_NAME_TIME_FILTER,
-      JSON.stringify(WAZUH_PLUGIN_PLATFORM_SETTING_TIME_FILTER),
-      (checkLogger: CheckLogger, options: { defaultAppValue: any }) => {
-        getDataPlugin().query.timefilter.timefilter.setTime(WAZUH_PLUGIN_PLATFORM_SETTING_TIME_FILTER)
-          && checkLogger.action(`Timefilter set to ${JSON.stringify(options.defaultAppValue)}`);
-      }),
-    awaitFor: [],
-    canRetry: true,
-  }
 };
 
 function HealthCheckComponent() {

--- a/public/components/health-check/services/check-index-pattern/check-index-pattern.service.ts
+++ b/public/components/health-check/services/check-index-pattern/check-index-pattern.service.ts
@@ -16,10 +16,27 @@ import { checkFieldsService } from './check-fields.service';
 import { checkIndexPatternObjectService } from './check-index-pattern-object.service';
 import { checkTemplateService } from './check-template.service';
 
-export const checkIndexPatternService = (appConfig) => async (checkLogger: CheckLogger) =>  await checkPattern(appConfig, checkLogger);
+import { checkPluginPlatformSettings } from '../../services';
+import {
+  PLUGIN_PLATFORM_SETTING_NAME_MAX_BUCKETS,
+  PLUGIN_PLATFORM_SETTING_NAME_METAFIELDS,
+  PLUGIN_PLATFORM_SETTING_NAME_TIME_FILTER,
+  WAZUH_PLUGIN_PLATFORM_SETTING_MAX_BUCKETS,
+  WAZUH_PLUGIN_PLATFORM_SETTING_METAFIELDS,
+  WAZUH_PLUGIN_PLATFORM_SETTING_TIME_FILTER,
+} from '../../../../../common/constants';
 
-const checkPattern = async (appConfig, checkLogger: CheckLogger) =>  {
-  if(!appConfig.data['checks.pattern']){
+import { getDataPlugin } from '../../../../kibana-services';
+
+export const checkIndexPatternService = (appConfig) => async (checkLogger: CheckLogger) => {
+  await checkPattern(appConfig, checkLogger);
+  await checkMaxBuckets(appConfig, checkLogger);
+  await checkMetaFields(appConfig, checkLogger);
+  await checkTimeFilter(appConfig, checkLogger);
+};
+
+const checkPattern = async (appConfig, checkLogger: CheckLogger) => {
+  if (!appConfig.data['checks.pattern']) {
     checkLogger.info('Check [pattern]: disabled. Some minimal tasks will be done.');
   };
   await checkIndexPatternObjectService(appConfig, checkLogger);
@@ -29,9 +46,9 @@ const checkPattern = async (appConfig, checkLogger: CheckLogger) =>  {
 
 const decoratorHealthCheckRunCheckEnabled = (checkKey, fn) => {
   return async (appConfig: any, checkLogger: CheckLogger) => {
-    if(appConfig.data[`checks.${checkKey}`]){
+    if (appConfig.data[`checks.${checkKey}`]) {
       await fn(appConfig, checkLogger);
-    }else{
+    } else {
       checkLogger.info(`Check [${checkKey}]: disabled. Skipped.`);
     };
   }
@@ -39,3 +56,24 @@ const decoratorHealthCheckRunCheckEnabled = (checkKey, fn) => {
 
 const checkTemplate = decoratorHealthCheckRunCheckEnabled('template', checkTemplateService);
 const checkFields = decoratorHealthCheckRunCheckEnabled('fields', checkFieldsService);
+
+const checkMaxBuckets = decoratorHealthCheckRunCheckEnabled('maxBuckets',
+  (appConfig, checkLogger) => checkPluginPlatformSettings(
+    PLUGIN_PLATFORM_SETTING_NAME_MAX_BUCKETS,
+    WAZUH_PLUGIN_PLATFORM_SETTING_MAX_BUCKETS
+  )(appConfig)(checkLogger));
+
+const checkMetaFields = decoratorHealthCheckRunCheckEnabled('metaFields',
+  (appConfig, checkLogger) => checkPluginPlatformSettings(
+    PLUGIN_PLATFORM_SETTING_NAME_METAFIELDS,
+    WAZUH_PLUGIN_PLATFORM_SETTING_METAFIELDS
+  )(appConfig)(checkLogger));
+
+const checkTimeFilter = decoratorHealthCheckRunCheckEnabled('timeFilter',
+  (appConfig, checkLogger) => checkPluginPlatformSettings(
+    PLUGIN_PLATFORM_SETTING_NAME_TIME_FILTER,
+    JSON.stringify(WAZUH_PLUGIN_PLATFORM_SETTING_TIME_FILTER),
+    (checkLogger: CheckLogger, options: { defaultAppValue: any }) => {
+      getDataPlugin().query.timefilter.timefilter.setTime(WAZUH_PLUGIN_PLATFORM_SETTING_TIME_FILTER)
+        && checkLogger.action(`Timefilter set to ${JSON.stringify(options.defaultAppValue)}`);
+    })(appConfig)(checkLogger));

--- a/public/components/health-check/services/check-plugin-platform-settings.service.ts
+++ b/public/components/health-check/services/check-plugin-platform-settings.service.ts
@@ -17,7 +17,11 @@ import _ from 'lodash';
 import { getUiSettings } from '../../../kibana-services';
 import { PLUGIN_PLATFORM_NAME } from '../../../../common/constants';
 
-export const checkPluginPlatformSettings = (pluginPlatformSettingName: string, defaultAppValue: any, callback?: (checkLogger: CheckLogger, options: {defaultAppValue: any}) => void) => (appConfig: any) => async (checkLogger: CheckLogger) => {
+export const checkPluginPlatformSettings = (
+  pluginPlatformSettingName: string,
+  defaultAppValue: any,
+  callback?: (checkLogger: CheckLogger, options: { defaultAppValue: any }) => void
+) => (appConfig: any) => async (checkLogger: CheckLogger) => {
   checkLogger.info('Getting settings...');
   const valuePluginPlatformSetting = getUiSettings().get(pluginPlatformSettingName);
   const settingsAreDifferent = !_.isEqual(
@@ -27,11 +31,11 @@ export const checkPluginPlatformSettings = (pluginPlatformSettingName: string, d
   checkLogger.info(`Check ${PLUGIN_PLATFORM_NAME} setting [${pluginPlatformSettingName}]: ${stringifySetting(valuePluginPlatformSetting)}`);
   checkLogger.info(`App setting [${pluginPlatformSettingName}]: ${stringifySetting(defaultAppValue)}`);
   checkLogger.info(`Settings mismatch [${pluginPlatformSettingName}]: ${settingsAreDifferent ? 'yes' : 'no'}`);
-  if ( !valuePluginPlatformSetting || settingsAreDifferent ){
+  if (!valuePluginPlatformSetting || settingsAreDifferent) {
     checkLogger.info(`Updating [${pluginPlatformSettingName}] setting...`);
     await updateSetting(pluginPlatformSettingName, defaultAppValue);
     checkLogger.action(`Updated [${pluginPlatformSettingName}] setting to: ${stringifySetting(defaultAppValue)}`);
-    callback && callback(checkLogger,{ defaultAppValue });
+    callback && callback(checkLogger, { defaultAppValue });
   }
 }
 
@@ -46,10 +50,10 @@ async function updateSetting(pluginPlatformSettingName, defaultAppValue, retries
     });
 }
 
-function stringifySetting(setting: any){
-  try{
+function stringifySetting(setting: any) {
+  try {
     return JSON.stringify(setting);
-  }catch(error){
+  } catch (error) {
     return setting;
   };
 };


### PR DESCRIPTION
## Description
Hi team,

This PR migrates the `timeFilter`, `metaFields`, `maxBuckets` checks inside the `pattern` check.
 
### Issues Resolved
Closes #5310 

### Evidence
![image](https://user-images.githubusercontent.com/9343732/232742475-e4c1942a-43b7-4e44-802c-b628a8958cec.png)


## Test
To test this pull request enable or disable health-check configuration in `wazuh.yml`.

### Pattern enabled


wazuh.yml entries to change:

`checks.pattern:` true
`checks.metaFields:` false
`checks.timeFilter:` false
`checks.maxBuckets:` false

The pattern check log should look like this:

```
INFO: Index pattern id in cookie: yes [wazuh-alerts-*]
INFO: Getting list of valid index patterns...
INFO: Valid index patterns found: 1
INFO: Found default index pattern with title [wazuh-alerts-*]: yes
INFO: Checking the app default pattern exists: id [wazuh-alerts-*]...
INFO: Default pattern with id [wazuh-alerts-*] exists: yes
ACTION: Default pattern id [wazuh-alerts-*] set as default index pattern
INFO: Checking the index pattern id [wazuh-alerts-*] exists...
INFO: Index pattern id exists [wazuh-alerts-*]: yes
INFO: Index pattern id in cookie: yes [wazuh-alerts-*]
INFO: Checking if the index pattern id [wazuh-alerts-*] exists...
INFO: Index pattern id [wazuh-alerts-*] found: yes title [wazuh-alerts-*]
INFO: Checking if exists a template compatible with the index pattern title [wazuh-alerts-*]
INFO: Template found for the selected index-pattern title [wazuh-alerts-*]: yes
INFO: Index pattern id in cookie: [wazuh-alerts-*]
INFO: Getting index pattern data [wazuh-alerts-*]...
INFO: Index pattern data found: [yes]
INFO: Refreshing index pattern fields: title [wazuh-alerts-*], id [wazuh-alerts-*]...
ACTION: Refreshed index pattern fields: title [wazuh-alerts-*], id [wazuh-alerts-*]
INFO: Check [maxBuckets]: disabled. Skipped.
INFO: Check [metaFields]: disabled. Skipped.
INFO: Check [timeFilter]: disabled. Skipped.
```

### Pattern disabled

wazuh.yml entries to change:

`checks.pattern:` false
`checks.metaFields:` true
`checks.timeFilter:` true
`checks.maxBuckets:` true


The pattern check log should look like this:

```
INFO: Check [pattern]: disabled. Some minimal tasks will be done.
INFO: Index pattern id in cookie: yes [wazuh-alerts-*]
INFO: Getting list of valid index patterns...
INFO: Valid index patterns found: 1
INFO: Found default index pattern with title [wazuh-alerts-*]: yes
INFO: Checking the app default pattern exists: id [wazuh-alerts-*]...
INFO: Default pattern with id [wazuh-alerts-*] exists: yes
ACTION: Default pattern id [wazuh-alerts-*] set as default index pattern
INFO: Checking the index pattern id [wazuh-alerts-*] exists...
INFO: Index pattern id exists [wazuh-alerts-*]: yes
INFO: Index pattern id in cookie: yes [wazuh-alerts-*]
INFO: Checking if the index pattern id [wazuh-alerts-*] exists...
INFO: Index pattern id [wazuh-alerts-*] found: yes title [wazuh-alerts-*]
INFO: Checking if exists a template compatible with the index pattern title [wazuh-alerts-*]
INFO: Template found for the selected index-pattern title [wazuh-alerts-*]: yes
INFO: Index pattern id in cookie: [wazuh-alerts-*]
INFO: Getting index pattern data [wazuh-alerts-*]...
INFO: Index pattern data found: [yes]
INFO: Refreshing index pattern fields: title [wazuh-alerts-*], id [wazuh-alerts-*]...
ACTION: Refreshed index pattern fields: title [wazuh-alerts-*], id [wazuh-alerts-*]
INFO: Getting settings...
INFO: Check Wazuh dashboard setting [timeline:max_buckets]: 200000
INFO: App setting [timeline:max_buckets]: 200000
INFO: Settings mismatch [timeline:max_buckets]: no
INFO: Getting settings...
INFO: Check Wazuh dashboard setting [metaFields]: ["_source","_index"]
INFO: App setting [metaFields]: ["_source","_index"]
INFO: Settings mismatch [metaFields]: no
INFO: Getting settings...
INFO: Check Wazuh dashboard setting [timepicker:timeDefaults]: {"from":"now-24h","to":"now"}
INFO: App setting [timepicker:timeDefaults]: "{\"from\":\"now-24h\",\"to\":\"now\"}"
INFO: Settings mismatch [timepicker:timeDefaults]: no
```
### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff 
