### PR TITLE
[Register Agent ] Fixed package URLs in aarch64 commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fixed repeated requests in the group table when adding a group or refreshing the table [#5465](https://github.com/wazuh/wazuh-kibana-app/pull/5465)
 - Fixed an error in the request body suggestions of API Console [#5521](https://github.com/wazuh/wazuh-kibana-app/pull/5521)
 - Fixed some errors related to relative dirname of rule and decoder files [#5734](https://github.com/wazuh/wazuh-kibana-app/pull/5734)
+- Fixed package URLs in aarch64 commands [#5879](https://github.com/wazuh/wazuh-kibana-app/pull/5879)
 
 ### Removed
 

--- a/plugins/main/public/controllers/register-agent/core/config/os-commands-definitions.ts
+++ b/plugins/main/public/controllers/register-agent/core/config/os-commands-definitions.ts
@@ -1,11 +1,13 @@
 import { 
-  getDEBInstallCommand,
-  getRPMInstallCommand,
   getLinuxStartCommand, 
   getMacOsInstallCommand, 
   getMacosStartCommand, 
   getWindowsInstallCommand, 
-  getWindowsStartCommand } from '../../services/register-agent-os-commands-services';
+  getWindowsStartCommand, 
+  getDEBAMD64InstallCommand,
+  getRPMAMD64InstallCommand,
+  getRPMARM64InstallCommand,
+  getDEBARM64InstallCommand} from '../../services/register-agent-os-commands-services';
 import { IOSDefinition, tOptionalParams } from '../register-commands/types';
 
 // Defined OS combinations
@@ -76,28 +78,28 @@ const linuxDefinition: IOSDefinition<ILinuxOSTypes, tOptionalParameters> = {
       architecture: 'DEB amd64',
       urlPackage: props =>
         `https://packages.wazuh.com/4.x/apt/pool/main/w/wazuh-agent/wazuh-agent_${props.wazuhVersion}-1_amd64.deb`,
-      installCommand: props => getDEBInstallCommand(props),
-      startCommand: props => getLinuxStartCommand(props),
-    },
-    {
-      architecture: 'DEB aarch64',
-      urlPackage: props =>
-        `https://packages.wazuh.com/4.x/apt/pool/main/w/wazuh-agent/wazuh-agent_${props.wazuhVersion}-1_amd64.deb`,
-      installCommand: props => getDEBInstallCommand(props),
+      installCommand: props => getDEBAMD64InstallCommand(props),
       startCommand: props => getLinuxStartCommand(props),
     },
     {
       architecture: 'RPM amd64',
       urlPackage: props =>
         `https://packages.wazuh.com/4.x/yum/wazuh-agent-${props.wazuhVersion}-1.x86_64.rpm`,
-      installCommand: props => getRPMInstallCommand(props),
+      installCommand: props => getRPMAMD64InstallCommand(props),
+      startCommand: props => getLinuxStartCommand(props),
+    },
+    {
+      architecture: 'DEB aarch64',
+      urlPackage: props =>
+        `https://packages.wazuh.com/4.x/apt/pool/main/w/wazuh-agent/wazuh-agent_${props.wazuhVersion}-1_arm64.deb`,
+      installCommand: props => getDEBARM64InstallCommand(props),
       startCommand: props => getLinuxStartCommand(props),
     },
     {
       architecture: 'RPM aarch64',
       urlPackage: props =>
-      `https://packages.wazuh.com/4.x/yum/wazuh-agent-${props.wazuhVersion}-1.x86_64.rpm`,
-      installCommand: props => getRPMInstallCommand(props),
+      `https://packages.wazuh.com/4.x/yum/wazuh-agent-${props.wazuhVersion}-1.aarch64.rpm`,
+      installCommand: props => getRPMARM64InstallCommand(props),
       startCommand: props => getLinuxStartCommand(props),
     },
   ],

--- a/plugins/main/public/controllers/register-agent/services/register-agent-os-commands-services.tsx
+++ b/plugins/main/public/controllers/register-agent/services/register-agent-os-commands-services.tsx
@@ -53,26 +53,9 @@ const getAllOptionalsMacos = (
   );
 };
 
-
-/******* RPM *******/
-
-// curl -o wazuh-agent-4.4.5-1.x86_64.rpm https://packages.wazuh.com/4.x/yum/wazuh-agent-4.4.5-1.x86_64.rpm && sudo WAZUH_MANAGER='172.30.30.20' rpm -ihv wazuh-agent-4.4.5-1.x86_64.rpm
-
-export const getRPMInstallCommand = (
-  props: tOSEntryInstallCommand<tOptionalParameters>,
-) => {
-  const { optionals, urlPackage, wazuhVersion } = props;
-  const packageName = `wazuh-agent-${wazuhVersion}-1.x86_64.rpm`
-  return `curl -o ${packageName} ${urlPackage} && sudo ${
-    optionals && getAllOptionals(optionals)
-  }rpm -ihv ${packageName}`;
-};
-
 /******* DEB *******/
 
-// wget https://packages.wazuh.com/4.x/apt/pool/main/w/wazuh-agent/wazuh-agent_4.4.5-1_amd64.deb && sudo WAZUH_MANAGER='172.30.30.20' dpkg -i ./wazuh-agent_4.4.5-1_amd64.deb
-
-export const getDEBInstallCommand = (
+export const getDEBAMD64InstallCommand = (
   props: tOSEntryInstallCommand<tOptionalParameters>,
 ) => {
   const { optionals, urlPackage, wazuhVersion } = props;
@@ -80,6 +63,39 @@ export const getDEBInstallCommand = (
   return `wget ${urlPackage} && sudo ${
     optionals && getAllOptionals(optionals)
   }dpkg -i ./${packageName}`;
+};
+
+
+export const getDEBARM64InstallCommand = (
+  props: tOSEntryInstallCommand<tOptionalParameters>,
+) => {
+  const { optionals, urlPackage, wazuhVersion } = props;
+  const packageName = `wazuh-agent_${wazuhVersion}-1_arm64.deb`
+  return `wget ${urlPackage} && sudo ${
+    optionals && getAllOptionals(optionals)
+  }dpkg -i ./${packageName}`;
+};
+
+/******* RPM *******/
+
+export const getRPMAMD64InstallCommand = (
+  props: tOSEntryInstallCommand<tOptionalParameters>,
+) => {
+  const { optionals, urlPackage, wazuhVersion, architecture } = props;
+  const packageName = `wazuh-agent-${wazuhVersion}-1.x86_64.rpm`
+  return `curl -o ${packageName} ${urlPackage} && sudo ${
+    optionals && getAllOptionals(optionals)
+  }rpm -ihv ${packageName}`;
+};
+
+export const getRPMARM64InstallCommand = (
+  props: tOSEntryInstallCommand<tOptionalParameters>,
+) => {
+  const { optionals, urlPackage, wazuhVersion, architecture } = props;
+  const packageName = `wazuh-agent-${wazuhVersion}-1.aarch64.rpm`
+  return `curl -o ${packageName} ${urlPackage} && sudo ${
+    optionals && getAllOptionals(optionals)
+  }rpm -ihv ${packageName}`;
 };
 
 /******* Linux *******/


### PR DESCRIPTION
### Description
Fix package URLs in aarch64 commands
Closes #5870 

### Test

Check all the LINUX commands

1. Select one-by-one Linux Distros
2. Check if the package URL works (copy and paste in a new browser tab) 
  - **Important:** Use `package-dev` and `/pre-release/` instead /4.x/
3. Check in the command if the package name and package downloaded have the same name
4. If you have the same distro, check the agent package installation

## Linux RPM amd64

<img width="259" alt="Captura de pantalla 2023-09-11 a la(s) 12 28 34" src="https://github.com/wazuh/wazuh-kibana-app/assets/6089438/8dd34a1a-1106-4d6d-a055-084b9a25d632">


```bash
curl -o wazuh-agent-4.6.0-1.x86_64.rpm https://packages.wazuh.com/4.x/yum/wazuh-agent-4.6.0-1.x86_64.rpm && sudo WAZUH_MANAGER='0.0.0.0' rpm -ihv wazuh-agent-4.6.0-1.x86_64.rpm
```

> Annotation: 
> In this case, the `amd64.rpm` package doesn't exist because of that we use the `x86_64.rpm`

<img width="785" alt="Captura de pantalla 2023-09-11 a la(s) 12 39 38" src="https://github.com/wazuh/wazuh-kibana-app/assets/6089438/34ba9084-fadb-436c-8f3a-5308b5618672">


## Linux DEB amd64

<img width="272" alt="Captura de pantalla 2023-09-11 a la(s) 12 32 14" src="https://github.com/wazuh/wazuh-kibana-app/assets/6089438/98f055e3-29db-4199-ac31-37555d9afe7a">

```bash
wget https://packages.wazuh.com/4.x/apt/pool/main/w/wazuh-agent/wazuh-agent_4.6.0-1_amd64.deb && sudo WAZUH_MANAGER='0.0.0.0' dpkg -i ./wazuh-agent_4.6.0-1_amd64.deb
```

## Linux RPM aarch64

<img width="265" alt="Captura de pantalla 2023-09-11 a la(s) 12 34 44" src="https://github.com/wazuh/wazuh-kibana-app/assets/6089438/83719a87-8d9e-443a-a857-ecd6a719fd75">

```bash
curl -o wazuh-agent-4.6.0-1.aarch64.rpm https://packages.wazuh.com/4.x/yum/wazuh-agent-4.6.0-1.aarch64.rpm && sudo WAZUH_MANAGER='0.0.0.0' rpm -ihv wazuh-agent-4.6.0-1.aarch64.rpm
```


## Linux DEB aarch64

<img width="270" alt="Captura de pantalla 2023-09-11 a la(s) 12 36 53" src="https://github.com/wazuh/wazuh-kibana-app/assets/6089438/e5896673-d2bf-4fdc-9615-55bd0421485a">

```bash
wget https://packages.wazuh.com/4.x/apt/pool/main/w/wazuh-agent/wazuh-agent_4.6.0-1_arm64.deb && sudo WAZUH_MANAGER='0.0.0.0' dpkg -i ./wazuh-agent_4.6.0-1_arm64.deb
```

> Annotation: 
> In this case, the `aarch64.deb` package doesn't exist because of that we use the `arm64.deb`
<img width="882" alt="Captura de pantalla 2023-09-11 a la(s) 12 38 19" src="https://github.com/wazuh/wazuh-kibana-app/assets/6089438/40df5bc3-ec18-4bf8-a093-82eed3114be3">


### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff 
