### PR TITLE
Update docs to centralize dashboard config in one file

### DIFF
--- a/docs/ref/getting-started/installation.md
+++ b/docs/ref/getting-started/installation.md
@@ -129,30 +129,28 @@ echo -e '[wazuh]\ngpgcheck=1\ngpgkey=https://packages.wazuh.com/key/GPG-KEY-WAZU
 Edit the `/etc/wazuh-dashboard/opensearch_dashboards.yml` file and replace the following values:
 
 - **`server.host`**: This setting specifies the host of the Wazuh dashboard server. To allow remote users to connect, set the value to the IP address or DNS name of the Wazuh dashboard server. The value `0.0.0.0` will accept all the available IP addresses of the host.
-- **`server.port`**: Port that the dashboard exposes. Use `443` if you serve it over HTTPS.
 - **`opensearch.hosts`**: The URLs of the Wazuh indexer instances to use for all your queries. The Wazuh dashboard can be configured to connect to multiple Wazuh indexer nodes in the same cluster. The addresses of the nodes can be separated by commas. For example, `["https://10.0.0.2:9200", "https://10.0.0.3:9200","https://10.0.0.4:9200"]`
+- **`wazuh_core.hosts`**: The Wazuh server hosts that the dashboard will use to query the Wazuh server API. At least one host is required. Each host entry defined with an **unique ID** and must include:
+  - `url`: The URL to the server API including the protocol and address (DNS or IP).
+  - `port`: The port where is served.
+  - `username`: The user that runs the requests.
+  - `password`: The password for the user.
+  - `run_as`: This defines how the dashboard requests the data, using the default configured account (`false`) or the current user's context (`true`).
 
 ```yaml
 server.host: 0.0.0.0
 server.port: 443
 opensearch.hosts: https://localhost:9200
 opensearch.ssl.verificationMode: certificate
-```
-
-Define the Wazuh server hosts that the dashboard will use to query the Wazuh API. At least one host is required. Each host entry must include the URL, port, and credentials:
-
-```yaml
+---
 wazuh_core.hosts:
   default:
-    url: https://<WAZUH_SERVER_IP_OR_DNS>
+    url: https://localhost
     port: 55000
     username: wazuh-wui
     password: wazuh-wui
     run_as: false
 ```
-
-- `run_as: true` will make the dashboard request data using the current user's context; leave it as `false` for the default service account.
-- If you manage multiple Wazuh servers, add more entries under `wazuh_core.hosts` (for example, `regional_eu`, `regional_us`), each with its own connection details.
 
 ### Deploying certificates
 


### PR DESCRIPTION
### Description

clarify that Wazuh dashboard configuration is now managed entirely in «/etc/wazuh-dashboard/opensearch_dashboards.yml», removing references to the deprecated «wazuh.yml» location

add details about configuring Wazuh server hosts, SSL fields, and port settings in the main config file to simplify setup and reduce confusion for new users
 
### Issues Resolved

closes https://github.com/wazuh/wazuh-dashboard/issues/1024

### Test

Recently we made major changes that affect Wazuh dashboard installation. We need to update the deployment guide to reflect these changes.

References:
- https://github.com/wazuh/wazuh-dashboard-plugins/blob/main/docs/ref/getting-started/installation.md
- https://github.com/wazuh/wazuh-dashboard/issues/985

---

- Verify that the Wazuh dashboard installation guide (`docs/ref/getting-started/installation.md`) include the latest changes.

### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 
