### PR TITLE
Rename Ossec to Wazuh manager

### DIFF
--- a/docker/osd-dev/manager/entrypoint.sh
+++ b/docker/osd-dev/manager/entrypoint.sh
@@ -17,7 +17,7 @@ if [ -n "$INDEXER_SSL_CERTIFICATE" ]; then
 fi
 
 if [ -n "$INDEXER_SSL_CERTIFICATE_KEY" ]; then
-  sed -i "s|<key>/var/wazuh-manaer/etc/certs/server-key.pem</key>|<key>$INDEXER_SSL_CERTIFICATE_KEY</key>|g" /var/wazuh-manager/etc/wazuh-manager.conf
+  sed -i "s|<key>/var/wazuh-manager/etc/certs/server-key.pem</key>|<key>$INDEXER_SSL_CERTIFICATE_KEY</key>|g" /var/wazuh-manager/etc/wazuh-manager.conf
   chmod 400 $INDEXER_SSL_CERTIFICATE_KEY
   chown root:root $INDEXER_SSL_CERTIFICATE_KEY
 fi


### PR DESCRIPTION
### Description
This pull request applies these changes in the dev environmet:

- Rename the `/var/ossec` folder to `/var/wazuh-manager`
- Rename `ossec.log` to `wazuh-manager.log` 
- Rename `ossec.conf` to `wazuh-manager.conf `
 
### Issues Resolved
- https://github.com/wazuh/wazuh-dashboard-plugins/issues/8126

### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 
