### PR TITLE
[Backport 4.4-7.10] Change macOS register agent installation command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 
 ### Fixed
 
-- Fixed command to install the macOS agent on the agent wizard [#5481](https://github.com/wazuh/wazuh-kibana-app/pull/5481)
+- Fixed command to install the macOS agent on the agent wizard [#5481](https://github.com/wazuh/wazuh-kibana-app/pull/5481) [#5484](https://github.com/wazuh/wazuh-kibana-app/pull/5484)
 - Fixed command to start the macOS agent on the agent wizard [#5470](https://github.com/wazuh/wazuh-kibana-app/pull/5470)
 
 ## Wazuh v4.4.2 - Kibana 7.10.2, 7.16.x, 7.17.x - Revision 01

--- a/public/controllers/agent/components/register-agent.js
+++ b/public/controllers/agent/components/register-agent.js
@@ -358,7 +358,7 @@ export const RegisterAgent = withErrorBoundary(
 
     obfuscatePassword(text) {
       let obfuscate = '';
-      const regex = /WAZUH_REGISTRATION_PASSWORD=?\040?\'(.*?)\'/gm;
+      const regex = /WAZUH_REGISTRATION_PASSWORD=?\040?\'(.*?)\'[\"| ]/gm;
       const match = regex.exec(text);
       const password = match[1];
       if (password) {
@@ -381,15 +381,16 @@ export const RegisterAgent = withErrorBoundary(
     }
 
     optionalDeploymentVariables() {
+      const escapeQuotes = (value) => value.replace(/'/g, "\\'");
       let deployment =
         this.state.serverAddress &&
-        `WAZUH_MANAGER='${this.state.serverAddress}' `;
+        `WAZUH_MANAGER='${escapeQuotes(this.state.serverAddress)}' `;
       if (this.state.selectedOS == 'win') {
-        deployment += `WAZUH_REGISTRATION_SERVER='${this.state.serverAddress}' `;
+        deployment += `WAZUH_REGISTRATION_SERVER='${escapeQuotes(this.state.serverAddress)}' `;
       }
 
       if (this.state.needsPassword) {
-        deployment += `WAZUH_REGISTRATION_PASSWORD='${this.state.wazuhPassword}' `;
+        deployment += `WAZUH_REGISTRATION_PASSWORD='${escapeQuotes(this.state.wazuhPassword)}' `;
       }
 
       if (this.state.udpProtocol) {
@@ -966,7 +967,8 @@ export const RegisterAgent = withErrorBoundary(
       // Set macOS installation script with environment variables
       const macOSInstallationOptions = `${this.optionalDeploymentVariables()}${this.agentNameVariable()}`
         .replace(/\' ([a-zA-Z])/g, '\' && $1') // Separate environment variables with &&
-        .replace(/\"/g, '\\"'); // Escape double quotes
+        .replace(/\"/g, '\\"') // Escape double quotes
+        .trim();
 
       // If no variables are set, the echo will be empty
       const macOSInstallationSetEnvVariablesScript = macOSInstallationOptions ?

--- a/public/controllers/agent/components/register-agent.js
+++ b/public/controllers/agent/components/register-agent.js
@@ -963,7 +963,7 @@ export const RegisterAgent = withErrorBoundary(
 
       // Select macOS installation script based on architecture
       const macOSInstallationOptions = (this.optionalDeploymentVariables() + this.agentNameVariable()).replaceAll('\' ', '\'\\n');
-      const macOSInstallationSetEnvVariablesScript = macOSInstallationOptions ? `echo -e "${macOSInstallationOptions}" > /tmp/wazuh_envs && ` : ``;
+      const macOSInstallationSetEnvVariablesScript = macOSInstallationOptions ? `echo "${macOSInstallationOptions}" > /tmp/wazuh_envs && ` : ``;
       const macOSInstallationScript = `curl -so wazuh-agent.pkg https://packages.wazuh.com/4.x/macos/wazuh-agent-${this.state.wazuhVersion
         }-1.pkg && ${macOSInstallationSetEnvVariablesScript}sudo installer -pkg ./wazuh-agent.pkg -target /`;
 

--- a/public/controllers/agent/components/register-agent.js
+++ b/public/controllers/agent/components/register-agent.js
@@ -961,11 +961,24 @@ export const RegisterAgent = withErrorBoundary(
         zIndex: '100',
       };
 
-      // Select macOS installation script based on architecture
-      const macOSInstallationOptions = (this.optionalDeploymentVariables() + this.agentNameVariable()).replaceAll('\' ', '\'\\n');
-      const macOSInstallationSetEnvVariablesScript = macOSInstallationOptions ? `echo "${macOSInstallationOptions}" > /tmp/wazuh_envs && ` : ``;
+      /*** macOS installation script customization ***/
+
+      // Set macOS installation script with environment variables
+      const macOSInstallationOptions = `${this.optionalDeploymentVariables()}${this.agentNameVariable()}`
+        .replace(/\' ([a-zA-Z])/g, '\' && $1') // Separate environment variables with &&
+        .replace(/\"/g, '\\"'); // Escape double quotes
+
+      // If no variables are set, the echo will be empty
+      const macOSInstallationSetEnvVariablesScript = macOSInstallationOptions ?
+        `sudo echo "${macOSInstallationOptions}" > /tmp/wazuh_envs && `
+        : ``;
+
+      // Merge environment variables with installation script
       const macOSInstallationScript = `curl -so wazuh-agent.pkg https://packages.wazuh.com/4.x/macos/wazuh-agent-${this.state.wazuhVersion
         }-1.pkg && ${macOSInstallationSetEnvVariablesScript}sudo installer -pkg ./wazuh-agent.pkg -target /`;
+
+      /*** end macOS installation script customization ***/
+
 
       const customTexts = {
         rpmText: `sudo ${this.optionalDeploymentVariables()}${this.agentNameVariable()}yum install -y ${this.optionalPackages()}`,
@@ -985,8 +998,8 @@ apk add wazuh-agent=${this.state.wazuhVersion}-r1`,
             }-1.msi -OutFile \${env:tmp}\\wazuh-agent.msi; msiexec.exe /i \${env:tmp}\\wazuh-agent.msi /q ${this.optionalDeploymentVariables()}${this.agentNameVariable()}`,
         openText: `sudo rpm --import https://packages.wazuh.com/key/GPG-KEY-WAZUH && sudo ${this.optionalDeploymentVariables()}${this.agentNameVariable()}zypper install -y ${this.optionalPackages()}`,
         solText: `sudo curl -so ${this.state.selectedVersion == 'solaris11'
-            ? 'wazuh-agent.p5p'
-            : 'wazuh-agent.pkg'
+          ? 'wazuh-agent.p5p'
+          : 'wazuh-agent.pkg'
           } ${this.optionalPackages()} && ${this.state.selectedVersion == 'solaris11'
             ? 'pkg install -g wazuh-agent.p5p wazuh-agent'
             : 'pkgadd -d wazuh-agent.pkg'


### PR DESCRIPTION
### Description
Hi team, 
this PR changes the agent installation command for macOS.
 
### Issues Resolved
Closes #5466 

Base pull request #5484  

### Evidence
![Screenshot from 2023-05-24 12-07-01](https://github.com/wazuh/wazuh-kibana-app/assets/9343732/1c430144-f1a7-4801-9891-c8e623dd813b)


### Test cases

- Go to Agents
- Click on "Deploy new agent"
- On step 1 select `macOS`
  - With Password
    - Check the password is shown by default with the correct value
    - Fill in the rest of the configuration and check the double quotes `"` are escaped `\"`
    - Check the environment variables are separated by `&&`
   - Without password
     - When all inputs are empty the `echo` section of the script should not appear
     - Fill in the rest of the configuration and check the double quotes `"` are escaped `\"`
     - Check the environment variables are separated by `&&`

### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff 
