### PR TITLE
Fix remove policy from roles

### DIFF
--- a/plugins/main/public/components/security/roles/edit-role-table.tsx
+++ b/plugins/main/public/components/security/roles/edit-role-table.tsx
@@ -87,7 +87,7 @@ export const EditRolesTable = ({
               iconType='trash'
               color='danger'
               isDisabled={isDisabled && !isLoading}
-              onClick={async item => {
+              onClick={async ev => {
                 try {
                   setIsLoading(true);
                   const response = await WzRequest.apiReq(


### PR DESCRIPTION
### Description
The name of the onclick function parameter was changed because it was called the same as the render function parameter and was using the wrong one.
 
### Issues Resolved
- #5935

### Evidence

![image](https://github.com/wazuh/wazuh-kibana-app/assets/63758389/e6dcd53b-8f01-4a79-abcb-e0780d092758)

### Test
1. Navigate to 'Security/Roles'
2. Click on 'a custom role'
3. Try to remove any policy
4. If you use a real manager, the policy has to be removed. If you use the imposter, make sure that in the delete request you have policy_ids


### Check List
- [x] All tests pass
  - [x] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 
