### PR TITLE
Revert 4.4 to v4.4.4

### DIFF
--- a/opensearch_dashboards.json
+++ b/opensearch_dashboards.json
@@ -1,6 +1,6 @@
 {
   "id": "wazuh",
-  "version": "4.4.4-00",
+  "version": "4.4.4-01",
   "opensearchDashboardsVersion": "opensearchDashboards",
   "configPath": [
     "wazuh"

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "wazuh",
   "version": "4.4.4",
-  "revision": "00",
+  "revision": "01",
   "stage": "stable",
-  "commit": "1ec339caf",
+  "commit": "0e7201ff8",
   "pluginPlatform": {
     "version": "2.6.0"
   },


### PR DESCRIPTION
### Description
As 4.4.4 has been cancelled and replaces by 4.5.1, we revert the 4.4 branch to the latest 4.4.x patch, which is 4.4.4.

The 4.5.1 branch has been already created from 4.4, containing the merged changes which were supposed to be included in 4.4.5.
 
### Issues Resolved
None

### Evidence
```$ git log
commit 9f99758e119e47d85913af2dcfa962c3931a8f86 (HEAD -> revert-to-v4.4.4, tag: v4.4.4-2.6.0, origin/revert-to-v4.4.4)
Author: yenienserrano <ian.serrano@wazuh.com>
Date:   Thu Jun 8 13:09:10 2023 +0200

    Bump v4.4.4-2.6.0-rc2

commit 0e7201ff8b7fb6a76de789160b94e665c0af41e1
Author: Ian Yenien Serrano <63758389+yenienserrano@users.noreply.github.com>
Date:   Thu Jun 8 12:54:18 2023 +0200

    Improved changelog (#5544)
    
    * Update changelog
    
    * Update revision for RC2

commit cb8a8bee7f7217031ce94e6241893e611288a146
Author: Ian Yenien Serrano <63758389+yenienserrano@users.noreply.github.com>
Date:   Mon Jun 5 11:11:06 2023 +0200

    Bump Wazuh and platform versions for v4.4.4 (#5524)
    
    * Prepare the app for Wazuh 4.4.4
    
    * Update readme
```

### Test
- Check that `git log` returns the output above as the first item.
- Check that `git log` does not contain these commits

![image](https://github.com/wazuh/wazuh-kibana-app/assets/15186973/281c9a42-dfe5-403b-9a22-7debe2486703)

### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 
