### PR TITLE
Fix accessing property in getConfiguration backend service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 
 ### Fixed
 
-- Fixed a problem in the backend service to get the plugin configuration [#5428](https://github.com/wazuh/wazuh-kibana-app/pull/5428)
+- Fixed a problem in the backend service to get the plugin configuration [#5428](https://github.com/wazuh/wazuh-kibana-app/pull/5428) [#5432](https://github.com/wazuh/wazuh-kibana-app/pull/5432)
 
 ## Wazuh v4.4.1 - OpenSearch Dashboards 2.6.0 - Revision 00
 

--- a/server/lib/get-configuration.ts
+++ b/server/lib/get-configuration.ts
@@ -59,7 +59,7 @@ function obfuscateHostsConfiguration(configuration: any, obfuscateHostConfigurat
   if(configuration.hosts){
     configuration.hosts = configuration.hosts
       .map((host) => {
-        const hostID = Object.keys(host);
+        const hostID = Object.keys(host)[0];
         return {
           [hostID]: {
             ...host[hostID],


### PR DESCRIPTION
### Description
This pull request fixes a problem accessing to an object property in the `getConfiguration` backend service.
 
### Issues Resolved
#5427 

### Evidence
![image](https://github.com/wazuh/wazuh-kibana-app/assets/34042064/866153ec-df88-4b45-a660-f2b586f84616)

### Test
[Provide instructions to test this PR]

### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 
