### PR TITLE
Add useDashboardConfiguration hook for configuring vulnerability dashboards

### DIFF
--- a/plugins/main/public/components/overview/vulnerabilities/dashboards/hooks/use-dashboard-configuration.test.ts
+++ b/plugins/main/public/components/overview/vulnerabilities/dashboards/hooks/use-dashboard-configuration.test.ts
@@ -1,0 +1,69 @@
+import { renderHook, act } from '@testing-library/react-hooks';
+import { ViewMode } from '../../../../../../../../src/plugins/embeddable/public';
+import { DashboardContainerInput } from '../../../../../../../../src/plugins/dashboard/public';
+import { useDashboardConfiguration } from './use-dashboard-configuration';
+
+describe('useDashboardConfiguration', () => {
+  test('initial configuration is set correctly', () => {
+    const emptyInitialConfiguration: DashboardContainerInput = {
+      viewMode: ViewMode.EDIT,
+      filters: [],
+      query: undefined,
+      timeRange: undefined,
+      useMargins: false,
+      title: '',
+      isFullScreenMode: false,
+      panels: {},
+      id: '',
+    };
+
+    const { result } = renderHook(() => useDashboardConfiguration());
+
+    expect(result.current.configuration).toEqual(emptyInitialConfiguration);
+    expect(typeof result.current.updateConfiguration).toBe('function');
+  });
+
+  test('updateConfiguration updates configuration correctly', () => {
+    const { result } = renderHook(() => useDashboardConfiguration());
+
+    const updatedConfig = {
+      viewMode: ViewMode.VIEW,
+      title: 'Updated Title',
+    };
+
+    act(() => {
+      result.current.updateConfiguration(updatedConfig);
+    });
+
+    expect(result.current.configuration.viewMode).toBe(updatedConfig.viewMode);
+    expect(result.current.configuration.title).toBe(updatedConfig.title);
+  });
+
+  test('updateConfiguration merges properties correctly', () => {
+    const { result } = renderHook(() => useDashboardConfiguration());
+
+    const updatedConfig = {
+      viewMode: ViewMode.VIEW,
+      title: 'Updated Title',
+    };
+
+    act(() => {
+      result.current.updateConfiguration(updatedConfig);
+    });
+
+    expect(result.current.configuration.viewMode).toBe(updatedConfig.viewMode);
+    expect(result.current.configuration.title).toBe(updatedConfig.title);
+
+    const additionalUpdate = {
+      description: 'Updated Description',
+    };
+
+    act(() => {
+      result.current.updateConfiguration(additionalUpdate);
+    });
+
+    expect(result.current.configuration.viewMode).toBe(updatedConfig.viewMode);
+    expect(result.current.configuration.title).toBe(updatedConfig.title);
+    expect(result.current.configuration.description).toBe(additionalUpdate.description);
+  });
+});

--- a/plugins/main/public/components/overview/vulnerabilities/dashboards/hooks/use-dashboard-configuration.tsx
+++ b/plugins/main/public/components/overview/vulnerabilities/dashboards/hooks/use-dashboard-configuration.tsx
@@ -16,7 +16,7 @@ const emptyInitialConfiguration: DashboardContainerInput = {
 
 export const useDashboardConfiguration = (initialConfiguration?: DashboardContainerInput) => {
   const [configuration, setConfiguration] = useState<DashboardContainerInput>(
-    initialConfiguration ? initialConfiguration : emptyInitialConfiguration
+    initialConfiguration ?? emptyInitialConfiguration
   );
 
   const updateConfiguration = (updatedConfig: Partial<DashboardContainerInput>) => {

--- a/plugins/main/public/components/overview/vulnerabilities/dashboards/hooks/use-dashboard-configuration.tsx
+++ b/plugins/main/public/components/overview/vulnerabilities/dashboards/hooks/use-dashboard-configuration.tsx
@@ -1,0 +1,33 @@
+import { useState } from 'react';
+import { DashboardContainerInput } from '../../../../../../../../src/plugins/dashboard/public';
+import { ViewMode } from '../../../../../../../../src/plugins/embeddable/public';
+
+const emptyInitialConfiguration: DashboardContainerInput = {
+  viewMode: ViewMode.EDIT,
+  filters: [],
+  query: undefined,
+  timeRange: undefined,
+  useMargins: false,
+  title: '',
+  isFullScreenMode: false,
+  panels: {},
+  id: '',
+};
+
+export const useDashboardConfiguration = (initialConfiguration?: DashboardContainerInput) => {
+  const [configuration, setConfiguration] = useState<DashboardContainerInput>(
+    initialConfiguration ? initialConfiguration : emptyInitialConfiguration
+  );
+
+  const updateConfiguration = (updatedConfig: Partial<DashboardContainerInput>) => {
+    setConfiguration((prevConfig: DashboardContainerInput) => ({
+      ...prevConfig,
+      ...updatedConfig,
+    }));
+  };
+
+  return {
+    configuration,
+    updateConfiguration,
+  };
+};


### PR DESCRIPTION
## Description
This PR adds the useDashboardConfiguration hook for configuring vulnerability dashboards.
 
## Issues Resolved
- #5946 

## Evidence
### Test `use-dashboard-configuration.test.ts`

![use-dashboard-configuration-test](https://github.com/wazuh/wazuh-kibana-app/assets/43619595/d1f6f1c4-320a-4d91-a793-eeedb843ca6a)


## Test
- Check code
- Run `use-dashboard-configuration.test.ts`

### Check List
- [x] All tests pass
  - [x] `yarn test:jest`
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 
