### PR TITLE
Events count evolution visualization does not use the server API context filter

### DIFF
--- a/plugins/main/public/components/common/data-source/pattern/alerts/alerts-data-source.ts
+++ b/plugins/main/public/components/common/data-source/pattern/alerts/alerts-data-source.ts
@@ -7,10 +7,6 @@ export class AlertsDataSource extends PatternDataSource {
     super(id, title);
   }
 
-  getFixedFilters(): tFilter[] {
-    return [...this.getClusterManagerFilters(), ...super.getFixedFilters()];
-  }
-
   getFixedFiltersClusterManager(): tFilter[] {
     return [...this.getClusterManagerFilters()];
   }

--- a/plugins/main/public/components/common/data-source/pattern/alerts/events-count/events-count-data-source.ts
+++ b/plugins/main/public/components/common/data-source/pattern/alerts/events-count/events-count-data-source.ts
@@ -1,0 +1,15 @@
+import { tFilter } from '../../../index';
+import { AlertsDataSource } from '../alerts-data-source';
+
+export class EventsCountDataSource extends AlertsDataSource {
+  constructor(id: string, title: string) {
+    super(id, title);
+  }
+
+  getFixedFilters(): tFilter[] {
+    return [
+      ...super.getFixedFiltersClusterManager(),
+      ...super.getFixedFilters(),
+    ];
+  }
+}

--- a/plugins/main/public/components/common/data-source/pattern/alerts/events-count/index.ts
+++ b/plugins/main/public/components/common/data-source/pattern/alerts/events-count/index.ts
@@ -1,0 +1,1 @@
+export * from './events-count-data-source';

--- a/plugins/main/public/components/common/welcome/dashboard/events-count.tsx
+++ b/plugins/main/public/components/common/welcome/dashboard/events-count.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { AlertsDataSource } from '../../data-source/pattern/alerts/alerts-data-source';
 import { AlertsDataSourceRepository } from '../../data-source/pattern/alerts/alerts-data-source-repository';
 import { getPlugins } from '../../../../kibana-services';
 import { getDashboardPanels } from './dashboard_panels';
@@ -15,6 +14,7 @@ import {
 } from '@elastic/eui';
 import { useTimeFilter } from '../../hooks';
 import { LoadingSearchbarProgress } from '../../loading-searchbar-progress/loading-searchbar-progress';
+import { EventsCountDataSource } from '../../data-source/pattern/alerts/events-count';
 
 const plugins = getPlugins();
 const DashboardByRenderer = plugins.dashboard.DashboardContainerByValueRenderer;
@@ -25,7 +25,7 @@ export const EventsCount = () => {
     fetchFilters,
     isLoading: isDataSourceLoading,
   } = useDataSource<tParsedIndexPattern, PatternDataSource>({
-    DataSource: AlertsDataSource,
+    DataSource: EventsCountDataSource,
     repository: new AlertsDataSourceRepository(),
   });
 


### PR DESCRIPTION
### Description
The Events count evolution visualization in the agent welcome now use the server API context filter, adding (cluster.name/manager.name) to query.
 
### Issues Resolved
https://github.com/wazuh/wazuh-dashboard-plugins/issues/7699

### Evidence
<img width="1480" height="483" alt="Screenshot 2025-09-05 at 2 18 03 PM" src="https://github.com/user-attachments/assets/2c83dee4-3242-4da7-a076-36df10c89e05" />


### Test

1. Navigate to agent welcome
2. Review the related opensearch request using the browser dev tools and see the query include the mentioned filter.

### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 
