### PR TITLE
Change tag reference to 4.14.2

### DIFF
--- a/docker/imposter/wazuh-config.yml
+++ b/docker/imposter/wazuh-config.yml
@@ -1,6 +1,6 @@
 ---
 plugin: openapi
-specFile: https://raw.githubusercontent.com/wazuh/wazuh/v4.14.2-rc1/api/api/spec/spec.yaml
+specFile: https://raw.githubusercontent.com/wazuh/wazuh/v4.14.2/api/api/spec/spec.yaml
 system:
   stores:
     # this store is preloaded from file


### PR DESCRIPTION
### Description
This pull request changes the tag reference to 4.14.2.
 
### Issues Resolved
#7943

### Check List
- [x] All tests pass
  - [x] `yarn test:jest`
- [x] Commits are signed per the DCO using --signoff 
