### PR TITLE
Fix communication agent main settings error

### DIFF
--- a/plugins/main/public/controllers/management/components/management/configuration/client/client.js
+++ b/plugins/main/public/controllers/management/components/management/configuration/client/client.js
@@ -12,7 +12,7 @@
 
 import React, { Component, Fragment } from 'react';
 
-import { EuiBasicTable } from '@elastic/eui';
+import { EuiBasicTable, EuiCallOut } from '@elastic/eui';
 
 import WzNoConfig from '../util-components/no-config';
 import WzConfigurationSettingsHeader from '../util-components/configuration-settings-header';
@@ -103,17 +103,27 @@ class WzConfigurationClient extends Component {
                 config={currentConfig['agent-client'].client}
                 items={mainSettings}
               />
-              {currentConfig['agent-client'].client.server.length && (
+              {currentConfig['agent-client'].client && (
                 <Fragment>
                   <WzConfigurationSettingsHeader
                     title='Server settings'
                     description='List of managers to connect'
                   />
-                  <EuiBasicTable
-                    items={currentConfig['agent-client'].client.server}
-                    columns={columns}
-                    tableLayout='auto'
-                  />
+                  {currentConfig['agent-client'].client.manager?.length ? (
+                    <EuiBasicTable
+                      items={currentConfig['agent-client'].client.manager}
+                      columns={columns}
+                      tableLayout='auto'
+                    />
+                  ) : (
+                    <EuiCallOut
+                      title='Client manager configuration error'
+                      color='warning'
+                      iconType='alert'
+                    >
+                      <p>The manager configuration is undefined or empty.</p>
+                    </EuiCallOut>
+                  )}
                 </Fragment>
               )}
             </WzConfigurationSettingsHeader>


### PR DESCRIPTION
### Description
This PR fixes a bug that showed an undefined error in the communication section in the agent configuration.
 
### Issues Resolved
[#1165](https://github.com/wazuh/wazuh-dashboard/issues/1165)

### Evidence
<img width="1295" height="661" alt="imagen" src="https://github.com/user-attachments/assets/5ac449d0-e851-4915-9892-778737519386" />

### Test
- Using manager-local navigate to `Agent management > Summary > select an agent > Configuration > Main configurations > Communication` and verify it renders without errors.

### Check List
- [x] Commits are signed per the DCO using --signoff 
