### PR TITLE
Fixes that the limit does not change when turning the page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fixed the GitHub and Office 365 modules appear in the main menu when they were not configured [#5376](https://github.com/wazuh/wazuh-kibana-app/pull/5376)
 - Fixed TypeError in FIM Inventory using new error handler [#5364](https://github.com/wazuh/wazuh-kibana-app/pull/5364)
 - Fixed error when using invalid group configuration [#5423](https://github.com/wazuh/wazuh-kibana-app/pull/5423)
+- Fixed that the limit does not change when turning the page in `Explore agent` [#5423](https://github.com/wazuh/wazuh-kibana-app/pull/5423)
 
 ## Wazuh v4.4.1 - OpenSearch Dashboards 2.6.0 - Revision 01
 

--- a/public/controllers/overview/components/overview-actions/agents-selection-table.js
+++ b/public/controllers/overview/components/overview-actions/agents-selection-table.js
@@ -223,7 +223,7 @@ export class AgentSelectionTable extends Component {
     const filter = {
       ...filtersToObject(filters),
       offset: (pageIndex * itemsPerPage) || 0,
-      limit: pageIndex * itemsPerPage + itemsPerPage,
+      limit: itemsPerPage,
       ...this.buildSortFilter()
     };
     filter.q = !filter.q ? `id!=000` : `id!=000;${filter.q}`;


### PR DESCRIPTION
### Description
Corrects the limit of the agent exploration table in the dashboards, since when turning the page the limit was increased.
 
### Issues Resolved
- #5245

### Evidence
<details><summary>Screenshot</summary>

![image](https://github.com/wazuh/wazuh-kibana-app/assets/63758389/6eb26498-6781-4b95-a83b-46aa4abf2981)

![image](https://github.com/wazuh/wazuh-kibana-app/assets/63758389/abef2e96-32f9-4d16-9d2c-9c26e867d56c)

</details> 

### Test
1. Navegate to some dashboard
2. Click on Explore agent
3. Turn the page
4. See that the limit does not change

### Check List
- [x] All tests pass
  - [x] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [X] Commits are signed per the DCO using --signoff 
