### PR TITLE
Fix error parsing manager configuration to XML

### DIFF
--- a/plugins/main/public/components/add-modules-data/module-guide.js
+++ b/plugins/main/public/components/add-modules-data/module-guide.js
@@ -1,16 +1,16 @@
 /*
-* Wazuh app - React component for show a module guide.
-* Copyright (C) 2015-2022 Wazuh, Inc.
-*
-* This program is free software; you can redistribute it and/or modify
-* it under the terms of the GNU General Public License as published by
-* the Free Software Foundation; either version 2 of the License, or
-* (at your option) any later version.
-*
-* Find more information about this on the LICENSE file.
-*/
-import React, { Component, Fragment } from "react";
-import PropTypes from "prop-types";
+ * Wazuh app - React component for show a module guide.
+ * Copyright (C) 2015-2022 Wazuh, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Find more information about this on the LICENSE file.
+ */
+import React, { Component, Fragment } from 'react';
+import PropTypes from 'prop-types';
 
 import {
   EuiFlexGroup,
@@ -41,59 +41,77 @@ import {
   EuiTabs,
   EuiTab,
   EuiCode,
-  EuiBadge
-} from "@elastic/eui";
+  EuiBadge,
+} from '@elastic/eui';
 
 import moduleGuides from './guides';
-import js2xmlparser from 'js2xmlparser';
+import { parse } from 'js2xmlparser';
 import XMLBeautifier from '../../controllers/management/components/management/configuration/utils/xml-beautifier';
-import { getToasts }  from '../../../kibana-services';
+import { getToasts } from '../../../kibana-services';
 
 const js2xmlOptionsParser = {
   format: {
-    doubleQuotes: true
-  }
+    doubleQuotes: true,
+  },
 };
 
-const capitalize = (str) => str[0].toUpperCase() + str.slice(1);
+const capitalize = str => str[0].toUpperCase() + str.slice(1);
 
 const agentTypeButtons = [
   {
     id: 'manager',
-    label: 'Manager'
+    label: 'Manager',
   },
   {
     id: 'agent',
-    label: 'Agent'
-  }
+    label: 'Agent',
+  },
 ];
 
 const agentOsTabs = [
   {
     id: 'linux',
-    name: 'Linux'
+    name: 'Linux',
   },
   {
     id: 'windows',
-    name: 'Windows'
-  }
+    name: 'Windows',
+  },
 ];
 
-const renderOSIcon = (os) => <i className={`fa fa-${os} AgentsTable__soBadge AgentsTable__soBadge--${os}`} aria-hidden="true"/>;
+const renderOSIcon = os => (
+  <i
+    className={`fa fa-${os} AgentsTable__soBadge AgentsTable__soBadge--${os}`}
+    aria-hidden='true'
+  />
+);
 
 class WzModuleGuide extends Component {
   constructor(props) {
     super(props);
-    this.guide = Object.keys(moduleGuides).map(key => moduleGuides[key]).find(guide => guide.id === props.guideId);
+    this.guide = Object.keys(moduleGuides)
+      .map(key => moduleGuides[key])
+      .find(guide => guide.id === props.guideId);
     this.specificGuide = Boolean(this.props.agent);
     this.state = {
       modalRestartIsVisble: false,
-      agentTypeSelected: (this.props.agent && ((this.props.agent.id === '000' ? 'manager' : 'agent') || this.props.agent.type)) || (this.guide.avaliable_for_manager ? 'manager' : 'agent'),
-      agentOSSelected: this.props.agent && (typeof this.props.agent.os === 'string' ? this.props.agent.os : (this.props.agent.os.platform === 'windows' ? 'windows' : 'linux')) || ''
+      agentTypeSelected:
+        (this.props.agent &&
+          ((this.props.agent.id === '000' ? 'manager' : 'agent') ||
+            this.props.agent.type)) ||
+        (this.guide.avaliable_for_manager ? 'manager' : 'agent'),
+      agentOSSelected:
+        (this.props.agent &&
+          (typeof this.props.agent.os === 'string'
+            ? this.props.agent.os
+            : this.props.agent.os.platform === 'windows'
+            ? 'windows'
+            : 'linux')) ||
+        '',
     };
     this.state.steps = this.buildInitialSteps(this.guide.steps);
   }
-  componentDidMount(){
+  componentDidMount() {
     window.scrollTo(0, 0);
   }
   setElementProp(keyID, prop, value) {
@@ -104,21 +122,34 @@ class WzModuleGuide extends Component {
   getSettingbyKeyID(keyID, last = false) {
     let obj = this.state.steps;
     for (let i = 0, length = keyID.length; i < length; i++) {
-      obj = last && ((i + 1) === length) ? obj : obj[keyID[i]];
+      obj = last && i + 1 === length ? obj : obj[keyID[i]];
     }
     return obj;
   }
   buildInitialSteps(steps) {
-    return [...steps.map(step => ({ ...step, elements: step.elements && step.elements.filter((element) => this.filterElementByAgent(element)).map((element) => this.buildConfigurationElement(element)) || [] }))].filter((step) => step.elements && step.elements.length);
+    return [
+      ...steps.map(step => ({
+        ...step,
+        elements:
+          (step.elements &&
+            step.elements
+              .filter(element => this.filterElementByAgent(element))
+              .map(element => this.buildConfigurationElement(element))) ||
+          [],
+      })),
+    ].filter(step => step.elements && step.elements.length);
   }
   buildConfigurationElementValue(option) {
-    const defaultValue = option.default_value_linux !== undefined && this.state.agentOSSelected === 'linux' ?
-    option.default_value_linux
-    : option.default_value_windows !== undefined && this.state.agentOSSelected === 'windows' ?
-    option.default_value_windows
-    : option.default_value
+    const defaultValue =
+      option.default_value_linux !== undefined &&
+      this.state.agentOSSelected === 'linux'
+        ? option.default_value_linux
+        : option.default_value_windows !== undefined &&
+          this.state.agentOSSelected === 'windows'
+        ? option.default_value_windows
+        : option.default_value;
     switch (option.type) {
-      case 'input':{
+      case 'input': {
         return defaultValue || '';
       }
       case 'input-number':
@@ -126,104 +157,149 @@ class WzModuleGuide extends Component {
       case 'switch':
         return defaultValue || false;
       case 'select':
-        return defaultValue !== undefined ? defaultValue : option.values[0].value;
+        return defaultValue !== undefined
+          ? defaultValue
+          : option.values[0].value;
       default:
         return undefined;
     }
   }
-  buildConfigurationElementToggleable(option){
-    return option.required ? false : option.toggleable !== undefined ? option.toggleable : true;
+  buildConfigurationElementToggleable(option) {
+    return option.required
+      ? false
+      : option.toggleable !== undefined
+      ? option.toggleable
+      : true;
   }
-  buildConfigurationElementEnabled(option){
-    return option.required ? true : option.enabled !== undefined ? option.enabled : false;
+  buildConfigurationElementEnabled(option) {
+    return option.required
+      ? true
+      : option.enabled !== undefined
+      ? option.enabled
+      : false;
   }
-  filterElementByAgent(element){
-    if(element.agent_os && element.agent_type){
-      return this.state.agentOSSelected !== '' ? element.agent_os === this.state.agentOSSelected && element.agent_type === this.state.agentTypeSelected : true;
-    }else if(element.agent_os){
-      return this.state.agentOSSelected !== '' ? element.agent_os === this.state.agentOSSelected : true;
-    }else if(element.agent_type){
+  filterElementByAgent(element) {
+    if (element.agent_os && element.agent_type) {
+      return this.state.agentOSSelected !== ''
+        ? element.agent_os === this.state.agentOSSelected &&
+            element.agent_type === this.state.agentTypeSelected
+        : true;
+    } else if (element.agent_os) {
+      return this.state.agentOSSelected !== ''
+        ? element.agent_os === this.state.agentOSSelected
+        : true;
+    } else if (element.agent_type) {
       return element.agent_type === this.state.agentTypeSelected;
     }
-    return true
+    return true;
   }
   resetGuideWithNotification = () => {
     this.resetGuide(true);
     this.addToast({
       title: 'The guide was restarted',
-      color: 'success'
+      color: 'success',
     });
-  }
-  resetGuide(){
+  };
+  resetGuide() {
     this.setState({
       steps: this.buildInitialSteps(this.guide.steps),
-      modalRestartIsVisble: false
+      modalRestartIsVisble: false,
     });
   }
-  addToast({color, title, text, time = 3000}){
-    getToasts().add({title, text, toastLifeTimeMs: time, color})
+  addToast({ color, title, text, time = 3000 }) {
+    getToasts().add({ title, text, toastLifeTimeMs: time, color });
   }
-  transformStateElementToJSON(element, accum){
-    if (!element.enabled && !element.elements) { return accum}
+  transformStateElementToJSON(element, accum) {
+    if (!element.enabled && !element.elements) {
+      return accum;
+    }
     if (element.repeatable) {
       if (!accum[element.name]) {
-        accum[element.name] = []
+        accum[element.name] = [];
       }
     }
     if (element.elements && element.elements.length) {
-      element.elements.forEach((el) => {
+      element.elements.forEach(el => {
         this.transformStateElementToJSON(el, accum);
       });
       return accum;
-    }else if(element.elements && !element.elements.length){
+    } else if (element.elements && !element.elements.length) {
       return accum;
     }
     const obj = {
-      '#': this.getConfigurationValueFromForm(element)
-    }
-    if(obj['#'] === undefined){
+      '#': this.getConfigurationValueFromForm(element),
+    };
+    if (obj['#'] === undefined) {
       delete obj['#'];
     }
     if (element.attributes && element.attributes.length) {
-      obj['@'] = element.attributes.filter(attribute => attribute.enabled).reduce((accumAttribute, attribute) => ({
-        ...accumAttribute,
-        [attribute.name]: this.getConfigurationValueFromForm(attribute)
-      }), {})
+      obj['@'] = element.attributes
+        .filter(attribute => attribute.enabled)
+        .reduce(
+          (accumAttribute, attribute) => ({
+            ...accumAttribute,
+            [attribute.name]: this.getConfigurationValueFromForm(attribute),
+          }),
+          {},
+        );
     }
     if (element.options && element.options.length) {
-      element.options.filter(option => option.enabled || (option.repeatable && option.elements && option.elements.length)).forEach((option) => {
-        if(option.elements){
-          option.elements.forEach(optionRepeatable => {
-            this.transformStateElementToJSON(optionRepeatable, obj)
-          });
-        }else{
-          obj[option.name] = this.getConfigurationValueFromForm(option);
-        }
-      })
+      element.options
+        .filter(
+          option =>
+            option.enabled ||
+            (option.repeatable && option.elements && option.elements.length),
+        )
+        .forEach(option => {
+          if (option.elements) {
+            option.elements.forEach(optionRepeatable => {
+              this.transformStateElementToJSON(optionRepeatable, obj);
+            });
+          } else {
+            obj[option.name] = this.getConfigurationValueFromForm(option);
+          }
+        });
     }
     if (element.repeatable) {
       accum[element.name].push(obj);
     } else {
       accum[element.name] = obj;
     }
-    return accum
+    return accum;
   }
   transformStateToJSON() {
     return {
       ...this.state.steps.reduce((accum, step) => {
         return {
-          ...accum, ...step.elements.reduce((accumStep, element) => {
+          ...accum,
+          ...step.elements.reduce((accumStep, element) => {
             return this.transformStateElementToJSON(element, accumStep);
-          }, {})
-        }
-      }, {})
-    }
+          }, {}),
+        };
+      }, {}),
+    };
   }
   transformToXML() {
     const json = this.transformStateToJSON();
-    return (this.guide.wodle_name) ?
-    XMLBeautifier(js2xmlparser.parse('configuration', { wodle: {'@': {name: this.guide.wodle_name}, ...json}}, js2xmlOptionsParser).replace("<?xml version=\"1.0\"?>\n", "").replace("<configuration>\n", "").replace("</configuration>","").replace("    <wodle", "<wodle"))
-    : XMLBeautifier(js2xmlparser.parse(this.guide.xml_tag || this.guide.id, json, js2xmlOptionsParser).replace("<?xml version=\"1.0\"?>\n", ""));
+    return this.guide.wodle_name
+      ? XMLBeautifier(
+          parse(
+            'configuration',
+            { wodle: { '@': { name: this.guide.wodle_name }, ...json } },
+            js2xmlOptionsParser,
+          )
+            .replace('<?xml version="1.0"?>\n', '')
+            .replace('<configuration>\n', '')
+            .replace('</configuration>', '')
+            .replace('    <wodle', '<wodle'),
+        )
+      : XMLBeautifier(
+          parse(
+            this.guide.xml_tag || this.guide.id,
+            json,
+            js2xmlOptionsParser,
+          ).replace('<?xml version="1.0"?>\n', ''),
+        );
   }
   buildConfigurationElement(element, params = {}) {
     return {
@@ -231,28 +307,65 @@ class WzModuleGuide extends Component {
       value: this.buildConfigurationElementValue(element),
       toggleable: this.buildConfigurationElementToggleable(element),
       enabled: this.buildConfigurationElementEnabled(element),
-      collapsible: (element.attributes || element.options) ? true : false,
-      collapsed: (element.attributes || element.options) ? false : undefined,
-      elements: !params.ignore_repeatable && element.repeatable ? (element.repeatable_insert_first ? [this.buildConfigurationElement({...element, ...element.repeatable_insert_first_properties }, {ignore_repeatable: true})] : []) : undefined,
+      collapsible: element.attributes || element.options ? true : false,
+      collapsed: element.attributes || element.options ? false : undefined,
+      elements:
+        !params.ignore_repeatable && element.repeatable
+          ? element.repeatable_insert_first
+            ? [
+                this.buildConfigurationElement(
+                  { ...element, ...element.repeatable_insert_first_properties },
+                  { ignore_repeatable: true },
+                ),
+              ]
+            : []
+          : undefined,
       show_options: element.show_options || false,
-      options: element.options && element.options.filter((option) => this.filterElementByAgent(option)).map(option => ({
-        ...option,
-        value: this.buildConfigurationElementValue(option),
-        toggleable: this.buildConfigurationElementToggleable(option),
-        enabled: this.buildConfigurationElementEnabled(option),
-        elements: option.repeatable ? (option.repeatable_insert_first ? [this.buildConfigurationElement({...option, ...option.repeatable_insert_first_properties}, {ignore_repeatable: true})] : []) : undefined,
-        attributes: option.attributes && option.attributes.length ? option.attributes.map((optionAtribute) => this.buildConfigurationElement(optionAtribute)) : undefined
-      })) || undefined,
+      options:
+        (element.options &&
+          element.options
+            .filter(option => this.filterElementByAgent(option))
+            .map(option => ({
+              ...option,
+              value: this.buildConfigurationElementValue(option),
+              toggleable: this.buildConfigurationElementToggleable(option),
+              enabled: this.buildConfigurationElementEnabled(option),
+              elements: option.repeatable
+                ? option.repeatable_insert_first
+                  ? [
+                      this.buildConfigurationElement(
+                        {
+                          ...option,
+                          ...option.repeatable_insert_first_properties,
+                        },
+                        { ignore_repeatable: true },
+                      ),
+                    ]
+                  : []
+                : undefined,
+              attributes:
+                option.attributes && option.attributes.length
+                  ? option.attributes.map(optionAtribute =>
+                      this.buildConfigurationElement(optionAtribute),
+                    )
+                  : undefined,
+            }))) ||
+        undefined,
       show_attributes: element.show_attributes || false,
-      attributes: element.attributes && element.attributes.filter((attribute) => this.filterElementByAgent(attribute)).map(attribute => ({
-        ...attribute,
-        value: this.buildConfigurationElementValue(attribute),
-        toggleable: this.buildConfigurationElementToggleable(attribute),
-        enabled: this.buildConfigurationElementEnabled(attribute)
-      })) || undefined
-    }
+      attributes:
+        (element.attributes &&
+          element.attributes
+            .filter(attribute => this.filterElementByAgent(attribute))
+            .map(attribute => ({
+              ...attribute,
+              value: this.buildConfigurationElementValue(attribute),
+              toggleable: this.buildConfigurationElementToggleable(attribute),
+              enabled: this.buildConfigurationElementEnabled(attribute),
+            }))) ||
+        undefined,
+    };
   }
-  addElementToStep(keyID, element, params){
+  addElementToStep(keyID, element, params) {
     const obj = this.getSettingbyKeyID(keyID);
     obj.push(this.buildConfigurationElement(element, params));
     this.setState({ steps: this.state.steps });
@@ -287,45 +400,70 @@ class WzModuleGuide extends Component {
           ) : null}
         </Fragment>
       ),
-      status: this.checkInvalidElements(step.elements) ? 'danger' : 'complete'
+      status: this.checkInvalidElements(step.elements) ? 'danger' : 'complete',
     }));
-    const invalidConfiguration = configurationSteps.reduce((accum, step) => accum || step.status === 'danger', false);
+    const invalidConfiguration = configurationSteps.reduce(
+      (accum, step) => accum || step.status === 'danger',
+      false,
+    );
 
     return [
       ...configurationSteps,
       {
-        title: !invalidConfiguration ? 'Edit ossec.conf' : 'Configuration error',
+        title: !invalidConfiguration
+          ? 'Edit ossec.conf'
+          : 'Configuration error',
         children: (
           <Fragment>
             {!invalidConfiguration ? (
               <Fragment>
-                <EuiCodeBlock
-                  language="xml"
-                  color="dark"
-                  isCopyable>
+                <EuiCodeBlock language='xml' color='dark' isCopyable>
                   {xmlConfig}
                 </EuiCodeBlock>
-                <EuiSpacer size='s'/>
+                <EuiSpacer size='s' />
                 {this.state.agentTypeSelected === 'manager' ? (
                   <Fragment>
-                    <EuiText>When you finish of configure the module, copy above XML configuration. Go to <EuiCode>Management</EuiCode> {'>'} <EuiCode>Configuration</EuiCode> {'>'} <EuiCode>Edit configuration</EuiCode>, paste configuration, save and restart manager or node.</EuiText>
+                    <EuiText>
+                      When you finish of configure the module, copy above XML
+                      configuration. Go to <EuiCode>Management</EuiCode> {'>'}{' '}
+                      <EuiCode>Configuration</EuiCode> {'>'}{' '}
+                      <EuiCode>Edit configuration</EuiCode>, paste
+                      configuration, save and restart manager or node.
+                    </EuiText>
                   </Fragment>
-                  ) : this.state.agentOSSelected === 'linux' ? (
-                    <EuiText>When you finish of configure the module, copy above XML configuration. Go to <EuiCode>/var/ossec/etc</EuiCode> in Linux agent, include the above configuration in <EuiCode>ossec.conf</EuiCode> and restart the agent.</EuiText>
-                    ) : (
-                      <EuiText>When you finish of configure the module, copy above XML configuration. Go to <EuiCode>C:\Program Files (x86)\ossec-agent</EuiCode> in Windows agent, include the above configuration in <EuiCode>ossec.conf</EuiCode> and restart the agent.</EuiText>
+                ) : this.state.agentOSSelected === 'linux' ? (
+                  <EuiText>
+                    When you finish of configure the module, copy above XML
+                    configuration. Go to <EuiCode>/var/ossec/etc</EuiCode> in
+                    Linux agent, include the above configuration in{' '}
+                    <EuiCode>ossec.conf</EuiCode> and restart the agent.
+                  </EuiText>
+                ) : (
+                  <EuiText>
+                    When you finish of configure the module, copy above XML
+                    configuration. Go to{' '}
+                    <EuiCode>C:\Program Files (x86)\ossec-agent</EuiCode> in
+                    Windows agent, include the above configuration in{' '}
+                    <EuiCode>ossec.conf</EuiCode> and restart the agent.
+                  </EuiText>
                 )}
                 <EuiSpacer size='s' />
-                <EuiText>The above section must be located within the top-level <EuiCode>{`<ossec_config>`}</EuiCode> tag.</EuiText>
+                <EuiText>
+                  The above section must be located within the top-level{' '}
+                  <EuiCode>{`<ossec_config>`}</EuiCode> tag.
+                </EuiText>
               </Fragment>
-              ) : (
-                <EuiText color='danger'>There is an error in the configuration, please check fields that have errors.</EuiText>
+            ) : (
+              <EuiText color='danger'>
+                There is an error in the configuration, please check fields that
+                have errors.
+              </EuiText>
             )}
           </Fragment>
         ),
-        status: invalidConfiguration ? 'danger' : 'complete'
-      }
-    ]
+        status: invalidConfiguration ? 'danger' : 'complete',
+      },
+    ];
   }
   renderOption(guideOption, keyID, options) {
     return (
@@ -333,93 +471,164 @@ class WzModuleGuide extends Component {
         {!guideOption.elements ? (
           <EuiPanel>
             {this.renderOptionSetting(guideOption, keyID, options)}
-            {guideOption.enabled && guideOption.attributes && guideOption.attributes.length && ((guideOption.collapsible && !guideOption.collapsed) || !guideOption.collapsible)? (
+            {guideOption.enabled &&
+            guideOption.attributes &&
+            guideOption.attributes.length &&
+            ((guideOption.collapsible && !guideOption.collapsed) ||
+              !guideOption.collapsible) ? (
               <Fragment>
-                {guideOption.type && (<EuiSpacer size='m' />)}
-                <EuiToolTip
-                  position='top'
-                  content='Show / hide attributes'
-                >
+                {guideOption.type && <EuiSpacer size='m' />}
+                <EuiToolTip position='top' content='Show / hide attributes'>
                   <EuiButtonToggle
                     label='Attributes'
-                    color={this.checkInvalidElements(guideOption.attributes) ? 'danger' : 'primary'}
+                    color={
+                      this.checkInvalidElements(guideOption.attributes)
+                        ? 'danger'
+                        : 'primary'
+                    }
                     fill={guideOption.show_attributes}
-                    iconType={!guideOption.show_attributes ? 'eye' : 'eyeClosed'}
-                    onChange={() => this.setElementProp(keyID, 'show_attributes', !guideOption.show_attributes)}
-                    style={{marginRight: '4px'}}
+                    iconType={
+                      !guideOption.show_attributes ? 'eye' : 'eyeClosed'
+                    }
+                    onChange={() =>
+                      this.setElementProp(
+                        keyID,
+                        'show_attributes',
+                        !guideOption.show_attributes,
+                      )
+                    }
+                    style={{ marginRight: '4px' }}
                   />
                 </EuiToolTip>
-                {guideOption.show_attributes && guideOption.attributes && guideOption.attributes.length && (
-                  <Fragment>
-                    <EuiSpacer size='m' />
-                    <EuiFlexGrid columns={2} style={{ marginLeft: '8px' }}>
-                      {guideOption.attributes.map((guideSubOption, key) => (
-                        <EuiFlexItem key={`module-guide-${guideOption.name}-${guideSubOption.name}`}>
-                          {this.renderOptionSetting(guideSubOption, [...keyID, 'attributes', key], { ignore_description: true })}
-                        </EuiFlexItem>
-                      ))}
-                    </EuiFlexGrid>
-                  </Fragment>
-                )}
+                {guideOption.show_attributes &&
+                  guideOption.attributes &&
+                  guideOption.attributes.length && (
+                    <Fragment>
+                      <EuiSpacer size='m' />
+                      <EuiFlexGrid columns={2} style={{ marginLeft: '8px' }}>
+                        {guideOption.attributes.map((guideSubOption, key) => (
+                          <EuiFlexItem
+                            key={`module-guide-${guideOption.name}-${guideSubOption.name}`}
+                          >
+                            {this.renderOptionSetting(
+                              guideSubOption,
+                              [...keyID, 'attributes', key],
+                              { ignore_description: true },
+                            )}
+                          </EuiFlexItem>
+                        ))}
+                      </EuiFlexGrid>
+                    </Fragment>
+                  )}
               </Fragment>
             ) : null}
-            {guideOption.enabled && guideOption.options && guideOption.options.length && ((guideOption.collapsible && !guideOption.collapsed) || !guideOption.collapsible)? (
+            {guideOption.enabled &&
+            guideOption.options &&
+            guideOption.options.length &&
+            ((guideOption.collapsible && !guideOption.collapsed) ||
+              !guideOption.collapsible) ? (
               <Fragment>
-                {guideOption.show_attributes && (<EuiSpacer size='m' />)}
-                <EuiToolTip
-                  position='top'
-                  content='Show / hide options'
-                >
+                {guideOption.show_attributes && <EuiSpacer size='m' />}
+                <EuiToolTip position='top' content='Show / hide options'>
                   <EuiButtonToggle
                     label='Options'
-                    color={this.checkInvalidElements(guideOption.options) ? 'danger' : 'primary'}
+                    color={
+                      this.checkInvalidElements(guideOption.options)
+                        ? 'danger'
+                        : 'primary'
+                    }
                     fill={guideOption.show_options}
                     iconType={!guideOption.show_options ? 'eye' : 'eyeClosed'}
-                    onChange={() => this.setElementProp(keyID, 'show_options', !guideOption.show_options)}
-                    style={{marginRight: '4px'}}
+                    onChange={() =>
+                      this.setElementProp(
+                        keyID,
+                        'show_options',
+                        !guideOption.show_options,
+                      )
+                    }
+                    style={{ marginRight: '4px' }}
                   />
                 </EuiToolTip>
-                {guideOption.show_options && guideOption.options && guideOption.options.length && (
-                  <Fragment>
-                    <EuiSpacer size='m' />
-                    {guideOption.options.map((guideSubOption, key) => {
-                      return !guideSubOption.elements ? (
-                      <Fragment key={`${guideOption.name}-options-${guideSubOption.name}`}>
-                        <EuiFlexGroup>
-                          <EuiFlexItem key={`module-guide-${guideOption.name}-${guideSubOption.name}`}>
-                            {/* {this.renderOptionSetting(guideSubOption, [...keyID, 'options', key], { ignore_description: true })} */}
-                            {this.renderOption(guideSubOption, [...keyID, 'options', key])}
-                            <EuiSpacer size='s'/>
-                          </EuiFlexItem>
-                        </EuiFlexGroup>
-                      </Fragment>
-                    ) : (
-                      <Fragment key={`${guideOption.name}-options-${guideSubOption.name}`}>
-                        {guideSubOption.elements.map((guideSubOptionElement, keyGuideSubOptionElement) => (
-                          <Fragment key={`module-guide-${guideOption.name}-${guideSubOption.name}-${keyGuideSubOptionElement}`}>
+                {guideOption.show_options &&
+                  guideOption.options &&
+                  guideOption.options.length && (
+                    <Fragment>
+                      <EuiSpacer size='m' />
+                      {guideOption.options.map((guideSubOption, key) => {
+                        return !guideSubOption.elements ? (
+                          <Fragment
+                            key={`${guideOption.name}-options-${guideSubOption.name}`}
+                          >
                             <EuiFlexGroup>
-                              <EuiFlexItem>
-                                {this.renderOption(guideSubOptionElement, [...keyID,'options', key,'elements',keyGuideSubOptionElement])}
+                              <EuiFlexItem
+                                key={`module-guide-${guideOption.name}-${guideSubOption.name}`}
+                              >
+                                {/* {this.renderOptionSetting(guideSubOption, [...keyID, 'options', key], { ignore_description: true })} */}
+                                {this.renderOption(guideSubOption, [
+                                  ...keyID,
+                                  'options',
+                                  key,
+                                ])}
+                                <EuiSpacer size='s' />
                               </EuiFlexItem>
                             </EuiFlexGroup>
-                            <EuiSpacer size='s'/>
                           </Fragment>
-                        ))}
-                        <EuiFlexGroup justifyContent='center'>
-                          <EuiFlexItem grow={false}>
-                          <EuiToolTip
-                            position='top'
-                            content={guideSubOption.description}
+                        ) : (
+                          <Fragment
+                            key={`${guideOption.name}-options-${guideSubOption.name}`}
                           >
-                            <EuiButtonEmpty iconType='plusInCircle' onClick={() => this.addElementToStep([...keyID,'options', key,'elements'], guideSubOption, {ignore_repeatable: true})}>Add {guideSubOption.name}</EuiButtonEmpty>
-                          </EuiToolTip>
-                          </EuiFlexItem>
-                        </EuiFlexGroup>
-                      </Fragment>
-                    )
-                    })}
-                  </Fragment>
-                )}
+                            {guideSubOption.elements.map(
+                              (
+                                guideSubOptionElement,
+                                keyGuideSubOptionElement,
+                              ) => (
+                                <Fragment
+                                  key={`module-guide-${guideOption.name}-${guideSubOption.name}-${keyGuideSubOptionElement}`}
+                                >
+                                  <EuiFlexGroup>
+                                    <EuiFlexItem>
+                                      {this.renderOption(
+                                        guideSubOptionElement,
+                                        [
+                                          ...keyID,
+                                          'options',
+                                          key,
+                                          'elements',
+                                          keyGuideSubOptionElement,
+                                        ],
+                                      )}
+                                    </EuiFlexItem>
+                                  </EuiFlexGroup>
+                                  <EuiSpacer size='s' />
+                                </Fragment>
+                              ),
+                            )}
+                            <EuiFlexGroup justifyContent='center'>
+                              <EuiFlexItem grow={false}>
+                                <EuiToolTip
+                                  position='top'
+                                  content={guideSubOption.description}
+                                >
+                                  <EuiButtonEmpty
+                                    iconType='plusInCircle'
+                                    onClick={() =>
+                                      this.addElementToStep(
+                                        [...keyID, 'options', key, 'elements'],
+                                        guideSubOption,
+                                        { ignore_repeatable: true },
+                                      )
+                                    }
+                                  >
+                                    Add {guideSubOption.name}
+                                  </EuiButtonEmpty>
+                                </EuiToolTip>
+                              </EuiFlexItem>
+                            </EuiFlexGroup>
+                          </Fragment>
+                        );
+                      })}
+                    </Fragment>
+                  )}
               </Fragment>
             ) : null}
           </EuiPanel>
@@ -429,103 +638,122 @@ class WzModuleGuide extends Component {
               <Fragment key={`module-guide-${guideSubOption.name}-${key}`}>
                 <EuiFlexGroup>
                   <EuiFlexItem>
-                    {this.renderOption(guideSubOption, [...keyID, 'elements', key])}
+                    {this.renderOption(guideSubOption, [
+                      ...keyID,
+                      'elements',
+                      key,
+                    ])}
                   </EuiFlexItem>
                 </EuiFlexGroup>
-                <EuiSpacer size='s'/>
+                <EuiSpacer size='s' />
               </Fragment>
             ))}
             <EuiFlexGroup justifyContent='center'>
               <EuiFlexItem grow={false}>
-              <EuiToolTip
-                position='top'
-                content={guideOption.description}
-              >
-                <EuiButtonEmpty iconType='plusInCircle' onClick={() => this.addElementToStep([...keyID,'elements'], guideOption, {ignore_repeatable: true})}>Add {guideOption.name}</EuiButtonEmpty>
-              </EuiToolTip>
+                <EuiToolTip position='top' content={guideOption.description}>
+                  <EuiButtonEmpty
+                    iconType='plusInCircle'
+                    onClick={() =>
+                      this.addElementToStep(
+                        [...keyID, 'elements'],
+                        guideOption,
+                        { ignore_repeatable: true },
+                      )
+                    }
+                  >
+                    Add {guideOption.name}
+                  </EuiButtonEmpty>
+                </EuiToolTip>
               </EuiFlexItem>
             </EuiFlexGroup>
           </Fragment>
         )}
         {/* <EuiSpacer size='m' /> */}
       </Fragment>
-    )
+    );
   }
   renderOptionSetting(guideOption, keyID, options = {}) {
     const checkboxLabel = (
       <Fragment>
-        <EuiText color={guideOption.enabled ? 'default' : 'subdued'} style={{ display: 'inline' }} size='m'>
+        <EuiText
+          color={guideOption.enabled ? 'default' : 'subdued'}
+          style={{ display: 'inline' }}
+          size='m'
+        >
           <span>{guideOption.name}</span>
           {guideOption.description && options.ignore_description && (
-            <span style={{margin: '0 0 0 6px'}}>
-              <EuiToolTip
-                position='top'
-                content={guideOption.description}
-              >
-                <EuiIcon type='questionInCircle' color='primary'/>
+            <span style={{ margin: '0 0 0 6px' }}>
+              <EuiToolTip position='top' content={guideOption.description}>
+                <EuiIcon type='questionInCircle' color='primary' />
               </EuiToolTip>
-           </span>
+            </span>
           )}
           {guideOption.info && (
-            <span style={{margin: '0 0 0 6px'}}>
-              <EuiToolTip
-                position='top'
-                content={guideOption.info}
-              >
-                <EuiIcon type='iInCircle' color='primary'/>
+            <span style={{ margin: '0 0 0 6px' }}>
+              <EuiToolTip position='top' content={guideOption.info}>
+                <EuiIcon type='iInCircle' color='primary' />
               </EuiToolTip>
             </span>
           )}
           {guideOption.warning && (
-            <span style={{margin: '0 0 0 6px'}}>
-              <EuiToolTip
-                position='top'
-                content={guideOption.warning}
-              >
-                <EuiIcon type='alert' color='warning'/>
+            <span style={{ margin: '0 0 0 6px' }}>
+              <EuiToolTip position='top' content={guideOption.warning}>
+                <EuiIcon type='alert' color='warning' />
               </EuiToolTip>
             </span>
           )}
           {guideOption.agent_os && (
-            <span style={{margin: '0 0 0 6px'}}>
+            <span style={{ margin: '0 0 0 6px' }}>
               <EuiToolTip
                 position='top'
                 content={`only for ${capitalize(guideOption.agent_os)}`}
               >
-                <i className={`fa fa-${guideOption.agent_os} AgentsTable__soBadge AgentsTable__soBadge--${guideOption.agent_os}`} aria-hidden="true"/>
+                <i
+                  className={`fa fa-${guideOption.agent_os} AgentsTable__soBadge AgentsTable__soBadge--${guideOption.agent_os}`}
+                  aria-hidden='true'
+                />
               </EuiToolTip>
             </span>
           )}
           {guideOption.removable && (
-            <span style={{margin: '0 0 0 6px'}}>
-              <EuiToolTip
-                position='top'
-                content='Remove this option'
-              >
-                <EuiButtonIcon color='danger' iconType='minusInCircle' onClick={() => this.removeElementOfStep(keyID)}/>
+            <span style={{ margin: '0 0 0 6px' }}>
+              <EuiToolTip position='top' content='Remove this option'>
+                <EuiButtonIcon
+                  color='danger'
+                  iconType='minusInCircle'
+                  onClick={() => this.removeElementOfStep(keyID)}
+                />
               </EuiToolTip>
             </span>
           )}
           {guideOption.enabled && guideOption.collapsible && (
             <Fragment>
-              <EuiToolTip
-                position='top'
-                content='Show / hide option'
-              >
-              <EuiButtonToggle
-                label=''
-                color={this.checkInvalidElements([guideOption]) ? 'danger' : 'primary'}
-                isEmpty
-                isIconOnly
-                size='s'
-                iconType={guideOption.collapsed ? 'eye' : 'eyeClosed'}
-                onChange={() => this.setElementProp(keyID, 'collapsed', !guideOption.collapsed)}
-              />
-            </EuiToolTip>
+              <EuiToolTip position='top' content='Show / hide option'>
+                <EuiButtonToggle
+                  label=''
+                  color={
+                    this.checkInvalidElements([guideOption])
+                      ? 'danger'
+                      : 'primary'
+                  }
+                  isEmpty
+                  isIconOnly
+                  size='s'
+                  iconType={guideOption.collapsed ? 'eye' : 'eyeClosed'}
+                  onChange={() =>
+                    this.setElementProp(
+                      keyID,
+                      'collapsed',
+                      !guideOption.collapsed,
+                    )
+                  }
+                />
+              </EuiToolTip>
             </Fragment>
           )}
         </EuiText>
-      </Fragment>)
+      </Fragment>
+    );
     return (
       <Fragment>
         {guideOption.toggleable ? (
@@ -535,58 +763,95 @@ class WzModuleGuide extends Component {
             style={{ display: 'inline' }}
             checked={guideOption.enabled}
             onChange={() => {
-              this.setElementProp(keyID, 'enabled', !guideOption.enabled)
-              if(guideOption.collapsible){
-                this.setElementProp(keyID, 'collapsed', false)
+              this.setElementProp(keyID, 'enabled', !guideOption.enabled);
+              if (guideOption.collapsible) {
+                this.setElementProp(keyID, 'collapsed', false);
               }
             }}
           />
-        ) : checkboxLabel}
+        ) : (
+          checkboxLabel
+        )}
         {!options.ignore_description && guideOption.description && (
           <Fragment>
             <EuiSpacer size='xs' />
             <EuiText color='subdued'>{guideOption.description}</EuiText>
           </Fragment>
         )}
-        {((guideOption.collapsible && !guideOption.collapsed) || !guideOption.collapsible) && (
+        {((guideOption.collapsible && !guideOption.collapsed) ||
+          !guideOption.collapsible) && (
           <Fragment>
             <div>
-              {guideOption.enabled && (<EuiSpacer size='s' />)}
-              {typeof guideOption.enabled === 'boolean' ?
-                (guideOption.enabled ? this.renderOptionType(guideOption, keyID) : null)
-                : this.renderOptionType(guideOption, keyID)
-              }
+              {guideOption.enabled && <EuiSpacer size='s' />}
+              {typeof guideOption.enabled === 'boolean'
+                ? guideOption.enabled
+                  ? this.renderOptionType(guideOption, keyID)
+                  : null
+                : this.renderOptionType(guideOption, keyID)}
             </div>
             {/* {typeof guideOption.enabled === 'boolean' && (<EuiSpacer size='m' />)} */}
           </Fragment>
         )}
       </Fragment>
-    )
+    );
   }
   checkInvalidElements(elements) {
     return elements.reduce((accum, element) => {
-      return accum
-        || !element.repeatable && !element.elements && this.checkInvalidElement(element)
-        || element.repeatable && !element.elements && this.checkInvalidElement(element)
-        || element.elements && element.elements.length && this.checkInvalidElements(element.elements)
-        || !element.elements && element.enabled && element.attributes && element.attributes.length && this.checkInvalidElements(element.attributes)
-        || !element.elements && element.enabled && element.options && element.options.length && this.checkInvalidElements(element.options)
-    }, false)
+      return (
+        accum ||
+        (!element.repeatable &&
+          !element.elements &&
+          this.checkInvalidElement(element)) ||
+        (element.repeatable &&
+          !element.elements &&
+          this.checkInvalidElement(element)) ||
+        (element.elements &&
+          element.elements.length &&
+          this.checkInvalidElements(element.elements)) ||
+        (!element.elements &&
+          element.enabled &&
+          element.attributes &&
+          element.attributes.length &&
+          this.checkInvalidElements(element.attributes)) ||
+        (!element.elements &&
+          element.enabled &&
+          element.options &&
+          element.options.length &&
+          this.checkInvalidElements(element.options))
+      );
+    }, false);
   }
   checkInvalidElement(element) {
-    if (!element.enabled) { return undefined }
+    if (!element.enabled) {
+      return undefined;
+    }
     switch (element.type) {
       case 'input': {
-        return (element.validate && !element.validate(element))
-        || (element.validate_regex && !element.value.match(element.validate_regex))
-        || (!element.value)
+        return (
+          (element.validate && !element.validate(element)) ||
+          (element.validate_regex &&
+            !element.value.match(element.validate_regex)) ||
+          !element.value
+        );
       }
       case 'input-number': {
-        return (element.validate && !element.validate(element))
-        || (element.values && (element.values.min !== undefined && element.values.max !== undefined && element.value < element.values.min || element.value > element.values.max))
-        || (element.values && (element.values.min !== undefined && element.values.max === undefined && element.value < element.values.min))
-        || (element.values && (element.values.min === undefined && element.values.max !== undefined && element.value > element.values.max))
-        || (element.value === '')
+        return (
+          (element.validate && !element.validate(element)) ||
+          (element.values &&
+            ((element.values.min !== undefined &&
+              element.values.max !== undefined &&
+              element.value < element.values.min) ||
+              element.value > element.values.max)) ||
+          (element.values &&
+            element.values.min !== undefined &&
+            element.values.max === undefined &&
+            element.value < element.values.min) ||
+          (element.values &&
+            element.values.min === undefined &&
+            element.values.max !== undefined &&
+            element.value > element.values.max) ||
+          element.value === ''
+        );
       }
       default:
         return undefined;
@@ -604,11 +869,17 @@ class WzModuleGuide extends Component {
               isInvalid={invalid}
               disabled={guideOption.field_disabled}
               readOnly={guideOption.field_read_only}
-              onChange={(e) => { this.setElementProp(keyID, 'value', e.target.value) }}
+              onChange={e => {
+                this.setElementProp(keyID, 'value', e.target.value);
+              }}
             />
-            {invalid === true && <EuiText color='danger'>{guideOption.validate_error_message}</EuiText>}
+            {invalid === true && (
+              <EuiText color='danger'>
+                {guideOption.validate_error_message}
+              </EuiText>
+            )}
           </Fragment>
-        )
+        );
       }
       case 'input-number': {
         const invalid = this.checkInvalidElement(guideOption);
@@ -622,21 +893,33 @@ class WzModuleGuide extends Component {
               isInvalid={invalid === true}
               disabled={guideOption.field_disabled}
               readOnly={guideOption.field_read_only}
-              onChange={(e) => { this.setElementProp(keyID, 'value', e.target.value) }}
+              onChange={e => {
+                this.setElementProp(keyID, 'value', e.target.value);
+              }}
             />
-            {invalid === true && <EuiText color='danger'>{guideOption.validate_error_message}</EuiText>}
+            {invalid === true && (
+              <EuiText color='danger'>
+                {guideOption.validate_error_message}
+              </EuiText>
+            )}
           </Fragment>
-        )
+        );
       }
       case 'switch':
         return (
           <EuiSwitch
-            label={guideOption.values && guideOption.values[String(guideOption.value)] || ({ true: 'yes', false: 'no' })[String(guideOption.value)]}
+            label={
+              (guideOption.values &&
+                guideOption.values[String(guideOption.value)]) ||
+              { true: 'yes', false: 'no' }[String(guideOption.value)]
+            }
             checked={guideOption.value}
             disabled={guideOption.field_disabled}
-            onChange={(e) => { this.setElementProp(keyID, 'value', e.target.checked) }}
+            onChange={e => {
+              this.setElementProp(keyID, 'value', e.target.checked);
+            }}
           />
-        )
+        );
       case 'select':
         return (
           <EuiSelect
@@ -644,46 +927,57 @@ class WzModuleGuide extends Component {
             options={guideOption.values}
             value={guideOption.value}
             disabled={guideOption.field_disabled}
-            onChange={(e) => this.setElementProp(keyID, 'value', e.target.value)}
+            onChange={e => this.setElementProp(keyID, 'value', e.target.value)}
             aria-label={`${guideOption.name}-select`}
           />
-        )
+        );
       default:
-        return null
+        return null;
     }
   }
   getConfigurationValueFromForm(guideOption) {
     switch (guideOption.type) {
       case 'input': {
-        return guideOption.value
+        return guideOption.value;
       }
       case 'input-number': {
-        return guideOption.value
+        return guideOption.value;
       }
       case 'switch':
-        return guideOption.values && guideOption.values[String(guideOption.value)] || ({ true: 'yes', false: 'no' })[String(guideOption.value)]
+        return (
+          (guideOption.values &&
+            guideOption.values[String(guideOption.value)]) ||
+          { true: 'yes', false: 'no' }[String(guideOption.value)]
+        );
       case 'select':
-        return guideOption.value
+        return guideOption.value;
       default:
-        return guideOption.value
+        return guideOption.value;
     }
   }
   toggleResetGuideModal = () => {
     this.setState({ modalRestartIsVisble: !this.state.modalRestartIsVisble });
-  }
-  onChangeAgentTypeSelected = (agentTypeSelected) => {
-    this.setState({ agentTypeSelected, agentOSSelected: agentTypeSelected === 'agent' ? 'linux' : '' }, () => {
-      this.resetGuide()
-    });
-  }
-  onChangeAgentOSSelected(agentOSSelected){
+  };
+  onChangeAgentTypeSelected = agentTypeSelected => {
+    this.setState(
+      {
+        agentTypeSelected,
+        agentOSSelected: agentTypeSelected === 'agent' ? 'linux' : '',
+      },
+      () => {
+        this.resetGuide();
+      },
+    );
+  };
+  onChangeAgentOSSelected(agentOSSelected) {
     this.setState({ agentOSSelected }, () => {
-      this.resetGuide()
+      this.resetGuide();
     });
   }
   render() {
     const { guide } = this;
-    const { modalRestartIsVisble, agentTypeSelected, agentOSSelected } = this.state;
+    const { modalRestartIsVisble, agentTypeSelected, agentOSSelected } =
+      this.state;
     return (
       <div>
         <EuiFlexGroup alignItems='center'>
@@ -696,20 +990,25 @@ class WzModuleGuide extends Component {
                       position='top'
                       content='Back to add modules data'
                     >
-                      <EuiButtonIcon onClick={() => this.props.close()} iconType='arrowLeft' iconSize='l' aria-label='Back to add modules data'/>
+                      <EuiButtonIcon
+                        onClick={() => this.props.close()}
+                        iconType='arrowLeft'
+                        iconSize='l'
+                        aria-label='Back to add modules data'
+                      />
                     </EuiToolTip>
-                    {guide.icon && (
-                      <EuiIcon size='xl' type={guide.icon} />
-                    )}
+                    {guide.icon && <EuiIcon size='xl' type={guide.icon} />}
                     <span> {guide.name}</span>
                   </h2>
                 </EuiTitle>
                 <EuiSpacer size='m' />
                 <EuiText>
-                  {guide.description} {guide.documentation_link && (
+                  {guide.description}{' '}
+                  {guide.documentation_link && (
                     <EuiLink
                       href={guide.documentation_link}
-                      external target="_blank"
+                      external
+                      target='_blank'
                       rel='noopener noreferrer'
                     >
                       Learn more
@@ -720,7 +1019,11 @@ class WzModuleGuide extends Component {
                 {guide.callout_warning && (
                   <EuiFlexGroup>
                     <EuiFlexItem>
-                      <EuiCallOut title='Warning' color="warning" iconType="alert">
+                      <EuiCallOut
+                        title='Warning'
+                        color='warning'
+                        iconType='alert'
+                      >
                         <p>{guide.callout_warning}</p>
                       </EuiCallOut>
                     </EuiFlexItem>
@@ -728,17 +1031,19 @@ class WzModuleGuide extends Component {
                 )}
                 {this.specificGuide && (
                   <Fragment>
-                    {guide.callout_warning && (
-                      <EuiSpacer size='s' />
-                    )}
+                    {guide.callout_warning && <EuiSpacer size='s' />}
                     <EuiFlexGroup>
                       <EuiFlexItem>
                         <span>
-                          <EuiBadge color='hollow' style={{padding: '4px'}}>{capitalize(agentTypeSelected)}</EuiBadge>
-                          <EuiBadge color='hollow' style={{padding: '4px'}}>
-                            <span style={{marginLeft: '6px'}}>
-                              {renderOSIcon(agentOSSelected)} {capitalize(agentOSSelected)}
-                            </span></EuiBadge>
+                          <EuiBadge color='hollow' style={{ padding: '4px' }}>
+                            {capitalize(agentTypeSelected)}
+                          </EuiBadge>
+                          <EuiBadge color='hollow' style={{ padding: '4px' }}>
+                            <span style={{ marginLeft: '6px' }}>
+                              {renderOSIcon(agentOSSelected)}{' '}
+                              {capitalize(agentOSSelected)}
+                            </span>
+                          </EuiBadge>
                         </span>
                       </EuiFlexItem>
                     </EuiFlexGroup>
@@ -749,27 +1054,37 @@ class WzModuleGuide extends Component {
           </EuiFlexItem>
           {guide.image && (
             <EuiFlexItem>
-              <EuiFlexGroup justifyContent='flexEnd' style={{marginRight: '8px'}}>
+              <EuiFlexGroup
+                justifyContent='flexEnd'
+                style={{ marginRight: '8px' }}
+              >
                 <EuiFlexItem grow={false}>
-                  <EuiImage allowFullScreen size='l' alt={`${guide.id} image`} url={guide.image}/>
+                  <EuiImage
+                    allowFullScreen
+                    size='l'
+                    alt={`${guide.id} image`}
+                    url={guide.image}
+                  />
                 </EuiFlexItem>
               </EuiFlexGroup>
             </EuiFlexItem>
           )}
         </EuiFlexGroup>
-        {!this.specificGuide && guide.avaliable_for_manager && guide.avaliable_for_agent && (
-          <EuiFlexGroup justifyContent='center'>
-            <EuiFlexItem grow={false}>
-              <EuiButtonGroup
-                color='primary'
-                legend='Agent type'
-                options={agentTypeButtons}
-                idSelected={this.state.agentTypeSelected}
-                onChange={this.onChangeAgentTypeSelected}
-              />
-            </EuiFlexItem>
-          </EuiFlexGroup>
-        )}
+        {!this.specificGuide &&
+          guide.avaliable_for_manager &&
+          guide.avaliable_for_agent && (
+            <EuiFlexGroup justifyContent='center'>
+              <EuiFlexItem grow={false}>
+                <EuiButtonGroup
+                  color='primary'
+                  legend='Agent type'
+                  options={agentTypeButtons}
+                  idSelected={this.state.agentTypeSelected}
+                  onChange={this.onChangeAgentTypeSelected}
+                />
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          )}
         <EuiSpacer size='l' />
         <EuiFlexGroup>
           <EuiFlexItem>
@@ -777,15 +1092,18 @@ class WzModuleGuide extends Component {
               <EuiFlexGroup>
                 <EuiFlexItem>
                   <EuiTitle>
-                    <h2>
-                      {guide.title || 'Getting started'}
-                    </h2>
+                    <h2>{guide.title || 'Getting started'}</h2>
                   </EuiTitle>
                 </EuiFlexItem>
                 <EuiFlexItem grow={false}>
                   <EuiFlexGroup justifyContent='flexEnd'>
                     <EuiFlexItem>
-                      <EuiButtonEmpty iconType='refresh' onClick={() => this.toggleResetGuideModal()}>Reset guide</EuiButtonEmpty>
+                      <EuiButtonEmpty
+                        iconType='refresh'
+                        onClick={() => this.toggleResetGuideModal()}
+                      >
+                        Reset guide
+                      </EuiButtonEmpty>
                     </EuiFlexItem>
                   </EuiFlexGroup>
                 </EuiFlexItem>
@@ -795,19 +1113,22 @@ class WzModuleGuide extends Component {
                   {!this.specificGuide && agentTypeSelected === 'agent' && (
                     <Fragment>
                       <EuiTabs size='m' display='default' expand={false}>
-                        {agentOsTabs.map((agentOSTab) => (
-                          <EuiTab key={`agent-tab-${agentOSTab.name}`}
+                        {agentOsTabs.map(agentOSTab => (
+                          <EuiTab
+                            key={`agent-tab-${agentOSTab.name}`}
                             isSelected={agentOSTab.id === agentOSSelected}
-                            onClick={() => this.onChangeAgentOSSelected(agentOSTab.id)}
-                            >
+                            onClick={() =>
+                              this.onChangeAgentOSSelected(agentOSTab.id)
+                            }
+                          >
                             {agentOSTab.name}
                           </EuiTab>
                         ))}
                       </EuiTabs>
-                      <EuiSpacer size='l'/>
+                      <EuiSpacer size='l' />
                     </Fragment>
                   )}
-                  <EuiSteps headingElement="h2" steps={this.renderSteps()} />
+                  <EuiSteps headingElement='h2' steps={this.renderSteps()} />
                 </EuiFlexItem>
               </EuiFlexGroup>
             </EuiPanel>
@@ -816,17 +1137,17 @@ class WzModuleGuide extends Component {
         {modalRestartIsVisble && (
           <EuiOverlayMask>
             <EuiConfirmModal
-              title="Do you want reset the guide?"
+              title='Do you want reset the guide?'
               onCancel={this.toggleResetGuideModal}
               onConfirm={this.resetGuideWithNotification}
               cancelButtonText="No, don't do it"
-              confirmButtonText="Yes, do it"
-              defaultFocusedButton="confirm">
-            </EuiConfirmModal>
+              confirmButtonText='Yes, do it'
+              defaultFocusedButton='confirm'
+            ></EuiConfirmModal>
           </EuiOverlayMask>
         )}
       </div>
-    )
+    );
   }
 }
 
@@ -837,15 +1158,15 @@ WzModuleGuide.propTypes = {
     PropTypes.shape({
       id: PropTypes.string,
       os: {
-        platform: PropTypes.string
-      }
+        platform: PropTypes.string,
+      },
     }),
     PropTypes.shape({
-      type: PropTypes.oneOf['manager','agent'],
-      os: PropTypes.oneOf['linux','windows']
+      type: PropTypes.oneOf[('manager', 'agent')],
+      os: PropTypes.oneOf[('linux', 'windows')],
     }),
-    PropTypes.any
-  ])
-}
+    PropTypes.any,
+  ]),
+};
 
 export default WzModuleGuide;

--- a/plugins/main/public/controllers/management/components/management/configuration/utils/utils.js
+++ b/plugins/main/public/controllers/management/components/management/configuration/utils/utils.js
@@ -10,7 +10,7 @@
  * Find more information about this on the LICENSE file.
  */
 
-import js2xmlparser from 'js2xmlparser';
+import { parse } from 'js2xmlparser';
 import XMLBeautifier from './xml-beautifier';
 
 /**
@@ -29,9 +29,7 @@ export const getXML = currentConfig => {
   const config = {};
   Object.assign(config, currentConfig);
   const cleaned = objectWithoutProperties(config);
-  const XMLContent = XMLBeautifier(
-    js2xmlparser.parse('configuration', cleaned)
-  );
+  const XMLContent = XMLBeautifier(parse('configuration', cleaned));
   return XMLContent;
 };
 
@@ -90,7 +88,7 @@ export const objectWithoutProperties = obj => {
           return undefined;
         }
         return val;
-      })
+      }),
     );
     return result;
   } catch (error) {

--- a/plugins/main/public/utils/config-handler.js
+++ b/plugins/main/public/utils/config-handler.js
@@ -9,7 +9,7 @@
  *
  * Find more information about this on the LICENSE file.
  */
-import js2xmlparser from 'js2xmlparser';
+import { parse } from 'js2xmlparser';
 import XMLBeautifier from './xml-beautifier';
 import { queryConfig } from '../react-services/query-config';
 import { objectWithoutProperties } from './remove-hash-key.js';
@@ -32,7 +32,7 @@ export class ConfigurationHandler {
       const wmodulesArray =
         ((config || {})['wmodules-wmodules'] || {}).wmodules || [];
       const result = wmodulesArray.filter(
-        item => typeof item[wodleKey] !== 'undefined'
+        item => typeof item[wodleKey] !== 'undefined',
       );
       return result.length ? result[0][wodleKey] : false;
     } catch (error) {
@@ -50,7 +50,7 @@ export class ConfigurationHandler {
     sections,
     $scope,
     agentId = false,
-    node = false
+    node = false,
   ) {
     try {
       $scope.load = true;
@@ -62,7 +62,7 @@ export class ConfigurationHandler {
       $scope.currentConfig = await queryConfig(
         agentId || '000',
         sections,
-        node
+        node,
       );
 
       if ($scope.configurationSubTab === 'pm-sca') {
@@ -72,7 +72,7 @@ export class ConfigurationHandler {
       if (sections[0].component === 'integrator') {
         this.buildIntegrations(
           $scope.currentConfig['integrator-integration'].integration,
-          $scope
+          $scope,
         );
       } else {
         $scope.integrations = {};
@@ -80,17 +80,15 @@ export class ConfigurationHandler {
 
       if (($scope.currentConfig['logcollector-localfile'] || {}).localfile) {
         const data = $scope.currentConfig['logcollector-localfile'].localfile;
-        $scope.currentConfig['logcollector-localfile'][
-          'localfile-logs'
-        ] = data.filter(item => typeof item.file !== 'undefined');
-        $scope.currentConfig['logcollector-localfile'][
-          'localfile-commands'
-        ] = data.filter(item => typeof item.file === 'undefined');
+        $scope.currentConfig['logcollector-localfile']['localfile-logs'] =
+          data.filter(item => typeof item.file !== 'undefined');
+        $scope.currentConfig['logcollector-localfile']['localfile-commands'] =
+          data.filter(item => typeof item.file === 'undefined');
 
         const sanitizeLocalfile = file => {
           if (file.target) {
             file.targetStr = '';
-            file.target.forEach(function(target, idx) {
+            file.target.forEach(function (target, idx) {
               file.targetStr = file.targetStr.concat(target);
               if (idx != file.target.length - 1) {
                 file.targetStr = file.targetStr.concat(', ');
@@ -131,7 +129,7 @@ export class ConfigurationHandler {
       $scope.currentConfig = await queryConfig(
         agentId || '000',
         [{ component: 'wmodules', configuration: 'wmodules' }],
-        node
+        node,
       );
 
       // Filter by provided wodleName
@@ -141,7 +139,7 @@ export class ConfigurationHandler {
         (($scope.currentConfig || {})['wmodules-wmodules'] || {}).wmodules
       ) {
         result = $scope.currentConfig['wmodules-wmodules'].wmodules.filter(
-          item => typeof item[wodleName] !== 'undefined'
+          item => typeof item[wodleName] !== 'undefined',
         );
       }
 
@@ -169,10 +167,9 @@ export class ConfigurationHandler {
   async isWodleEnabled(wodleName, agentId = false) {
     try {
       // Get wodles configuration
-      const wodlesConfig = await queryConfig(
-        agentId || '000',
-        [{ component: 'wmodules', configuration: 'wmodules' }],
-      );
+      const wodlesConfig = await queryConfig(agentId || '000', [
+        { component: 'wmodules', configuration: 'wmodules' },
+      ]);
 
       // Filter by provided wodleName
       let result = [];
@@ -184,7 +181,7 @@ export class ConfigurationHandler {
         result = wodlesConfig['wmodules-wmodules'].wmodules.filter(
           item =>
             typeof item[wodleName] !== 'undefined' &&
-            item[wodleName].disabled === 'no'
+            item[wodleName].disabled === 'no',
         );
       }
 
@@ -233,9 +230,7 @@ export class ConfigurationHandler {
     } else {
       try {
         const cleaned = objectWithoutProperties(config);
-        $scope.XMLContent = XMLBeautifier(
-          js2xmlparser.parse('configuration', cleaned)
-        );
+        $scope.XMLContent = XMLBeautifier(parse('configuration', cleaned));
         $scope.$broadcast('XMLContentReady', { data: $scope.XMLContent });
       } catch (error) {
         $scope.XMLContent = false;
@@ -246,7 +241,7 @@ export class ConfigurationHandler {
 
   json2xml(data) {
     if (data) {
-      const result = XMLBeautifier(js2xmlparser.parse('configuration', data));
+      const result = XMLBeautifier(parse('configuration', data));
       return result;
     }
     return false;


### PR DESCRIPTION
### Description
This pull request fixes a problem parsing the XML configuration in Management > Configuration
 
### Issues Resolved
#5868

### Evidence
![image](https://github.com/wazuh/wazuh-kibana-app/assets/34042064/49c01636-deec-4b2f-bb2c-ccc783bcf324)

### Test

Legend:
:black_circle:: none
:green_circle:: pass
:yellow_circle:: warning
:red_circle:: fail
:white_circle:: not applicable

## UI

| Test | Chrome | Firefox | Safari |
| --- |  --- | --- | --- |
| Go to Management > Configuration > Any section and open the XML viewer, it should not throw any error and the configuration should be visible. | :black_circle: | :black_circle: | :black_circle: |

**Details**
<details>
<summary>:black_circle: Go to Management > Configuration > Any section and open the XML viewer, it should not throw any error and the configuration should be visible.</summary>

Chrome - :black_circle:

Firefox - :black_circle:

Safari - :black_circle:

</details>




### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 
