### PR TITLE
[Backport 4.4.5-7.16] Bump Wazuh and platform versions for v4.4.5 (#5639)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the Wazuh app project will be documented in this file.
 
+## Wazuh v4.4.5 - Kibana 7.10.2, 7.16.x, 7.17.x - Revision 01
+
+### Added
+
+- Support for Wazuh 4.4.5
+
 ## Wazuh v4.4.4 - Kibana 7.10.2, 7.16.x, 7.17.x - Revision 01
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ This plugin for Kibana allows you to visualize and analyze Wazuh alerts stored i
 
 ## Requisites
 
-- Wazuh HIDS 4.4.4
+- Wazuh HIDS 4.4.5
 - Kibana 7.16.x or 7.17.x
 - Elasticsearch 7.16.x or 7.17.x
 
@@ -107,7 +107,7 @@ Install the Wazuh app plugin for Kibana
 
 ```
 cd /usr/share/kibana
-sudo -u kibana bin/kibana-plugin install https://packages.wazuh.com/4.x/ui/kibana/wazuh_kibana-4.4.4_7.16.0-1.zip
+sudo -u kibana bin/kibana-plugin install https://packages.wazuh.com/4.x/ui/kibana/wazuh_kibana-4.4.5_7.16.0-1.zip
 ```
 
 Restart Kibana

--- a/kibana.json
+++ b/kibana.json
@@ -1,10 +1,8 @@
 {
   "id": "wazuh",
-  "version": "4.4.4-01",
+  "version": "4.4.5-01",
   "kibanaVersion": "kibana",
-  "configPath": [
-    "wazuh"
-  ],
+  "configPath": ["wazuh"],
   "requiredPlugins": [
     "navigation",
     "data",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wazuh",
-  "version": "4.4.4",
+  "version": "4.4.5",
   "revision": "01",
   "stage": "stable",
   "commit": "6267c16e8",

--- a/scripts/tag.py
+++ b/scripts/tag.py
@@ -15,7 +15,7 @@ import subprocess
 # ======================================================= #
 
 # Wazuh version: major.minor.patch
-version = '4.4.4'
+version = '4.4.5'
 # App's revision number (previous rev + 1)
 revision = '01'
 # One of 'pre-alpha', 'alpha', 'beta', 'release-candidate', 'stable'

--- a/scripts/tag.py
+++ b/scripts/tag.py
@@ -20,8 +20,8 @@ version = '4.4.5'
 revision = '01'
 # One of 'pre-alpha', 'alpha', 'beta', 'release-candidate', 'stable'
 stage = 'stable'
-# Tag suffix. Usually set to stage + stage iteration.
-tag_suffix = '-rc2'
+# Tag suffix. Usually set to stage + stage iteration. E.g. '-rc1'
+tag_suffix = ''
 
 # ================================================ #
 # Constants and global variables                   #

--- a/scripts/tag.py
+++ b/scripts/tag.py
@@ -30,7 +30,7 @@ LOG_FILE = 'output.log'
 TAGS_FILE = 'tags.log'
 # Global variable. Will be set later
 branch = None
-minor = ".".join(version.split('.')[:2])
+minor = version
 
 # Supported versions of Kibana
 kbn_versions = [


### PR DESCRIPTION
Backport https://github.com/wazuh/wazuh-kibana-app/commit/b33c4a5dfcc4349dd0c4635f8b242f5208f17722 from https://github.com/wazuh/wazuh-kibana-app/pull/5639.