### PR TITLE
Show dash for epoch-zero registration date

### DIFF
--- a/plugins/main/public/components/endpoints-summary/table/columns.tsx
+++ b/plugins/main/public/components/endpoints-summary/table/columns.tsx
@@ -118,7 +118,8 @@ export const agentsTableColumns = (
         />
       </span>
     ),
-    render: dateAdd => formatUIDate(dateAdd),
+    render: dateAdd =>
+      dateAdd && new Date(dateAdd).getTime() !== 0 ? formatUIDate(dateAdd) : '-',
     sortable: true,
     show: false,
     searchable: false,


### PR DESCRIPTION
### Description

Closes #5270

When an agent is not registered through `authd`, the Wazuh manager stores
`dateAdd` as `1970-01-01T00:00:00Z` (Unix epoch zero), which is a sentinel
value meaning "registration date unknown".

The **Registration date** column in the agents table was passing this value
directly to `formatUIDate`, which formatted it as a real date
(e.g. `Jan 1, 1970 @ 00:00:00.000`). This is misleading: the epoch date
appears valid but has no meaningful value for the user.

### Issues Resolved

Closes #5270 — Fix the agent `Registration date` is displayed as `1970-01-01T00:00:00Z`

### Evidence

<details><summary>Code diff — columns.tsx</summary>

```diff
-    render: dateAdd => formatUIDate(dateAdd),
+    render: dateAdd =>
+      dateAdd && new Date(dateAdd).getTime() !== 0 ? formatUIDate(dateAdd) : '-',
```

</details>

<details><summary>Before / After</summary>

| `dateAdd` from API | Before | After |
|---|---|---|
| `'2024-06-01T10:00:00Z'` | `Jun 1, 2024 @ 10:00:00.000` ✓ | `Jun 1, 2024 @ 10:00:00.000` ✓ |
| `'1970-01-01T00:00:00Z'` | `Jan 1, 1970 @ 00:00:00.000` ✗ | `-` ✓ |
| `undefined` | `-` ✓ | `-` ✓ |

</details>

### Test

1. Add a Wazuh agent without registering it through `authd` (or manually set its `dateAdd` field to epoch zero in the manager database).
2. Navigate to **Endpoints Summary**.
3. Show the **Registration date** column.

**Expected:** The column displays `-` instead of a 1970 date.

### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff