### PR TITLE
Reuse of common form on the card

### DIFF
--- a/public/components/common/form/hooks.test.tsx
+++ b/public/components/common/form/hooks.test.tsx
@@ -1,178 +1,215 @@
+import { fireEvent, render } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
 import { renderHook, act } from '@testing-library/react-hooks';
+import React, { useState } from 'react';
 import { useForm } from './hooks';
+import { IFormFields, IInputForm } from './types';
 
 describe('[hook] useForm', () => {
+  it(`[hook] useForm. Verify the initial state`, async () => {
+    const initialFields: IFormFields = {
+      text1: {
+        type: 'text',
+        initialValue: '',
+      },
+    };
 
-	it(`[hook] useForm. Verify the initial state`, async () => {
+    const { result } = renderHook(() => useForm(initialFields));
 
-		const initialFields = {
-			text1: {
-				type: 'text',
-				initialValue: ''
-			},
-		};
+    // assert initial state
+    expect(result.current.fields.text1.changed).toBe(false);
+    expect(result.current.fields.text1.error).toBeUndefined();
+    expect(result.current.fields.text1.type).toBe('text');
+    expect(result.current.fields.text1.value).toBe('');
+    expect(result.current.fields.text1.initialValue).toBe('');
+    expect(result.current.fields.text1.onChange).toBeDefined();
+  });
 
-		const { result } = renderHook(() => useForm(initialFields));
+  it(`[hook] useForm. Verify the initial state. Multiple fields.`, async () => {
+    const initialFields: IFormFields = {
+      text1: {
+        type: 'text',
+        initialValue: '',
+      },
+      number1: {
+        type: 'number',
+        initialValue: 1,
+      },
+    };
 
-		// assert initial state
-		expect(result.current.fields.text1.changed).toBe(false);
-		expect(result.current.fields.text1.error).toBeUndefined();
-		expect(result.current.fields.text1.type).toBe('text');
-		expect(result.current.fields.text1.value).toBe('');
-		expect(result.current.fields.text1.initialValue).toBe('');
-		expect(result.current.fields.text1.onChange).toBeDefined();
-	});
+    const { result } = renderHook(() => useForm(initialFields));
 
-	it(`[hook] useForm. Verify the initial state. Multiple fields.`, async () => {
+    // assert initial state
+    expect(result.current.fields.text1.changed).toBe(false);
+    expect(result.current.fields.text1.error).toBeUndefined();
+    expect(result.current.fields.text1.type).toBe('text');
+    expect(result.current.fields.text1.value).toBe('');
+    expect(result.current.fields.text1.initialValue).toBe('');
+    expect(result.current.fields.text1.onChange).toBeDefined();
 
-		const initialFields = {
-			text1: {
-				type: 'text',
-				initialValue: ''
-			},
-			number1: {
-				type: 'number',
-				initialValue: 1
-			},
-		};
+    expect(result.current.fields.number1.changed).toBe(false);
+    expect(result.current.fields.number1.error).toBeUndefined();
+    expect(result.current.fields.number1.type).toBe('number');
+    expect(result.current.fields.number1.value).toBe(1);
+    expect(result.current.fields.number1.initialValue).toBe(1);
+    expect(result.current.fields.number1.onChange).toBeDefined();
+  });
 
-		const { result } = renderHook(() => useForm(initialFields));
+  it(`[hook] useForm lifecycle. Set the initial value. Change the field value. Undo changes. Change the field. Do changes.`, async () => {
+    const initialFieldValue = '';
+    const fieldType = 'text';
 
-		// assert initial state
-		expect(result.current.fields.text1.changed).toBe(false);
-		expect(result.current.fields.text1.error).toBeUndefined();
-		expect(result.current.fields.text1.type).toBe('text');
-		expect(result.current.fields.text1.value).toBe('');
-		expect(result.current.fields.text1.initialValue).toBe('');
-		expect(result.current.fields.text1.onChange).toBeDefined();
+    const initialFields: IFormFields = {
+      text1: {
+        type: fieldType,
+        initialValue: initialFieldValue,
+      },
+    };
 
-		expect(result.current.fields.number1.changed).toBe(false);
-		expect(result.current.fields.number1.error).toBeUndefined();
-		expect(result.current.fields.number1.type).toBe('number');
-		expect(result.current.fields.number1.value).toBe(1);
-		expect(result.current.fields.number1.initialValue).toBe(1);
-		expect(result.current.fields.number1.onChange).toBeDefined();
-	});
+    const { result } = renderHook(() => useForm(initialFields));
 
-	it(`[hook] useForm lifecycle. Set the initial value. Change the field value. Undo changes. Change the field. Do changes.`, async () => {
+    // assert initial state
+    expect(result.current.fields.text1.changed).toBe(false);
+    expect(result.current.fields.text1.error).toBeUndefined();
+    expect(result.current.fields.text1.type).toBe(fieldType);
+    expect(result.current.fields.text1.value).toBe(initialFieldValue);
+    expect(result.current.fields.text1.initialValue).toBe(initialFieldValue);
+    expect(result.current.fields.text1.onChange).toBeDefined();
 
-		const initialFieldValue = '';
-		const fieldType = 'text';
+    // change the input
+    const changedValue = 't';
+    act(() => {
+      result.current.fields.text1.onChange({
+        target: {
+          value: changedValue,
+        },
+      });
+    });
 
-		const initialFields = {
-			text1: {
-				type: fieldType,
-				initialValue: initialFieldValue
-			}
-		};
+    // assert changed state
+    expect(result.current.fields.text1.changed).toBe(true);
+    expect(result.current.fields.text1.error).toBeUndefined();
+    expect(result.current.fields.text1.type).toBe(fieldType);
+    expect(result.current.fields.text1.value).toBe(changedValue);
+    expect(result.current.fields.text1.initialValue).toBe(initialFieldValue);
 
-		const { result } = renderHook(() => useForm(initialFields));
+    // undone changes
+    act(() => {
+      result.current.undoChanges();
+    });
 
-		// assert initial state
-		expect(result.current.fields.text1.changed).toBe(false);
-		expect(result.current.fields.text1.error).toBeUndefined();
-		expect(result.current.fields.text1.type).toBe(fieldType);
-		expect(result.current.fields.text1.value).toBe(initialFieldValue);
-		expect(result.current.fields.text1.initialValue).toBe(initialFieldValue);
-		expect(result.current.fields.text1.onChange).toBeDefined();
+    // assert undo changes state
+    expect(result.current.fields.text1.changed).toBe(false);
+    expect(result.current.fields.text1.error).toBeUndefined();
+    expect(result.current.fields.text1.type).toBe(fieldType);
+    expect(result.current.fields.text1.value).toBe(initialFieldValue);
+    expect(result.current.fields.text1.initialValue).toBe(initialFieldValue);
 
-		// change the input
-		const changedValue = 't';
-		act(() => {
-			result.current.fields.text1.onChange({
-				target: {
-					value: changedValue
-				}
-			});
-		});
+    // change the input
+    const changedValue2 = 'e';
+    act(() => {
+      result.current.fields.text1.onChange({
+        target: {
+          value: changedValue2,
+        },
+      });
+    });
 
-		// assert changed state
-		expect(result.current.fields.text1.changed).toBe(true);
-		expect(result.current.fields.text1.error).toBeUndefined();
-		expect(result.current.fields.text1.type).toBe(fieldType);
-		expect(result.current.fields.text1.value).toBe(changedValue);
-		expect(result.current.fields.text1.initialValue).toBe(initialFieldValue);
+    // assert changed state
+    expect(result.current.fields.text1.changed).toBe(true);
+    expect(result.current.fields.text1.error).toBeUndefined();
+    expect(result.current.fields.text1.type).toBe(fieldType);
+    expect(result.current.fields.text1.value).toBe(changedValue2);
+    expect(result.current.fields.text1.initialValue).toBe(initialFieldValue);
 
-		// undone changes
-		act(() => {
-			result.current.undoChanges();
-		});
+    // done changes
+    act(() => {
+      result.current.doChanges();
+    });
 
-		// assert undo changes state
-		expect(result.current.fields.text1.changed).toBe(false);
-		expect(result.current.fields.text1.error).toBeUndefined();
-		expect(result.current.fields.text1.type).toBe(fieldType);
-		expect(result.current.fields.text1.value).toBe(initialFieldValue);
-		expect(result.current.fields.text1.initialValue).toBe(initialFieldValue);
+    // assert do changes state
+    expect(result.current.fields.text1.changed).toBe(false);
+    expect(result.current.fields.text1.error).toBeUndefined();
+    expect(result.current.fields.text1.type).toBe(fieldType);
+    expect(result.current.fields.text1.value).toBe(changedValue2);
+    expect(result.current.fields.text1.initialValue).toBe(changedValue2);
+  });
 
-		// change the input
-		const changedValue2 = 'e';
-		act(() => {
-			result.current.fields.text1.onChange({
-				target: {
-					value: changedValue2
-				}
-			});
-		});
+  it(`[hook] useForm lifecycle. Set the initial value. Change the field value to invalid value`, async () => {
+    const initialFieldValue = 'test';
+    const fieldType = 'text';
 
-		// assert changed state
-		expect(result.current.fields.text1.changed).toBe(true);
-		expect(result.current.fields.text1.error).toBeUndefined();
-		expect(result.current.fields.text1.type).toBe(fieldType);
-		expect(result.current.fields.text1.value).toBe(changedValue2);
-		expect(result.current.fields.text1.initialValue).toBe(initialFieldValue);
+    const initialFields: IFormFields = {
+      text1: {
+        type: fieldType,
+        initialValue: initialFieldValue,
+        validate: (value: string): string | undefined =>
+          value.length ? undefined : `Validation error: string can be empty.`,
+      },
+    };
 
-		// done changes
-		act(() => {
-			result.current.doChanges()
-		});
+    const { result } = renderHook(() => useForm(initialFields));
 
-		// assert do changes state
-		expect(result.current.fields.text1.changed).toBe(false);
-		expect(result.current.fields.text1.error).toBeUndefined();
-		expect(result.current.fields.text1.type).toBe(fieldType);
-		expect(result.current.fields.text1.value).toBe(changedValue2);
-		expect(result.current.fields.text1.initialValue).toBe(changedValue2);
-	});
+    // assert initial state
+    expect(result.current.fields.text1.changed).toBe(false);
+    expect(result.current.fields.text1.error).toBeUndefined();
+    expect(result.current.fields.text1.type).toBe(fieldType);
+    expect(result.current.fields.text1.value).toBe(initialFieldValue);
+    expect(result.current.fields.text1.initialValue).toBe(initialFieldValue);
+    expect(result.current.fields.text1.onChange).toBeDefined();
 
-	it(`[hook] useForm lifecycle. Set the initial value. Change the field value to invalid value`, async () => {
+    // change the input
+    const changedValue = '';
+    act(() => {
+      result.current.fields.text1.onChange({
+        target: {
+          value: changedValue,
+        },
+      });
+    });
 
-		const initialFieldValue = 'test';
-		const fieldType = 'text';
+    // assert changed state
+    expect(result.current.fields.text1.changed).toBe(true);
+    expect(result.current.fields.text1.error).toBeTruthy();
+    expect(result.current.fields.text1.type).toBe(fieldType);
+    expect(result.current.fields.text1.value).toBe(changedValue);
+    expect(result.current.fields.text1.initialValue).toBe(initialFieldValue);
+  });
 
-		const initialFields = {
-			text1: {
-				type: fieldType,
-				initialValue: initialFieldValue,
-				validate: (value: string): string | undefined => value.length ? undefined : `Validation error: string can be empty.`
-			}
-		};
+  it('[hook] useForm. Verify the hook behavior when receives a custom field type', async () => {
+    const CustomComponent = (props: IInputForm) => {
+      const { onChange, field, initialValue } = props;
+      const [value, setValue] = useState(initialValue || '');
 
-		const { result } = renderHook(() => useForm(initialFields));
+      const handleOnChange = (e: any) => {
+		setValue(e.target.value);
+		onChange(e);
+      };
 
-		// assert initial state
-		expect(result.current.fields.text1.changed).toBe(false);
-		expect(result.current.fields.text1.error).toBeUndefined();
-		expect(result.current.fields.text1.type).toBe(fieldType);
-		expect(result.current.fields.text1.value).toBe(initialFieldValue);
-		expect(result.current.fields.text1.initialValue).toBe(initialFieldValue);
-		expect(result.current.fields.text1.onChange).toBeDefined();
+      return (
+        <>
+          {field}
+          <input type='text' value={value} onChange={handleOnChange} />
+        </>
+      );
+    };
 
-		// change the input
-		const changedValue = '';
-		act(() => {
-			result.current.fields.text1.onChange({
-				target: {
-					value: changedValue
-				}
-			});
-		});
+    const formFields: IFormFields = {
+      customField: {
+        type: 'custom',
+        initialValue: 'default value',
+        component: props => CustomComponent(props),
+      },
+    };
 
-		// assert changed state
-		expect(result.current.fields.text1.changed).toBe(true);
-		expect(result.current.fields.text1.error).toBeTruthy();
-		expect(result.current.fields.text1.type).toBe(fieldType);
-		expect(result.current.fields.text1.value).toBe(changedValue);
-		expect(result.current.fields.text1.initialValue).toBe(initialFieldValue);
-	});
+    const { result } = renderHook(() => useForm(formFields));
+	const { container, getByRole } = render(CustomComponent(...result.current.fields.customField))
+
+	expect(container).toBeInTheDocument();
+	const input = getByRole('textbox');
+	expect(input).toHaveValue('default value');
+	fireEvent.change(input, { target: { value: 'new value' } });
+	expect(result.current.fields.customField.component).toBeInstanceOf(Function);
+	expect(result.current.fields.customField.value).toBe('new value');
+  });
 });

--- a/public/components/common/form/hooks.test.tsx
+++ b/public/components/common/form/hooks.test.tsx
@@ -2,12 +2,12 @@ import { fireEvent, render } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import { renderHook, act } from '@testing-library/react-hooks';
 import React, { useState } from 'react';
-import { useForm } from './hooks';
-import { IFormFields, IInputForm } from './types';
+import { FormConfiguration, useForm } from './hooks';
+import { IInputForm } from './types';
 
 describe('[hook] useForm', () => {
   it(`[hook] useForm. Verify the initial state`, async () => {
-    const initialFields: IFormFields = {
+    const initialFields: FormConfiguration = {
       text1: {
         type: 'text',
         initialValue: '',
@@ -26,7 +26,7 @@ describe('[hook] useForm', () => {
   });
 
   it(`[hook] useForm. Verify the initial state. Multiple fields.`, async () => {
-    const initialFields: IFormFields = {
+    const initialFields: FormConfiguration = {
       text1: {
         type: 'text',
         initialValue: '',
@@ -59,7 +59,7 @@ describe('[hook] useForm', () => {
     const initialFieldValue = '';
     const fieldType = 'text';
 
-    const initialFields: IFormFields = {
+    const initialFields: FormConfiguration = {
       text1: {
         type: fieldType,
         initialValue: initialFieldValue,
@@ -139,7 +139,7 @@ describe('[hook] useForm', () => {
     const initialFieldValue = 'test';
     const fieldType = 'text';
 
-    const initialFields: IFormFields = {
+    const initialFields: FormConfiguration = {
       text1: {
         type: fieldType,
         initialValue: initialFieldValue,
@@ -177,14 +177,14 @@ describe('[hook] useForm', () => {
   });
 
   it('[hook] useForm. Verify the hook behavior when receives a custom field type', async () => {
-    const CustomComponent = (props: IInputForm) => {
+    const CustomComponent = (props: any) => {
       const { onChange, field, initialValue } = props;
       const [value, setValue] = useState(initialValue || '');
 
       const handleOnChange = (e: any) => {
         setValue(e.target.value);
         onChange(e);
-          };
+      };
 
           return (
             <>
@@ -194,7 +194,7 @@ describe('[hook] useForm', () => {
           );
       };
 
-      const formFields: IFormFields = {
+      const formFields: FormConfiguration = {
         customField: {
           type: 'custom',
           initialValue: 'default value',
@@ -203,7 +203,7 @@ describe('[hook] useForm', () => {
       };
 
     const { result } = renderHook(() => useForm(formFields));
-    const { container, getByRole } = render(CustomComponent(...result.current.fields.customField))
+    const { container, getByRole } = render(<CustomComponent {...result.current.fields.customField} />)
 
     expect(container).toBeInTheDocument();
     const input = getByRole('textbox');

--- a/public/components/common/form/hooks.test.tsx
+++ b/public/components/common/form/hooks.test.tsx
@@ -182,34 +182,34 @@ describe('[hook] useForm', () => {
       const [value, setValue] = useState(initialValue || '');
 
       const handleOnChange = (e: any) => {
-		setValue(e.target.value);
-		onChange(e);
+        setValue(e.target.value);
+        onChange(e);
+          };
+
+          return (
+            <>
+              {field}
+              <input type='text' value={value} onChange={handleOnChange} />
+            </>
+          );
       };
 
-      return (
-        <>
-          {field}
-          <input type='text' value={value} onChange={handleOnChange} />
-        </>
-      );
-    };
-
-    const formFields: IFormFields = {
-      customField: {
-        type: 'custom',
-        initialValue: 'default value',
-        component: props => CustomComponent(props),
-      },
-    };
+      const formFields: IFormFields = {
+        customField: {
+          type: 'custom',
+          initialValue: 'default value',
+          component: props => CustomComponent(props),
+        },
+      };
 
     const { result } = renderHook(() => useForm(formFields));
-	const { container, getByRole } = render(CustomComponent(...result.current.fields.customField))
+    const { container, getByRole } = render(CustomComponent(...result.current.fields.customField))
 
-	expect(container).toBeInTheDocument();
-	const input = getByRole('textbox');
-	expect(input).toHaveValue('default value');
-	fireEvent.change(input, { target: { value: 'new value' } });
-	expect(result.current.fields.customField.component).toBeInstanceOf(Function);
-	expect(result.current.fields.customField.value).toBe('new value');
+    expect(container).toBeInTheDocument();
+    const input = getByRole('textbox');
+    expect(input).toHaveValue('default value');
+    fireEvent.change(input, { target: { value: 'new value' } });
+    expect(result.current.fields.customField.component).toBeInstanceOf(Function);
+    expect(result.current.fields.customField.value).toBe('new value');
   });
 });

--- a/public/components/common/form/hooks.tsx
+++ b/public/components/common/form/hooks.tsx
@@ -27,8 +27,6 @@ interface IUseFormFieldsDataCustom extends IUseFormFieldsData {
   component: (props: IInputForm) => JSX.Element;
 }
 
-
-
 interface IUseFormFields {
   [key: string]: IUseFormFieldsDataDefault | IUseFormFieldsDataCustom;
 }

--- a/public/components/common/form/hooks.tsx
+++ b/public/components/common/form/hooks.tsx
@@ -1,151 +1,154 @@
 import { useState, useRef } from 'react';
 import { isEqual } from 'lodash';
 import { EpluginSettingType } from '../../../../common/constants';
-import { IFormFields, IInputForm, IInputFormType, IInputTypes, IInputTypesCustom } from './types';
 
-interface IInputFormEvent {
-  [key: string]: (event: any) => any;
-  default: (event: any) => any;
+type SettingTypes = 'text' | 'textarea' | 'number' | 'select' | 'switch' | 'editor' | 'filepicker';
+
+interface FieldConfiguration {
+  initialValue: any;
+  validate?: (value: any) => string | undefined;
+  transformChangedInputValue?: (value: any) => any;
+  transformChangedOutputValue?: (value: any) => any;
 }
 
-interface IUseFormFieldsData {
+export interface DefaultFieldConfiguration extends FieldConfiguration {
+  type: SettingTypes;
+}
+
+type CustomSettingType = 'custom';
+interface CustomFieldConfiguration extends FieldConfiguration {
+  type: CustomSettingType;
+  component: (props: any) => JSX.Element;
+}
+
+export interface FormConfiguration {
+  [key: string]: DefaultFieldConfiguration | CustomFieldConfiguration;
+}
+
+
+interface EnhancedField {
+  currentValue: any;
+  initialValue: any;
   value: any;
   changed: boolean;
   error: string;
   setInputRef: (reference: any) => void;
   inputRef: any;
   onChange: (event: any) => void;
-  initialValue: any;
 }
 
-interface IUseFormFieldsDataDefault extends IUseFormFieldsData {
-  type: IInputTypes;
+interface EnhancedDefaultField extends EnhancedField {
+  type: SettingTypes;
 }
 
-interface IUseFormFieldsDataCustom extends IUseFormFieldsData {
-  type: IInputTypesCustom;
-  component: (props: IInputForm) => JSX.Element;
+interface EnhancedCustomField extends EnhancedField {
+  type: CustomSettingType;
+  component: (props: any) => JSX.Element;
 }
 
-interface IUseFormFields {
-  [key: string]: IUseFormFieldsDataDefault | IUseFormFieldsDataCustom;
+interface EnhancedFields {
+  [key: string]: EnhancedDefaultField | EnhancedCustomField;
 }
-interface IUseFormResponse {
-  fields: IUseFormFields;
+
+interface UseFormReturn {
+  fields: EnhancedFields;
   changed: { [key: string]: any };
   errors: { [key: string]: string };
   undoChanges: () => void;
   doChanges: () => void;
 }
 
-const getValueFromEventType: IInputFormEvent = {
-  [EpluginSettingType.switch]: (event: any) => event.target.checked,
+function getValueFromEvent(event: any, type: SettingTypes | CustomSettingType): any {
+  return (getValueFromEventType[type] || getValueFromEventType.default)(event);
+};
+
+const getValueFromEventType = {
+  [EpluginSettingType.switch] : (event: any) => event.target.checked,
   [EpluginSettingType.editor]: (value: any) => value,
   [EpluginSettingType.filepicker]: (value: any) => value,
+  [EpluginSettingType.select]: (event: any) => event.target.value,
+  [EpluginSettingType.text]: (event: any) => event.target.value,
+  [EpluginSettingType.textarea]: (event: any) => event.target.value,
+  [EpluginSettingType.number]: (event: any) => event.target.value,
+  custom: (event: any) => event.target.value,
   default: (event: any) => event.target.value,
 };
 
-function getValueFromEvent(event: any, type: IInputTypes | IInputTypesCustom) {
-  return (getValueFromEventType[type] || getValueFromEventType.default)(event);
-}
-
-
-export const useForm = (fields: IFormFields): IUseFormResponse => {
-  const [formFields, setFormFields] = useState(
-    Object.entries(fields).reduce(
-      (accum, [fieldKey, fieldConfiguration]) => ({
-        ...accum,
-        [fieldKey]: {
-          currentValue: fieldConfiguration.initialValue,
-          initialValue: fieldConfiguration.initialValue,
-        },
-      }),
-      {},
-    ),
-  );
-
-  const fieldRefs = useRef({});
-
-  const enhanceFields = Object.entries(formFields).reduce(
-    (accum, [fieldKey, { currentValue: value, ...restFieldState }]) => ({
+export const useForm = (fields: FormConfiguration): UseFormReturn => {
+  const [formFields, setFormFields] = useState<{ [key: string]: { currentValue: any, initialValue: any } }>(
+    Object.entries(fields).reduce((accum, [fieldKey, fieldConfiguration]) => ({
       ...accum,
       [fieldKey]: {
-        ...fields[fieldKey],
-        ...restFieldState,
-        type: fields[fieldKey].type,
-        value,
-        changed: !isEqual(restFieldState.initialValue, value),
-        error: fields[fieldKey]?.validate?.(value),
-        setInputRef: reference => {
-          fieldRefs.current[fieldKey] = reference;
-        },
-        inputRef: fieldRefs.current[fieldKey],
-        onChange: event => {
-          const inputValue = getValueFromEvent(event, fields[fieldKey].type);
-          const currentValue =
-            fields[fieldKey]?.transformChangedInputValue?.(inputValue) ??
-            inputValue;
-          setFormFields(state => ({
-            ...state,
-            [fieldKey]: {
-              ...state[fieldKey],
-              currentValue,
-            },
-          }));
-        },
+        currentValue: fieldConfiguration.initialValue,
+        initialValue: fieldConfiguration.initialValue,
+      }
+    }), {})
+  );
+
+  const fieldRefs = useRef<{ [key: string]: any }>({});
+
+  const enhanceFields = Object.entries(formFields).reduce((accum, [fieldKey, {currentValue: value, ...restFieldState}]) => ({
+    ...accum,
+    [fieldKey]: {
+      ...fields[fieldKey],
+      ...restFieldState,
+      type: fields[fieldKey].type,
+      value,
+      changed: !isEqual(restFieldState.initialValue, value),
+      error: fields[fieldKey]?.validate?.(value),
+      setInputRef: (reference: any) => {fieldRefs.current[fieldKey] = reference},
+      inputRef: fieldRefs.current[fieldKey],
+      onChange: (event: any) => {
+        const inputValue = getValueFromEvent(event, fields[fieldKey].type);
+        const currentValue = fields[fieldKey]?.transformChangedInputValue?.(inputValue) ?? inputValue;
+        setFormFields(state => ({
+          ...state,
+          [fieldKey]: {
+            ...state[fieldKey],
+            currentValue,
+          }
+        }))
       },
-    }),
-    {},
-  ) as IUseFormFields;
+    }
+  }), {});
 
   const changed = Object.fromEntries(
-    Object.entries(enhanceFields)
-      .filter(([, { changed }]) => changed)
-      .map(([fieldKey, { value }]) => [
-        fieldKey,
-        fields[fieldKey]?.transformChangedOutputValue?.(value) ?? value,
-      ]),
+    Object.entries(enhanceFields as EnhancedFields).filter(([, {changed}]) => changed).map(([fieldKey, {value}]) => ([fieldKey, fields[fieldKey]?.transformChangedOutputValue?.(value) ?? value]))
   );
 
   const errors = Object.fromEntries(
-    Object.entries(enhanceFields)
-      .filter(([, { error }]) => error)
-      .map(([fieldKey, { error }]) => [fieldKey, error]),
+    Object.entries(enhanceFields as EnhancedFields).filter(([, {error}]) => error).map(([fieldKey, {error}]) => ([fieldKey, error]))
   );
 
-  function undoChanges() {
-    setFormFields(state =>
-      Object.fromEntries(
-        Object.entries(state).map(([fieldKey, fieldConfiguration]) => [
-          fieldKey,
-          {
-            ...fieldConfiguration,
-            currentValue: fieldConfiguration.initialValue,
-          },
-        ]),
-      ),
-    );
-  }
+  function undoChanges(){
+    setFormFields(state => Object.fromEntries(
+      Object.entries(state).map(([fieldKey, fieldConfiguration]) => ([
+        fieldKey,
+        {
+          ...fieldConfiguration,
+          currentValue: fieldConfiguration.initialValue
+        }
+      ]))
+    ));
+  };
 
-  function doChanges() {
-    setFormFields(state =>
-      Object.fromEntries(
-        Object.entries(state).map(([fieldKey, fieldConfiguration]) => [
-          fieldKey,
-          {
-            ...fieldConfiguration,
-            initialValue: fieldConfiguration.currentValue,
-          },
-        ]),
-      ),
-    );
-  }
+  function doChanges(){
+    setFormFields(state => Object.fromEntries(
+      Object.entries(state).map(([fieldKey, fieldConfiguration]) => ([
+        fieldKey,
+        {
+          ...fieldConfiguration,
+          initialValue: fieldConfiguration.currentValue
+        }
+      ]))
+    ));
+  };
 
   return {
     fields: enhanceFields,
     changed,
     errors,
     undoChanges,
-    doChanges,
+    doChanges
   };
 };

--- a/public/components/common/form/hooks.tsx
+++ b/public/components/common/form/hooks.tsx
@@ -1,91 +1,153 @@
 import { useState, useRef } from 'react';
 import { isEqual } from 'lodash';
 import { EpluginSettingType } from '../../../../common/constants';
+import { IFormFields, IInputForm, IInputFormType, IInputTypes, IInputTypesCustom } from './types';
 
-function getValueFromEvent(event, type){
-  return (getValueFromEventType[type] || getValueFromEventType.default)(event);
-};
+interface IInputFormEvent {
+  [key: string]: (event: any) => any;
+  default: (event: any) => any;
+}
 
-const getValueFromEventType = {
-  [EpluginSettingType.switch] : (event: any) => event.target.checked,
+interface IUseFormFieldsData {
+  value: any;
+  changed: boolean;
+  error: string;
+  setInputRef: (reference: any) => void;
+  inputRef: any;
+  onChange: (event: any) => void;
+  initialValue: any;
+}
+
+interface IUseFormFieldsDataDefault extends IUseFormFieldsData {
+  type: IInputTypes;
+}
+
+interface IUseFormFieldsDataCustom extends IUseFormFieldsData {
+  type: IInputTypesCustom;
+  component: (props: IInputForm) => JSX.Element;
+}
+
+
+
+interface IUseFormFields {
+  [key: string]: IUseFormFieldsDataDefault | IUseFormFieldsDataCustom;
+}
+interface IUseFormResponse {
+  fields: IUseFormFields;
+  changed: { [key: string]: any };
+  errors: { [key: string]: string };
+  undoChanges: () => void;
+  doChanges: () => void;
+}
+
+const getValueFromEventType: IInputFormEvent = {
+  [EpluginSettingType.switch]: (event: any) => event.target.checked,
   [EpluginSettingType.editor]: (value: any) => value,
   [EpluginSettingType.filepicker]: (value: any) => value,
   default: (event: any) => event.target.value,
 };
 
-export const useForm = (fields) => {
-  const [formFields, setFormFields] = useState(Object.entries(fields).reduce((accum, [fieldKey, fieldConfiguration]) => ({
-    ...accum,
-    [fieldKey]: {
-      currentValue: fieldConfiguration.initialValue,
-      initialValue: fieldConfiguration.initialValue,
-    }
-  }), {}));
+function getValueFromEvent(event: any, type: IInputTypes | IInputTypesCustom) {
+  return (getValueFromEventType[type] || getValueFromEventType.default)(event);
+}
+
+
+export const useForm = (fields: IFormFields): IUseFormResponse => {
+  const [formFields, setFormFields] = useState(
+    Object.entries(fields).reduce(
+      (accum, [fieldKey, fieldConfiguration]) => ({
+        ...accum,
+        [fieldKey]: {
+          currentValue: fieldConfiguration.initialValue,
+          initialValue: fieldConfiguration.initialValue,
+        },
+      }),
+      {},
+    ),
+  );
 
   const fieldRefs = useRef({});
 
-  const enhanceFields = Object.entries(formFields).reduce((accum, [fieldKey, {currentValue: value, ...restFieldState}]) => ({
-    ...accum,
-    [fieldKey]: {
-      ...fields[fieldKey],
-      ...restFieldState,
-      type: fields[fieldKey].type,
-      value,
-      changed: !isEqual(restFieldState.initialValue, value),
-      error: fields[fieldKey]?.validate?.(value),
-      setInputRef: (reference) => {fieldRefs.current[fieldKey] = reference},
-      inputRef: fieldRefs.current[fieldKey],
-      onChange: (event) => {
-        const inputValue = getValueFromEvent(event, fields[fieldKey].type);
-        const currentValue = fields[fieldKey]?.transformChangedInputValue?.(inputValue) ?? inputValue;
-        setFormFields(state => ({
-          ...state,
-          [fieldKey]: {
-            ...state[fieldKey],
-            currentValue,
-          }
-        }))
+  const enhanceFields = Object.entries(formFields).reduce(
+    (accum, [fieldKey, { currentValue: value, ...restFieldState }]) => ({
+      ...accum,
+      [fieldKey]: {
+        ...fields[fieldKey],
+        ...restFieldState,
+        type: fields[fieldKey].type,
+        value,
+        changed: !isEqual(restFieldState.initialValue, value),
+        error: fields[fieldKey]?.validate?.(value),
+        setInputRef: reference => {
+          fieldRefs.current[fieldKey] = reference;
+        },
+        inputRef: fieldRefs.current[fieldKey],
+        onChange: event => {
+          const inputValue = getValueFromEvent(event, fields[fieldKey].type);
+          const currentValue =
+            fields[fieldKey]?.transformChangedInputValue?.(inputValue) ??
+            inputValue;
+          setFormFields(state => ({
+            ...state,
+            [fieldKey]: {
+              ...state[fieldKey],
+              currentValue,
+            },
+          }));
+        },
       },
-    }
-  }), {});
+    }),
+    {},
+  ) as IUseFormFields;
 
   const changed = Object.fromEntries(
-    Object.entries(enhanceFields).filter(([, {changed}]) => changed).map(([fieldKey, {value}]) => ([fieldKey, fields[fieldKey]?.transformChangedOutputValue?.(value) ?? value]))
+    Object.entries(enhanceFields)
+      .filter(([, { changed }]) => changed)
+      .map(([fieldKey, { value }]) => [
+        fieldKey,
+        fields[fieldKey]?.transformChangedOutputValue?.(value) ?? value,
+      ]),
   );
 
   const errors = Object.fromEntries(
-    Object.entries(enhanceFields).filter(([, {error}]) => error).map(([fieldKey, {error}]) => ([fieldKey, error]))
+    Object.entries(enhanceFields)
+      .filter(([, { error }]) => error)
+      .map(([fieldKey, { error }]) => [fieldKey, error]),
   );
 
-  function undoChanges(){
-    setFormFields(state => Object.fromEntries(
-      Object.entries(state).map(([fieldKey, fieldConfiguration]) => ([
-        fieldKey,
-        {
-          ...fieldConfiguration,
-          currentValue: fieldConfiguration.initialValue
-        }
-      ]))
-    ));
-  };
+  function undoChanges() {
+    setFormFields(state =>
+      Object.fromEntries(
+        Object.entries(state).map(([fieldKey, fieldConfiguration]) => [
+          fieldKey,
+          {
+            ...fieldConfiguration,
+            currentValue: fieldConfiguration.initialValue,
+          },
+        ]),
+      ),
+    );
+  }
 
-  function doChanges(){
-    setFormFields(state => Object.fromEntries(
-      Object.entries(state).map(([fieldKey, fieldConfiguration]) => ([
-        fieldKey,
-        {
-          ...fieldConfiguration,
-          initialValue: fieldConfiguration.currentValue
-        }
-      ]))
-    ));
-  };
+  function doChanges() {
+    setFormFields(state =>
+      Object.fromEntries(
+        Object.entries(state).map(([fieldKey, fieldConfiguration]) => [
+          fieldKey,
+          {
+            ...fieldConfiguration,
+            initialValue: fieldConfiguration.currentValue,
+          },
+        ]),
+      ),
+    );
+  }
 
   return {
     fields: enhanceFields,
     changed,
     errors,
     undoChanges,
-    doChanges
+    doChanges,
   };
 };

--- a/public/components/common/form/hooks.tsx
+++ b/public/components/common/form/hooks.tsx
@@ -1,69 +1,23 @@
 import { useState, useRef } from 'react';
 import { isEqual } from 'lodash';
 import { EpluginSettingType } from '../../../../common/constants';
+import {
+  CustomSettingType,
+  EnhancedFields,
+  FormConfiguration,
+  SettingTypes,
+  UseFormReturn,
+} from './types';
 
-type SettingTypes = 'text' | 'textarea' | 'number' | 'select' | 'switch' | 'editor' | 'filepicker';
-
-interface FieldConfiguration {
-  initialValue: any;
-  validate?: (value: any) => string | undefined;
-  transformChangedInputValue?: (value: any) => any;
-  transformChangedOutputValue?: (value: any) => any;
-}
-
-export interface DefaultFieldConfiguration extends FieldConfiguration {
-  type: SettingTypes;
-}
-
-type CustomSettingType = 'custom';
-interface CustomFieldConfiguration extends FieldConfiguration {
-  type: CustomSettingType;
-  component: (props: any) => JSX.Element;
-}
-
-export interface FormConfiguration {
-  [key: string]: DefaultFieldConfiguration | CustomFieldConfiguration;
-}
-
-
-interface EnhancedField {
-  currentValue: any;
-  initialValue: any;
-  value: any;
-  changed: boolean;
-  error: string;
-  setInputRef: (reference: any) => void;
-  inputRef: any;
-  onChange: (event: any) => void;
-}
-
-interface EnhancedDefaultField extends EnhancedField {
-  type: SettingTypes;
-}
-
-interface EnhancedCustomField extends EnhancedField {
-  type: CustomSettingType;
-  component: (props: any) => JSX.Element;
-}
-
-interface EnhancedFields {
-  [key: string]: EnhancedDefaultField | EnhancedCustomField;
-}
-
-interface UseFormReturn {
-  fields: EnhancedFields;
-  changed: { [key: string]: any };
-  errors: { [key: string]: string };
-  undoChanges: () => void;
-  doChanges: () => void;
-}
-
-function getValueFromEvent(event: any, type: SettingTypes | CustomSettingType): any {
+function getValueFromEvent(
+  event: any,
+  type: SettingTypes | CustomSettingType,
+): any {
   return (getValueFromEventType[type] || getValueFromEventType.default)(event);
-};
+}
 
 const getValueFromEventType = {
-  [EpluginSettingType.switch] : (event: any) => event.target.checked,
+  [EpluginSettingType.switch]: (event: any) => event.target.checked,
   [EpluginSettingType.editor]: (value: any) => value,
   [EpluginSettingType.filepicker]: (value: any) => value,
   [EpluginSettingType.select]: (event: any) => event.target.value,
@@ -75,80 +29,103 @@ const getValueFromEventType = {
 };
 
 export const useForm = (fields: FormConfiguration): UseFormReturn => {
-  const [formFields, setFormFields] = useState<{ [key: string]: { currentValue: any, initialValue: any } }>(
-    Object.entries(fields).reduce((accum, [fieldKey, fieldConfiguration]) => ({
-      ...accum,
-      [fieldKey]: {
-        currentValue: fieldConfiguration.initialValue,
-        initialValue: fieldConfiguration.initialValue,
-      }
-    }), {})
+  const [formFields, setFormFields] = useState<{
+    [key: string]: { currentValue: any; initialValue: any };
+  }>(
+    Object.entries(fields).reduce(
+      (accum, [fieldKey, fieldConfiguration]) => ({
+        ...accum,
+        [fieldKey]: {
+          currentValue: fieldConfiguration.initialValue,
+          initialValue: fieldConfiguration.initialValue,
+        },
+      }),
+      {},
+    ),
   );
 
   const fieldRefs = useRef<{ [key: string]: any }>({});
 
-  const enhanceFields = Object.entries(formFields).reduce((accum, [fieldKey, {currentValue: value, ...restFieldState}]) => ({
-    ...accum,
-    [fieldKey]: {
-      ...fields[fieldKey],
-      ...restFieldState,
-      type: fields[fieldKey].type,
-      value,
-      changed: !isEqual(restFieldState.initialValue, value),
-      error: fields[fieldKey]?.validate?.(value),
-      setInputRef: (reference: any) => {fieldRefs.current[fieldKey] = reference},
-      inputRef: fieldRefs.current[fieldKey],
-      onChange: (event: any) => {
-        const inputValue = getValueFromEvent(event, fields[fieldKey].type);
-        const currentValue = fields[fieldKey]?.transformChangedInputValue?.(inputValue) ?? inputValue;
-        setFormFields(state => ({
-          ...state,
-          [fieldKey]: {
-            ...state[fieldKey],
-            currentValue,
-          }
-        }))
+  const enhanceFields = Object.entries(formFields).reduce(
+    (accum, [fieldKey, { currentValue: value, ...restFieldState }]) => ({
+      ...accum,
+      [fieldKey]: {
+        ...fields[fieldKey],
+        ...restFieldState,
+        type: fields[fieldKey].type,
+        value,
+        changed: !isEqual(restFieldState.initialValue, value),
+        error: fields[fieldKey]?.validate?.(value),
+        setInputRef: (reference: any) => {
+          fieldRefs.current[fieldKey] = reference;
+        },
+        inputRef: fieldRefs.current[fieldKey],
+        onChange: (event: any) => {
+          const inputValue = getValueFromEvent(event, fields[fieldKey].type);
+          const currentValue =
+            fields[fieldKey]?.transformChangedInputValue?.(inputValue) ??
+            inputValue;
+          setFormFields(state => ({
+            ...state,
+            [fieldKey]: {
+              ...state[fieldKey],
+              currentValue,
+            },
+          }));
+        },
       },
-    }
-  }), {});
+    }),
+    {},
+  );
 
   const changed = Object.fromEntries(
-    Object.entries(enhanceFields as EnhancedFields).filter(([, {changed}]) => changed).map(([fieldKey, {value}]) => ([fieldKey, fields[fieldKey]?.transformChangedOutputValue?.(value) ?? value]))
+    Object.entries(enhanceFields as EnhancedFields)
+      .filter(([, { changed }]) => changed)
+      .map(([fieldKey, { value }]) => [
+        fieldKey,
+        fields[fieldKey]?.transformChangedOutputValue?.(value) ?? value,
+      ]),
   );
 
   const errors = Object.fromEntries(
-    Object.entries(enhanceFields as EnhancedFields).filter(([, {error}]) => error).map(([fieldKey, {error}]) => ([fieldKey, error]))
+    Object.entries(enhanceFields as EnhancedFields)
+      .filter(([, { error }]) => error)
+      .map(([fieldKey, { error }]) => [fieldKey, error]),
   );
 
-  function undoChanges(){
-    setFormFields(state => Object.fromEntries(
-      Object.entries(state).map(([fieldKey, fieldConfiguration]) => ([
-        fieldKey,
-        {
-          ...fieldConfiguration,
-          currentValue: fieldConfiguration.initialValue
-        }
-      ]))
-    ));
-  };
+  function undoChanges() {
+    setFormFields(state =>
+      Object.fromEntries(
+        Object.entries(state).map(([fieldKey, fieldConfiguration]) => [
+          fieldKey,
+          {
+            ...fieldConfiguration,
+            currentValue: fieldConfiguration.initialValue,
+          },
+        ]),
+      ),
+    );
+  }
 
-  function doChanges(){
-    setFormFields(state => Object.fromEntries(
-      Object.entries(state).map(([fieldKey, fieldConfiguration]) => ([
-        fieldKey,
-        {
-          ...fieldConfiguration,
-          initialValue: fieldConfiguration.currentValue
-        }
-      ]))
-    ));
-  };
+  function doChanges() {
+    setFormFields(state =>
+      Object.fromEntries(
+        Object.entries(state).map(([fieldKey, fieldConfiguration]) => [
+          fieldKey,
+          {
+            ...fieldConfiguration,
+            initialValue: fieldConfiguration.currentValue,
+          },
+        ]),
+      ),
+    );
+  }
 
   return {
     fields: enhanceFields,
     changed,
     errors,
     undoChanges,
-    doChanges
+    doChanges,
   };
 };

--- a/public/components/common/form/index.tsx
+++ b/public/components/common/form/index.tsx
@@ -7,6 +7,7 @@ import { InputFormSwitch } from './input_switch';
 import { InputFormFilePicker } from './input_filepicker';
 import { InputFormTextArea } from './input_text_area';
 import { EuiFlexGroup, EuiFlexItem, EuiFormRow } from '@elastic/eui';
+import OsCard from '../../../controllers/register-agent/components/os-card';
 
 interface InputFormProps {
   type: string;
@@ -14,10 +15,18 @@ interface InputFormProps {
   onChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
   error?: string;
   label?: string;
-  header?: React.ReactNode | ((props: { value: any; error?: string }) => React.ReactNode);
-  footer?: React.ReactNode | ((props: { value: any; error?: string }) => React.ReactNode);
-  preInput?: React.ReactNode | ((props: { value: any; error?: string }) => React.ReactNode);
-  postInput?: React.ReactNode | ((props: { value: any; error?: string }) => React.ReactNode);
+  header?:
+    | React.ReactNode
+    | ((props: { value: any; error?: string }) => React.ReactNode);
+  footer?:
+    | React.ReactNode
+    | ((props: { value: any; error?: string }) => React.ReactNode);
+  preInput?:
+    | React.ReactNode
+    | ((props: { value: any; error?: string }) => React.ReactNode);
+  postInput?:
+    | React.ReactNode
+    | ((props: { value: any; error?: string }) => React.ReactNode);
 }
 
 interface InputFormComponentProps extends InputFormProps {
@@ -36,12 +45,13 @@ export const InputForm = ({
   postInput,
   ...rest
 }: InputFormComponentProps) => {
+  const ComponentInput = Input[
+    type as keyof typeof Input
+  ] as React.ComponentType<InputFormComponentProps & any>;
 
-  const ComponentInput = Input[type as keyof typeof Input] as React.ComponentType<InputFormComponentProps & any>;
-
-  if(!ComponentInput){
+  if (!ComponentInput) {
     return null;
-  };
+  }
 
   const isInvalid = Boolean(error);
 
@@ -54,23 +64,29 @@ export const InputForm = ({
     />
   );
 
-  return label
-    ? (
-      <EuiFormRow label={label} fullWidth isInvalid={isInvalid} error={error}>
-        <>
-          {typeof header === 'function' ? header({value, error}) : header}
-          <EuiFlexGroup responsive={false}>
-            {typeof preInput === 'function' ? preInput({value, error}) : preInput}
-            <EuiFlexItem>
-              {input}
-            </EuiFlexItem>
-            {typeof postInput === 'function' ? postInput({value, error}) : postInput}
-          </EuiFlexGroup>
-          {typeof footer === 'function' ? footer({value, error}) : footer}
-        </>
-      </EuiFormRow>)
-    : input;
+  if (type === 'custom') {
+    return <OsCard {...rest} />;
+  }
 
+  return label ? (
+    <EuiFormRow label={label} fullWidth isInvalid={isInvalid} error={error}>
+      <>
+        {typeof header === 'function' ? header({ value, error }) : header}
+        <EuiFlexGroup responsive={false}>
+          {typeof preInput === 'function'
+            ? preInput({ value, error })
+            : preInput}
+          <EuiFlexItem>{input}</EuiFlexItem>
+          {typeof postInput === 'function'
+            ? postInput({ value, error })
+            : postInput}
+        </EuiFlexGroup>
+        {typeof footer === 'function' ? footer({ value, error }) : footer}
+      </>
+    </EuiFormRow>
+  ) : (
+    input
+  );
 };
 
 const Input = {
@@ -81,4 +97,5 @@ const Input = {
   select: InputFormSelect,
   text: InputFormText,
   textarea: InputFormTextArea,
+  custom: OsCard,
 };

--- a/public/components/common/form/index.tsx
+++ b/public/components/common/form/index.tsx
@@ -8,6 +8,22 @@ import { InputFormFilePicker } from './input_filepicker';
 import { InputFormTextArea } from './input_text_area';
 import { EuiFlexGroup, EuiFlexItem, EuiFormRow } from '@elastic/eui';
 
+interface InputFormProps {
+  type: string;
+  value: any;
+  onChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  error?: string;
+  label?: string;
+  header?: React.ReactNode | ((props: { value: any; error?: string }) => React.ReactNode);
+  footer?: React.ReactNode | ((props: { value: any; error?: string }) => React.ReactNode);
+  preInput?: React.ReactNode | ((props: { value: any; error?: string }) => React.ReactNode);
+  postInput?: React.ReactNode | ((props: { value: any; error?: string }) => React.ReactNode);
+}
+
+interface InputFormComponentProps extends InputFormProps {
+  rest: any;
+}
+
 export const InputForm = ({
   type,
   value,
@@ -18,9 +34,10 @@ export const InputForm = ({
   footer,
   preInput,
   postInput,
-...rest}) => {
+  ...rest
+}: InputFormComponentProps) => {
 
-  const ComponentInput = Input[type];
+  const ComponentInput = Input[type as keyof typeof Input] as React.ComponentType<InputFormComponentProps & any>;
 
   if(!ComponentInput){
     return null;

--- a/public/components/common/form/types.ts
+++ b/public/components/common/form/types.ts
@@ -1,19 +1,83 @@
-import { TPluginSettingWithKey } from "../../../../common/constants";
+import { TPluginSettingWithKey } from '../../../../common/constants';
 
 export interface IInputFormType {
-	field: TPluginSettingWithKey
-	value: any
-	onChange: (event: any) => void
-	isInvalid?: boolean
-	options: any
-	setInputRef: (reference: any) => void
-};
+  field: TPluginSettingWithKey;
+  value: any;
+  onChange: (event: any) => void;
+  isInvalid?: boolean;
+  options: any;
+  setInputRef: (reference: any) => void;
+}
 
 export interface IInputForm {
-	field: TPluginSettingWithKey
-	initialValue: any
-	onChange: (event: any) => void
-	label?: string
-	preInput?: ((options: {value: any, error: string | null}) => JSX.Element)
-	postInput?: ((options: {value: any, error: string | null}) => JSX.Element)
-};
+  field: TPluginSettingWithKey;
+  initialValue: any;
+  onChange: (event: any) => void;
+  label?: string;
+  preInput?: (options: { value: any; error: string | null }) => JSX.Element;
+  postInput?: (options: { value: any; error: string | null }) => JSX.Element;
+}
+
+/// use form hook types
+
+export type SettingTypes =
+  | 'text'
+  | 'textarea'
+  | 'number'
+  | 'select'
+  | 'switch'
+  | 'editor'
+  | 'filepicker';
+
+interface FieldConfiguration {
+  initialValue: any;
+  validate?: (value: any) => string | undefined;
+  transformChangedInputValue?: (value: any) => any;
+  transformChangedOutputValue?: (value: any) => any;
+}
+
+export interface DefaultFieldConfiguration extends FieldConfiguration {
+  type: SettingTypes;
+}
+
+export type CustomSettingType = 'custom';
+interface CustomFieldConfiguration extends FieldConfiguration {
+  type: CustomSettingType;
+  component: (props: any) => JSX.Element;
+}
+
+export interface FormConfiguration {
+  [key: string]: DefaultFieldConfiguration | CustomFieldConfiguration;
+}
+
+interface EnhancedField {
+  currentValue: any;
+  initialValue: any;
+  value: any;
+  changed: boolean;
+  error: string;
+  setInputRef: (reference: any) => void;
+  inputRef: any;
+  onChange: (event: any) => void;
+}
+
+interface EnhancedDefaultField extends EnhancedField {
+  type: SettingTypes;
+}
+
+interface EnhancedCustomField extends EnhancedField {
+  type: CustomSettingType;
+  component: (props: any) => JSX.Element;
+}
+
+export interface EnhancedFields {
+  [key: string]: EnhancedDefaultField | EnhancedCustomField;
+}
+
+export interface UseFormReturn {
+  fields: EnhancedFields;
+  changed: { [key: string]: any };
+  errors: { [key: string]: string };
+  undoChanges: () => void;
+  doChanges: () => void;
+}

--- a/public/components/common/form/types.ts
+++ b/public/components/common/form/types.ts
@@ -1,19 +1,40 @@
-import { TPluginSettingWithKey } from "../../../../common/constants";
+import { TPluginSettingWithKey } from '../../../../common/constants';
+
+export type IInputTypes = 'text' | 'number' | 'switch' | 'editor' | 'filepicker';
+export type IInputTypesCustom = 'custom';
 
 export interface IInputFormType {
-	field: TPluginSettingWithKey
-	value: any
-	onChange: (event: any) => void
-	isInvalid?: boolean
-	options: any
-	setInputRef: (reference: any) => void
-};
+  field: TPluginSettingWithKey;
+  value: any;
+  onChange: (event: any) => void;
+  isInvalid?: boolean;
+  options: any;
+  setInputRef: (reference: any) => void;
+}
 
 export interface IInputForm {
-	field: TPluginSettingWithKey
-	initialValue: any
-	onChange: (event: any) => void
-	label?: string
-	preInput?: ((options: {value: any, error: string | null}) => JSX.Element)
-	postInput?: ((options: {value: any, error: string | null}) => JSX.Element)
-};
+  field: TPluginSettingWithKey;
+  initialValue: any;
+  onChange: (event: any) => void;
+  label?: string;
+  preInput?: (options: { value: any; error: string | null }) => JSX.Element;
+  postInput?: (options: { value: any; error: string | null }) => JSX.Element;
+}
+
+interface IFormField {
+  initialValue: any;
+  validate?: (value: any) => string | undefined;
+}
+interface IFormFieldDefault extends IFormField {
+  type: IInputTypes;
+  initialValue: any;
+}
+
+interface IFormFieldCustom extends IFormField {
+  type: IInputTypesCustom;
+  component: (props: IInputForm) => JSX.Element;
+}
+
+export interface IFormFields {
+  [key: string]: IFormFieldCustom | IFormFieldDefault;
+}

--- a/public/components/common/form/types.ts
+++ b/public/components/common/form/types.ts
@@ -1,40 +1,19 @@
-import { TPluginSettingWithKey } from '../../../../common/constants';
-
-export type IInputTypes = 'text' | 'number' | 'switch' | 'editor' | 'filepicker';
-export type IInputTypesCustom = 'custom';
+import { TPluginSettingWithKey } from "../../../../common/constants";
 
 export interface IInputFormType {
-  field: TPluginSettingWithKey;
-  value: any;
-  onChange: (event: any) => void;
-  isInvalid?: boolean;
-  options: any;
-  setInputRef: (reference: any) => void;
-}
+	field: TPluginSettingWithKey
+	value: any
+	onChange: (event: any) => void
+	isInvalid?: boolean
+	options: any
+	setInputRef: (reference: any) => void
+};
 
 export interface IInputForm {
-  field: TPluginSettingWithKey;
-  initialValue: any;
-  onChange: (event: any) => void;
-  label?: string;
-  preInput?: (options: { value: any; error: string | null }) => JSX.Element;
-  postInput?: (options: { value: any; error: string | null }) => JSX.Element;
-}
-
-interface IFormField {
-  initialValue: any;
-  validate?: (value: any) => string | undefined;
-}
-interface IFormFieldDefault extends IFormField {
-  type: IInputTypes;
-  initialValue: any;
-}
-
-interface IFormFieldCustom extends IFormField {
-  type: IInputTypesCustom;
-  component: (props: IInputForm) => JSX.Element;
-}
-
-export interface IFormFields {
-  [key: string]: IFormFieldCustom | IFormFieldDefault;
-}
+	field: TPluginSettingWithKey
+	initialValue: any
+	onChange: (event: any) => void
+	label?: string
+	preInput?: ((options: {value: any, error: string | null}) => JSX.Element)
+	postInput?: ((options: {value: any, error: string | null}) => JSX.Element)
+};

--- a/public/controllers/register-agent/components/os-card.tsx
+++ b/public/controllers/register-agent/components/os-card.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const OsCard = () => {
+  return <div>hola</div>;
+};
+
+export default OsCard;

--- a/public/controllers/register-agent/container/os-card-container.tsx
+++ b/public/controllers/register-agent/container/os-card-container.tsx
@@ -1,8 +1,23 @@
-import React from 'react';
+import React, { ChangeEvent } from 'react';
+import { InputForm } from '../../../components/common/form';
 import './os-card-container.scss';
 
-const Container: React.FC = () => {
-  return <div className='container'></div>;
+const Container = () => {
+  const handleChange = (event: ChangeEvent<any>) => {
+    // ver
+  };
+
+  return (
+    <div className='container'>
+      <InputForm
+        type='custom'
+        onChange={handleChange}
+        label='Etiqueta del Campo'
+        rest={undefined}
+        value={undefined}
+      />
+    </div>
+  );
 };
 
 export default Container;


### PR DESCRIPTION
### Description

Reuse the common form in the card. The common form is already used in other parts of the application, so we make sure not to repeat code.

### Issues Resolved

#5456 

### Test

Verify that the reuse of the common form is optimal.

### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff 
