### PR TITLE
Hide MITRE module

### DIFF
--- a/plugins/main/public/utils/applications.ts
+++ b/plugins/main/public/utils/applications.ts
@@ -775,7 +775,7 @@ export const Applications = [
   configurationAssessment,
   // threatHunting,
   vulnerabilityDetection,
-  mitreAttack,
+  // mitreAttack,
   // pciDss,
   // hipaa,
   // gdpr,


### PR DESCRIPTION
### Description
This PR hides de MITRE ATT&CK module until we further progress in the development.
 
### Issues Resolved
https://github.com/wazuh/wazuh-dashboard-plugins/issues/7955

### Evidence

<img width="2708" height="1885" alt="image" src="https://github.com/user-attachments/assets/e45ef2e0-9bd7-406e-bbca-7af07c3ae09e" />

<img width="1938" height="923" alt="image" src="https://github.com/user-attachments/assets/a9e9e53e-dba8-4d59-a71d-bf2a5ce9c81b" />


### Test
- Check all navigation links to Mitre ATT&CK are hidden.

### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff 
