### PR TITLE
Fix documentation link of manager address in the Deploy new agent guide

### DIFF
--- a/plugins/main/public/controllers/register-agent/components/server-address/server-address.tsx
+++ b/plugins/main/public/controllers/register-agent/components/server-address/server-address.tsx
@@ -23,7 +23,7 @@ const popoverServerAddress = (
     Learn about{' '}
     <EuiLink
       href={webDocumentationLink(
-        'user-manual/reference/ossec-conf/client.html#groups',
+        'user-manual/reference/ossec-conf/client.html#manager-address',
         PLUGIN_VERSION_SHORT,
       )}
       target='_blank'


### PR DESCRIPTION
### Description
This pull request fixes the documenation link to the manager address.
 
### Issues Resolved
#5865

### Evidence
![image](https://github.com/wazuh/wazuh-kibana-app/assets/34042064/3f9d0a3d-f328-4f4a-abad-ce2f7e1d3bb5)

### Test

Legend:
:black_circle:: none
:green_circle:: pass
:yellow_circle:: warning
:red_circle:: fail
:white_circle:: not applicable

## UI

| Test | Chrome | Firefox | Safari |
| --- |  --- | --- | --- |
| Ensure the Server address documentation link is pointing to https://documentation.wazuh.com/4.6/user-manual/reference/ossec-conf/client.html#manager-address | :black_circle: | :black_circle: | :black_circle: |

**Details**
<details>
<summary>:black_circle: Ensure the Server address documentation link is pointing to https://documentation.wazuh.com/4.6/user-manual/reference/ossec-conf/client.html#manager-address</summary>

Chrome - :black_circle:

Firefox - :black_circle:

Safari - :black_circle:

</details>

### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 
