### PR TITLE
Remove home:useNewHomePage setting of the dev configuration file

### DIFF
--- a/docker/osd-dev/config/2.x/osd/opensearch_dashboards.yml
+++ b/docker/osd-dev/config/2.x/osd/opensearch_dashboards.yml
@@ -14,10 +14,7 @@ server.ssl.enabled: true
 server.ssl.key: '/home/node/kbn/certs/osd.key'
 server.ssl.certificate: '/home/node/kbn/certs/osd.pem'
 opensearch.ssl.certificateAuthorities: ['/home/node/kbn/certs/root-ca.pem']
-uiSettings:
-  overrides:
-    defaultRoute: /app/wz-home
-    "home:useNewHomePage": true
+uiSettings.overrides.defaultRoute: /app/wz-home
 opensearch.username: 'kibanaserver'
 opensearch.password: 'kibanaserver'
 opensearchDashboards.branding:


### PR DESCRIPTION
### Description

This pull request removes the defition of home:useNewHomePage setting in the dev configuration file .

### Issues Resolved
https://github.com/wazuh/wazuh-dashboard/issues/1055

### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 
