### PR TITLE
Refactor navigation menu order and integrate new normalization app

### DIFF
--- a/plugins/main/public/components/normalization/normalization.tsx
+++ b/plugins/main/public/components/normalization/normalization.tsx
@@ -20,6 +20,7 @@ import { normalization } from '../../utils/applications';
 import { DecodersView } from './views/decoders';
 import { KVDBsView } from './views/kvdbs';
 import { OverviewView } from './views/overview';
+import { getUiSettings } from '../../kibana-services';
 
 export const Normalization: React.FC = compose(withErrorBoundary)(
   ({ history }: { history: RouteComponentProps['history'] }) => {
@@ -68,9 +69,11 @@ export const Normalization: React.FC = compose(withErrorBoundary)(
 
     return (
       <EuiPage>
-        <EuiPageSideBar style={{ minWidth: 200 }}>
-          <EuiSideNav style={{ width: 200 }} items={sideNav} />
-        </EuiPageSideBar>
+        {!getUiSettings().get('home:useNewHomePage') && (
+          <EuiPageSideBar style={{ minWidth: 200 }}>
+            <EuiSideNav style={{ width: 200 }} items={sideNav} />
+          </EuiPageSideBar>
+        )}
         <EuiPageBody>
           <Switch>
             <Route

--- a/plugins/main/public/components/normalization/views/decoders/decoders.tsx
+++ b/plugins/main/public/components/normalization/views/decoders/decoders.tsx
@@ -43,6 +43,7 @@ import {
 import { Metadata } from '../../components/metadata/metadata';
 import { get, omit } from 'lodash';
 import { JSONViewer } from '../../components/json-viewer/json-viewer';
+import { getUiSettings } from '../../../../kibana-services';
 
 const relationIntegrationIDField = '__integration';
 
@@ -404,7 +405,7 @@ export const Decoders: React.FC = compose(
 )(() => {
   return (
     <EuiFlexGroup direction='column' gutterSize={'m'}>
-      <Header />
+      {!getUiSettings().get('home:useNewHomePage') && <Header />}
       <Body />
     </EuiFlexGroup>
   );

--- a/plugins/main/public/components/normalization/views/kvdbs/kvdbs.tsx
+++ b/plugins/main/public/components/normalization/views/kvdbs/kvdbs.tsx
@@ -43,6 +43,7 @@ import { Metadata } from '../../components/metadata/metadata';
 import { get, omit } from 'lodash';
 import { AssetViewer } from './asset-viewer';
 import { JSONViewer } from '../../components/json-viewer/json-viewer';
+import { getUiSettings } from '../../../../kibana-services';
 
 const relationIntegrationIDField = '__integration';
 
@@ -353,7 +354,7 @@ export const KVDBs: React.FC = compose(
 )(() => {
   return (
     <EuiFlexGroup direction='column' gutterSize={'m'}>
-      <Header />
+      {!getUiSettings().get('home:useNewHomePage') && <Header />}
       <Body />
     </EuiFlexGroup>
   );

--- a/plugins/main/public/components/normalization/views/overview/overview.tsx
+++ b/plugins/main/public/components/normalization/views/overview/overview.tsx
@@ -22,6 +22,7 @@ import {
 } from '../../components/search-bar/search-bar';
 import { WzButtonPermissionsOpenFlyout } from '../../../common/buttons';
 import { Details } from './details';
+import { getUiSettings } from '../../../../kibana-services';
 
 const decodersCountKey = '___decoders_count';
 const kvdbsCountKey = '___kvdbs_count';
@@ -199,7 +200,7 @@ export const Overview: React.FC = compose(
 )(() => {
   return (
     <EuiFlexGroup direction='column' gutterSize={'m'}>
-      <Header />
+      {!getUiSettings().get('home:useNewHomePage') && <Header />}
       <Body />
     </EuiFlexGroup>
   );

--- a/plugins/main/public/utils/applications.ts
+++ b/plugins/main/public/utils/applications.ts
@@ -7,6 +7,7 @@ import {
   LogoMicrosoftGraphAPI,
   LogoOffice365,
 } from '../components/common/logos';
+import { DEFAULT_NAV_GROUPS } from '../../../../src/core/public';
 
 /* Applications
 Convention: the order of each application must according to the order of the category
@@ -762,11 +763,81 @@ export const normalization = {
     defaultMessage: 'PLACEHOLDER.',
   }),
   euiIconType: 'indexRollupApp',
-  order: 10007,
+  order: 7003,
   showInOverviewApp: false,
   showInAgentMenu: false,
-  redirectTo: () => '/normalization',
 };
+
+export const overviewNormalization = {
+  category: DEFAULT_NAV_GROUPS['security-analytics'],
+  id: 'overview-normalization',
+  parentNavLinkId: 'normalization',
+  title: i18n.translate('wz-app-overview-normalization-title', {
+    defaultMessage: 'Overview',
+  }),
+  breadcrumbLabel: i18n.translate(
+    'wz-app-overview-normalization-breadcrumbLabel',
+    {
+      defaultMessage: 'Overview',
+    },
+  ),
+  description: i18n.translate('wz-app-overview-normalization-description', {
+    defaultMessage: 'PLACEHOLDER.',
+  }),
+  euiIconType: 'indexRollupApp',
+  order: 10008,
+  showInOverviewApp: false,
+  showInAgentMenu: false,
+  redirectTo: () => '/normalization/overview',
+};
+
+export const decoders = {
+  category: 'security_analytics',
+  id: 'decoders',
+  parentNavLinkId: 'normalization',
+  showInAllNavGroup: true,
+  title: i18n.translate('wz-app-decoders-title', {
+    defaultMessage: 'Decoders',
+  }),
+  breadcrumbLabel: i18n.translate('wz-app-decoders-breadcrumbLabel', {
+    defaultMessage: 'Decoders',
+  }),
+  description: i18n.translate('wz-app-decoders-description', {
+    defaultMessage: 'PLACEHOLDER.',
+  }),
+  euiIconType: 'indexRollupApp',
+  order: 10009,
+  showInOverviewApp: false,
+  showInAgentMenu: false,
+  redirectTo: () => '/normalization/decoders',
+};
+
+export const KVDBs = {
+  category: 'security_analytics',
+  id: 'kvdbs',
+  parentNavLinkId: 'normalization',
+  title: i18n.translate('wz-app-kvdbs-title', {
+    defaultMessage: 'KVDBs',
+  }),
+  breadcrumbLabel: i18n.translate('wz-app-kvdbs-breadcrumbLabel', {
+    defaultMessage: 'KVDBs',
+  }),
+  description: i18n.translate('wz-app-kvdbs-description', {
+    defaultMessage: 'PLACEHOLDER.',
+  }),
+  euiIconType: 'indexRollupApp',
+  order: 10010,
+  showInOverviewApp: false,
+  showInAgentMenu: false,
+  redirectTo: () => '/normalization/kvdbs',
+};
+
+export const NormalizationApps = [
+  normalization,
+  overviewNormalization,
+  decoders,
+  KVDBs,
+];
 
 export const Applications = [
   fileIntegrityMonitoring,
@@ -801,6 +872,9 @@ export const Applications = [
   about,
   ITHygiene,
   normalization,
+  overviewNormalization,
+  decoders,
+  KVDBs,
 ].sort((a, b) => {
   // Sort applications by order
   if (a.order < b.order) {

--- a/plugins/main/public/utils/nav-groups.ts
+++ b/plugins/main/public/utils/nav-groups.ts
@@ -15,7 +15,7 @@ import {
   DEFAULT_NAV_GROUPS,
   DEFAULT_APP_CATEGORIES,
 } from '../../../../src/core/public';
-import { Applications } from './applications';
+import { Applications, NormalizationApps } from './applications';
 
 /**
  * Interface for ChromeNavGroup compatible with OpenSearch Dashboards.
@@ -148,8 +148,32 @@ export function registerWazuhNavLinks(
     return;
   }
 
+  // TODO: Remove this when Normalization is migrated to security analytics
+
+  const appsNormalization = [
+    'normalization',
+    'overview-normalization',
+    'decoders',
+    'kvdbs',
+  ];
+
+  const apps = Applications.filter(app => !appsNormalization.includes(app.id));
+
+  const navLinksNormalization =
+    createNavLinksFromApplications(NormalizationApps);
+  addNavLinksToGroup(
+    DEFAULT_NAV_GROUPS.all,
+    navLinksNormalization.map(link => ({
+      id: link.id,
+      ...(link.id !== 'normalization' && { parentNavLinkId: 'normalization' }),
+      title: link.title,
+      order: link.order,
+      category: DEFAULT_NAV_GROUPS['security-analytics'],
+    })),
+  );
+
   // Get all nav link configurations from applications
-  const navLinks = createNavLinksFromApplications(Applications);
+  const navLinks = createNavLinksFromApplications(apps);
 
   // Also register in "All" (Analytics) use case for visibility
   addNavLinksToGroup(


### PR DESCRIPTION
### Description

Modify the order in the normalization app menu
 
### Issues Resolved

- https://github.com/wazuh/wazuh-dashboard-security-analytics/issues/13

### Evidence

<img width="292" height="663" alt="image" src="https://github.com/user-attachments/assets/f605d51e-5d37-4eb5-8fde-96b1e706cc5b" />

### Test

The menu order should be:
- Overview
- Insights
  - Findings
  - Alerts
  - Correlations
- Integrations
- Normalization
  - Overview
  - Decoders
  - KVDBs
- Detection
  - Detectors
  - Detection rules
  - Correlation rules

### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 
