### PR TITLE
Wazuh api usage magement/status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Removed deprecated request and code in agent's view [#5451](https://github.com/wazuh/wazuh-kibana-app/pull/5451)
 - Removed unnecessary dashboard queries caused by the deploy agent view. [#5453](https://github.com/wazuh/wazuh-kibana-app/pull/5453)
 - Removed repeated and unnecessary requests in security section. [#5500](https://github.com/wazuh/wazuh-kibana-app/pull/5500)
+- Removed unnecessary requests in `Management/Status` section. [#5528](https://github.com/wazuh/wazuh-kibana-app/pull/5528)
 
 ## Wazuh v4.4.3 - OpenSearch Dashboards 2.6.0 - Revision 01
 

--- a/docker/imposter/overview/agents.json
+++ b/docker/imposter/overview/agents.json
@@ -1,0 +1,84 @@
+{
+  "data": {
+    "nodes": [
+      {
+        "node_name": "worker1",
+        "count": 1
+      },
+      {
+        "node_name": "worker2",
+        "count": 1
+      },
+      {
+        "node_name": "master-node",
+        "count": 1
+      }
+    ],
+    "groups": [
+      {
+        "name": "default",
+        "count": 6,
+        "mergedSum": "9a016508cea1e997ab8569f5cfab30f5",
+        "configSum": "ab73af41699f13fdd81903b5f23d8d00"
+      }
+    ],
+    "agent_os": [
+      {
+        "os": {
+          "name": "Ubuntu",
+          "platform": "ubuntu",
+          "version": "20.04.02 LTS"
+        },
+        "count": 6
+      }
+    ],
+    "agent_status": {
+      "connection": {
+          "active": 1,
+          "disconnected": 2,
+          "never_connected": 0,
+          "pending": 0,
+          "total": 3
+      },
+      "configuration": {
+          "synced": 3,
+          "total": 3,
+          "not_synced": 0
+      }
+    },
+    "agent_version": [
+      {
+        "version": "Wazuh v4.3.0",
+        "count": 6
+      }
+    ],
+    "last_registered_agent": [
+      {
+        "os": {
+          "arch": "x86_64",
+          "codename": "Focal Fossa",
+          "major": 20,
+          "minor": 4,
+          "name": "Ubuntu",
+          "platform": "ubuntu",
+          "uname": "Linux |77000bae7bd0 |5.8.0-45-generic |#51~20.04.1-Ubuntu SMP Tue Feb 23 13:46:31 UTC 2021 |x86_64",
+          "version": "20.04.02 LTS"
+        },
+        "node_name": "worker1",
+        "lastKeepAlive": "2021-05-31T10:56:52Z",
+        "configSum": "ab73af41699f13fdd81903b5f23d8d00",
+        "status": "active",
+        "ip": "172.18.0.7",
+        "group": ["default"],
+        "name": "77000bae7bd0",
+        "registerIP": "any",
+        "dateAdd": "2021-05-31T09:49:28Z",
+        "manager": "wazuh-worker1",
+        "id": "004",
+        "mergedSum": "9a016508cea1e997ab8569f5cfab30f5",
+        "version": "Wazuh v4.3.0"
+      }
+    ]
+  },
+  "error": 0
+}

--- a/docker/imposter/wazuh-config.yml
+++ b/docker/imposter/wazuh-config.yml
@@ -544,6 +544,9 @@ resources:
   # Get agents overview
   - method: GET
     path: /overview/agents
+    response:
+      statusCode: 200
+      staticFile: overview/agents.json
 
   # ===================================================== #
   #   ROOTCHECK

--- a/public/controllers/management/components/management/status/actions-buttons-main.js
+++ b/public/controllers/management/components/management/status/actions-buttons-main.js
@@ -135,12 +135,15 @@ class WzStatusActionButtons extends Component {
 
       const { connection: agentsCount } = agentsCountByManagerNodes?.data?.data?.agent_status;
 
+      const agentsActiveCoverage = (
+        (agentsCount.active / agentsCount.total) *
+        100
+      ).toFixed(2);
+
       this.props.updateStats({
         agentsCountByManagerNodes: agentsCountByManagerNodes?.data?.data?.nodes,
         agentsCount,
-        agentsCoverage: agentsCount?.total
-          ? ((agentsCount?.active / agentsCount?.total) * 100).toFixed(2)
-          : 0,
+        agentsCoverage: isNaN(agentsActiveCoverage) ? 0 : agentsActiveCoverage,
       });
 
       const daemons = await this.statusHandler.clusterNodeStatus(node);

--- a/public/controllers/management/components/management/status/status-overview.js
+++ b/public/controllers/management/components/management/status/status-overview.js
@@ -101,15 +101,21 @@ export class WzStatusOverview extends Component {
         this.statusHandler.clusterAgentsCount()
       ])).map(response => response?.data?.data);
       const { connection: agentsCount, configuration } = agentsCountByManagerNodes?.agent_status;
+
+      const agentsActiveCoverage = (
+        (agentsCount.active / agentsCount.total) *
+        100
+      ).toFixed(2);
+      const agentsSyncedCoverage = (
+        (configuration.synced / configuration.total) *
+        100
+      ).toFixed(2);
+
       this.props.updateStats({
         agentsCountByManagerNodes: agentsCountByManagerNodes.nodes,
         agentsCount,
-        agentsSynced: configuration.total
-          ? ((configuration.synced / configuration.total) * 100).toFixed(2)
-          : 0,
-        agentsCoverage: agentsCount.total
-          ? ((agentsCount.active / agentsCount.total) * 100).toFixed(2)
-          : 0,
+        agentsSynced: isNaN(agentsSyncedCoverage) ? 0 : agentsSyncedCoverage,
+        agentsCoverage: isNaN(agentsActiveCoverage) ? 0 : agentsActiveCoverage,
       });
 
       this.props.updateClusterEnabled(clusterStatus && clusterStatus.enabled === 'yes');


### PR DESCRIPTION
### Description
Unnecessary requests have been eliminated
 
### Issues Resolved
- #5243 

### Evidence

Before

![image](https://github.com/wazuh/wazuh-kibana-app/assets/63758389/a82ea01e-07d5-4af4-ab55-293091c0ab69)

After

![image](https://github.com/wazuh/wazuh-kibana-app/assets/63758389/14108827-74ba-483b-b56f-a21f7cb63c71)


### Test

Legend:
:black_circle:: none
:green_circle:: pass
:yellow_circle:: warning
:red_circle:: fail
:white_circle:: not applicable

## UI

| Test | Chrome | Firefox | Safari |
| --- |  --- | --- | --- |
| Navigate to management status and do not see the request `GET /agents/summary/status` | :black_circle: | :black_circle: | :black_circle: |
| Navigate to management status and do not see the request `GET /agents" with parameters {"limit": "1", "sort": "-dateAdd", "q": "id!=000"}` | :black_circle: | :black_circle: | :black_circle: |
| In cluster mode do not see the request `GET /manager/info`  | :black_circle: | :black_circle: | :black_circle: |
| In manager mode see the request `GET /manager/info`  | :black_circle: | :black_circle: | :black_circle: |
| when you change the node you do not have to see the request `GET /agents/summary/status` | :black_circle: | :black_circle: | :black_circle: |
| when you change the node you do not have to see the request `GET /agents" with parameters {"limit": "1", "sort": "-dateAdd", "q": "id!=000"}` | :black_circle: | :black_circle: | :black_circle: |

**Details**
<details>
<summary>:black_circle: Navigate to management status and do not see the request `GET /agents/summary/status`</summary>

Chrome - :black_circle:

Firefox - :black_circle:

Safari - :black_circle:

</details>

<details>
<summary>:black_circle: Navigate to management status and do not see the request `GET /agents" with parameters {"limit": "1", "sort": "-dateAdd", "q": "id!=000"}`</summary>

Chrome - :black_circle:

Firefox - :black_circle:

Safari - :black_circle:

</details>

<details>
<summary>:black_circle: In cluster mode do not see the request `GET /manager/info` </summary>

Chrome - :black_circle:

Firefox - :black_circle:

Safari - :black_circle:

</details>

<details>
<summary>:black_circle: In manager mode see the request `GET /manager/info` </summary>

Chrome - :black_circle:

Firefox - :black_circle:

Safari - :black_circle:

</details>

<details>
<summary>:black_circle: when you change the node you do not have to see the request `GET /agents/summary/status`</summary>

Chrome - :black_circle:

Firefox - :black_circle:

Safari - :black_circle:

</details>

<details>
<summary>:black_circle: when you change the node you do not have to see the request `GET /agents" with parameters {"limit": "1", "sort": "-dateAdd", "q": "id!=000"}`</summary>

Chrome - :black_circle:

Firefox - :black_circle:

Safari - :black_circle:

</details>




### Check List
- [x] All tests pass
  - [x] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 
