### PR TITLE
Change macOS register agent installation script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 
 ### Fixed
 
-- Fixed macos apple install command [#5466](https://github.com/wazuh/wazuh-kibana-app/pull/5466)
+- Fixed macos apple install command [#5466](https://github.com/wazuh/wazuh-kibana-app/pull/5466) [#5481](https://github.com/wazuh/wazuh-kibana-app/pull/5481)
 
 ## Wazuh v4.4.2 - OpenSearch Dashboards 2.6.0 - Revision 01
 

--- a/public/controllers/agent/components/register-agent.js
+++ b/public/controllers/agent/components/register-agent.js
@@ -403,23 +403,11 @@ export const RegisterAgent = withErrorBoundary(
           .join(',')}' `;
       }
 
-      // macos doesnt need = param
-      if (this.state.selectedOS === 'macos') {
-        return deployment.replace(/=/g, ' ');
-      }
-
       return deployment;
     }
 
     agentNameVariable() {
       let agentName = `WAZUH_AGENT_NAME='${this.state.agentName}' `;
-      if (
-        this.state.selectedOS === 'macos' &&
-        this.state.selectedArchitecture &&
-        this.state.agentName !== ''
-      ) {
-        return agentName.replace(/=/g, ' ');
-      }
       if (this.state.selectedArchitecture && this.state.agentName !== '') {
         return agentName;
       } else {
@@ -975,6 +963,12 @@ export const RegisterAgent = withErrorBoundary(
         zIndex: '100',
       };
 
+       // Select macOS installation script based on architecture
+       const macOSInstallationOptions = (this.optionalDeploymentVariables() + this.agentNameVariable()).replaceAll('\' ', '\'\\n');
+       const macOSInstallationSetEnvVariablesScript = macOSInstallationOptions ? `echo -e "${macOSInstallationOptions}" > /tmp/wazuh_envs && ` : ``;
+       const macOSInstallationScript = `curl -so wazuh-agent.pkg https://packages.wazuh.com/4.x/macos/wazuh-agent-${this.state.wazuhVersion
+           }-1.pkg && ${macOSInstallationSetEnvVariablesScript}sudo installer -pkg ./wazuh-agent.pkg -target /`;
+
       const customTexts = {
         rpmText: `sudo ${this.optionalDeploymentVariables()}${this.agentNameVariable()}yum install -y ${this.optionalPackages()}`,
         alpineText: `wget -O /etc/apk/keys/alpine-devel@wazuh.com-633d7457.rsa.pub ${this.optionalPackages()} >> /etc/apk/repositories && \
@@ -983,9 +977,7 @@ apk add wazuh-agent=${this.state.wazuhVersion}-r1`,
         centText: `sudo ${this.optionalDeploymentVariables()}${this.agentNameVariable()}yum install -y ${this.optionalPackages()}`,
         debText: `curl -so wazuh-agent.deb ${this.optionalPackages()} && sudo ${this.optionalDeploymentVariables()}${this.agentNameVariable()}dpkg -i ./wazuh-agent.deb`,
         ubuText: `curl -so wazuh-agent.deb ${this.optionalPackages()} && sudo ${this.optionalDeploymentVariables()}${this.agentNameVariable()}dpkg -i ./wazuh-agent.deb`,
-        macosText: `curl -so wazuh-agent.pkg https://packages.wazuh.com/4.x/macos/wazuh-agent-${
-          this.state.wazuhVersion
-        }-1.pkg && sudo launchctl setenv ${this.optionalDeploymentVariables()}${this.agentNameVariable()}&& sudo installer -pkg ./wazuh-agent.pkg -target /`,
+        macosText: macOSInstallationScript,
         winText:
           this.state.selectedVersion == 'windowsxp' ||
           this.state.selectedVersion == 'windowsserver2008'
@@ -1539,7 +1531,7 @@ apk add wazuh-agent=${this.state.wazuhVersion}-r1`,
             serverAddress: nodeSelected,
             udpProtocol: this.state.haveUdpProtocol,
             connectionSecure: this.state.haveConnectionSecure
-          }); 
+          });
       };
 
       const steps = [


### PR DESCRIPTION
### Description
Hi team,

this pull request changes the register agent installation script for macOS. It sets de environment variables to the `/tmp/wazuh_envs`

### Issues Resolved
Closes #5466 

### Evidence
![image](https://github.com/wazuh/wazuh-kibana-app/assets/9343732/4f9ac048-4a1b-4e28-b542-308f4d387190)


### Test

- Go to the register agents wizard
- Select macOS
- With empty fields you should **NOT** see the `echo -e ""  > /tmp/wazuh_envs`
- With any filled input you **should** see `echo -e ""  > /tmp/wazuh_envs` with environmental variables like this:
```
curl -so wazuh-agent.pkg https://packages.wazuh.com/4.x/macos/wazuh-agent-4.4.3-1.pkg && echo -e "WAZUH_MANAGER='192.168.0.1'\nWAZUH_AGENT_GROUP='default'\nWAZUH_AGENT_NAME='new-agent'\n" > /tmp/wazuh_envs && sudo installer -pkg ./wazuh-agent.pkg -target /
```


### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff 
