### PR TITLE
Remove toLowerCase on level to fix crash and key mismatch

### DIFF
--- a/plugins/main/public/react-services/error-orchestrator/error-orchestrator-base.ts
+++ b/plugins/main/public/react-services/error-orchestrator/error-orchestrator-base.ts
@@ -37,7 +37,7 @@ export class ErrorOrchestratorBase implements ErrorOrchestrator {
     }
 
     try {
-      const winstonLevel = winstonLevelDict[errorLog.level.toLowerCase()] || 'error';
+      const winstonLevel = winstonLevelDict[errorLog.level] || 'error';
 
       await GenericRequest.request('POST', `/utils/logs/ui`, {
         message: errorLog?.error?.message || 'No message',


### PR DESCRIPTION
## Description

Closes #8019

`storeError()` in `ErrorOrchestratorBase` called `.toLowerCase()` on `errorLog.level` before looking it up in `winstonLevelDict`. This caused two issues:

1. **TypeError crash** when `errorLog.level` is `undefined` at runtime (`Cannot read properties of undefined (reading 'toLowerCase')`),  is what triggered the visible error on the Microsoft Graph API dashboard tab.

2. **Silent key mismatch**: `winstonLevelDict` keys are uppercase ERROR'`, `'WARNING'`, `'INFO'`), matching `UILogLevel` values,  the lookup was converting them to lowercase first — so the lookup always missed and every level was logged as `'error'` via the fallback.

## Proposed Changes

Remove `.toLowerCase()` from the `winstonLevelDict` lookup in `error-orchestrator-base.ts`. The dictionary keys already match the `UILogLevel` union type values directly.

```diff
- const winstonLevel = winstonLevelDict[errorLog.level.toLowerCase()] || 'error';
+ const winstonLevel = winstonLevelDict[errorLog.level] || 'error';
```

`winstonLevelDict[undefined]` returns `undefined`, so the `|| 'error'` fallback handles any missing level without throwing.

### Results and Evidence

<details><summary>Before — TypeError on undefined level</summary>

```
TypeError: Cannot read properties of undefined (reading 'toLowerCase')
    at ErrorOrchestratorBase.storeError (error-orchestrator-base.ts:40)
```

</details>

<details><summary>After — correct level mapping</summary>

| `errorLog.level` | before (always) | after |
|---|---|---|
| `'ERROR'` | `'error'` (fallback) | `'error'` ✓ |
| `'WARNING'` | `'error'` (fallback) | `'warn'` ✓ |
| `'INFO'` | `'error'` (fallback) | `'info'` ✓ |
| `undefined` | TypeError 💥 | `'error'` (fallback) ✓ |

</details>

### Manual tests with their corresponding evidence

- Compilation without warnings on every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [x] Log syntax and correct language review

- Memory tests for Linux
  - N/A

- Memory tests for Windows
  - N/A

- Memory tests for macOS
  - N/A

- Decoder/Rule tests
  - N/A

- Engine
  - N/A

- Wazuh server API/Framework
  - N/A

### Artifacts Affected

- Wazuh Dashboard plugin (all platforms)

### Configuration Changes

N/A

### Tests Introduced

N/A — single-line fix in a private error logging utility.

## Review Checklist

- [ ] Code changes reviewed
- [x] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues