### PR TITLE
Fixes null reference errors and improves API data generation

### DIFF
--- a/plugins/main/scripts/generate-api-data.js
+++ b/plugins/main/scripts/generate-api-data.js
@@ -399,8 +399,9 @@ node ${cliFilePath} --spec https://raw.githubusercontent.com/wazuh/wazuh/main/ap
               {
                 name,
                 documentation,
-                description: description.replace(/Wazuh/g, 'Server'),
-                summary: summary.replace(/Wazuh/g, 'Server'),
+                description:
+                  description && description.replace(/Wazuh/g, 'Server'),
+                summary: summary && summary.replace(/Wazuh/g, 'Server'),
                 tags,
                 ...(args.length ? { args } : {}),
                 ...(query.length
@@ -409,10 +410,9 @@ node ${cliFilePath} --spec https://raw.githubusercontent.com/wazuh/wazuh/main/ap
                         ...params,
                         ...(params.description
                           ? {
-                              description: params.description.replace(
-                                /Wazuh/g,
-                                'Server',
-                              ),
+                              description:
+                                params?.description &&
+                                params.description.replace(/Wazuh/g, 'Server'),
                             }
                           : {}),
                       })),

--- a/tools/repository_bumper.sh
+++ b/tools/repository_bumper.sh
@@ -109,7 +109,30 @@ update_json() {
 update_endpoints_json() {
   local old_doc_version="$1"
   local new_doc_version="$2"
-  local endpoints_file="${REPO_PATH}/plugins/main/common/api-info/endpoints.json"
+  local main_plugin_dir="${REPO_PATH}/plugins/main"
+  local endpoints_file="${main_plugin_dir}/common/api-info/endpoints.json"
+
+  # Paths to the files to be updated with the yarn command
+  local path_file_change="common/api-info"
+  local api_info_files="${path_file_change}/endpoints.json ${path_file_change}/security-actions.json"
+
+  # First, try to run yarn generate:api-data
+  log "Attempting to run 'yarn generate:api-data' in $main_plugin_dir..."
+
+  # Temporarily disable 'set -e' to handle the yarn command failure gracefully
+  set +e
+  (cd "$main_plugin_dir" && yarn generate:api-data && yarn prettier --write $api_info_files) >> "$LOG_FILE" 2>&1
+  local yarn_exit_code=$?
+  set -e
+
+  if [ $yarn_exit_code -eq 0 ]; then
+    log "Successfully generated API data using yarn command"
+    return
+  else
+    log "WARNING: 'yarn generate:api-data' failed with exit code $yarn_exit_code. Falling back to sed-based update."
+  fi
+
+  # Fallback: Use sed to replace the version string within the documentation URLs
 
   # If the versions are the same, no update is needed.
   if [ "$old_doc_version" = "$new_doc_version" ]; then
@@ -117,21 +140,20 @@ update_endpoints_json() {
     return
   fi
 
+  # Check if endpoints.json exists
   if [ ! -f "$endpoints_file" ]; then
     log "WARNING: $endpoints_file not found. Skipping documentation URL update."
     return
   fi
 
-  log "Updating documentation URLs in $endpoints_file from $old_doc_version to $new_doc_version"
-
-  # Use sed to replace the version string within the documentation URLs
   # Escape dots in the version strings for sed
   local escaped_old_version=$(echo "$old_doc_version" | sed 's/\./\\./g')
   local escaped_new_version=$(echo "$new_doc_version" | sed 's/\./\\./g')
 
+  log "Updating documentation URLs in $endpoints_file from $old_doc_version to $new_doc_version"
+
   sed -i "s|documentation.wazuh.com/${escaped_old_version}|documentation.wazuh.com/${escaped_new_version}|g" "$endpoints_file" && log "Successfully updated documentation URLs in $endpoints_file" || {
     log "ERROR: Failed to update documentation URLs in $endpoints_file using sed."
-    # Consider adding error handling or attempting to restore a backup if needed
     exit 1
   }
 }
@@ -511,22 +533,13 @@ main() {
   update_package_json_files
   update_osd_json_files
   update_changelog
-
-
-  # Conditionally update endpoints.json
-  if [[ -n "$VERSION" && "$CURRENT_MAJOR_MINOR" != "$NEW_MAJOR_MINOR" ]]; then
-    log "Major.minor version changed ($CURRENT_MAJOR_MINOR -> $NEW_MAJOR_MINOR). Updating endpoints.json..."
-    update_endpoints_json "$CURRENT_MAJOR_MINOR" "$NEW_MAJOR_MINOR"
-  else
-    log "Major.minor version ($CURRENT_MAJOR_MINOR) remains the same. Skipping endpoints.json update."
-  fi
+  update_endpoints_json "$CURRENT_MAJOR_MINOR" "$NEW_MAJOR_MINOR"
 
   # Update docker/imposter/wazuh-config.yml
   log "Updating docker/imposter/wazuh-config.yml..."
   update_imposter_config "$VERSION"
 
   log "File modifications completed."
-  log "WARNING: API spec data generation (if applicable) needs to be done manually or with other tools."
   log "Repository bump completed successfully. Log file: $LOG_FILE"
   exit 0
 }


### PR DESCRIPTION
### Description

Update the bumping script to use `generate:api-data` and correctly update the endpoints.json and security-actions.json files.
 
### Issues Resolved

- #8009 

### Evidence

<details><summary>./repository_bumper.sh --version 4.14.3 --stage alpha0</summary>
<p>

Since the version and stage are the same as those in the branch, and the branch exists in the `wazuh/wazuh` repository, just update `endpoint.json` and `security-actions.json` because they are out of date.

```console
node@osd:/tmp/wazuh-dashboard-plugins/tools$ ./repository_bumper.sh --version 4.14.3 --stage alpha0
[2026-01-05 12:27:09] Starting repository bump process
[2026-01-05 12:27:09] Repository path: /tmp/wazuh-dashboard-plugins
[2026-01-05 12:27:09] Version: 4.14.3
[2026-01-05 12:27:09] Stage: alpha0
[2026-01-05 12:27:09] Attempting to extract current version from /tmp/wazuh-dashboard-plugins/VERSION.json using sed...
[2026-01-05 12:27:09] Successfully extracted version using sed: 4.14.3
[2026-01-05 12:27:09] Current version detected in VERSION.json: 4.14.3
[2026-01-05 12:27:09] Current major.minor: 4.14
[2026-01-05 12:27:09] New major.minor: 4.14
[2026-01-05 12:27:09] Default revision set to: 00
[2026-01-05 12:27:09] Attempting to extract current stage from /tmp/wazuh-dashboard-plugins/VERSION.json using sed...
[2026-01-05 12:27:09] Successfully extracted stage using sed: alpha0
[2026-01-05 12:27:09] Current stage detected in VERSION.json: alpha0
[2026-01-05 12:27:09] Comparing new version (4.14.3) with current version (4.14.3)...
[2026-01-05 12:27:09] New version (4.14.3) is identical to current version (4.14.3)
[2026-01-05 12:27:09] Attempting to extract current revision from /tmp/wazuh-dashboard-plugins/plugins/main/package.json using sed (Note: This is fragile)
[2026-01-05 12:27:09] Successfully extracted revision using sed: 00
[2026-01-05 12:27:09] Current revision: 00.
[2026-01-05 12:27:09] Final revision determined: 00
[2026-01-05 12:27:09] Tag suffix set to: -alpha0
[2026-01-05 12:27:09] Starting file modifications...
[2026-01-05 12:27:09] Processing /tmp/wazuh-dashboard-plugins/VERSION.json
[2026-01-05 12:27:09] Updating package.json files...
[2026-01-05 12:27:09] Processing /tmp/wazuh-dashboard-plugins/plugins/main/package.json
[2026-01-05 12:27:09] Processing /tmp/wazuh-dashboard-plugins/plugins/wazuh-check-updates/package.json
[2026-01-05 12:27:09] Processing /tmp/wazuh-dashboard-plugins/plugins/wazuh-core/package.json
[2026-01-05 12:27:09] Combined version-revision string: 4.14.3-00
[2026-01-05 12:27:09] Updating opensearch_dashboards.json files...
[2026-01-05 12:27:09] Processing /tmp/wazuh-dashboard-plugins/plugins/main/opensearch_dashboards.json
[2026-01-05 12:27:09] Processing /tmp/wazuh-dashboard-plugins/plugins/wazuh-check-updates/opensearch_dashboards.json
[2026-01-05 12:27:09] Processing /tmp/wazuh-dashboard-plugins/plugins/wazuh-core/opensearch_dashboards.json
[2026-01-05 12:27:09] Updating CHANGELOG.md...
[2026-01-05 12:27:09] Attempting to extract pluginPlatform.version from /tmp/wazuh-dashboard-plugins/plugins/main/package.json using sed (Note: This is fragile)
[2026-01-05 12:27:09] Detected OpenSearch Dashboards version for changelog: 2.19.4
[2026-01-05 12:27:09] Changelog entry for this version and OpenSearch Dashboards version exists. Updating revision only.
[2026-01-05 12:27:09] CHANGELOG.md revision updated successfully.
[2026-01-05 12:27:09] Attempting to run 'yarn generate:api-data' in /tmp/wazuh-dashboard-plugins/plugins/main...
[2026-01-05 12:27:11] Successfully generated API data using yarn command
[2026-01-05 12:27:11] Updating docker/imposter/wazuh-config.yml...
[2026-01-05 12:27:11] File modifications completed.
[2026-01-05 12:27:11] Repository bump completed successfully. Log file: /tmp/wazuh-dashboard-plugins/tools/repository_bumper_2026-01-05_12-27-09-109.log
```

<img width="419" height="202" alt="image" src="https://github.com/user-attachments/assets/6b5301ac-a457-42d1-a557-8572b0b13b1c" />

</p>
</details> 

<details><summary>./repository_bumper.sh --version 4.14.4 --stage alpha0</summary>
<p>

The patch is different and the branch does not exist in the `wazuh/wazuh` repository, so it does not update the `endpoints.json` and `security-actions.json` files because it would only update the documentation version with `major.minor` and instead of patch it does not affect.

```console
node@osd:/tmp/wazuh-dashboard-plugins/tools$ ./repository_bumper.sh --version 4.14.4 --stage alpha0
[2026-01-05 12:34:33] Starting repository bump process
[2026-01-05 12:34:33] Repository path: /tmp/wazuh-dashboard-plugins
[2026-01-05 12:34:33] Version: 4.14.4
[2026-01-05 12:34:33] Stage: alpha0
[2026-01-05 12:34:33] Attempting to extract current version from /tmp/wazuh-dashboard-plugins/VERSION.json using sed...
[2026-01-05 12:34:33] Successfully extracted version using sed: 4.14.3
[2026-01-05 12:34:33] Current version detected in VERSION.json: 4.14.3
[2026-01-05 12:34:33] Current major.minor: 4.14
[2026-01-05 12:34:33] New major.minor: 4.14
[2026-01-05 12:34:33] Default revision set to: 00
[2026-01-05 12:34:33] Attempting to extract current stage from /tmp/wazuh-dashboard-plugins/VERSION.json using sed...
[2026-01-05 12:34:33] Successfully extracted stage using sed: alpha0
[2026-01-05 12:34:33] Current stage detected in VERSION.json: alpha0
[2026-01-05 12:34:33] Comparing new version (4.14.4) with current version (4.14.3)...
[2026-01-05 12:34:33] Version check passed: New version (4.14.4) is greater than current version (4.14.3) (Patch increased).
[2026-01-05 12:34:33] Final revision determined: 00
[2026-01-05 12:34:33] Tag suffix set to: -alpha0
[2026-01-05 12:34:33] Starting file modifications...
[2026-01-05 12:34:33] Processing /tmp/wazuh-dashboard-plugins/VERSION.json
[2026-01-05 12:34:33] Updating version to 4.14.4 in /tmp/wazuh-dashboard-plugins/VERSION.json using sed
[2026-01-05 12:34:33] Attempting to update version to 4.14.4 in /tmp/wazuh-dashboard-plugins/VERSION.json using sed (Note: This is fragile)
[2026-01-05 12:34:33] Successfully updated version in /tmp/wazuh-dashboard-plugins/VERSION.json using sed
[2026-01-05 12:34:33] Updating package.json files...
[2026-01-05 12:34:33] Processing /tmp/wazuh-dashboard-plugins/plugins/main/package.json
[2026-01-05 12:34:33] Updating version to 4.14.4 in /tmp/wazuh-dashboard-plugins/plugins/main/package.json using sed
[2026-01-05 12:34:33] Attempting to update version to 4.14.4 in /tmp/wazuh-dashboard-plugins/plugins/main/package.json using sed (Note: This is fragile)
[2026-01-05 12:34:33] Successfully updated version in /tmp/wazuh-dashboard-plugins/plugins/main/package.json using sed
[2026-01-05 12:34:33] Processing /tmp/wazuh-dashboard-plugins/plugins/wazuh-check-updates/package.json
[2026-01-05 12:34:33] Updating version to 4.14.4 in /tmp/wazuh-dashboard-plugins/plugins/wazuh-check-updates/package.json using sed
[2026-01-05 12:34:33] Attempting to update version to 4.14.4 in /tmp/wazuh-dashboard-plugins/plugins/wazuh-check-updates/package.json using sed (Note: This is fragile)
[2026-01-05 12:34:33] Successfully updated version in /tmp/wazuh-dashboard-plugins/plugins/wazuh-check-updates/package.json using sed
[2026-01-05 12:34:33] Processing /tmp/wazuh-dashboard-plugins/plugins/wazuh-core/package.json
[2026-01-05 12:34:33] Updating version to 4.14.4 in /tmp/wazuh-dashboard-plugins/plugins/wazuh-core/package.json using sed
[2026-01-05 12:34:33] Attempting to update version to 4.14.4 in /tmp/wazuh-dashboard-plugins/plugins/wazuh-core/package.json using sed (Note: This is fragile)
[2026-01-05 12:34:33] Successfully updated version in /tmp/wazuh-dashboard-plugins/plugins/wazuh-core/package.json using sed
[2026-01-05 12:34:33] Combined version-revision string: 4.14.4-00
[2026-01-05 12:34:33] Updating opensearch_dashboards.json files...
[2026-01-05 12:34:33] Processing /tmp/wazuh-dashboard-plugins/plugins/main/opensearch_dashboards.json
[2026-01-05 12:34:33] Updating version to 4.14.4-00 in /tmp/wazuh-dashboard-plugins/plugins/main/opensearch_dashboards.json using sed
[2026-01-05 12:34:33] Attempting to update version to 4.14.4-00 in /tmp/wazuh-dashboard-plugins/plugins/main/opensearch_dashboards.json using sed (Note: This is fragile)
[2026-01-05 12:34:33] Successfully updated version in /tmp/wazuh-dashboard-plugins/plugins/main/opensearch_dashboards.json using sed
[2026-01-05 12:34:33] Processing /tmp/wazuh-dashboard-plugins/plugins/wazuh-check-updates/opensearch_dashboards.json
[2026-01-05 12:34:33] Updating version to 4.14.4-00 in /tmp/wazuh-dashboard-plugins/plugins/wazuh-check-updates/opensearch_dashboards.json using sed
[2026-01-05 12:34:33] Attempting to update version to 4.14.4-00 in /tmp/wazuh-dashboard-plugins/plugins/wazuh-check-updates/opensearch_dashboards.json using sed (Note: This is fragile)
[2026-01-05 12:34:33] Successfully updated version in /tmp/wazuh-dashboard-plugins/plugins/wazuh-check-updates/opensearch_dashboards.json using sed
[2026-01-05 12:34:33] Processing /tmp/wazuh-dashboard-plugins/plugins/wazuh-core/opensearch_dashboards.json
[2026-01-05 12:34:33] Updating version to 4.14.4-00 in /tmp/wazuh-dashboard-plugins/plugins/wazuh-core/opensearch_dashboards.json using sed
[2026-01-05 12:34:33] Attempting to update version to 4.14.4-00 in /tmp/wazuh-dashboard-plugins/plugins/wazuh-core/opensearch_dashboards.json using sed (Note: This is fragile)
[2026-01-05 12:34:33] Successfully updated version in /tmp/wazuh-dashboard-plugins/plugins/wazuh-core/opensearch_dashboards.json using sed
[2026-01-05 12:34:33] Updating CHANGELOG.md...
[2026-01-05 12:34:33] Attempting to extract pluginPlatform.version from /tmp/wazuh-dashboard-plugins/plugins/main/package.json using sed (Note: This is fragile)
[2026-01-05 12:34:33] Detected OpenSearch Dashboards version for changelog: 2.19.4
[2026-01-05 12:34:33] No existing changelog entry for this version and OpenSearch Dashboards version. Inserting new entry.
[2026-01-05 12:34:33] CHANGELOG.md updated successfully.
[2026-01-05 12:34:33] Attempting to run 'yarn generate:api-data' in /tmp/wazuh-dashboard-plugins/plugins/main...
[2026-01-05 12:34:34] WARNING: 'yarn generate:api-data' failed with exit code 1. Falling back to sed-based update.
[2026-01-05 12:34:34] Documentation version (4.14) hasn't changed. Skipping endpoints.json update.
[2026-01-05 12:34:34] Updating docker/imposter/wazuh-config.yml...
[2026-01-05 12:34:34] Updating specFile URL in /tmp/wazuh-dashboard-plugins/docker/imposter/wazuh-config.yml to version 4.14.4
[2026-01-05 12:34:34] Successfully updated specFile URL in /tmp/wazuh-dashboard-plugins/docker/imposter/wazuh-config.yml
[2026-01-05 12:34:34] File modifications completed.
[2026-01-05 12:34:34] Repository bump completed successfully. Log file: /tmp/wazuh-dashboard-plugins/tools/repository_bumper_2026-01-05_12-34-33-726.log
```

<img width="427" height="471" alt="image" src="https://github.com/user-attachments/assets/d125f7e1-a621-494a-b5fe-7b5e230bcd53" />

</p>
</details> 


<details><summary>./repository_bumper.sh --version 4.15.0 --stage alpha0</summary>
<p>

The minor is different and the branch does not exist in the wazuh/wazuh repository, so update the `endpoints.json` files and not the `security-actions.json` because it only updates the version in the documentation URL of the `endpoints.json`.

```console
node@osd:/tmp/wazuh-dashboard-plugins/tools$ ./repository_bumper.sh --version 4.15.0 --stage alpha0
[2026-01-05 12:38:15] Starting repository bump process
[2026-01-05 12:38:15] Repository path: /tmp/wazuh-dashboard-plugins
[2026-01-05 12:38:15] Version: 4.15.0
[2026-01-05 12:38:15] Stage: alpha0
[2026-01-05 12:38:15] Attempting to extract current version from /tmp/wazuh-dashboard-plugins/VERSION.json using sed...
[2026-01-05 12:38:15] Successfully extracted version using sed: 4.14.3
[2026-01-05 12:38:15] Current version detected in VERSION.json: 4.14.3
[2026-01-05 12:38:15] Current major.minor: 4.14
[2026-01-05 12:38:16] New major.minor: 4.15
[2026-01-05 12:38:16] Default revision set to: 00
[2026-01-05 12:38:16] Attempting to extract current stage from /tmp/wazuh-dashboard-plugins/VERSION.json using sed...
[2026-01-05 12:38:16] Successfully extracted stage using sed: alpha0
[2026-01-05 12:38:16] Current stage detected in VERSION.json: alpha0
[2026-01-05 12:38:16] Comparing new version (4.15.0) with current version (4.14.3)...
[2026-01-05 12:38:16] Version check passed: New version (4.15.0) is greater than current version (4.14.3) (Minor increased).
[2026-01-05 12:38:16] Final revision determined: 00
[2026-01-05 12:38:16] Tag suffix set to: -alpha0
[2026-01-05 12:38:16] Starting file modifications...
[2026-01-05 12:38:16] Processing /tmp/wazuh-dashboard-plugins/VERSION.json
[2026-01-05 12:38:16] Updating version to 4.15.0 in /tmp/wazuh-dashboard-plugins/VERSION.json using sed
[2026-01-05 12:38:16] Attempting to update version to 4.15.0 in /tmp/wazuh-dashboard-plugins/VERSION.json using sed (Note: This is fragile)
[2026-01-05 12:38:16] Successfully updated version in /tmp/wazuh-dashboard-plugins/VERSION.json using sed
[2026-01-05 12:38:16] Updating package.json files...
[2026-01-05 12:38:16] Processing /tmp/wazuh-dashboard-plugins/plugins/main/package.json
[2026-01-05 12:38:16] Updating version to 4.15.0 in /tmp/wazuh-dashboard-plugins/plugins/main/package.json using sed
[2026-01-05 12:38:16] Attempting to update version to 4.15.0 in /tmp/wazuh-dashboard-plugins/plugins/main/package.json using sed (Note: This is fragile)
[2026-01-05 12:38:16] Successfully updated version in /tmp/wazuh-dashboard-plugins/plugins/main/package.json using sed
[2026-01-05 12:38:16] Processing /tmp/wazuh-dashboard-plugins/plugins/wazuh-check-updates/package.json
[2026-01-05 12:38:16] Updating version to 4.15.0 in /tmp/wazuh-dashboard-plugins/plugins/wazuh-check-updates/package.json using sed
[2026-01-05 12:38:16] Attempting to update version to 4.15.0 in /tmp/wazuh-dashboard-plugins/plugins/wazuh-check-updates/package.json using sed (Note: This is fragile)
[2026-01-05 12:38:16] Successfully updated version in /tmp/wazuh-dashboard-plugins/plugins/wazuh-check-updates/package.json using sed
[2026-01-05 12:38:16] Processing /tmp/wazuh-dashboard-plugins/plugins/wazuh-core/package.json
[2026-01-05 12:38:16] Updating version to 4.15.0 in /tmp/wazuh-dashboard-plugins/plugins/wazuh-core/package.json using sed
[2026-01-05 12:38:16] Attempting to update version to 4.15.0 in /tmp/wazuh-dashboard-plugins/plugins/wazuh-core/package.json using sed (Note: This is fragile)
[2026-01-05 12:38:16] Successfully updated version in /tmp/wazuh-dashboard-plugins/plugins/wazuh-core/package.json using sed
[2026-01-05 12:38:16] Combined version-revision string: 4.15.0-00
[2026-01-05 12:38:16] Updating opensearch_dashboards.json files...
[2026-01-05 12:38:16] Processing /tmp/wazuh-dashboard-plugins/plugins/main/opensearch_dashboards.json
[2026-01-05 12:38:16] Updating version to 4.15.0-00 in /tmp/wazuh-dashboard-plugins/plugins/main/opensearch_dashboards.json using sed
[2026-01-05 12:38:16] Attempting to update version to 4.15.0-00 in /tmp/wazuh-dashboard-plugins/plugins/main/opensearch_dashboards.json using sed (Note: This is fragile)
[2026-01-05 12:38:16] Successfully updated version in /tmp/wazuh-dashboard-plugins/plugins/main/opensearch_dashboards.json using sed
[2026-01-05 12:38:16] Processing /tmp/wazuh-dashboard-plugins/plugins/wazuh-check-updates/opensearch_dashboards.json
[2026-01-05 12:38:16] Updating version to 4.15.0-00 in /tmp/wazuh-dashboard-plugins/plugins/wazuh-check-updates/opensearch_dashboards.json using sed
[2026-01-05 12:38:16] Attempting to update version to 4.15.0-00 in /tmp/wazuh-dashboard-plugins/plugins/wazuh-check-updates/opensearch_dashboards.json using sed (Note: This is fragile)
[2026-01-05 12:38:16] Successfully updated version in /tmp/wazuh-dashboard-plugins/plugins/wazuh-check-updates/opensearch_dashboards.json using sed
[2026-01-05 12:38:16] Processing /tmp/wazuh-dashboard-plugins/plugins/wazuh-core/opensearch_dashboards.json
[2026-01-05 12:38:16] Updating version to 4.15.0-00 in /tmp/wazuh-dashboard-plugins/plugins/wazuh-core/opensearch_dashboards.json using sed
[2026-01-05 12:38:16] Attempting to update version to 4.15.0-00 in /tmp/wazuh-dashboard-plugins/plugins/wazuh-core/opensearch_dashboards.json using sed (Note: This is fragile)
[2026-01-05 12:38:16] Successfully updated version in /tmp/wazuh-dashboard-plugins/plugins/wazuh-core/opensearch_dashboards.json using sed
[2026-01-05 12:38:16] Updating CHANGELOG.md...
[2026-01-05 12:38:16] Attempting to extract pluginPlatform.version from /tmp/wazuh-dashboard-plugins/plugins/main/package.json using sed (Note: This is fragile)
[2026-01-05 12:38:16] Detected OpenSearch Dashboards version for changelog: 2.19.4
[2026-01-05 12:38:16] No existing changelog entry for this version and OpenSearch Dashboards version. Inserting new entry.
[2026-01-05 12:38:16] CHANGELOG.md updated successfully.
[2026-01-05 12:38:16] Attempting to run 'yarn generate:api-data' in /tmp/wazuh-dashboard-plugins/plugins/main...
[2026-01-05 12:38:17] WARNING: 'yarn generate:api-data' failed with exit code 1. Falling back to sed-based update.
[2026-01-05 12:38:17] Updating documentation URLs in /tmp/wazuh-dashboard-plugins/plugins/main/common/api-info/endpoints.json from 4.14 to 4.15
[2026-01-05 12:38:17] Successfully updated documentation URLs in /tmp/wazuh-dashboard-plugins/plugins/main/common/api-info/endpoints.json
[2026-01-05 12:38:17] Updating docker/imposter/wazuh-config.yml...
[2026-01-05 12:38:17] Updating specFile URL in /tmp/wazuh-dashboard-plugins/docker/imposter/wazuh-config.yml to version 4.15.0
[2026-01-05 12:38:17] Successfully updated specFile URL in /tmp/wazuh-dashboard-plugins/docker/imposter/wazuh-config.yml
[2026-01-05 12:38:17] File modifications completed.
[2026-01-05 12:38:17] Repository bump completed successfully. Log file: /tmp/wazuh-dashboard-plugins/tools/repository_bumper_2026-01-05_12-38-15-980.log
```

<img width="409" height="367" alt="image" src="https://github.com/user-attachments/assets/8c9329e3-0f88-4ad2-b65d-fd914e6d20d9" />

</p>
</details> 

### Test

- Execute the following commands and obtain the results explained in the evidence:
  - `./repository_bumper.sh --version 4.14.3 --stage alpha0`
  - `./repository_bumper.sh --version 4.14.4 --stage alpha0`
  - `./repository_bumper.sh --version 4.15.0 --stage alpha0`

### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 
