### PR TITLE
feat(#25587): add CephFS type to skip_nfs flag

### DIFF
--- a/plugins/main/public/controllers/management/components/management/configuration/integrity-monitoring/integrity-monitoring-general.js
+++ b/plugins/main/public/controllers/management/components/management/configuration/integrity-monitoring/integrity-monitoring-general.js
@@ -59,7 +59,7 @@ const mainSettings = [
     when: 'manager'
   },
   { field: 'scan_on_start', label: 'Scan on start' },
-  { field: 'skip_nfs', label: 'Skip scan on CIFS/NFS mounts' },
+  { field: 'skip_nfs', label: 'Skip scan on CephFS/CIFS/NFS mounts' },
   { field: 'skip_dev', label: 'Skip scan of /dev directory' },
   { field: 'skip_sys', label: 'Skip scan of /sys directory' },
   { field: 'skip_proc', label: 'Skip scan of /proc directory' },

--- a/plugins/main/public/controllers/management/components/management/configuration/policy-monitoring/policy-monitoring-general.js
+++ b/plugins/main/public/controllers/management/components/management/configuration/policy-monitoring/policy-monitoring-general.js
@@ -38,7 +38,7 @@ const allSettings = [
   { field: 'check_winapps', label: 'Check Windows apps' },
   { field: 'check_winaudit', label: 'Check Windows audit' },
   { field: 'check_winmalware', label: 'Check Windows malware' },
-  { field: 'skip_nfs', label: 'Skip scan on CIFS/NFS mounts' },
+  { field: 'skip_nfs', label: 'Skip scan on CephFS/CIFS/NFS mounts' },
   { field: 'rootkit_files', label: 'Rootkit files database path' },
   { field: 'rootkit_trojans', label: 'Rootkit trojans database path' },
   { field: 'windows_audit', label: 'Windows audit definition file path' },

--- a/plugins/main/server/lib/reporting/agent-configuration.ts
+++ b/plugins/main/server/lib/reporting/agent-configuration.ts
@@ -94,7 +94,7 @@ export const AgentConfiguration = {
               rootkit_files: 'Rootkit files database path',
               rootkit_trojans: 'Rootkit trojans database path',
               scanall: 'Scan the entire system',
-              skip_nfs: 'Skip scan on CIFS/NFS mounts',
+              skip_nfs: 'Skip scan on CephFS/CIFS/NFS mounts',
               frequency: 'Frequency (in seconds) to run the scan',
               check_dev: 'Check /dev path',
               check_files: 'Check files',
@@ -246,7 +246,7 @@ export const AgentConfiguration = {
             {
               disabled: 'Integrity monitoring disabled',
               frequency: 'Interval (in seconds) to run the integrity scan',
-              skip_nfs: 'Skip scan on CIFS/NFS mounts',
+              skip_nfs: 'Skip scan on CephFS/CIFS/NFS mounts',
               scan_on_start: 'Scan on start',
               directories: 'Monitored directories',
               nodiff: 'No diff directories',


### PR DESCRIPTION
[ceph-csi](https://github.com/ceph/ceph-csi) for Kubernetes mounts CephFS filesystems under /var/lib/kubelet/plugins/kubernetes.io/csi/cephfs.csi.ceph.com/*/globalmount
 
Wazuh rootcheck scans include /var/lib by default
https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/rootcheck.html?utm_source=chatgpt.com#readall
 
As a result, Wazuh on Kubernetes hosts will recurse into those network filesystems, which is typically not desired, as they may be mounted by multiple hosts at the same time, as well as potentially causing performance issues.
 
I suggest that skip_nfs include CephFS (but not necessarily Ceph RBD) in addition to CIFS and NFS.
 
Closes https://github.com/wazuh/wazuh/issues/25587