### PR TITLE
Add CTI link to inventory and Findings tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,7 +65,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Removed the Cluster app and relocated some panels to the Status app [#8220](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8220)
 - Changed the default value of `wazuh.updates.disabled` from `false` to `true` [#8236](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8236)
 - Centralized regulatory compliance modules (PCI DSS, GDPR, HIPAA, NIST 800-53, and TSC) into a single "Regulatory Compliance" application [#8239](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8239)
-- Updated Vulnerability Detection Discover tab filters, and inventory columns [#8262](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8262) [#8283](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8283)
+- Updated Vulnerability Detection Discover tab filters, and inventory columns [#8262](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8262) [#8283](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8283) [#8292](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8292)
 - Changed FIM table columns and index source in the agent view [#8269](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8269)
 
 ### Fixed

--- a/plugins/main/common/constants.ts
+++ b/plugins/main/common/constants.ts
@@ -1145,4 +1145,5 @@ export const TAB_VIEW_NAME_EVENTS = 'Findings';
 export const TAB_VIEW_ID_DASHBOARD = 'dashboard';
 export const TAB_VIEW_NAME_DASHBOARD = 'Dashboard';
 
-export const CTI_CVE_LINK_BASE_PATH = 'https://cti.wazuh.com/vulnerabilities/cves/';
+export const CTI_CVE_LINK_BASE_PATH =
+  'https://cti.wazuh.com/vulnerabilities/cves/';

--- a/plugins/main/common/constants.ts
+++ b/plugins/main/common/constants.ts
@@ -1144,3 +1144,5 @@ export const TAB_VIEW_ID_EVENTS = 'findings';
 export const TAB_VIEW_NAME_EVENTS = 'Findings';
 export const TAB_VIEW_ID_DASHBOARD = 'dashboard';
 export const TAB_VIEW_NAME_DASHBOARD = 'Dashboard';
+
+export const CTI_CVE_LINK_BASE_PATH = 'https://cti.wazuh.com/vulnerabilities/cves/';

--- a/plugins/main/public/components/common/wazuh-discover/render-columns.tsx
+++ b/plugins/main/public/components/common/wazuh-discover/render-columns.tsx
@@ -4,6 +4,7 @@ import { tDataGridRenderColumn } from '../data-grid';
 import { endpointSummary, mitreAttack } from '../../../utils/applications';
 import { WzLink } from '../../wz-link/wz-link';
 import { i18n } from '@osd/i18n';
+import { CTI_CVE_LINK_BASE_PATH } from '../../../../common/constants';
 
 export const MAX_ENTRIES_PER_QUERY = 10000;
 
@@ -138,7 +139,7 @@ export const wzDiscoverRenderColumns: tDataGridRenderColumn[] = [
   {
     id: 'vulnerability.id',
     render: (value, row) => {
-      if (!row.vulnerability?.reference) {
+      if (!(row.vulnerability?.reference || row.vulnerability?.scanner?.reference)) {
         return value;
       }
       return (
@@ -152,7 +153,7 @@ export const wzDiscoverRenderColumns: tDataGridRenderColumn[] = [
           )}
         >
           <EuiLink
-            href={row.vulnerability.reference}
+            href={`${CTI_CVE_LINK_BASE_PATH}${row.vulnerability.id}`}
             target='_blank'
             rel='noopener noreferrer'
             external
@@ -166,7 +167,7 @@ export const wzDiscoverRenderColumns: tDataGridRenderColumn[] = [
   {
     id: 'data.vulnerability.cve',
     render: (value, row) => {
-      if (!row.data?.vulnerability?.scanner?.reference) {
+      if (!(row.data?.vulnerability?.reference || row.data?.vulnerability?.scanner?.reference)) {
         return value;
       }
       return (
@@ -180,7 +181,7 @@ export const wzDiscoverRenderColumns: tDataGridRenderColumn[] = [
           )}
         >
           <EuiLink
-            href={row.data.vulnerability.scanner.reference}
+            href={`${CTI_CVE_LINK_BASE_PATH}${row.data.vulnerability.cve}`}
             target='_blank'
             rel='noopener noreferrer'
             external

--- a/plugins/main/public/components/common/wazuh-discover/render-columns.tsx
+++ b/plugins/main/public/components/common/wazuh-discover/render-columns.tsx
@@ -139,7 +139,9 @@ export const wzDiscoverRenderColumns: tDataGridRenderColumn[] = [
   {
     id: 'vulnerability.id',
     render: (value, row) => {
-      if (!(row.vulnerability?.reference || row.vulnerability?.scanner?.reference)) {
+      if (
+        !(row.vulnerability?.reference || row.vulnerability?.scanner?.reference)
+      ) {
         return value;
       }
       return (
@@ -167,7 +169,12 @@ export const wzDiscoverRenderColumns: tDataGridRenderColumn[] = [
   {
     id: 'data.vulnerability.cve',
     render: (value, row) => {
-      if (!(row.data?.vulnerability?.reference || row.data?.vulnerability?.scanner?.reference)) {
+      if (
+        !(
+          row.data?.vulnerability?.reference ||
+          row.data?.vulnerability?.scanner?.reference
+        )
+      ) {
         return value;
       }
       return (


### PR DESCRIPTION
### Description
This PR fixes CTI links to the Inventory and Findings tabs tables.
 
### Issues Resolved
- https://github.com/wazuh/wazuh-dashboard-plugins/issues/8282

### Evidence

[Screencast from 2026-04-09 17-31-58.webm](https://github.com/user-attachments/assets/c75504f6-3616-4b1b-93e0-e6146b5aaede)


### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 
