### PR TITLE
[Backport 4.6.0-7.10] Fix API endpoint documentation link in static file

### DIFF
--- a/plugins/main/common/api-info/endpoints.json
+++ b/plugins/main/common/api-info/endpoints.json
@@ -4,7 +4,7 @@
     "endpoints": [
       {
         "name": "/",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_default_controller_default_info",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.default_controller.default_info",
         "description": "Return basic information about the API",
         "summary": "Get API info",
         "tags": [
@@ -23,7 +23,7 @@
       },
       {
         "name": "/agents",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_agent_controller_get_agents",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.agent_controller.get_agents",
         "description": "Return information about all available agents or a list of them",
         "summary": "List agents",
         "tags": [
@@ -235,7 +235,7 @@
       },
       {
         "name": "/agents/:agent_id/config/:component/:configuration",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_agent_controller_get_agent_config",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.agent_controller.get_agent_config",
         "description": "Return the active configuration the agent is currently using. This can be different from the configuration present in the configuration file, if it has been modified and the agent has not been restarted yet",
         "summary": "Get active configuration",
         "tags": [
@@ -335,7 +335,7 @@
       },
       {
         "name": "/agents/:agent_id/daemons/stats",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_agent_controller_get_daemon_stats",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.agent_controller.get_daemon_stats",
         "description": "Return Wazuh statistical information from specified daemons in a specified agent",
         "summary": "Get Wazuh daemon stats from an agent",
         "tags": [
@@ -389,7 +389,7 @@
       },
       {
         "name": "/agents/:agent_id/group/is_sync",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_agent_controller_get_sync_agent",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.agent_controller.get_sync_agent",
         "description": "Return whether the agent configuration has been synchronized with the agent or not. This can be useful to check after updating a group configuration",
         "summary": "Get configuration sync status",
         "tags": [
@@ -429,7 +429,7 @@
       },
       {
         "name": "/agents/:agent_id/key",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_agent_controller_get_agent_key",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.agent_controller.get_agent_key",
         "description": "Return the key of an agent",
         "summary": "Get key",
         "tags": [
@@ -469,7 +469,7 @@
       },
       {
         "name": "/agents/:agent_id/stats/:component",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_agent_controller_get_component_stats",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.agent_controller.get_component_stats",
         "description": "Return Wazuh's {component} statistical information from agent {agent_id}",
         "summary": "Get agent's component stats",
         "tags": [
@@ -521,7 +521,7 @@
       },
       {
         "name": "/agents/no_group",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_agent_controller_get_agent_no_group",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.agent_controller.get_agent_no_group",
         "description": "Return a list with all the available agents without an assigned group",
         "summary": "List agents without group",
         "tags": [
@@ -603,7 +603,7 @@
       },
       {
         "name": "/agents/outdated",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_agent_controller_get_agent_outdated",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.agent_controller.get_agent_outdated",
         "description": "Return the list of outdated agents",
         "summary": "List outdated agents",
         "tags": [
@@ -674,7 +674,7 @@
       },
       {
         "name": "/agents/stats/distinct",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_agent_controller_get_agent_fields",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.agent_controller.get_agent_fields",
         "description": "Return all the different combinations that agents have for the selected fields. It also indicates the total number of agents that have each combination",
         "summary": "List agents distinct",
         "tags": [
@@ -756,7 +756,7 @@
       },
       {
         "name": "/agents/summary/os",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_agent_controller_get_agent_summary_os",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.agent_controller.get_agent_summary_os",
         "description": "Return a summary of the OS of available agents",
         "summary": "Summarize agents OS",
         "tags": [
@@ -783,7 +783,7 @@
       },
       {
         "name": "/agents/summary/status",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_agent_controller_get_agent_summary_status",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.agent_controller.get_agent_summary_status",
         "description": "Return a summary of the connection and groups configuration synchronization statuses of available agents",
         "summary": "Summarize agents status",
         "tags": [
@@ -810,7 +810,7 @@
       },
       {
         "name": "/agents/upgrade_result",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_agent_controller_get_agent_upgrade",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.agent_controller.get_agent_upgrade",
         "description": "Return the agents upgrade results",
         "summary": "Get upgrade results",
         "tags": [
@@ -938,7 +938,7 @@
       },
       {
         "name": "/ciscat/:agent_id/results",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_ciscat_controller_get_agents_ciscat_results",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.ciscat_controller.get_agents_ciscat_results",
         "description": "Return the agent's ciscat results info",
         "summary": "Get results",
         "tags": [
@@ -1102,7 +1102,7 @@
       },
       {
         "name": "/cluster/:node_id/configuration",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_cluster_controller_get_configuration_node",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.cluster_controller.get_configuration_node",
         "description": "Return wazuh configuration used in node {node_id}. The 'section' and 'field' parameters will be ignored if 'raw' parameter is provided.",
         "summary": "Get node config",
         "tags": [
@@ -1196,7 +1196,7 @@
       },
       {
         "name": "/cluster/:node_id/configuration/:component/:configuration",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_cluster_controller_get_node_config",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.cluster_controller.get_node_config",
         "description": "Return the requested configuration in JSON format for the specified node",
         "summary": "Get node active configuration",
         "tags": [
@@ -1294,7 +1294,7 @@
       },
       {
         "name": "/cluster/:node_id/daemons/stats",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_cluster_controller_get_daemon_stats_node",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.cluster_controller.get_daemon_stats_node",
         "description": "Return Wazuh statistical information from specified daemons in a specified cluster node",
         "summary": "Get Wazuh daemon stats from a cluster node",
         "tags": [
@@ -1347,7 +1347,7 @@
       },
       {
         "name": "/cluster/:node_id/info",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_cluster_controller_get_info_node",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.cluster_controller.get_info_node",
         "description": "Return basic information about a specified node such as version, compilation date, installation path",
         "summary": "Get node info",
         "tags": [
@@ -1385,7 +1385,7 @@
       },
       {
         "name": "/cluster/:node_id/logs",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_cluster_controller_get_log_node",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.cluster_controller.get_log_node",
         "description": "Return the last 2000 wazuh log entries in the specified node",
         "summary": "Get node logs",
         "tags": [
@@ -1490,7 +1490,7 @@
       },
       {
         "name": "/cluster/:node_id/logs/summary",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_cluster_controller_get_log_summary_node",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.cluster_controller.get_log_summary_node",
         "description": "Return a summary of the last 2000 wazuh log entries in the specified node",
         "summary": "Get node logs summary",
         "tags": [
@@ -1528,7 +1528,7 @@
       },
       {
         "name": "/cluster/:node_id/stats",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_cluster_controller_get_stats_node",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.cluster_controller.get_stats_node",
         "description": "Return Wazuh statistical information in node {node_id} for the current or specified date",
         "summary": "Get node stats",
         "tags": [
@@ -1574,7 +1574,7 @@
       },
       {
         "name": "/cluster/:node_id/stats/analysisd",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_cluster_controller_get_stats_analysisd_node",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.cluster_controller.get_stats_analysisd_node",
         "description": "Return Wazuh analysisd statistical information in node {node_id}",
         "summary": "Get node stats analysisd",
         "tags": [
@@ -1612,7 +1612,7 @@
       },
       {
         "name": "/cluster/:node_id/stats/hourly",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_cluster_controller_get_stats_hourly_node",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.cluster_controller.get_stats_hourly_node",
         "description": "Return Wazuh statistical information in node {node_id} per hour. Each number in the averages field represents the average of alerts per hour",
         "summary": "Get node stats hour",
         "tags": [
@@ -1650,7 +1650,7 @@
       },
       {
         "name": "/cluster/:node_id/stats/remoted",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_cluster_controller_get_stats_remoted_node",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.cluster_controller.get_stats_remoted_node",
         "description": "Return Wazuh remoted statistical information in node {node_id}",
         "summary": "Get node stats remoted",
         "tags": [
@@ -1688,7 +1688,7 @@
       },
       {
         "name": "/cluster/:node_id/stats/weekly",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_cluster_controller_get_stats_weekly_node",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.cluster_controller.get_stats_weekly_node",
         "description": "Return Wazuh statistical information in node {node_id} per week. Each number in the averages field represents the average of alerts per hour for that specific day",
         "summary": "Get node stats week",
         "tags": [
@@ -1726,7 +1726,7 @@
       },
       {
         "name": "/cluster/:node_id/status",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_cluster_controller_get_status_node",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.cluster_controller.get_status_node",
         "description": "Return the status of all Wazuh daemons in node node_id",
         "summary": "Get node status",
         "tags": [
@@ -1764,7 +1764,7 @@
       },
       {
         "name": "/cluster/api/config",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_cluster_controller_get_api_config",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.cluster_controller.get_api_config",
         "description": "Return the API configuration of all nodes (or a list of them) in JSON format",
         "summary": "Get nodes API config",
         "tags": [
@@ -1801,7 +1801,7 @@
       },
       {
         "name": "/cluster/configuration/validation",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_cluster_controller_get_conf_validation",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.cluster_controller.get_conf_validation",
         "description": "Return whether the Wazuh configuration is correct or not in all cluster nodes or a list of them",
         "summary": "Check nodes config",
         "tags": [
@@ -1838,7 +1838,7 @@
       },
       {
         "name": "/cluster/healthcheck",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_cluster_controller_get_healthcheck",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.cluster_controller.get_healthcheck",
         "description": "Return cluster healthcheck information for all nodes or a list of them. Such information includes last keep alive, last synchronization time and number of agents reporting on each node",
         "summary": "Get nodes healthcheck",
         "tags": [
@@ -1875,7 +1875,7 @@
       },
       {
         "name": "/cluster/local/config",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_cluster_controller_get_config",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.cluster_controller.get_config",
         "description": "Return the current node cluster configuration",
         "summary": "Get local node config",
         "tags": [
@@ -1902,7 +1902,7 @@
       },
       {
         "name": "/cluster/local/info",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_cluster_controller_get_cluster_node",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.cluster_controller.get_cluster_node",
         "description": "Return basic information about the cluster node receiving the request",
         "summary": "Get local node info",
         "tags": [
@@ -1929,7 +1929,7 @@
       },
       {
         "name": "/cluster/nodes",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_cluster_controller_get_cluster_nodes",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.cluster_controller.get_cluster_nodes",
         "description": "Get information about all nodes in the cluster or a list of them",
         "summary": "Get nodes info",
         "tags": [
@@ -2032,7 +2032,7 @@
       },
       {
         "name": "/cluster/ruleset/synchronization",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_cluster_controller_get_nodes_ruleset_sync_status",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.cluster_controller.get_nodes_ruleset_sync_status",
         "description": "Return ruleset synchronization status for all nodes or a list of them. This synchronization only covers the user custom ruleset",
         "summary": "Get cluster nodes ruleset synchronization status",
         "tags": [
@@ -2069,7 +2069,7 @@
       },
       {
         "name": "/cluster/status",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_cluster_controller_get_status",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.cluster_controller.get_status",
         "description": "Return information about the cluster status",
         "summary": "Get cluster status",
         "tags": [
@@ -2096,7 +2096,7 @@
       },
       {
         "name": "/decoders",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_decoder_controller_get_decoders",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.decoder_controller.get_decoders",
         "description": "Return information about all decoders included in ossec.conf. This information include decoder's route, decoder's name, decoder's file among others",
         "summary": "List decoders",
         "tags": [
@@ -2221,7 +2221,7 @@
       },
       {
         "name": "/decoders/files",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_decoder_controller_get_decoders_files",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.decoder_controller.get_decoders_files",
         "description": "Return information about all decoders files used in Wazuh. This information include decoder's file, decoder's route and decoder's status among others",
         "summary": "Get files",
         "tags": [
@@ -2317,7 +2317,7 @@
       },
       {
         "name": "/decoders/files/:filename",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_decoder_controller_get_file",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.decoder_controller.get_file",
         "description": "Get the content of a specified decoder file",
         "summary": "Get decoders file content",
         "tags": [
@@ -2363,7 +2363,7 @@
       },
       {
         "name": "/decoders/parents",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_decoder_controller_get_decoders_parents",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.decoder_controller.get_decoders_parents",
         "description": "Return information about all parent decoders. A parent decoder is a decoder used as base of other decoders",
         "summary": "Get parent decoders",
         "tags": [
@@ -2438,7 +2438,7 @@
       },
       {
         "name": "/experimental/ciscat/results",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_experimental_controller_get_cis_cat_results",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.experimental_controller.get_cis_cat_results",
         "description": "Return CIS-CAT results for all agents or a list of them",
         "summary": "Get agents CIS-CAT results",
         "tags": [
@@ -2595,7 +2595,7 @@
       },
       {
         "name": "/experimental/syscollector/hardware",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_experimental_controller_get_hardware_info",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.experimental_controller.get_hardware_info",
         "description": "Return all agents (or a list of them) hardware info. This information include cpu, ram, scan info among others of all agents",
         "summary": "Get agents hardware",
         "tags": [
@@ -2734,7 +2734,7 @@
       },
       {
         "name": "/experimental/syscollector/hotfixes",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_experimental_controller_get_hotfixes_info",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.experimental_controller.get_hotfixes_info",
         "description": "Return all agents (or a list of them) hotfixes info",
         "summary": "Get agents hotfixes",
         "tags": [
@@ -2829,7 +2829,7 @@
       },
       {
         "name": "/experimental/syscollector/netaddr",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_experimental_controller_get_network_address_info",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.experimental_controller.get_network_address_info",
         "description": "Return all agents (or a list of them) IPv4 and IPv6 addresses associated to their network interfaces. This information include used IP protocol, interface, and IP address among others",
         "summary": "Get agents netaddr",
         "tags": [
@@ -2949,7 +2949,7 @@
       },
       {
         "name": "/experimental/syscollector/netiface",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_experimental_controller_get_network_interface_info",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.experimental_controller.get_network_interface_info",
         "description": "Return all agents (or a list of them) network interfaces. This information includes rx, scan, tx info and some network information among other",
         "summary": "Get agents netiface",
         "tags": [
@@ -3150,7 +3150,7 @@
       },
       {
         "name": "/experimental/syscollector/netproto",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_experimental_controller_get_network_protocol_info",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.experimental_controller.get_network_protocol_info",
         "description": "Return all agents (or a list of them) routing configuration for each network interface. This information includes interface, type protocol information among other",
         "summary": "Get agents netproto",
         "tags": [
@@ -3276,7 +3276,7 @@
       },
       {
         "name": "/experimental/syscollector/os",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_experimental_controller_get_os_info",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.experimental_controller.get_os_info",
         "description": "Return all agents (or a list of them) OS info. This information includes os information, architecture information among other",
         "summary": "Get agents OS",
         "tags": [
@@ -3404,7 +3404,7 @@
       },
       {
         "name": "/experimental/syscollector/packages",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_experimental_controller_get_packages_info",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.experimental_controller.get_packages_info",
         "description": "Return all agents (or a list of them) packages info. This information includes name, section, size, and priority information of all packages among other",
         "summary": "Get agents packages",
         "tags": [
@@ -3530,7 +3530,7 @@
       },
       {
         "name": "/experimental/syscollector/ports",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_experimental_controller_get_ports_info",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.experimental_controller.get_ports_info",
         "description": "Return all agents (or a list of them) ports info. This information includes local IP, Remote IP, protocol information among other",
         "summary": "Get agents ports",
         "tags": [
@@ -3682,7 +3682,7 @@
       },
       {
         "name": "/experimental/syscollector/processes",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_experimental_controller_get_processes_info",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.experimental_controller.get_processes_info",
         "description": "Return all agents (or a list of them) processes info",
         "summary": "Get agents processes",
         "tags": [
@@ -3882,7 +3882,7 @@
       },
       {
         "name": "/groups",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_agent_controller_get_list_group",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.agent_controller.get_list_group",
         "description": "Get information about all groups or a list of them. Returns a list containing basic information about each group such as number of agents belonging to the group and the checksums of the configuration and shared files",
         "summary": "Get groups",
         "tags": [
@@ -3979,7 +3979,7 @@
       },
       {
         "name": "/groups/:group_id/agents",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_agent_controller_get_agents_in_group",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.agent_controller.get_agents_in_group",
         "description": "Return the list of agents that belong to the specified group",
         "summary": "Get agents in a group",
         "tags": [
@@ -4090,7 +4090,7 @@
       },
       {
         "name": "/groups/:group_id/configuration",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_agent_controller_get_group_config",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.agent_controller.get_group_config",
         "description": "Return the group configuration defined in the `agent.conf` file",
         "summary": "Get group configuration",
         "tags": [
@@ -4150,7 +4150,7 @@
       },
       {
         "name": "/groups/:group_id/files",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_agent_controller_get_group_files",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.agent_controller.get_group_files",
         "description": "Return the files placed under the group directory",
         "summary": "Get group files",
         "tags": [
@@ -4247,7 +4247,7 @@
       },
       {
         "name": "/groups/:group_id/files/:file_name/json",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_agent_controller_get_group_file_json",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.agent_controller.get_group_file_json",
         "description": "Return the content of the specified group file parsed to JSON",
         "summary": "Get a file in group",
         "tags": [
@@ -4311,7 +4311,7 @@
       },
       {
         "name": "/groups/:group_id/files/:file_name/xml",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_agent_controller_get_group_file_xml",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.agent_controller.get_group_file_xml",
         "description": "Return the contents of the specified group file parsed to XML",
         "summary": "Get a file in group",
         "tags": [
@@ -4375,7 +4375,7 @@
       },
       {
         "name": "/lists",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_cdb_list_controller_get_lists",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.cdb_list_controller.get_lists",
         "description": "Return the contents of all CDB lists. Optionally, the result can be filtered by several criteria. See available parameters for more details",
         "summary": "Get CDB lists info",
         "tags": [
@@ -4469,7 +4469,7 @@
       },
       {
         "name": "/lists/files",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_cdb_list_controller_get_lists_files",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.cdb_list_controller.get_lists_files",
         "description": "Return the path from all CDB lists. Use this method to know all the CDB lists and their location in the filesystem relative to Wazuh installation folder",
         "summary": "Get CDB lists files",
         "tags": [
@@ -4552,7 +4552,7 @@
       },
       {
         "name": "/lists/files/:filename",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_cdb_list_controller_get_file",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.cdb_list_controller.get_file",
         "description": "Return the content of a CDB list file. Only the filename can be specified. It will be searched recursively if not found",
         "summary": "Get CDB list file content",
         "tags": [
@@ -4598,7 +4598,7 @@
       },
       {
         "name": "/manager/api/config",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_manager_controller_get_api_config",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.manager_controller.get_api_config",
         "description": "Return the local API configuration in JSON format",
         "summary": "Get API config",
         "tags": [
@@ -4625,7 +4625,7 @@
       },
       {
         "name": "/manager/configuration",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_manager_controller_get_configuration",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.manager_controller.get_configuration",
         "description": "Return wazuh configuration used. The 'section' and 'field' parameters will be ignored if 'raw' parameter is provided.",
         "summary": "Get configuration",
         "tags": [
@@ -4708,7 +4708,7 @@
       },
       {
         "name": "/manager/configuration/:component/:configuration",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_manager_controller_get_manager_config_ondemand",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.manager_controller.get_manager_config_ondemand",
         "description": "Return the requested active configuration in JSON format",
         "summary": "Get active configuration",
         "tags": [
@@ -4797,7 +4797,7 @@
       },
       {
         "name": "/manager/configuration/validation",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_manager_controller_get_conf_validation",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.manager_controller.get_conf_validation",
         "description": "Return whether the Wazuh configuration is correct",
         "summary": "Check config",
         "tags": [
@@ -4824,7 +4824,7 @@
       },
       {
         "name": "/manager/daemons/stats",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_manager_controller_get_daemon_stats",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.manager_controller.get_daemon_stats",
         "description": "Return Wazuh statistical information from specified daemons",
         "summary": "Get Wazuh daemon stats",
         "tags": [
@@ -4866,7 +4866,7 @@
       },
       {
         "name": "/manager/info",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_manager_controller_get_info",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.manager_controller.get_info",
         "description": "Return basic information such as version, compilation date, installation path",
         "summary": "Get information",
         "tags": [
@@ -4893,7 +4893,7 @@
       },
       {
         "name": "/manager/logs",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_manager_controller_get_log",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.manager_controller.get_log",
         "description": "Return the last 2000 wazuh log entries",
         "summary": "Get logs",
         "tags": [
@@ -4987,7 +4987,7 @@
       },
       {
         "name": "/manager/logs/summary",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_manager_controller_get_log_summary",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.manager_controller.get_log_summary",
         "description": "Return a summary of the last 2000 wazuh log entries",
         "summary": "Get logs summary",
         "tags": [
@@ -5014,7 +5014,7 @@
       },
       {
         "name": "/manager/stats",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_manager_controller_get_stats",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.manager_controller.get_stats",
         "description": "Return Wazuh statistical information for the current or specified date",
         "summary": "Get stats",
         "tags": [
@@ -5049,7 +5049,7 @@
       },
       {
         "name": "/manager/stats/analysisd",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_manager_controller_get_stats_analysisd",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.manager_controller.get_stats_analysisd",
         "description": "Return Wazuh analysisd statistical information",
         "summary": "Get stats analysisd",
         "tags": [
@@ -5076,7 +5076,7 @@
       },
       {
         "name": "/manager/stats/hourly",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_manager_controller_get_stats_hourly",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.manager_controller.get_stats_hourly",
         "description": "Return Wazuh statistical information per hour. Each number in the averages field represents the average of alerts per hour",
         "summary": "Get stats hour",
         "tags": [
@@ -5103,7 +5103,7 @@
       },
       {
         "name": "/manager/stats/remoted",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_manager_controller_get_stats_remoted",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.manager_controller.get_stats_remoted",
         "description": "Return Wazuh remoted statistical information",
         "summary": "Get stats remoted",
         "tags": [
@@ -5130,7 +5130,7 @@
       },
       {
         "name": "/manager/stats/weekly",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_manager_controller_get_stats_weekly",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.manager_controller.get_stats_weekly",
         "description": "Return Wazuh statistical information per week. Each number in the averages field represents the average of alerts per hour for that specific day",
         "summary": "Get stats week",
         "tags": [
@@ -5157,7 +5157,7 @@
       },
       {
         "name": "/manager/status",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_manager_controller_get_status",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.manager_controller.get_status",
         "description": "Return the status of all Wazuh daemons",
         "summary": "Get status",
         "tags": [
@@ -5184,7 +5184,7 @@
       },
       {
         "name": "/mitre/groups",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_mitre_controller_get_groups",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.mitre_controller.get_groups",
         "description": "Return the groups from MITRE database",
         "summary": "Get MITRE groups",
         "tags": [
@@ -5277,7 +5277,7 @@
       },
       {
         "name": "/mitre/metadata",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_mitre_controller_get_metadata",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.mitre_controller.get_metadata",
         "description": "Return the metadata from MITRE database",
         "summary": "Get MITRE metadata",
         "tags": [
@@ -5304,7 +5304,7 @@
       },
       {
         "name": "/mitre/mitigations",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_mitre_controller_get_mitigations",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.mitre_controller.get_mitigations",
         "description": "Return the mitigations from MITRE database",
         "summary": "Get MITRE mitigations",
         "tags": [
@@ -5397,7 +5397,7 @@
       },
       {
         "name": "/mitre/references",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_mitre_controller_get_references",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.mitre_controller.get_references",
         "description": "Return the references from MITRE database",
         "summary": "Get MITRE references",
         "tags": [
@@ -5490,7 +5490,7 @@
       },
       {
         "name": "/mitre/software",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_mitre_controller_get_software",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.mitre_controller.get_software",
         "description": "Return the software from MITRE database",
         "summary": "Get MITRE software",
         "tags": [
@@ -5583,7 +5583,7 @@
       },
       {
         "name": "/mitre/tactics",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_mitre_controller_get_tactics",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.mitre_controller.get_tactics",
         "description": "Return the tactics from MITRE database",
         "summary": "Get MITRE tactics",
         "tags": [
@@ -5676,7 +5676,7 @@
       },
       {
         "name": "/mitre/techniques",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_mitre_controller_get_techniques",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.mitre_controller.get_techniques",
         "description": "Return the techniques from MITRE database",
         "summary": "Get MITRE techniques",
         "tags": [
@@ -5769,7 +5769,7 @@
       },
       {
         "name": "/overview/agents",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_overview_controller_get_overview_agents",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.overview_controller.get_overview_agents",
         "description": "Return a dictionary with a full agents overview",
         "summary": "Get agents overview",
         "tags": [
@@ -5796,7 +5796,7 @@
       },
       {
         "name": "/rootcheck/:agent_id",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_rootcheck_controller_get_rootcheck_agent",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.rootcheck_controller.get_rootcheck_agent",
         "description": "Return the rootcheck database of an agent",
         "summary": "Get results",
         "tags": [
@@ -5923,7 +5923,7 @@
       },
       {
         "name": "/rootcheck/:agent_id/last_scan",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_rootcheck_controller_get_last_scan_agent",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.rootcheck_controller.get_last_scan_agent",
         "description": "Return the timestamp of the last rootcheck scan of an agent",
         "summary": "Get last scan datetime",
         "tags": [
@@ -5963,7 +5963,7 @@
       },
       {
         "name": "/rules",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_rule_controller_get_rules",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.rule_controller.get_rules",
         "description": "Return a list containing information about each rule such as file where it's defined, description, rule group, status, etc",
         "summary": "List rules",
         "tags": [
@@ -6161,7 +6161,7 @@
       },
       {
         "name": "/rules/files",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_rule_controller_get_rules_files",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.rule_controller.get_rules_files",
         "description": "Return a list containing all files used to define rules and their status",
         "summary": "Get files",
         "tags": [
@@ -6257,7 +6257,7 @@
       },
       {
         "name": "/rules/files/:filename",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_rule_controller_get_file",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.rule_controller.get_file",
         "description": "Get the content of a specified rule in the ruleset",
         "summary": "Get rules file content",
         "tags": [
@@ -6303,7 +6303,7 @@
       },
       {
         "name": "/rules/groups",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_rule_controller_get_rules_groups",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.rule_controller.get_rules_groups",
         "description": "Return a list containing all rule groups names",
         "summary": "Get groups",
         "tags": [
@@ -6367,7 +6367,7 @@
       },
       {
         "name": "/rules/requirement/:requirement",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_rule_controller_get_rules_requirement",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.rule_controller.get_rules_requirement",
         "description": "Return all specified requirement names defined in the Wazuh ruleset",
         "summary": "Get requirements",
         "tags": [
@@ -6449,7 +6449,7 @@
       },
       {
         "name": "/sca/:agent_id",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_sca_controller_get_sca_agent",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.sca_controller.get_sca_agent",
         "description": "Return the security SCA database of an agent",
         "summary": "Get results",
         "tags": [
@@ -6574,7 +6574,7 @@
       },
       {
         "name": "/sca/:agent_id/checks/:policy_id",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_sca_controller_get_sca_checks",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.sca_controller.get_sca_checks",
         "description": "Return the policy monitoring alerts for a given policy",
         "summary": "Get policy checks",
         "tags": [
@@ -6787,7 +6787,7 @@
       },
       {
         "name": "/security/actions",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_security_controller_get_rbac_actions",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.security_controller.get_rbac_actions",
         "description": "Get all RBAC actions, including the potential related resources and endpoints.",
         "summary": "List RBAC actions",
         "tags": [
@@ -6813,7 +6813,7 @@
       },
       {
         "name": "/security/config",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_security_controller_get_security_config",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.security_controller.get_security_config",
         "description": "Return the security configuration in JSON format",
         "summary": "Get security config",
         "tags": [
@@ -6840,7 +6840,7 @@
       },
       {
         "name": "/security/policies",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_security_controller_get_policies",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.security_controller.get_policies",
         "description": "Get all policies in the system, including the administrator policy",
         "summary": "List policies",
         "tags": [
@@ -6927,7 +6927,7 @@
       },
       {
         "name": "/security/resources",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_security_controller_get_rbac_resources",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.security_controller.get_rbac_resources",
         "description": "This method should be called to get all current defined RBAC resources.",
         "summary": "List RBAC resources",
         "tags": [
@@ -6966,7 +6966,7 @@
       },
       {
         "name": "/security/roles",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_security_controller_get_roles",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.security_controller.get_roles",
         "description": "For a specific list, indicate the ids separated by commas. Example: ?role_ids=1,2,3",
         "summary": "List roles",
         "tags": [
@@ -7053,7 +7053,7 @@
       },
       {
         "name": "/security/rules",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_security_controller_get_rules",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.security_controller.get_rules",
         "description": "Get a list of security rules from the system or all of them. These rules must be mapped with roles to obtain certain access privileges. For a specific list, indicate the ids separated by commas. Example: ?rule_ids=1,2,3",
         "summary": "List security rules",
         "tags": [
@@ -7140,7 +7140,7 @@
       },
       {
         "name": "/security/user/authenticate",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_security_controller_deprecated_login_user",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.security_controller.deprecated_login_user",
         "description": "This method should be called to get an API token. This token will expire after auth_token_exp_timeout seconds (default: 900). This value can be changed using PUT /security/config",
         "summary": "Login",
         "tags": [
@@ -7159,7 +7159,7 @@
       },
       {
         "name": "/security/users",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_security_controller_get_users",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.security_controller.get_users",
         "description": "Get the information of a specified user",
         "summary": "List users",
         "tags": [
@@ -7246,7 +7246,7 @@
       },
       {
         "name": "/security/users/me",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_security_controller_get_user_me",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.security_controller.get_user_me",
         "description": "Get the information of the current user",
         "summary": "Get current user info",
         "tags": [
@@ -7273,7 +7273,7 @@
       },
       {
         "name": "/security/users/me/policies",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_security_controller_get_user_me_policies",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.security_controller.get_user_me_policies",
         "description": "Get the processed policies information for the current user",
         "summary": "Get current user processed policies",
         "tags": [
@@ -7292,7 +7292,7 @@
       },
       {
         "name": "/syscheck/:agent_id",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_syscheck_controller_get_syscheck_agent",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.syscheck_controller.get_syscheck_agent",
         "description": "Return FIM findings in the specified agent",
         "summary": "Get results",
         "tags": [
@@ -7482,7 +7482,7 @@
       },
       {
         "name": "/syscheck/:agent_id/last_scan",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_syscheck_controller_get_last_scan_agent",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.syscheck_controller.get_last_scan_agent",
         "description": "Return when the last syscheck scan started and ended. If the scan is still in progress the end date will be unknown",
         "summary": "Get last scan datetime",
         "tags": [
@@ -7522,7 +7522,7 @@
       },
       {
         "name": "/syscollector/:agent_id/hardware",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_syscollector_controller_get_hardware_info",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.syscollector_controller.get_hardware_info",
         "description": "Return the agent's hardware info. This information include cpu, ram, scan info among others",
         "summary": "Get agent hardware",
         "tags": [
@@ -7573,7 +7573,7 @@
       },
       {
         "name": "/syscollector/:agent_id/hotfixes",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_syscollector_controller_get_hotfix_info",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.syscollector_controller.get_hotfix_info",
         "description": "Return all hotfixes installed by Microsoft(R) in Windows(R) systems (KB... fixes)",
         "summary": "Get agent hotfixes",
         "tags": [
@@ -7675,7 +7675,7 @@
       },
       {
         "name": "/syscollector/:agent_id/netaddr",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_syscollector_controller_get_network_address_info",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.syscollector_controller.get_network_address_info",
         "description": "Return the agent's network address info. This information include used IP protocol, interface, IP address  among others",
         "summary": "Get agent netaddr",
         "tags": [
@@ -7810,7 +7810,7 @@
       },
       {
         "name": "/syscollector/:agent_id/netiface",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_syscollector_controller_get_network_interface_info",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.syscollector_controller.get_network_interface_info",
         "description": "Return the agent's network interface info. This information include rx, scan, tx info and some network information among others",
         "summary": "Get agent netiface",
         "tags": [
@@ -8017,7 +8017,7 @@
       },
       {
         "name": "/syscollector/:agent_id/netproto",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_syscollector_controller_get_network_protocol_info",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.syscollector_controller.get_network_protocol_info",
         "description": "Return the agent's routing configuration for each network interface",
         "summary": "Get agent netproto",
         "tags": [
@@ -8150,7 +8150,7 @@
       },
       {
         "name": "/syscollector/:agent_id/os",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_syscollector_controller_get_os_info",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.syscollector_controller.get_os_info",
         "description": "Return the agent's OS info. This information include os information, architecture information among others of all agents",
         "summary": "Get agent OS",
         "tags": [
@@ -8201,7 +8201,7 @@
       },
       {
         "name": "/syscollector/:agent_id/packages",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_syscollector_controller_get_packages_info",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.syscollector_controller.get_packages_info",
         "description": "Return the agent's packages info. This information include name, section, size, priority information of all packages among others",
         "summary": "Get agent packages",
         "tags": [
@@ -8334,7 +8334,7 @@
       },
       {
         "name": "/syscollector/:agent_id/ports",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_syscollector_controller_get_ports_info",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.syscollector_controller.get_ports_info",
         "description": "Return the agent's ports info. This information include local IP, Remote IP, protocol information among others",
         "summary": "Get agent ports",
         "tags": [
@@ -8493,7 +8493,7 @@
       },
       {
         "name": "/syscollector/:agent_id/processes",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_syscollector_controller_get_processes_info",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.syscollector_controller.get_processes_info",
         "description": "Return the agent's processes info",
         "summary": "Get agent processes",
         "tags": [
@@ -8700,7 +8700,7 @@
       },
       {
         "name": "/tasks/status",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_task_controller_get_tasks_status",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.task_controller.get_tasks_status",
         "description": "Returns all available information about the specified tasks",
         "summary": "List tasks",
         "tags": [
@@ -8839,7 +8839,7 @@
       },
       {
         "name": "/vulnerability/:agent_id",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_vulnerability_controller_get_vulnerability_agent",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.vulnerability_controller.get_vulnerability_agent",
         "description": "Return the vulnerabilities of an agent",
         "summary": "Get vulnerabilities",
         "tags": [
@@ -9005,7 +9005,7 @@
       },
       {
         "name": "/vulnerability/:agent_id/last_scan",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_vulnerability_controller_get_last_scan_agent",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.vulnerability_controller.get_last_scan_agent",
         "description": "Return when the last full and partial vulnerability scan of a specified agent ended.",
         "summary": "Get last scan datetime",
         "tags": [
@@ -9045,7 +9045,7 @@
       },
       {
         "name": "/vulnerability/:agent_id/summary/:field",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_vulnerability_controller_get_vulnerabilities_field_summary",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.vulnerability_controller.get_vulnerabilities_field_summary",
         "description": "Return a summary of the vulnerabilities' field of an agent",
         "summary": "Get agent vulnerabilities' field summary",
         "tags": [
@@ -9126,7 +9126,7 @@
     "endpoints": [
       {
         "name": "/active-response",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_active_response_controller_run_command",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.active_response_controller.run_command",
         "description": "Run an Active Response command on all agents or a list of them",
         "summary": "Run command",
         "tags": [
@@ -9202,7 +9202,7 @@
       },
       {
         "name": "/agents/:agent_id/group/:group_id",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_agent_controller_put_agent_single_group",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.agent_controller.put_agent_single_group",
         "description": "Assign an agent to a specified group",
         "summary": "Assign agent to group",
         "tags": [
@@ -9259,7 +9259,7 @@
       },
       {
         "name": "/agents/:agent_id/restart",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_agent_controller_restart_agent",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.agent_controller.restart_agent",
         "description": "Restart the specified agent",
         "summary": "Restart agent",
         "tags": [
@@ -9299,7 +9299,7 @@
       },
       {
         "name": "/agents/group",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_agent_controller_put_multiple_agent_single_group",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.agent_controller.put_multiple_agent_single_group",
         "description": "Assign all agents or a list of them to the specified group",
         "summary": "Assign agents to group",
         "tags": [
@@ -9356,7 +9356,7 @@
       },
       {
         "name": "/agents/group/:group_id/restart",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_agent_controller_restart_agents_by_group",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.agent_controller.restart_agents_by_group",
         "description": "Restart all agents which belong to a given group",
         "summary": "Restart agents in group",
         "tags": [
@@ -9395,7 +9395,7 @@
       },
       {
         "name": "/agents/node/:node_id/restart",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_agent_controller_restart_agents_by_node",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.agent_controller.restart_agents_by_node",
         "description": "Restart all agents which belong to a specific given node",
         "summary": "Restart agents in node",
         "tags": [
@@ -9433,7 +9433,7 @@
       },
       {
         "name": "/agents/reconnect",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_agent_controller_reconnect_agents",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.agent_controller.reconnect_agents",
         "description": "Force reconnect all agents or a list of them",
         "summary": "Force reconnect agents",
         "tags": [
@@ -9473,7 +9473,7 @@
       },
       {
         "name": "/agents/restart",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_agent_controller_restart_agents",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.agent_controller.restart_agents",
         "description": "Restart all agents or a list of them",
         "summary": "Restart agents",
         "tags": [
@@ -9513,7 +9513,7 @@
       },
       {
         "name": "/agents/upgrade",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_agent_controller_put_upgrade_agents",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.agent_controller.put_upgrade_agents",
         "description": "Upgrade agents using a WPK file from online repository. When upgrading more than 3000 agents at the same time, it's highly recommended to use the parameter `wait_for_complete` set to `true` to avoid a possible API timeout",
         "summary": "Upgrade agents",
         "tags": [
@@ -9674,7 +9674,7 @@
       },
       {
         "name": "/agents/upgrade_custom",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_agent_controller_put_upgrade_custom_agents",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.agent_controller.put_upgrade_custom_agents",
         "description": "Upgrade the agents using a local WPK file. When upgrading more than 3000 agents at the same time, it's highly recommended to use the parameter `wait_for_complete` set to `true` to avoid a possible API timeout",
         "summary": "Upgrade agents custom",
         "tags": [
@@ -9820,7 +9820,7 @@
       },
       {
         "name": "/cluster/:node_id/configuration",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_cluster_controller_update_configuration",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.cluster_controller.update_configuration",
         "description": "Replace wazuh configuration for the given node with the data contained in the API request",
         "summary": "Update node configuration",
         "tags": [
@@ -9858,7 +9858,7 @@
       },
       {
         "name": "/cluster/restart",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_cluster_controller_put_restart",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.cluster_controller.put_restart",
         "description": "Restart all nodes in the cluster or a list of them",
         "summary": "Restart nodes",
         "tags": [
@@ -9895,7 +9895,7 @@
       },
       {
         "name": "/decoders/files/:filename",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_decoder_controller_put_file",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.decoder_controller.put_file",
         "description": "Upload or replace a user decoder file content",
         "summary": "Update decoders file",
         "tags": [
@@ -9941,7 +9941,7 @@
       },
       {
         "name": "/groups/:group_id/configuration",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_agent_controller_put_group_config",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.agent_controller.put_group_config",
         "description": "Update an specified group's configuration. This API call expects a full valid XML file with the shared configuration tags/syntax",
         "summary": "Update group configuration",
         "tags": [
@@ -9980,7 +9980,7 @@
       },
       {
         "name": "/lists/files/:filename",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_cdb_list_controller_put_file",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.cdb_list_controller.put_file",
         "description": "Replace or upload a CDB list file with the data contained in the API request",
         "summary": "Update CDB list file",
         "tags": [
@@ -10026,7 +10026,7 @@
       },
       {
         "name": "/logtest",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_logtest_controller_run_logtest_tool",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.logtest_controller.run_logtest_tool",
         "description": "Run logtest tool to check if a specified log raises any alert among other information",
         "summary": "Run logtest",
         "tags": [
@@ -10081,7 +10081,7 @@
       },
       {
         "name": "/manager/configuration",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_manager_controller_update_configuration",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.manager_controller.update_configuration",
         "description": "Replace Wazuh configuration with the data contained in the API request",
         "summary": "Update Wazuh configuration",
         "tags": [
@@ -10108,7 +10108,7 @@
       },
       {
         "name": "/manager/restart",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_manager_controller_put_restart",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.manager_controller.put_restart",
         "description": "Restart the wazuh manager",
         "summary": "Restart manager",
         "tags": [
@@ -10135,7 +10135,7 @@
       },
       {
         "name": "/rootcheck",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_rootcheck_controller_put_rootcheck",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.rootcheck_controller.put_rootcheck",
         "description": "Run rootcheck scan in all agents or a list of them",
         "summary": "Run scan",
         "tags": [
@@ -10175,7 +10175,7 @@
       },
       {
         "name": "/rules/files/:filename",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_rule_controller_put_file",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.rule_controller.put_file",
         "description": "Upload or replace a user ruleset file content",
         "summary": "Update rules file",
         "tags": [
@@ -10221,7 +10221,7 @@
       },
       {
         "name": "/security/config",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_security_controller_put_security_config",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.security_controller.put_security_config",
         "description": "Update the security configuration with the data contained in the API request",
         "summary": "Update security config",
         "tags": [
@@ -10272,7 +10272,7 @@
       },
       {
         "name": "/security/policies/:policy_id",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_security_controller_update_policy",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.security_controller.update_policy",
         "description": "Modify a policy, at least one property must be indicated",
         "summary": "Update policy",
         "tags": [
@@ -10353,7 +10353,7 @@
       },
       {
         "name": "/security/roles/:role_id",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_security_controller_update_role",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.security_controller.update_role",
         "description": "Modify a role, cannot modify associated policies in this endpoint, at least one property must be indicated",
         "summary": "Update role",
         "tags": [
@@ -10405,7 +10405,7 @@
       },
       {
         "name": "/security/rules/:rule_id",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_security_controller_update_rule",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.security_controller.update_rule",
         "description": "Modify a security rule by specifying its ID",
         "summary": "Update security rule",
         "tags": [
@@ -10461,7 +10461,7 @@
       },
       {
         "name": "/security/user/revoke",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_security_controller_revoke_all_tokens",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.security_controller.revoke_all_tokens",
         "description": "This method should be called to revoke all active JWT tokens",
         "summary": "Revoke JWT tokens",
         "tags": [
@@ -10470,7 +10470,7 @@
       },
       {
         "name": "/security/users/:user_id",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_security_controller_update_user",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.security_controller.update_user",
         "description": "Modify a user's password by specifying their ID",
         "summary": "Update users",
         "tags": [
@@ -10520,7 +10520,7 @@
       },
       {
         "name": "/security/users/:user_id/run_as",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_security_controller_edit_run_as",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.security_controller.edit_run_as",
         "description": "Modify a user's allow_run_as flag by specifying their ID",
         "summary": "Enable/Disable run_as",
         "tags": [
@@ -10567,7 +10567,7 @@
       },
       {
         "name": "/syscheck",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_syscheck_controller_put_syscheck",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.syscheck_controller.put_syscheck",
         "description": "Run FIM scan in all agents",
         "summary": "Run scan",
         "tags": [
@@ -10607,7 +10607,7 @@
       },
       {
         "name": "/vulnerability",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_vulnerability_controller_run_vulnerability_scan",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.vulnerability_controller.run_vulnerability_scan",
         "description": "Run a vulnerability detector scan in all nodes",
         "summary": "Run vulnerability detector scan",
         "tags": [
@@ -10639,7 +10639,7 @@
     "endpoints": [
       {
         "name": "/agents",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_agent_controller_add_agent",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.agent_controller.add_agent",
         "description": "Add a new agent",
         "summary": "Add agent",
         "tags": [
@@ -10686,7 +10686,7 @@
       },
       {
         "name": "/agents/insert",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_agent_controller_insert_agent",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.agent_controller.insert_agent",
         "description": "Add an agent specifying its name, ID and IP. If an agent with the same name, the same ID or the same IP already exists, replace it using the `force` parameter",
         "summary": "Add agent full",
         "tags": [
@@ -10779,7 +10779,7 @@
       },
       {
         "name": "/agents/insert/quick",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_agent_controller_post_new_agent",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.agent_controller.post_new_agent",
         "description": "Add a new agent with name `agent_name`. This agent will use `any` as IP",
         "summary": "Add agent quick",
         "tags": [
@@ -10816,7 +10816,7 @@
       },
       {
         "name": "/groups",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_agent_controller_post_group",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.agent_controller.post_group",
         "description": "Create a new group",
         "summary": "Create a group",
         "tags": [
@@ -10859,7 +10859,7 @@
       },
       {
         "name": "/security/policies",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_security_controller_add_policy",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.security_controller.add_policy",
         "description": "Add a new policy, all fields need to be specified",
         "summary": "Add policy",
         "tags": [
@@ -10932,7 +10932,7 @@
       },
       {
         "name": "/security/roles",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_security_controller_add_role",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.security_controller.add_role",
         "description": "Add a new role, all fields need to be specified",
         "summary": "Add role",
         "tags": [
@@ -10975,7 +10975,7 @@
       },
       {
         "name": "/security/roles/:role_id/policies",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_security_controller_set_role_policy",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.security_controller.set_role_policy",
         "description": "Create a specified relation role-policy, one role may have multiples policies",
         "summary": "Add policies to role",
         "tags": [
@@ -11036,7 +11036,7 @@
       },
       {
         "name": "/security/roles/:role_id/rules",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_security_controller_set_role_rule",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.security_controller.set_role_rule",
         "description": "Create a specific role-rule relation. One role may have multiple security rules",
         "summary": "Add security rules to role",
         "tags": [
@@ -11088,7 +11088,7 @@
       },
       {
         "name": "/security/rules",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_security_controller_add_rule",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.security_controller.add_rule",
         "description": "Add a new security rule",
         "summary": "Add security rule",
         "tags": [
@@ -11136,7 +11136,7 @@
       },
       {
         "name": "/security/user/authenticate",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_security_controller_login_user",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.security_controller.login_user",
         "description": "This method should be called to get an API token. This token will expire after auth_token_exp_timeout seconds (default: 900). This value can be changed using PUT /security/config",
         "summary": "Login",
         "tags": [
@@ -11155,7 +11155,7 @@
       },
       {
         "name": "/security/user/authenticate/run_as",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_security_controller_run_as_login",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.security_controller.run_as_login",
         "description": "This method should be called to get an API token using an authorization context body. This token will expire after auth_token_exp_timeout seconds (default: 900). This value can be changed using PUT /security/config",
         "summary": "Login auth_context",
         "tags": [
@@ -11174,7 +11174,7 @@
       },
       {
         "name": "/security/users",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_security_controller_create_user",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.security_controller.create_user",
         "description": "Add a new API user to the system",
         "summary": "Add user",
         "tags": [
@@ -11222,7 +11222,7 @@
       },
       {
         "name": "/security/users/:user_id/roles",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_security_controller_set_user_role",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.security_controller.set_user_role",
         "description": "Create a specified relation role-policy, one user may have multiples roles",
         "summary": "Add roles to user",
         "tags": [
@@ -11288,7 +11288,7 @@
     "endpoints": [
       {
         "name": "/agents",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_agent_controller_delete_agents",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.agent_controller.delete_agents",
         "description": "Delete all agents or a list of them based on optional criteria",
         "summary": "Delete agents",
         "tags": [
@@ -11453,7 +11453,7 @@
       },
       {
         "name": "/agents/:agent_id/group",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_agent_controller_delete_single_agent_multiple_groups",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.agent_controller.delete_single_agent_multiple_groups",
         "description": "Remove the agent from all groups or a list of them. The agent will automatically revert to the default group if it is removed from all its assigned groups",
         "summary": "Remove agent from groups",
         "tags": [
@@ -11505,7 +11505,7 @@
       },
       {
         "name": "/agents/:agent_id/group/:group_id",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_agent_controller_delete_single_agent_single_group",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.agent_controller.delete_single_agent_single_group",
         "description": "Remove an agent from a specified group. If the agent belongs to several groups, only the specified group will be deleted.",
         "summary": "Remove agent from group",
         "tags": [
@@ -11555,7 +11555,7 @@
       },
       {
         "name": "/agents/group",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_agent_controller_delete_multiple_agent_single_group",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.agent_controller.delete_multiple_agent_single_group",
         "description": "Remove all agents assignment or a list of them from the specified group",
         "summary": "Remove agents from group",
         "tags": [
@@ -11606,7 +11606,7 @@
       },
       {
         "name": "/decoders/files/:filename",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_decoder_controller_delete_file",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.decoder_controller.delete_file",
         "description": "Delete a specified decoder file",
         "summary": "Delete decoders file",
         "tags": [
@@ -11644,7 +11644,7 @@
       },
       {
         "name": "/experimental/rootcheck",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_experimental_controller_clear_rootcheck_database",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.experimental_controller.clear_rootcheck_database",
         "description": "Clear rootcheck database for all agents or a list of them",
         "summary": "Clear rootcheck results",
         "tags": [
@@ -11685,7 +11685,7 @@
       },
       {
         "name": "/experimental/syscheck",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_experimental_controller_clear_syscheck_database",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.experimental_controller.clear_syscheck_database",
         "description": "Clear the syscheck database for all agents or a list of them",
         "summary": "Clear agents FIM results",
         "tags": [
@@ -11726,7 +11726,7 @@
       },
       {
         "name": "/groups",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_agent_controller_delete_groups",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.agent_controller.delete_groups",
         "description": "Delete all groups or a list of them",
         "summary": "Delete groups",
         "tags": [
@@ -11767,7 +11767,7 @@
       },
       {
         "name": "/lists/files/:filename",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_cdb_list_controller_delete_file",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.cdb_list_controller.delete_file",
         "description": "Delete a specified CDB list file. Only the filename can be specified. It will be searched recursively if not found",
         "summary": "Delete CDB list file",
         "tags": [
@@ -11805,7 +11805,7 @@
       },
       {
         "name": "/logtest/sessions/:token",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_logtest_controller_end_logtest_session",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.logtest_controller.end_logtest_session",
         "description": "Delete the saved logtest session corresponding to {token}",
         "summary": "End session",
         "tags": [
@@ -11843,7 +11843,7 @@
       },
       {
         "name": "/rootcheck/:agent_id",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_rootcheck_controller_delete_rootcheck",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.rootcheck_controller.delete_rootcheck",
         "description": "Clear an agent's rootcheck database",
         "summary": "Clear results",
         "tags": [
@@ -11883,7 +11883,7 @@
       },
       {
         "name": "/rules/files/:filename",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_rule_controller_delete_file",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.rule_controller.delete_file",
         "description": "Delete a specified rule file",
         "summary": "Delete rules file",
         "tags": [
@@ -11921,7 +11921,7 @@
       },
       {
         "name": "/security/config",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_security_controller_delete_security_config",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.security_controller.delete_security_config",
         "description": "Replaces the security configuration with the original one",
         "summary": "Restore default security config",
         "tags": [
@@ -11948,7 +11948,7 @@
       },
       {
         "name": "/security/policies",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_security_controller_remove_policies",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.security_controller.remove_policies",
         "description": "Delete a list of policies or all policies in the system, roles linked to policies are not going to be removed",
         "summary": "Delete policies",
         "tags": [
@@ -11988,7 +11988,7 @@
       },
       {
         "name": "/security/roles",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_security_controller_remove_roles",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.security_controller.remove_roles",
         "description": "Policies linked to roles are not going to be removed",
         "summary": "Delete roles",
         "tags": [
@@ -12028,7 +12028,7 @@
       },
       {
         "name": "/security/roles/:role_id/policies",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_security_controller_remove_role_policy",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.security_controller.remove_role_policy",
         "description": "Delete a specified relation role-policy",
         "summary": "Remove policies from role",
         "tags": [
@@ -12080,7 +12080,7 @@
       },
       {
         "name": "/security/roles/:role_id/rules",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_security_controller_remove_role_rule",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.security_controller.remove_role_rule",
         "description": "Delete a specific role-rule relation",
         "summary": "Remove security rules from role",
         "tags": [
@@ -12132,7 +12132,7 @@
       },
       {
         "name": "/security/rules",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_security_controller_remove_rules",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.security_controller.remove_rules",
         "description": "Delete a list of security rules or all security rules in the system, roles linked to rules are not going to be deleted",
         "summary": "Delete security rules",
         "tags": [
@@ -12172,7 +12172,7 @@
       },
       {
         "name": "/security/user/authenticate",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_security_controller_logout_user",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.security_controller.logout_user",
         "description": "This method should be called to invalidate all the current user's tokens",
         "summary": "Logout current user",
         "tags": [
@@ -12181,7 +12181,7 @@
       },
       {
         "name": "/security/users",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_security_controller_delete_users",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.security_controller.delete_users",
         "description": "Delete a list of users by specifying their IDs",
         "summary": "Delete users",
         "tags": [
@@ -12221,7 +12221,7 @@
       },
       {
         "name": "/security/users/:user_id/roles",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_security_controller_remove_user_role",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.security_controller.remove_user_role",
         "description": "Delete a specified relation user-roles",
         "summary": "Remove roles from user",
         "tags": [
@@ -12273,7 +12273,7 @@
       },
       {
         "name": "/syscheck/:agent_id",
-        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api_controllers_syscheck_controller_delete_syscheck_agent",
+        "documentation": "https://documentation.wazuh.com/4.6/user-manual/api/reference.html#operation/api.controllers.syscheck_controller.delete_syscheck_agent",
         "description": "Clear file integrity monitoring scan results for a specified agent. Only available for agents < 3.12.0, it doesn't apply for more recent ones",
         "summary": "Clear results",
         "tags": [

--- a/plugins/main/scripts/generate-api-data.js
+++ b/plugins/main/scripts/generate-api-data.js
@@ -361,7 +361,7 @@ node ${cliFilePath} --spec https://raw.githubusercontent.com/wazuh/wazuh/master/
 
             const name = formatEndpointPath(endpointPath);
             const documentation = generateEndpointDocumentationLink(
-              endpointMethodData.operationId,
+              endpointMethodData.__originalOperationId, // original operation ID
             );
             // Endpoint path parameters
             const args = endpointMethodParameters


### PR DESCRIPTION
Backport f33281701a6a3255b500527acf07d255f29bc921 from #5611
