### PR TITLE
Add do not make the queries in config or inventory data

### DIFF
--- a/public/components/common/welcome/agents-welcome.js
+++ b/public/components/common/welcome/agents-welcome.js
@@ -260,6 +260,8 @@ class AgentsWelcome extends Component {
 
   renderTitle() {
 
+      const notNeedStatus = true;
+
     return (
       <EuiFlexGroup>
         <EuiFlexItem className="wz-module-header-agent-title">
@@ -321,7 +323,7 @@ class AgentsWelcome extends Component {
               <EuiFlexItem grow={false} style={{ marginTop: 7 }}>
                 <EuiButtonEmpty
                   iconType="inspect"
-                  onClick={() => this.props.switchTab('syscollector')}>
+                  onClick={() => this.props.switchTab('syscollector', notNeedStatus)}>
                   Inventory data
                 </EuiButtonEmpty>
               </EuiFlexItem>
@@ -335,7 +337,7 @@ class AgentsWelcome extends Component {
               <EuiFlexItem grow={false} style={{ marginTop: 7 }}>
                 <EuiButtonEmpty
                   iconType="gear"
-                  onClick={() => this.props.switchTab('configuration')}>
+                  onClick={() => this.props.switchTab('configuration', notNeedStatus)}>
                   Configuration
                 </EuiButtonEmpty>
               </EuiFlexItem>

--- a/public/controllers/agent/agents.js
+++ b/public/controllers/agent/agents.js
@@ -500,9 +500,9 @@ export class AgentsController {
     }
 
     // Update agent status
-    if (!force && ((this.$scope || {}).agent || false)) {
+    if (!force && this.$scope.agent) {
       try {
-        const agentInfo = await WzRequest.apiReq('GET', `/agents`, {
+        const agentInfo = await WzRequest.apiReq('GET', '/agents', {
           params: {
             agents_list: this.$scope.agent.id,
             select: 'status',
@@ -511,9 +511,8 @@ export class AgentsController {
         this.$scope.agent.status =
           agentInfo?.data?.data?.affected_items?.[0]?.status ||
           this.$scope.agent.status;
-        this.$scope.isSynchronized = this.$scope.agent.status?.synced;
 
-    this.$scope.$applyAsync();
+        this.$scope.$applyAsync();
       } catch (error) {
         throw new Error(error);
       }
@@ -761,7 +760,6 @@ export class AgentsController {
   async getAgent(newAgentId) {
     try {
       this.$scope.emptyAgent = false;
-      this.$scope.isSynchronized = false;
       this.$scope.load = true;
       this.changeAgent = true;
 
@@ -837,7 +835,7 @@ export class AgentsController {
    */
   loadWelcomeCardsProps() {
     this.$scope.welcomeCardsProps = {
-      switchTab: (tab) => this.switchTab(tab),
+      switchTab: (tab, force) => this.switchTab(tab, force),
       extensions: this.cleanExtensions(this.$scope.extensions),
       agent: this.$scope.agent,
       api: AppState.getCurrentAPI(),

--- a/public/controllers/management/components/management/configuration/configuration-switch.js
+++ b/public/controllers/management/components/management/configuration/configuration-switch.js
@@ -53,7 +53,11 @@ import WzConfigurationPath from './util-components/configuration-path';
 import WzRefreshClusterInfoButton from './util-components/refresh-cluster-info-button';
 import { withUserAuthorizationPrompt } from '../../../../../components/common/hocs';
 
-import { clusterNodes, clusterReq } from './utils/wz-fetch';
+import {
+  clusterNodes,
+  clusterReq,
+  agentIsSynchronized,
+} from './utils/wz-fetch';
 import {
   updateClusterNodes,
   updateClusterNodeSelected,
@@ -64,7 +68,6 @@ import { compose } from 'redux';
 
 import { EuiPage, EuiPanel, EuiSpacer, EuiButtonEmpty, EuiFlexItem } from '@elastic/eui';
 
-import { agentIsSynchronized } from './utils/wz-fetch';
 import { WzRequest } from '../../../../../react-services/wz-request';
 import { API_NAME_AGENT_STATUS, UI_LOGGER_LEVELS } from '../../../../../../common/constants';
 import { UI_ERROR_SEVERITIES } from '../../../../../react-services/error-orchestrator/types';


### PR DESCRIPTION
### Description
Add to the buttons the parameter that controls if the request has to be made, and we delete a variable that was not used anywhere.
 
### Issues Resolved
- #5239
- #5240 

### Evidence
<details><summary>Details</summary>

Inventory data

![image](https://github.com/wazuh/wazuh-kibana-app/assets/63758389/8794ea9f-2384-44e0-980b-0c54367c180a)

![image](https://github.com/wazuh/wazuh-kibana-app/assets/63758389/6f688ebf-82d6-4bb0-8653-aeeef003bb0a)

![image](https://github.com/wazuh/wazuh-kibana-app/assets/63758389/40b8e10c-4074-4a00-a82c-a501a9e0739e)

![image](https://github.com/wazuh/wazuh-kibana-app/assets/63758389/87f98e2c-c457-4184-b10a-67174bf3c38c)

![image](https://github.com/wazuh/wazuh-kibana-app/assets/63758389/25834056-f95c-4a3a-a197-228e647ffba7)

Configuration

![image](https://github.com/wazuh/wazuh-kibana-app/assets/63758389/599d0077-8987-46a7-bf31-eb15df419457)

</details> 

### Test

1. Navigate to `an agent`
2. Click on `Inventory data | Configuration`
3. Check that the request is not made: `GET /agents" with parameters {"agents_list": "002", "select": "status"}` 

### Check List
- [x] All tests pass
  - [x] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [X] Commits are signed per the DCO using --signoff 
