### PR TITLE
Remove openssl_support from Dashboard manager info mock

### DIFF
--- a/docker/imposter/manager/info.json
+++ b/docker/imposter/manager/info.json
@@ -6,7 +6,6 @@
         "version": "v4.12.1",
         "type": "server",
         "max_agents": "unlimited",
-        "openssl_support": true,
         "tz_offset": 0,
         "tz_name": "UTC",
         "uuid": "c842f85c-c24b-4b39-9508-093ce53482e7"


### PR DESCRIPTION
### Description
Removed the `openssl_support` property from imposter info.json
 
### Issues Resolved
- **Issue:** https://github.com/wazuh/wazuh-dashboard-plugins/issues/8197

### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 
