### PR TITLE
Fix displaying ipv6 address on agent welcome view

### DIFF
--- a/public/components/common/welcome/agents-info.js
+++ b/public/components/common/welcome/agents-info.js
@@ -157,7 +157,7 @@ export class AgentInfo extends Component {
       arrayStats = [
         { title: agent.id, description: 'ID', style: { minWidth: 30 } },
         { title: agent.status, description: 'Status', style: { minWidth: 130 } },
-        { title: agent.ip, description: 'IP address', style: { minWidth: 80 } },
+        { title: agent.ip, description: 'IP address', style: { minWidth: 260 } },
         { title: agent.version, description: 'Version', style: { minWidth: 100 } },
         { title: agent.group, description: 'Groups', style: { minWidth: 150 } },
         { title: agent.name, description: 'Operating system', style: { minWidth: 150 } },


### PR DESCRIPTION
### Description
Fix displaying IPV6 address on agent welcome view.
 
### Issues Resolved
[List any issues this PR will resolve]

### Evidence
![bad](https://user-images.githubusercontent.com/3259948/236315277-9a2b89cb-72b1-4c47-a601-afb6bc952968.png)
![good](https://user-images.githubusercontent.com/3259948/236315338-c09c5122-0908-4e5e-b3f8-1fb442ffc307.png)


### Test
Select an agent with IPV6 address in agent preview page and check the IP address field in the detailed view.

### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff 
