### PR TITLE
Restrict workflows permissions

### DIFF
--- a/.github/workflows/6_builderpackage_on-update-tags.yml
+++ b/.github/workflows/6_builderpackage_on-update-tags.yml
@@ -21,6 +21,9 @@ jobs:
   build:
     name: Build app package (auto)
     uses: ./.github/workflows/6_builderprecompiled_base-dev-environment.yml
+    permissions:
+      actions: read
+      contents: read
     with:
       reference: ${{ github.ref_name }}
       command: 'yarn build'

--- a/.github/workflows/6_builderpackage_plugins.yml
+++ b/.github/workflows/6_builderpackage_plugins.yml
@@ -37,6 +37,9 @@ jobs:
   build:
     name: Build app package
     uses: ./.github/workflows/6_builderprecompiled_base-dev-environment.yml
+    permissions:
+      actions: read
+      contents: read
     with:
       reference: ${{ inputs.reference }}
       command: 'yarn build'

--- a/.github/workflows/6_builderprecompiled_base-dev-environment.yml
+++ b/.github/workflows/6_builderprecompiled_base-dev-environment.yml
@@ -51,6 +51,8 @@ jobs:
   # Deploy the plugin in a development environment and run a command
   # using a pre-built Docker image, hosted in Quay.io.
   deploy_and_run_command:
+    permissions:
+      pull-requests: write
     name: Deploy and run command
     runs-on: ubuntu-24.04
     strategy:

--- a/.github/workflows/6_testunit_jest.yml
+++ b/.github/workflows/6_testunit_jest.yml
@@ -15,6 +15,8 @@
 
 name: Run unit test
 
+permissions:
+  pull-requests: write
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
### Description
This pull request restricts dthe workflows permissions.
 

## Evidence
- Package building workflow worked as expected:
  - https://github.com/wazuh/wazuh-dashboard/actions/runs/15638737824

### Test
- Verify all tests pass
- Verify the package building process works as expected

### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff 
