### PR TITLE
Use always known fields to create index patterns

### DIFF
--- a/plugins/main/server/health-check/index-patterns.ts
+++ b/plugins/main/server/health-check/index-patterns.ts
@@ -39,8 +39,8 @@ async function getFieldMappings(
 interface CreateIndexPatternOptions {
   fieldsNoIndices?: any;
   savedObjectOverwrite?:
-    | Record<string, any>
-    | ((params: any) => Record<string, any>);
+  | Record<string, any>
+  | ((params: any) => Record<string, any>);
 }
 
 async function createIndexPattern(
@@ -51,21 +51,8 @@ async function createIndexPattern(
   try {
     let fieldsObj;
 
-    try {
-      fieldsObj = await getFieldMappings(
-        { logger, indexPatternsClient },
-        indexPatternID,
-      );
-    } catch (error) {
-      if (error?.output?.statusCode === 404 && options.fieldsNoIndices) {
-        const message = `Fields for index pattern with ID [${indexPatternID}] could not be obtained. This could indicate there are not matching indices because they were not generated or there is some error in the process that generates and indexes that data. The index pattern will be created with a set of pre-defined fields.`;
-
-        logger.warn(message);
-        fieldsObj = options.fieldsNoIndices;
-      } else {
-        throw error;
-      }
-    }
+    // The creation of the index pattern will always rely on the defined known fields.
+    fieldsObj = options.fieldsNoIndices;
 
     const title = indexPatternID;
     const fields = JSON.stringify(fieldsObj);
@@ -254,10 +241,9 @@ async function validateIndexPattern(indexPattern, options, ctx, logger) {
     !indexPatternHasTimeField(indexPattern, options.hasTimeFieldName)
   ) {
     throw new Error(
-      `Index pattern has missing the time field name: [${
-        options.hasTimeFieldName !== true
-          ? options.hasTimeFieldName
-          : 'any compatible field'
+      `Index pattern has missing the time field name: [${options.hasTimeFieldName !== true
+        ? options.hasTimeFieldName
+        : 'any compatible field'
       }]`,
     );
   }
@@ -359,7 +345,7 @@ export const initializationTaskCreatorIndexPattern = ({
           try {
             await validateIndexPattern(savedObject, options, ctx, logger);
             compatibleIndexPatterns.push(savedObject);
-          } catch {}
+          } catch { }
         }
       }
 


### PR DESCRIPTION
### Description
This pull request forces the creation of index patterns to always use the known fields, instead of the index.
 
### Issues Resolved
- https://github.com/wazuh/wazuh-dashboard-plugins/issues/8166

### Evidence

`wazuh-events*` has 1942 fields

<img width="3087" height="1744" alt="image" src="https://github.com/user-attachments/assets/54fba33b-c094-4101-8a64-b51203fd369c" />


### Test

- Go to the main plugin folder
- Run `GIT_REF='main' yarn generate:indexer-resources`
- Initialize Wazuh dashboard app (the health check will create the index patterns)
- Verify the index patterns contain all the known fields

### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff 
