### PR TITLE
Fix WQL documentation link

### DIFF
--- a/plugins/main/public/components/common/tables/__snapshots__/table-with-search-bar.test.tsx.snap
+++ b/plugins/main/public/components/common/tables/__snapshots__/table-with-search-bar.test.tsx.snap
@@ -109,7 +109,7 @@ exports[`Table With Search Bar component renders correctly to match the snapshot
               <EuiSpacer />
               <div>
                 <EuiLink
-                  href="https://github.com/wazuh/wazuh-kibana-app/blob/v4.6.0/plugins/main/public/components/search-bar/query-language/wql.md"
+                  href="https://documentation.wazuh.com/4.6/user-manual/wazuh-dashboard/queries.html"
                   rel="noopener noreferrer"
                   target="__blank"
                 >
@@ -178,7 +178,7 @@ exports[`Table With Search Bar component renders correctly to match the snapshot
                   <EuiSpacer />
                   <div>
                     <EuiLink
-                      href="https://github.com/wazuh/wazuh-kibana-app/blob/v4.6.0/plugins/main/public/components/search-bar/query-language/wql.md"
+                      href="https://documentation.wazuh.com/4.6/user-manual/wazuh-dashboard/queries.html"
                       rel="noopener noreferrer"
                       target="__blank"
                     >
@@ -258,7 +258,7 @@ exports[`Table With Search Bar component renders correctly to match the snapshot
                             <EuiSpacer />
                             <div>
                               <EuiLink
-                                href="https://github.com/wazuh/wazuh-kibana-app/blob/v4.6.0/plugins/main/public/components/search-bar/query-language/wql.md"
+                                href="https://documentation.wazuh.com/4.6/user-manual/wazuh-dashboard/queries.html"
                                 rel="noopener noreferrer"
                                 target="__blank"
                               >
@@ -368,7 +368,7 @@ exports[`Table With Search Bar component renders correctly to match the snapshot
                                       <EuiSpacer />
                                       <div>
                                         <EuiLink
-                                          href="https://github.com/wazuh/wazuh-kibana-app/blob/v4.6.0/plugins/main/public/components/search-bar/query-language/wql.md"
+                                          href="https://documentation.wazuh.com/4.6/user-manual/wazuh-dashboard/queries.html"
                                           rel="noopener noreferrer"
                                           target="__blank"
                                         >
@@ -434,7 +434,7 @@ exports[`Table With Search Bar component renders correctly to match the snapshot
                                         <EuiSpacer />
                                         <div>
                                           <EuiLink
-                                            href="https://github.com/wazuh/wazuh-kibana-app/blob/v4.6.0/plugins/main/public/components/search-bar/query-language/wql.md"
+                                            href="https://documentation.wazuh.com/4.6/user-manual/wazuh-dashboard/queries.html"
                                             rel="noopener noreferrer"
                                             target="__blank"
                                           >

--- a/plugins/main/public/components/search-bar/query-language/wql.tsx
+++ b/plugins/main/public/components/search-bar/query-language/wql.tsx
@@ -11,6 +11,7 @@ import {
   PLUGIN_VERSION,
   SEARCH_BAR_WQL_VALUE_SUGGESTIONS_DISPLAY_COUNT,
 } from '../../../../common/constants';
+import { webDocumentationLink } from '../../../../common/services/web_documentation';
 
 /* UI Query language
 https://documentation.wazuh.com/current/user-manual/api/queries.html
@@ -959,7 +960,9 @@ export const WQL = {
   label: 'WQL',
   description:
     'WQL (Wazuh Query Language) provides a human query syntax based on the Wazuh API query language.',
-  documentationLink: `https://github.com/wazuh/wazuh-kibana-app/blob/v${PLUGIN_VERSION}/plugins/main/public/components/search-bar/query-language/wql.md`,
+  documentationLink: webDocumentationLink(
+    'user-manual/wazuh-dashboard/queries.html',
+  ),
   getConfiguration() {
     return {
       isOpenPopoverImplicitFilter: false,


### PR DESCRIPTION
### Description
This pull request fixes the link to the WQL documentation. It redirects to the official documentation instead of repository documenation.
 
### Issues Resolved
#5867

### Evidence
![image](https://github.com/wazuh/wazuh-kibana-app/assets/34042064/110e678e-a443-434d-b917-e0bc8be68bac)

### Test

Legend:
:black_circle:: none
:green_circle:: pass
:yellow_circle:: warning
:red_circle:: fail
:white_circle:: not applicable

## UI

| Test | Chrome | Firefox | Safari |
| --- |  --- | --- | --- |
| Ensure the WQL documentation link is pointing to the official documentation and the link would be valid. | :black_circle: | :black_circle: | :black_circle: |

**Details**
<details>
<summary>:black_circle: Ensure the WQL documentation link is pointing to the official documentation and the link would be valid.</summary>

Chrome - :black_circle:

Firefox - :black_circle:

Safari - :black_circle:

</details>

### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 
