### PR TITLE
Change events templates source path

### DIFF
--- a/plugins/main/scripts/generate-known-fields/generate-known-fields.js
+++ b/plugins/main/scripts/generate-known-fields/generate-known-fields.js
@@ -61,7 +61,7 @@ const TEMPLATE_SOURCES = {
   'events-access-management': {
     urls: [
       wazuhUrl(
-        'plugins/setup/src/main/resources/templates/streams/access-management.json',
+        'plugins/setup/src/main/resources/templates/streams/events.json',
       ),
     ],
     outputFile: 'events-access-management.json',
@@ -69,7 +69,7 @@ const TEMPLATE_SOURCES = {
   'events-applications': {
     urls: [
       wazuhUrl(
-        'plugins/setup/src/main/resources/templates/streams/applications.json',
+        'plugins/setup/src/main/resources/templates/streams/events.json',
       ),
     ],
     outputFile: 'events-applications.json',
@@ -77,7 +77,7 @@ const TEMPLATE_SOURCES = {
   'events-cloud-services': {
     urls: [
       wazuhUrl(
-        'plugins/setup/src/main/resources/templates/streams/cloud-services.json',
+        'plugins/setup/src/main/resources/templates/streams/events.json',
       ),
     ],
     outputFile: 'events-cloud-services.json',
@@ -85,7 +85,7 @@ const TEMPLATE_SOURCES = {
   'events-cloud-services-aws': {
     urls: [
       wazuhUrl(
-        'plugins/setup/src/main/resources/templates/streams/cloud-services-aws.json',
+        'plugins/setup/src/main/resources/templates/streams/events.json',
       ),
     ],
     outputFile: 'events-cloud-services-aws.json',
@@ -93,7 +93,7 @@ const TEMPLATE_SOURCES = {
   'events-cloud-services-azure': {
     urls: [
       wazuhUrl(
-        'plugins/setup/src/main/resources/templates/streams/cloud-services-azure.json',
+        'plugins/setup/src/main/resources/templates/streams/events.json',
       ),
     ],
     outputFile: 'events-cloud-services-azure.json',
@@ -101,7 +101,7 @@ const TEMPLATE_SOURCES = {
   'events-cloud-services-gcp': {
     urls: [
       wazuhUrl(
-        'plugins/setup/src/main/resources/templates/streams/cloud-services-gcp.json',
+        'plugins/setup/src/main/resources/templates/streams/events.json',
       ),
     ],
     outputFile: 'events-cloud-services-gcp.json',
@@ -109,21 +109,23 @@ const TEMPLATE_SOURCES = {
   'events-network-activity': {
     urls: [
       wazuhUrl(
-        'plugins/setup/src/main/resources/templates/streams/network-activity.json',
+        'plugins/setup/src/main/resources/templates/streams/events.json',
       ),
     ],
     outputFile: 'events-network-activity.json',
   },
   'events-other': {
     urls: [
-      wazuhUrl('plugins/setup/src/main/resources/templates/streams/other.json'),
+      wazuhUrl(
+        'plugins/setup/src/main/resources/templates/streams/events.json',
+      ),
     ],
     outputFile: 'events-other.json',
   },
   'events-security': {
     urls: [
       wazuhUrl(
-        'plugins/setup/src/main/resources/templates/streams/security.json',
+        'plugins/setup/src/main/resources/templates/streams/events.json',
       ),
     ],
     outputFile: 'events-security.json',
@@ -131,7 +133,7 @@ const TEMPLATE_SOURCES = {
   'events-system-activity': {
     urls: [
       wazuhUrl(
-        'plugins/setup/src/main/resources/templates/streams/system-activity.json',
+        'plugins/setup/src/main/resources/templates/streams/events.json',
       ),
     ],
     outputFile: 'events-system-activity.json',


### PR DESCRIPTION
### Description
This pull request changes the events templates source path.
 
### Issues Resolved
- https://github.com/wazuh/wazuh-dashboard/issues/1150

### Evidence
<details><summary>Details</summary>
<p>

```console
$ yarn
yarn install v1.22.22
[1/4] Resolving packages...
warning Resolution field "cookie@0.7.0" is incompatible with requested version "cookie@^0.4.0"
success Already up-to-date.
$ yarn run generate:indexer-resources
yarn run v1.22.22
$ if [ -f scripts/build-tools/update-indexer-resources ]; then bash scripts/build-tools/update-indexer-resources; else echo 'File does not exist. This could be related to the script file not being included at build time. Skipping...'; fi
Enter the git reference (branch/tag) of the current source code. This reference will be used to get the referece in the indexer git repository to update the resource files (e.g., main, develop): main
Resolving branch references...
Getting candidate git references...
Candidate git references: main 5.0.0 v5.0.0
Resolved candidate: main
Updating known fields of index pattern templates with indexer reference [main]...
📦 Using Wazuh version: main
🚀 Starting known fields generation...

⚙️  Processing states-vulnerabilities template...
  ✅ Successfully fetched from: https://raw.githubusercontent.com/wazuh/wazuh-indexer-plugins/main/plugins/setup/src/main/resources/templates/states/vulnerabilities.json
  ✅ Generated 93 known fields for states-vulnerabilities -> /home/wazuh/git/wazuh-dashboard-plugins/plugins/main/common/known-fields/states-vulnerabilities.json

⚙️  Processing events-access-management template...
  ✅ Successfully fetched from: https://raw.githubusercontent.com/wazuh/wazuh-indexer-plugins/main/plugins/setup/src/main/resources/templates/streams/events.json
  ✅ Generated 1860 known fields for events-access-management -> /home/wazuh/git/wazuh-dashboard-plugins/plugins/main/common/known-fields/events-access-management.json

⚙️  Processing events-applications template...
  ✅ Successfully fetched from: https://raw.githubusercontent.com/wazuh/wazuh-indexer-plugins/main/plugins/setup/src/main/resources/templates/streams/events.json
  ✅ Generated 1860 known fields for events-applications -> /home/wazuh/git/wazuh-dashboard-plugins/plugins/main/common/known-fields/events-applications.json

⚙️  Processing events-cloud-services template...
  ✅ Successfully fetched from: https://raw.githubusercontent.com/wazuh/wazuh-indexer-plugins/main/plugins/setup/src/main/resources/templates/streams/events.json
  ✅ Generated 1860 known fields for events-cloud-services -> /home/wazuh/git/wazuh-dashboard-plugins/plugins/main/common/known-fields/events-cloud-services.json

⚙️  Processing events-cloud-services-aws template...
  ✅ Successfully fetched from: https://raw.githubusercontent.com/wazuh/wazuh-indexer-plugins/main/plugins/setup/src/main/resources/templates/streams/events.json
  ✅ Generated 1860 known fields for events-cloud-services-aws -> /home/wazuh/git/wazuh-dashboard-plugins/plugins/main/common/known-fields/events-cloud-services-aws.json

⚙️  Processing events-cloud-services-azure template...
  ✅ Successfully fetched from: https://raw.githubusercontent.com/wazuh/wazuh-indexer-plugins/main/plugins/setup/src/main/resources/templates/streams/events.json
  ✅ Generated 1860 known fields for events-cloud-services-azure -> /home/wazuh/git/wazuh-dashboard-plugins/plugins/main/common/known-fields/events-cloud-services-azure.json

⚙️  Processing events-cloud-services-gcp template...
  ✅ Successfully fetched from: https://raw.githubusercontent.com/wazuh/wazuh-indexer-plugins/main/plugins/setup/src/main/resources/templates/streams/events.json
  ✅ Generated 1860 known fields for events-cloud-services-gcp -> /home/wazuh/git/wazuh-dashboard-plugins/plugins/main/common/known-fields/events-cloud-services-gcp.json

⚙️  Processing events-network-activity template...
  ✅ Successfully fetched from: https://raw.githubusercontent.com/wazuh/wazuh-indexer-plugins/main/plugins/setup/src/main/resources/templates/streams/events.json
  ✅ Generated 1860 known fields for events-network-activity -> /home/wazuh/git/wazuh-dashboard-plugins/plugins/main/common/known-fields/events-network-activity.json

⚙️  Processing events-other template...
  ✅ Successfully fetched from: https://raw.githubusercontent.com/wazuh/wazuh-indexer-plugins/main/plugins/setup/src/main/resources/templates/streams/events.json
  ✅ Generated 1860 known fields for events-other -> /home/wazuh/git/wazuh-dashboard-plugins/plugins/main/common/known-fields/events-other.json

⚙️  Processing events-security template...
  ✅ Successfully fetched from: https://raw.githubusercontent.com/wazuh/wazuh-indexer-plugins/main/plugins/setup/src/main/resources/templates/streams/events.json
  ✅ Generated 1860 known fields for events-security -> /home/wazuh/git/wazuh-dashboard-plugins/plugins/main/common/known-fields/events-security.json

⚙️  Processing events-system-activity template...
  ✅ Successfully fetched from: https://raw.githubusercontent.com/wazuh/wazuh-indexer-plugins/main/plugins/setup/src/main/resources/templates/streams/events.json
  ✅ Generated 1860 known fields for events-system-activity -> /home/wazuh/git/wazuh-dashboard-plugins/plugins/main/common/known-fields/events-system-activity.json

⚙️  Processing monitoring template...
  ✅ Successfully fetched from: https://raw.githubusercontent.com/wazuh/wazuh-indexer-plugins/main/plugins/setup/src/main/resources/templates/monitoring.json
  ✅ Generated 12 known fields for monitoring -> /home/wazuh/git/wazuh-dashboard-plugins/plugins/main/common/known-fields/monitoring.json

⚙️  Processing statistics template...
  ✅ Successfully fetched from: https://raw.githubusercontent.com/wazuh/wazuh-indexer-plugins/main/plugins/setup/src/main/resources/templates/statistics.json
   ⚠️  Unsupported dynamic template structure in string_as_keyword, skipping field extraction
  ✅ Generated 75 known fields for statistics -> /home/wazuh/git/wazuh-dashboard-plugins/plugins/main/common/known-fields/statistics.json

⚙️  Processing states-fim-files template...
  ✅ Successfully fetched from: https://raw.githubusercontent.com/wazuh/wazuh-indexer-plugins/main/plugins/setup/src/main/resources/templates/states/fim-files.json
  ✅ Generated 37 known fields for states-fim-files -> /home/wazuh/git/wazuh-dashboard-plugins/plugins/main/common/known-fields/states-fim-files.json

⚙️  Processing states-fim-registries-keys template...
  ✅ Successfully fetched from: https://raw.githubusercontent.com/wazuh/wazuh-indexer-plugins/main/plugins/setup/src/main/resources/templates/states/fim-registry-keys.json
  ✅ Generated 33 known fields for states-fim-registries-keys -> /home/wazuh/git/wazuh-dashboard-plugins/plugins/main/common/known-fields/states-fim-registries-keys.json

⚙️  Processing states-fim-registries-values template...
  ✅ Successfully fetched from: https://raw.githubusercontent.com/wazuh/wazuh-indexer-plugins/main/plugins/setup/src/main/resources/templates/states/fim-registry-values.json
  ✅ Generated 33 known fields for states-fim-registries-values -> /home/wazuh/git/wazuh-dashboard-plugins/plugins/main/common/known-fields/states-fim-registries-values.json

⚙️  Processing states-inventory-system template...
  ✅ Successfully fetched from: https://raw.githubusercontent.com/wazuh/wazuh-indexer-plugins/main/plugins/setup/src/main/resources/templates/states/inventory-system.json
  ✅ Generated 39 known fields for states-inventory-system -> /home/wazuh/git/wazuh-dashboard-plugins/plugins/main/common/known-fields/states-inventory-system.json

⚙️  Processing states-inventory-hardware template...
  ✅ Successfully fetched from: https://raw.githubusercontent.com/wazuh/wazuh-indexer-plugins/main/plugins/setup/src/main/resources/templates/states/inventory-hardware.json
  ✅ Generated 31 known fields for states-inventory-hardware -> /home/wazuh/git/wazuh-dashboard-plugins/plugins/main/common/known-fields/states-inventory-hardware.json

⚙️  Processing states-inventory-networks template...
  ✅ Successfully fetched from: https://raw.githubusercontent.com/wazuh/wazuh-indexer-plugins/main/plugins/setup/src/main/resources/templates/states/inventory-networks.json
  ✅ Generated 30 known fields for states-inventory-networks -> /home/wazuh/git/wazuh-dashboard-plugins/plugins/main/common/known-fields/states-inventory-networks.json

⚙️  Processing states-inventory-packages template...
  ✅ Successfully fetched from: https://raw.githubusercontent.com/wazuh/wazuh-indexer-plugins/main/plugins/setup/src/main/resources/templates/states/inventory-packages.json
  ✅ Generated 36 known fields for states-inventory-packages -> /home/wazuh/git/wazuh-dashboard-plugins/plugins/main/common/known-fields/states-inventory-packages.json

⚙️  Processing states-inventory-ports template...
  ✅ Successfully fetched from: https://raw.githubusercontent.com/wazuh/wazuh-indexer-plugins/main/plugins/setup/src/main/resources/templates/states/inventory-ports.json
  ✅ Generated 34 known fields for states-inventory-ports -> /home/wazuh/git/wazuh-dashboard-plugins/plugins/main/common/known-fields/states-inventory-ports.json

⚙️  Processing states-inventory-processes template...
  ✅ Successfully fetched from: https://raw.githubusercontent.com/wazuh/wazuh-indexer-plugins/main/plugins/setup/src/main/resources/templates/states/inventory-processes.json
  ✅ Generated 33 known fields for states-inventory-processes -> /home/wazuh/git/wazuh-dashboard-plugins/plugins/main/common/known-fields/states-inventory-processes.json

⚙️  Processing states-inventory-protocols template...
  ✅ Successfully fetched from: https://raw.githubusercontent.com/wazuh/wazuh-indexer-plugins/main/plugins/setup/src/main/resources/templates/states/inventory-protocols.json
  ✅ Generated 28 known fields for states-inventory-protocols -> /home/wazuh/git/wazuh-dashboard-plugins/plugins/main/common/known-fields/states-inventory-protocols.json

⚙️  Processing states-inventory-users template...
  ✅ Successfully fetched from: https://raw.githubusercontent.com/wazuh/wazuh-indexer-plugins/main/plugins/setup/src/main/resources/templates/states/inventory-users.json
  ✅ Generated 55 known fields for states-inventory-users -> /home/wazuh/git/wazuh-dashboard-plugins/plugins/main/common/known-fields/states-inventory-users.json

⚙️  Processing states-inventory-groups template...
  ✅ Successfully fetched from: https://raw.githubusercontent.com/wazuh/wazuh-indexer-plugins/main/plugins/setup/src/main/resources/templates/states/inventory-groups.json
  ✅ Generated 30 known fields for states-inventory-groups -> /home/wazuh/git/wazuh-dashboard-plugins/plugins/main/common/known-fields/states-inventory-groups.json

⚙️  Processing states-inventory-services template...
  ✅ Successfully fetched from: https://raw.githubusercontent.com/wazuh/wazuh-indexer-plugins/main/plugins/setup/src/main/resources/templates/states/inventory-services.json
  ✅ Generated 55 known fields for states-inventory-services -> /home/wazuh/git/wazuh-dashboard-plugins/plugins/main/common/known-fields/states-inventory-services.json

⚙️  Processing states-inventory-interfaces template...
  ✅ Successfully fetched from: https://raw.githubusercontent.com/wazuh/wazuh-indexer-plugins/main/plugins/setup/src/main/resources/templates/states/inventory-interfaces.json
  ✅ Generated 37 known fields for states-inventory-interfaces -> /home/wazuh/git/wazuh-dashboard-plugins/plugins/main/common/known-fields/states-inventory-interfaces.json

⚙️  Processing states-inventory-hotfixes template...
  ✅ Successfully fetched from: https://raw.githubusercontent.com/wazuh/wazuh-indexer-plugins/main/plugins/setup/src/main/resources/templates/states/inventory-hotfixes.json
  ✅ Generated 24 known fields for states-inventory-hotfixes -> /home/wazuh/git/wazuh-dashboard-plugins/plugins/main/common/known-fields/states-inventory-hotfixes.json

⚙️  Processing states-inventory-browser-extensions template...
  ✅ Successfully fetched from: https://raw.githubusercontent.com/wazuh/wazuh-indexer-plugins/main/plugins/setup/src/main/resources/templates/states/inventory-browser-extensions.json
  ✅ Generated 45 known fields for states-inventory-browser-extensions -> /home/wazuh/git/wazuh-dashboard-plugins/plugins/main/common/known-fields/states-inventory-browser-extensions.json

⚙️  Processing states-sca template...
  ✅ Successfully fetched from: https://raw.githubusercontent.com/wazuh/wazuh-indexer-plugins/main/plugins/setup/src/main/resources/templates/states/sca.json
  ✅ Generated 51 known fields for states-sca -> /home/wazuh/git/wazuh-dashboard-plugins/plugins/main/common/known-fields/states-sca.json

⚙️  Processing active-responses template...
  ✅ Successfully fetched from: https://raw.githubusercontent.com/wazuh/wazuh-indexer-plugins/main/plugins/setup/src/main/resources/templates/streams/active-responses.json
  ✅ Generated 82 known fields for active-responses -> /home/wazuh/git/wazuh-dashboard-plugins/plugins/main/common/known-fields/active-responses.json

⚙️  Processing combined states-inventory fields...
  ✅ Generated 182 combined fields for states-inventory -> /home/wazuh/git/wazuh-dashboard-plugins/plugins/main/common/known-fields/states-inventory.json

⚙️  Processing combined events fields...
  ✅ Generated 1860 combined fields for events -> /home/wazuh/git/wazuh-dashboard-plugins/plugins/main/common/known-fields/events.json

📊 Summary:
  ✅  states-vulnerabilities: 93 fields generated
  ✅  events-access-management: 1860 fields generated
  ✅  events-applications: 1860 fields generated
  ✅  events-cloud-services: 1860 fields generated
  ✅  events-cloud-services-aws: 1860 fields generated
  ✅  events-cloud-services-azure: 1860 fields generated
  ✅  events-cloud-services-gcp: 1860 fields generated
  ✅  events-network-activity: 1860 fields generated
  ✅  events-other: 1860 fields generated
  ✅  events-security: 1860 fields generated
  ✅  events-system-activity: 1860 fields generated
  ✅  monitoring: 12 fields generated
  ⚠️  statistics: 75 fields generated (⚠️ 1 warnings)
    ⚠️  Warnings (1):
      - Unsupported dynamic template structure in string_as_keyword, skipping field extraction
  ✅  states-fim-files: 37 fields generated
  ✅  states-fim-registries-keys: 33 fields generated
  ✅  states-fim-registries-values: 33 fields generated
  ✅  states-inventory-system: 39 fields generated
  ✅  states-inventory-hardware: 31 fields generated
  ✅  states-inventory-networks: 30 fields generated
  ✅  states-inventory-packages: 36 fields generated
  ✅  states-inventory-ports: 34 fields generated
  ✅  states-inventory-processes: 33 fields generated
  ✅  states-inventory-protocols: 28 fields generated
  ✅  states-inventory-users: 55 fields generated
  ✅  states-inventory-groups: 30 fields generated
  ✅  states-inventory-services: 55 fields generated
  ✅  states-inventory-interfaces: 37 fields generated
  ✅  states-inventory-hotfixes: 24 fields generated
  ✅  states-inventory-browser-extensions: 45 fields generated
  ✅  states-sca: 51 fields generated
  ✅  active-responses: 82 fields generated
  ✅  states-inventory: 182 fields generated
  ✅  events: 1860 fields generated

✨ Known fields generation completed!
Updating sample data of index pattern templates with indexer reference [main]...
Using specified branch: main
Found 20 datasets to update.
Starting templates update...

Processing dataset: agents-monitoring
Downloading: https://raw.githubusercontent.com/wazuh/wazuh-indexer-plugins/main/plugins/setup/src/main/resources/templates/monitoring.json

Processing dataset: server-statistics
Downloading: https://raw.githubusercontent.com/wazuh/wazuh-indexer-plugins/main/plugins/setup/src/main/resources/templates/statistics.json

Processing dataset: states-fim-files
Downloading: https://raw.githubusercontent.com/wazuh/wazuh-indexer-plugins/main/plugins/setup/src/main/resources/templates/states/fim-files.json

Processing dataset: states-fim-registry-keys
Downloading: https://raw.githubusercontent.com/wazuh/wazuh-indexer-plugins/main/plugins/setup/src/main/resources/templates/states/fim-registry-keys.json

Processing dataset: states-fim-registry-values
Downloading: https://raw.githubusercontent.com/wazuh/wazuh-indexer-plugins/main/plugins/setup/src/main/resources/templates/states/fim-registry-values.json

Processing dataset: states-inventory-browser-extensions
Downloading: https://raw.githubusercontent.com/wazuh/wazuh-indexer-plugins/main/plugins/setup/src/main/resources/templates/states/inventory-browser-extensions.json

Processing dataset: states-inventory-groups
Downloading: https://raw.githubusercontent.com/wazuh/wazuh-indexer-plugins/main/plugins/setup/src/main/resources/templates/states/inventory-groups.json

Processing dataset: states-inventory-hardware
Downloading: https://raw.githubusercontent.com/wazuh/wazuh-indexer-plugins/main/plugins/setup/src/main/resources/templates/states/inventory-hardware.json

Processing dataset: states-inventory-hotfixes
Downloading: https://raw.githubusercontent.com/wazuh/wazuh-indexer-plugins/main/plugins/setup/src/main/resources/templates/states/inventory-hotfixes.json

Processing dataset: states-inventory-interfaces
Downloading: https://raw.githubusercontent.com/wazuh/wazuh-indexer-plugins/main/plugins/setup/src/main/resources/templates/states/inventory-interfaces.json

Processing dataset: states-inventory-networks
Downloading: https://raw.githubusercontent.com/wazuh/wazuh-indexer-plugins/main/plugins/setup/src/main/resources/templates/states/inventory-networks.json

Processing dataset: states-inventory-packages
Downloading: https://raw.githubusercontent.com/wazuh/wazuh-indexer-plugins/main/plugins/setup/src/main/resources/templates/states/inventory-packages.json

Processing dataset: states-inventory-ports
Downloading: https://raw.githubusercontent.com/wazuh/wazuh-indexer-plugins/main/plugins/setup/src/main/resources/templates/states/inventory-ports.json

Processing dataset: states-inventory-processes
Downloading: https://raw.githubusercontent.com/wazuh/wazuh-indexer-plugins/main/plugins/setup/src/main/resources/templates/states/inventory-processes.json

Processing dataset: states-inventory-protocols
Downloading: https://raw.githubusercontent.com/wazuh/wazuh-indexer-plugins/main/plugins/setup/src/main/resources/templates/states/inventory-protocols.json

Processing dataset: states-inventory-services
Downloading: https://raw.githubusercontent.com/wazuh/wazuh-indexer-plugins/main/plugins/setup/src/main/resources/templates/states/inventory-services.json

Processing dataset: states-inventory-system
Downloading: https://raw.githubusercontent.com/wazuh/wazuh-indexer-plugins/main/plugins/setup/src/main/resources/templates/states/inventory-system.json

Processing dataset: states-inventory-users
Downloading: https://raw.githubusercontent.com/wazuh/wazuh-indexer-plugins/main/plugins/setup/src/main/resources/templates/states/inventory-users.json

Processing dataset: states-sca
Downloading: https://raw.githubusercontent.com/wazuh/wazuh-indexer-plugins/main/plugins/setup/src/main/resources/templates/states/sca.json

Processing dataset: states-vulnerabilities
Downloading: https://raw.githubusercontent.com/wazuh/wazuh-indexer-plugins/main/plugins/setup/src/main/resources/templates/states/vulnerabilities.json
✅ Template updated for states-inventory-hotfixes
✅ Template updated for states-inventory-hardware
✅ Template updated for states-inventory-interfaces
✅ Template updated for states-inventory-networks
✅ Template updated for server-statistics
✅ Template updated for states-inventory-services
✅ Template updated for states-inventory-ports
✅ Template updated for states-inventory-system
✅ Template updated for states-fim-files
✅ Template updated for states-inventory-groups
✅ Template updated for states-sca
✅ Template updated for states-inventory-protocols
✅ Template updated for states-inventory-processes
✅ Template updated for states-inventory-browser-extensions
✅ Template updated for agents-monitoring
✅ Template updated for states-inventory-packages
✅ Template updated for states-fim-registry-keys
✅ Template updated for states-vulnerabilities
✅ Template updated for states-fim-registry-values
✅ Template updated for states-inventory-users

===== UPDATE SUMMARY =====
✅ Successfully updated datasets: 20
❌ Datasets with errors: 0
Done in 7.68s.
Done in 7.93s.
```

</p>
</details> 




### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff 
