### PR TITLE
Mock auhentication endpoint for 4.3.x in Docker environments

### DIFF
--- a/docker/imposter/wazuh-config.yml
+++ b/docker/imposter/wazuh-config.yml
@@ -622,6 +622,14 @@ resources:
   # ===================================================== #
 
   # Login
+  ## Wazuh 4.3
+  - method: GET
+    path: /security/user/authenticate
+    response:
+      statusCode: 200
+      scriptFile: security/login.js
+
+  ## Wazuh >= 4.4
   - method: POST
     path: /security/user/authenticate
     response:

--- a/docker/wazuh-4.x-es/config/imposter/wazuh-config.yml
+++ b/docker/wazuh-4.x-es/config/imposter/wazuh-config.yml
@@ -3,6 +3,14 @@ plugin: openapi
 specFile: https://raw.githubusercontent.com/wazuh/wazuh/v4.4.0/api/api/spec/spec.yaml
 
 resources:
+  # Login
+  ## Wazuh 4.3
+  - path: /security/user/authenticate
+    method: get
+    response:
+      statusCode: 200
+      scriptFile: login.js
+  ## Wazuh >= 4.4
   - path: /security/user/authenticate
     method: post
     response:


### PR DESCRIPTION
### Description
This pull request adds a mocked endpoint `GET /security/user/authenticate` for the user authentication in the imposter used by plugins 4.3.x.

### Changes
- Added mock endpoint to root imposter
- Added mock endpoint for `wazuh-4.x-es`
 
### Issues Resolved
[List any issues this PR will resolve]

### Evidence
[Provide screenshots or videos to prove this PR solves the issues]

### Test
[Provide instructions to test this PR]

### Check List
- [x] All tests pass
  - [x] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 
