### PR TITLE
Fix install agent command on SUSE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to the Wazuh app project will be documented in this file.
 
 - Support for Wazuh 4.5.3
 
+### Changed
+
+- Changed the command to install the agent on SUSE uses zypper [#5925](https://github.com/wazuh/wazuh-kibana-app/pull/5925)
+
 ## Wazuh v4.5.2 - OpenSearch Dashboards 2.6.0 - Revision 02
 
 ### Added

--- a/public/controllers/agent/components/register-agent.js
+++ b/public/controllers/agent/components/register-agent.js
@@ -1042,7 +1042,7 @@ apk add wazuh-agent=${this.state.wazuhVersion}-r1`,
         amazonlinuxText: `sudo ${this.optionalDeploymentVariables()}${this.agentNameVariable()}yum install -y ${this.optionalPackages()}`,
         fedoraText: `sudo ${this.optionalDeploymentVariables()}${this.agentNameVariable()}yum install -y ${this.optionalPackages()}`,
         oraclelinuxText: `sudo ${this.optionalDeploymentVariables()}${this.agentNameVariable()}yum install -y ${this.optionalPackages()}`,
-        suseText: `sudo ${this.optionalDeploymentVariables()}${this.agentNameVariable()}yum install -y ${this.optionalPackages()}`,
+        suseText: `sudo rpm --import https://packages.wazuh.com/key/GPG-KEY-WAZUH && sudo ${this.optionalDeploymentVariables()}${this.agentNameVariable()}zypper install -y ${this.optionalPackages()}`,
         raspbianText: `curl -so wazuh-agent.deb ${this.optionalPackages()} && sudo ${this.optionalDeploymentVariables()}${this.agentNameVariable()}dpkg -i ./wazuh-agent.deb`,
       };
 


### PR DESCRIPTION
### Description
This pull request fixes the command to install the agent on SUSE.
 
### Issues Resolved
#5924

### Evidence
![image](https://github.com/wazuh/wazuh-kibana-app/assets/34042064/f7eaf746-a45f-43bf-9f9a-a71f2972dbc7)

### Test
Legend:
:black_circle:: none
:green_circle:: pass
:yellow_circle:: warning
:red_circle:: fail
:white_circle:: not applicable

## UI

| Test | Chrome | Firefox | Safari |
| --- |  --- | --- | --- |
| Go to deploy new agent guide and select SUSE, the command to install the agent should use zypper package manager | :black_circle: | :black_circle: | :black_circle: |
| Go to deploy new agent guide and select SUSE, add agent name or group and the command to install the agent should use zypper package manager and display the defined setting in environment variables | :black_circle: | :black_circle: | :black_circle: |

**Details**
<details>
<summary>:black_circle: Go to deploy new agent guide and select SUSE, the command to install the agent should use zypper package manager</summary>

Chrome - :black_circle:

Firefox - :black_circle:

Safari - :black_circle:

</details>

<details>
<summary>:black_circle: Go to deploy new agent guide and select SUSE, add agent name or group and the command to install the agent should use zypper package manager and display the defined setting in environment variables</summary>

Chrome - :black_circle:

Firefox - :black_circle:

Safari - :black_circle:

</details>




### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 
