### PR TITLE
Fix API request to get the manager labels and broken documentation link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 
 - Fixed the rendering of tables that contains IPs and agent overview [#5471](https://github.com/wazuh/wazuh-kibana-app/pull/5471)
 - Fixed the agents active coverage stat as NaN in Details panel of Agents section [#5490](https://github.com/wazuh/wazuh-kibana-app/pull/5490)
+- Fixed a broken documentation link to agent labels [#5687](https://github.com/wazuh/wazuh-kibana-app/pull/5687)
 
 ### Removed
 
@@ -35,7 +36,6 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Support for Wazuh 4.4.5
 
 ## Wazuh v4.4.4 - OpenSearch Dashboards 2.6.0 - Revision 01
-
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 
 ### Changed
 
-- Chenged the requests to get the agent labels for the managers [#5687](https://github.com/wazuh/wazuh-kibana-app/pull/5687)
+- Changed the requests to get the agent labels for the managers [#5687](https://github.com/wazuh/wazuh-kibana-app/pull/5687)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,6 @@ All notable changes to the Wazuh app project will be documented in this file.
 
 - Add Apple Silicon architecture button to the register Agent wizard [#5478](https://github.com/wazuh/wazuh-kibana-app/pull/5478)
 
-### Changed
-
-- Changed the requests to get the agent labels for the managers [#5687](https://github.com/wazuh/wazuh-kibana-app/pull/5687)
-
 ### Fixed
 
 - Fixed the rendering of tables that contains IPs and agent overview [#5471](https://github.com/wazuh/wazuh-kibana-app/pull/5471)
@@ -26,6 +22,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 
 - Changed method to perform redirection on agent table buttons [#5539](https://github.com/wazuh/wazuh-kibana-app/pull/5539)
 - Changed windows agent service name in the deploy agent wizard [#5538](https://github.com/wazuh/wazuh-kibana-app/pull/5538)
+- Changed the requests to get the agent labels for the managers [#5687](https://github.com/wazuh/wazuh-kibana-app/pull/5687)
 
 ## Wazuh v4.5.0 - OpenSearch Dashboards 2.6.0 - Revision 01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to the Wazuh app project will be documented in this file.
 
 - Add Apple Silicon architecture button to the register Agent wizard [#5478](https://github.com/wazuh/wazuh-kibana-app/pull/5478)
 
+### Changed
+
+- Chenged the requests to get the agent labels for the managers [#5687](https://github.com/wazuh/wazuh-kibana-app/pull/5687)
+
 ### Fixed
 
 - Fixed the rendering of tables that contains IPs and agent overview [#5471](https://github.com/wazuh/wazuh-kibana-app/pull/5471)

--- a/docker/imposter/agents/configuration.js
+++ b/docker/imposter/agents/configuration.js
@@ -1,0 +1,15 @@
+var path = context.request.path;
+var pathConfiguration = path.split('/');
+pathConfiguration.splice(0, 5);
+console.log(pathConfiguration);
+switch (pathConfiguration[0]) {
+  case 'labels':
+    respond()
+      .withStatusCode(200)
+      .withFile('agents/configuration/agent_labels.json');
+
+    break;
+  default:
+    respond().withStatusCode(200).withFile('agents/configuration/default.json');
+    break;
+}

--- a/docker/imposter/agents/configuration/agent_labels.json
+++ b/docker/imposter/agents/configuration/agent_labels.json
@@ -1,0 +1,12 @@
+{
+  "data": {
+    "labels": [
+      {
+        "value": "customLabel",
+        "key": "custom",
+        "hidden": "no"
+      }
+    ]
+  },
+  "error": 0
+}

--- a/docker/imposter/agents/configuration/default.json
+++ b/docker/imposter/agents/configuration/default.json
@@ -1,0 +1,33 @@
+{
+  "data": {
+    "client": {
+      "config-profile": "ubuntu, ubuntu20, ubuntu20.04",
+      "notify_time": 10,
+      "time-reconnect": 60,
+      "force_reconnect_interval": 0,
+      "ip_update_interval": 0,
+      "auto_restart": "yes",
+      "remote_conf": "yes",
+      "crypto_method": "aes",
+      "server": [
+        {
+          "address": "nginx-lb/172.25.0.4",
+          "port": 1514,
+          "max_retries": 5,
+          "retry_interval": 10,
+          "protocol": "tcp"
+        }
+      ],
+      "enrollment": [
+        {
+          "enabled": "yes",
+          "delay_after_enrollment": 20,
+          "port": 1515,
+          "ssl_cipher": "HIGH:!ADH:!EXP:!MD5:!RC4:!3DES:!CAMELLIA:@STRENGTH",
+          "auto_method": "no"
+        }
+      ]
+    }
+  },
+  "error": 0
+}

--- a/docker/imposter/cluster/configuration/agent_labels.json
+++ b/docker/imposter/cluster/configuration/agent_labels.json
@@ -1,0 +1,20 @@
+{
+  "data": {
+    "affected_items": [
+      {
+        "labels": [
+          {
+            "value": "customLabel",
+            "key": "custom",
+            "hidden": "no"
+          }
+        ]
+      }
+    ],
+    "total_affected_items": 1,
+    "total_failed_items": 0,
+    "failed_items": []
+  },
+  "message": "Active configuration was successfully read in specified node.",
+  "error": 0
+}

--- a/docker/imposter/manager/configuration.js
+++ b/docker/imposter/manager/configuration.js
@@ -1,0 +1,22 @@
+var path = context.request.path;
+var pathConfiguration = path.split('/');
+pathConfiguration.splice(0, 4);
+switch (pathConfiguration[0]) {
+  case 'labels':
+    respond()
+      .withStatusCode(200)
+      .withFile('manager/configuration/agent_labels.json');
+
+    break;
+  case 'reports':
+    respond()
+      .withStatusCode(200)
+      .withFile('manager/configuration/monitor_reports.json');
+
+    break;
+  default:
+    respond()
+      .withStatusCode(200)
+      .withFile('manager/configuration/default.json');
+    break;
+}

--- a/docker/imposter/manager/configuration/agent_labels.json
+++ b/docker/imposter/manager/configuration/agent_labels.json
@@ -1,0 +1,20 @@
+{
+  "data": {
+    "affected_items": [
+      {
+        "labels": [
+          {
+            "value": "customLabel",
+            "key": "custom",
+            "hidden": "no"
+          }
+        ]
+      }
+    ],
+    "total_affected_items": 1,
+    "total_failed_items": 0,
+    "failed_items": []
+  },
+  "message": "Active configuration was successfully read in specified node.",
+  "error": 0
+}

--- a/docker/imposter/manager/configuration/default.json
+++ b/docker/imposter/manager/configuration/default.json
@@ -1,0 +1,35 @@
+{
+  "data": {
+    "affected_items": [
+      {
+        "global": {
+          "email_notification": "no",
+          "logall": "no",
+          "logall_json": "no",
+          "integrity_checking": 8,
+          "rootkit_detection": 8,
+          "host_information": 8,
+          "prelude_output": "no",
+          "zeromq_output": "no",
+          "jsonout_output": "yes",
+          "alerts_log": "yes",
+          "stats": 4,
+          "memory_size": 8192,
+          "white_list": [
+            "127.0.0.1",
+            "80.58.61.250",
+            "80.58.61.254",
+            "localhost.localdomain"
+          ],
+          "rotate_interval": 0,
+          "max_output_size": 0
+        }
+      }
+    ],
+    "total_affected_items": 1,
+    "total_failed_items": 0,
+    "failed_items": []
+  },
+  "message": "Active configuration was successfully read in specified node",
+  "error": 0
+}

--- a/docker/imposter/manager/configuration/monitor_reports.json
+++ b/docker/imposter/manager/configuration/monitor_reports.json
@@ -1,0 +1,16 @@
+{
+    "data": {
+        "affected_items": [{
+            "reports": [{
+                "category": "syscheck",
+                "title": "Daily report: File changes",
+                "email_to": "example@test.com"
+            }]
+        }],
+        "total_affected_items": 1,
+        "total_failed_items": 0,
+        "failed_items": []
+    },
+    "message": "Could not read active configuration in specified node",
+    "error": 0
+}

--- a/docker/imposter/wazuh-config.yml
+++ b/docker/imposter/wazuh-config.yml
@@ -50,6 +50,9 @@ resources:
   # Get active configuration
   - method: GET
     path: /agents/{agent_id}/config/{component}/{configuration}
+    response:
+      statusCode: 200
+      scriptFile: agents/configuration.js
 
   # Remove agent from groups
   - method: DELETE
@@ -501,6 +504,9 @@ resources:
   # Get active configuration
   - method: GET
     path: /manager/configuration/{component}/{configuration}
+    response:
+      statusCode: 200
+      scriptFile: manager/configuration.js
 
   # ===================================================== #
   #   MITRE

--- a/public/controllers/management/components/management/configuration/alerts/alerts-labels.js
+++ b/public/controllers/management/components/management/configuration/alerts/alerts-labels.js
@@ -49,56 +49,25 @@ class WzConfigurationAlertsLabels extends Component {
     const { currentConfig, agent, wazuhNotReadyYet } = this.props;
     return (
       <Fragment>
-        {currentConfig[
-          agent && agent.id !== '000' ? 'agent-labels' : 'analysis-labels'
-        ] &&
-          isString(
-            currentConfig[
-              agent && agent.id !== '000' ? 'agent-labels' : 'analysis-labels'
-            ],
-          ) && (
+        {currentConfig['agent-labels'] &&
+          isString(currentConfig['agent-labels']) && (
             <WzNoConfig
-              error={
-                currentConfig[
-                  agent && agent.id !== '000'
-                    ? 'agent-labels'
-                    : 'analysis-labels'
-                ]
-              }
+              error={currentConfig['agent-labels']}
               help={helpLinks}
             />
           )}
-        {currentConfig[
-          agent && agent.id !== '000' ? 'agent-labels' : 'analysis-labels'
-        ] &&
-          !isString(
-            currentConfig[
-              agent && agent.id !== '000' ? 'agent-labels' : 'analysis-labels'
-            ],
-          ) &&
-          !hasSize(
-            currentConfig[
-              agent && agent.id !== '000' ? 'agent-labels' : 'analysis-labels'
-            ].labels,
-          ) && <WzNoConfig error='not-present' help={helpLinks} />}
+        {currentConfig['agent-labels'] &&
+          !isString(currentConfig['agent-labels']) &&
+          !hasSize(currentConfig['agent-labels'].labels) && (
+            <WzNoConfig error='not-present' help={helpLinks} />
+          )}
         {wazuhNotReadyYet &&
-          (!currentConfig ||
-            !currentConfig[
-              agent && agent.id !== '000' ? 'agent-labels' : 'analysis-labels'
-            ]) && <WzNoConfig error='Wazuh not ready yet' />}
-        {currentConfig[
-          agent && agent.id !== '000' ? 'agent-labels' : 'analysis-labels'
-        ] &&
-        !isString(
-          currentConfig[
-            agent && agent.id !== '000' ? 'agent-labels' : 'analysis-labels'
-          ],
-        ) &&
-        hasSize(
-          currentConfig[
-            agent && agent.id !== '000' ? 'agent-labels' : 'analysis-labels'
-          ].labels,
-        ) ? (
+          (!currentConfig || !currentConfig['agent-labels']) && (
+            <WzNoConfig error='Wazuh not ready yet' />
+          )}
+        {currentConfig['agent-labels'] &&
+        !isString(currentConfig['agent-labels']) &&
+        hasSize(currentConfig['agent-labels'].labels) ? (
           <WzConfigurationSettingsTabSelector
             title='Defined labels'
             currentConfig={currentConfig}
@@ -107,13 +76,7 @@ class WzConfigurationAlertsLabels extends Component {
           >
             <EuiBasicTable
               columns={columns}
-              items={
-                currentConfig[
-                  agent && agent.id !== '000'
-                    ? 'agent-labels'
-                    : 'analysis-labels'
-                ].labels
-              }
+              items={currentConfig['agent-labels'].labels}
             />
           </WzConfigurationSettingsTabSelector>
         ) : null}

--- a/public/controllers/management/components/management/configuration/alerts/alerts-labels.js
+++ b/public/controllers/management/components/management/configuration/alerts/alerts-labels.js
@@ -27,18 +27,18 @@ import { webDocumentationLink } from '../../../../../../../common/services/web_d
 const columns = [
   { field: 'key', name: 'Label key' },
   { field: 'value', name: 'Label value' },
-  { field: 'hidden', name: 'Hidden' }
+  { field: 'hidden', name: 'Hidden' },
 ];
 
 const helpLinks = [
   {
     text: 'Agent labels',
-    href: webDocumentationLink('user-manual/capabilities/labels.html')
+    href: webDocumentationLink('user-manual/agents/labels.html'),
   },
   {
     text: 'Labels reference',
-    href: webDocumentationLink('user-manual/reference/ossec-conf/labels.html')
-  }
+    href: webDocumentationLink('user-manual/reference/ossec-conf/labels.html'),
+  },
 ];
 
 class WzConfigurationAlertsLabels extends Component {
@@ -55,7 +55,7 @@ class WzConfigurationAlertsLabels extends Component {
           isString(
             currentConfig[
               agent && agent.id !== '000' ? 'agent-labels' : 'analysis-labels'
-            ]
+            ],
           ) && (
             <WzNoConfig
               error={
@@ -74,33 +74,33 @@ class WzConfigurationAlertsLabels extends Component {
           !isString(
             currentConfig[
               agent && agent.id !== '000' ? 'agent-labels' : 'analysis-labels'
-            ]
+            ],
           ) &&
           !hasSize(
             currentConfig[
               agent && agent.id !== '000' ? 'agent-labels' : 'analysis-labels'
-            ].labels
-          ) && <WzNoConfig error="not-present" help={helpLinks} />}
+            ].labels,
+          ) && <WzNoConfig error='not-present' help={helpLinks} />}
         {wazuhNotReadyYet &&
           (!currentConfig ||
             !currentConfig[
               agent && agent.id !== '000' ? 'agent-labels' : 'analysis-labels'
-            ]) && <WzNoConfig error="Wazuh not ready yet" />}
+            ]) && <WzNoConfig error='Wazuh not ready yet' />}
         {currentConfig[
           agent && agent.id !== '000' ? 'agent-labels' : 'analysis-labels'
         ] &&
         !isString(
           currentConfig[
             agent && agent.id !== '000' ? 'agent-labels' : 'analysis-labels'
-          ]
+          ],
         ) &&
         hasSize(
           currentConfig[
             agent && agent.id !== '000' ? 'agent-labels' : 'analysis-labels'
-          ].labels
+          ].labels,
         ) ? (
           <WzConfigurationSettingsTabSelector
-            title="Defined labels"
+            title='Defined labels'
             currentConfig={currentConfig}
             minusHeight={agent.id === '000' ? 320 : 355}
             helpLinks={helpLinks}
@@ -123,7 +123,7 @@ class WzConfigurationAlertsLabels extends Component {
 }
 
 const mapStateToProps = state => ({
-  wazuhNotReadyYet: state.appStateReducers.wazuhNotReadyYet
+  wazuhNotReadyYet: state.appStateReducers.wazuhNotReadyYet,
 });
 
 export default connect(mapStateToProps)(WzConfigurationAlertsLabels);
@@ -132,15 +132,15 @@ const sectionsAgent = [{ component: 'agent', configuration: 'labels' }];
 
 export const WzConfigurationAlertsLabelsAgent = compose(
   connect(mapStateToProps),
-  withWzConfig(sectionsAgent)
+  withWzConfig(sectionsAgent),
 )(WzConfigurationAlertsLabels);
 
 WzConfigurationAlertsLabels.propTypes = {
   // currentConfig: PropTypes.object.isRequired,
-  wazuhNotReadyYet: PropTypes.oneOfType([PropTypes.bool, PropTypes.string])
+  wazuhNotReadyYet: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
 };
 
 WzConfigurationAlertsLabelsAgent.propTypes = {
   // currentConfig: PropTypes.object.isRequired,
-  wazuhNotReadyYet: PropTypes.oneOfType([PropTypes.bool, PropTypes.string])
+  wazuhNotReadyYet: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
 };

--- a/public/controllers/management/components/management/configuration/alerts/alerts.js
+++ b/public/controllers/management/components/management/configuration/alerts/alerts.js
@@ -14,7 +14,7 @@ import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 
 import WzTabSelector, {
-  WzTabSelectorTab
+  WzTabSelectorTab,
 } from '../util-components/tab-selector';
 import withWzConfig from '../util-hocs/wz-config';
 import WzConfigurationAlertsGeneral from './alerts-general';
@@ -34,19 +34,19 @@ class WzConfigurationAlerts extends Component {
     return (
       <Fragment>
         <WzTabSelector>
-          <WzTabSelectorTab label="General">
+          <WzTabSelectorTab label='General'>
             <WzConfigurationAlertsGeneral {...this.props} />
           </WzTabSelectorTab>
-          <WzTabSelectorTab label="Labels">
+          <WzTabSelectorTab label='Labels'>
             <WzConfigurationAlertsLabels {...this.props} />
           </WzTabSelectorTab>
-          <WzTabSelectorTab label="Email alerts">
+          <WzTabSelectorTab label='Email alerts'>
             <WzConfigurationAlertsEmailAlerts {...this.props} />
           </WzTabSelectorTab>
-          <WzTabSelectorTab label="Reports">
+          <WzTabSelectorTab label='Reports'>
             <WzConfigurationAlertsEmailReports {...this.props} />
           </WzTabSelectorTab>
-          <WzTabSelectorTab label="Syslog output">
+          <WzTabSelectorTab label='Syslog output'>
             <WzConfigurationAlertsSyslogOutput {...this.props} />
           </WzTabSelectorTab>
         </WzTabSelector>
@@ -57,22 +57,22 @@ class WzConfigurationAlerts extends Component {
 
 const sections = [
   { component: 'analysis', configuration: 'alerts' },
-  { component: 'analysis', configuration: 'labels' },
+  { component: 'agent', configuration: 'labels' },
   { component: 'mail', configuration: 'alerts' },
   { component: 'monitor', configuration: 'reports' },
-  { component: 'csyslog', configuration: 'csyslog' }
+  { component: 'csyslog', configuration: 'csyslog' },
 ];
 
 const mapStateToProps = state => ({
-  wazuhNotReadyYet: state.appStateReducers.wazuhNotReadyYet
+  wazuhNotReadyYet: state.appStateReducers.wazuhNotReadyYet,
 });
 
 WzConfigurationAlerts.propTypes = {
   // currentConfig: PropTypes.object.isRequired,
-  wazuhNotReadyYet: PropTypes.oneOfType([PropTypes.bool, PropTypes.string])
+  wazuhNotReadyYet: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
 };
 
 export default compose(
   withWzConfig(sections),
-  connect(mapStateToProps)
+  connect(mapStateToProps),
 )(WzConfigurationAlerts);


### PR DESCRIPTION
### Description

Changes:
- API request to get the manager labels

Fixed:
- Broken documentation link to the agent labels
 
### Issues Resolved
#5565

### Evidence


# Check

Check changes in https://github.com/wazuh/wazuh/issues/17610.

I installed from sources a Wazuh manager based in the current `4.5.1` version.
```json
{"data": {"title": "Wazuh API REST", "api_version": "4.5.1", "revision": 40501, "license_name": "GPL 2.0", "license_url": "https://github.com/wazuh/wazuh/blob/v4.5.1/LICENSE", "hostname": "wazuh-manager-master-7102", "timestamp": "2023-07-18T11:10:11Z"}, "error": 0}
```

Review changes in https://github.com/wazuh/wazuh/issues/17610

## Labels manager

- Manager
Adapting the API request and managing the response:
![image](https://github.com/wazuh/wazuh-kibana-app/assets/34042064/bdf1a0a2-b568-4aa3-9aa2-99d74082576a)
![image](https://github.com/wazuh/wazuh-kibana-app/assets/34042064/0db89bfd-36d0-4f51-8b10-4cfb440439f3)

- Cluster
Adapting the API request and managing the response:
![image](https://github.com/wazuh/wazuh-kibana-app/assets/34042064/ba8aef00-3f58-4cae-bb9e-3e76f25fb889)
![image](https://github.com/wazuh/wazuh-kibana-app/assets/34042064/a9b92548-3a25-482a-b719-b0d0cd1a64ec)

## Labels - agent

- API request
![image](https://github.com/wazuh/wazuh-kibana-app/assets/34042064/e9a36bf8-4226-4c37-baa8-fe839568ed9f)

- UI
![image](https://github.com/wazuh/wazuh-kibana-app/assets/34042064/7dfd7144-9d7f-4186-9c2e-a8c786700abf)

### Reports

- Cluster node
![image](https://github.com/wazuh/wazuh-kibana-app/assets/34042064/0c1cf56a-9795-4ed6-9f06-00a5c27515a4)

- Manager node
![image](https://github.com/wazuh/wazuh-kibana-app/assets/34042064/18c4dda7-6f4f-4cba-8335-654d623785d2)

- UI
![image](https://github.com/wazuh/wazuh-kibana-app/assets/34042064/ff04a9f8-57c9-4e94-be0d-b1082b8cbf90)

### Test

# Wazuh dashboard

Legend:
:black_circle:: none
:green_circle:: pass
:yellow_circle:: warning
:red_circle:: fail
:white_circle:: not applicable

## UI

| Test | Chrome | Firefox | Safari |
| --- |  --- | --- | --- |
| Select an agent and go to its Labels configuration. Review the Agents labels help link is pointing to user-manual/agents/labels.html | :black_circle: | :black_circle: | :black_circle: |
| Configure the manager labels and see in Management> Configuration > Alerts > Labels the labels are displayed (Manager mode) | :black_circle: | :black_circle: | :black_circle: |
| Configure the manager labels and see in Management> Configuration > Alerts > Labels the labels are displayed (Cluster mode) | :black_circle: | :black_circle: | :black_circle: |
| Configure the manager reports and see in Management> Configuration > Alerts > Reports the reports are displayed (Manager mode) | :black_circle: | :black_circle: | :black_circle: |
| Configure the manager reports and see in Management> Configuration > Alerts > Reports the reports are displayed (Cluster mode) | :black_circle: | :black_circle: | :black_circle: |
| Configure the agent labels and see in Configuration > Labels the labels are displayed | :black_circle: | :black_circle: | :black_circle: |

**Details**
<details>
<summary>:black_circle: Select an agent and go to its Labels configuration. Review the Agents labels help link is pointing to user-manual/agents/labels.html</summary>

Chrome - :black_circle:

Firefox - :black_circle:

Safari - :black_circle:

</details>

<details>
<summary>:black_circle: Configure the manager labels and see in Management> Configuration > Alerts > Labels the labels are displayed (Manager mode)</summary>

Chrome - :black_circle:

Firefox - :black_circle:

Safari - :black_circle:

</details>

<details>
<summary>:black_circle: Configure the manager labels and see in Management> Configuration > Alerts > Labels the labels are displayed (Cluster mode)</summary>

Chrome - :black_circle:

Firefox - :black_circle:

Safari - :black_circle:

</details>

<details>
<summary>:black_circle: Configure the manager reports and see in Management> Configuration > Alerts > Reports the reports are displayed (Manager mode)</summary>

Chrome - :black_circle:

Firefox - :black_circle:

Safari - :black_circle:

</details>

<details>
<summary>:black_circle: Configure the manager reports and see in Management> Configuration > Alerts > Reports the reports are displayed (Cluster mode)</summary>

Chrome - :black_circle:

Firefox - :black_circle:

Safari - :black_circle:

</details>

<details>
<summary>:black_circle: Configure the agent labels and see in Configuration > Labels the labels are displayed</summary>

Chrome - :black_circle:

Firefox - :black_circle:

Safari - :black_circle:

</details>

### Check List
- [x] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 
