### PR TITLE
Removed logic related to deprecated endpoint GET /api/agents-unique/{api}

### DIFF
--- a/public/controllers/management/components/management/configuration/utils/wz-fetch.js
+++ b/public/controllers/management/components/management/configuration/utils/wz-fetch.js
@@ -93,8 +93,7 @@ export const extractMessage = error => {
     const origin = ((error || {}).config || {}).url || '';
     const isFromAPI =
       origin.includes('/api/request') ||
-      origin.includes('/api/csv') ||
-      origin.includes('/api/agents-unique');
+      origin.includes('/api/csv');
     return isFromAPI ?
       'Wazuh API is not reachable. Reason: timeout.' :
       'Server did not respond';
@@ -242,7 +241,7 @@ export const fetchFile = async selectedNode => {
       'GET',
       isCluster ?
       `/cluster/${selectedNode}/configuration` :
-      `/manager/configuration`, 
+      `/manager/configuration`,
       {
         params: {
           raw: true

--- a/public/react-services/error-handler.ts
+++ b/public/react-services/error-handler.ts
@@ -36,8 +36,7 @@ export class ErrorHandler {
       const origin = ((error || {}).config || {}).url || '';
       const isFromAPI =
         origin.includes('/api/request') ||
-        origin.includes('/api/csv') ||
-        origin.includes('/api/agents-unique');
+        origin.includes('/api/csv');
       return isFromAPI ? 'Wazuh API is not reachable. Reason: timeout.' : 'Server did not respond';
     }
 

--- a/public/services/error-handler.js
+++ b/public/services/error-handler.js
@@ -34,8 +34,7 @@ export class ErrorHandler {
       const origin = ((error || {}).config || {}).url || '';
       const isFromAPI =
         origin.includes('/api/request') ||
-        origin.includes('/api/csv') ||
-        origin.includes('/api/agents-unique');
+        origin.includes('/api/csv');
       return isFromAPI
         ? 'Wazuh API is not reachable. Reason: timeout.'
         : 'Server did not respond';

--- a/test/server/wazuh-api.js
+++ b/test/server/wazuh-api.js
@@ -121,24 +121,6 @@ describe('wazuh-api', () => {
     res.body.ram.should.be.gt(1);
   });
 
-  it('GET /api/agents-unique/{api}', async () => {
-    const res = await needle(
-      'get',
-      `localhost:5601/api/agents-unique/${API_ID}`,
-      {},
-      {}
-    );
-    res.body.should.be.a('object');
-    res.body.error.should.be.eql(0);
-    res.body.result.should.be.a('object');
-    res.body.result.groups.should.be.a('array');
-    res.body.result.nodes.should.be.a('array');
-    res.body.result.versions.should.be.a('array');
-    res.body.result.osPlatforms.should.be.a('array');
-    res.body.result.lastAgent.should.be.a('object');
-    res.body.result.summary.should.be.a('object');
-  });
-
   it('GET /utils/logs', async () => {
     const res = await needle('get', `localhost:5601/utils/logs`, {}, {});
     res.body.should.be.a('object');


### PR DESCRIPTION
### Description
Removes obsolete logic and tests that were left after deleting the GET `/api/agents-unique` endpoint.
 
### Issues Resolved
- #4916 

### Test

See in the code that there is nothing left related to the endpoint `/api/agents-unique`


### Check List
- [x] All tests pass
  - [x] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 
