### PR TITLE
Change tag references to 4.14.0

### DIFF
--- a/docker/imposter/wazuh-config.yml
+++ b/docker/imposter/wazuh-config.yml
@@ -1,6 +1,6 @@
 ---
 plugin: openapi
-specFile: https://raw.githubusercontent.com/wazuh/wazuh/v4.14.0-rc2/api/api/spec/spec.yaml
+specFile: https://raw.githubusercontent.com/wazuh/wazuh/4.14.0/api/api/spec/spec.yaml
 system:
   stores:
     # this store is preloaded from file


### PR DESCRIPTION
### Description
 
This pull request changes the tag references to 4.14.0.

### Issues Resolved

#7821

### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [x] Commits are signed per the DCO using --signoff 
