### PR TITLE
Rename `manager` cert and tools references in the dev environment

### DIFF
--- a/docker/osd-dev/manager/entrypoint.sh
+++ b/docker/osd-dev/manager/entrypoint.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 # Configure Wazuh server-Wazuh indexer connection
-[ -n "$INDEXER_USERNAME" ] && echo "$INDEXER_USERNAME" | /var/wazuh-manager/bin/wazuh-keystore -f indexer -k username
-[ -n "$INDEXER_PASSWORD" ] && echo "$INDEXER_PASSWORD" | /var/wazuh-manager/bin/wazuh-keystore -f indexer -k password
+[ -n "$INDEXER_USERNAME" ] && echo "$INDEXER_USERNAME" | /var/wazuh-manager/bin/wazuh-manager-keystore -f indexer -k username
+[ -n "$INDEXER_PASSWORD" ] && echo "$INDEXER_PASSWORD" | /var/wazuh-manager/bin/wazuh-manager-keystore -f indexer -k password
 [ -n "$INDEXER_URL" ] && sed -i "s|<host>https://127.0.0.1:9200</host>|<host>$INDEXER_URL</host>|g" /var/wazuh-manager/etc/wazuh-manager.conf
 if [ -n "$INDEXER_SSL_CA" ]; then
   sed -i "s|<ca>/var/wazuh-manager/etc/certs/root-ca.pem</ca>|<ca>$INDEXER_SSL_CA</ca>|g" /var/wazuh-manager/etc/wazuh-manager.conf
@@ -11,19 +11,19 @@ if [ -n "$INDEXER_SSL_CA" ]; then
 fi
 
 if [ -n "$INDEXER_SSL_CERTIFICATE" ]; then
-  sed -i "s|<certificate>/var/wazuh-manager/etc/certs/server.pem</certificate>|<certificate>$INDEXER_SSL_CERTIFICATE</certificate>|g" /var/wazuh-manager/etc/wazuh-manager.conf
+  sed -i "s|<certificate>/var/wazuh-manager/etc/certs/manager.pem</certificate>|<certificate>$INDEXER_SSL_CERTIFICATE</certificate>|g" /var/wazuh-manager/etc/wazuh-manager.conf
   chmod 400 $INDEXER_SSL_CERTIFICATE
   chown root:root $INDEXER_SSL_CERTIFICATE
 fi
 
 if [ -n "$INDEXER_SSL_CERTIFICATE_KEY" ]; then
-  sed -i "s|<key>/var/wazuh-manager/etc/certs/server-key.pem</key>|<key>$INDEXER_SSL_CERTIFICATE_KEY</key>|g" /var/wazuh-manager/etc/wazuh-manager.conf
+  sed -i "s|<key>/var/wazuh-manager/etc/certs/manager-key.pem</key>|<key>$INDEXER_SSL_CERTIFICATE_KEY</key>|g" /var/wazuh-manager/etc/wazuh-manager.conf
   chmod 400 $INDEXER_SSL_CERTIFICATE_KEY
   chown root:root $INDEXER_SSL_CERTIFICATE_KEY
 fi
 
 # Start service
-/var/wazuh-manager/bin/wazuh-control start
+/var/wazuh-manager/bin/wazuh-manager-control start
 
 # Read logs file
 tail -f /var/wazuh-manager/logs/wazuh-manager.log


### PR DESCRIPTION
### Description
This pull request applies these changes in the dev environmet:

- Rename the `wazuh-keystore` to `wazuh-manager-keystore`
- Rename `server.pem` to `manager.pem`
- Rename `server-key.pem` to `manager-key.pem`
- Rename `wazuh-control` to `wazuh-manager-control`

### Issues Resolved
- https://github.com/wazuh/wazuh-dashboard-plugins/issues/8140

### Evidence
<img width="2264" height="830" alt="image" src="https://github.com/user-attachments/assets/f7ab8135-1e1a-40f8-8d1d-f5a3bcaf861c" />

### Test
- Check that manager container starts correctly using last package.

### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff 
