### PR TITLE
Chaged separator for nist 800 53 regulatory compliance module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,7 +64,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Swapped menu positions of Vulnerability detection and MITRE ATT&CK [#8230](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8230)
 - Removed the Cluster app and relocated some panels to the Status app [#8220](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8220)
 - Changed the default value of `wazuh.updates.disabled` from `false` to `true` [#8236](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8236)
-- Centralized regulatory compliance modules (PCI DSS, GDPR, HIPAA, NIST 800-53, and TSC) into a single "Regulatory Compliance" application [#8239](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8239)
+- Centralized regulatory compliance modules (PCI DSS, GDPR, HIPAA, NIST 800-53, and TSC) into a single "Regulatory Compliance" application [#8239](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8239) [#8303](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8303)
 - Updated Vulnerability Detection Discover tab filters, and inventory columns [#8262](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8262) [#8283](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8283) [#8292](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8292)
 - Changed FIM table columns and index source in the agent view [#8269](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8269)
 

--- a/plugins/main/common/compliance-requirements/nist-requirements.ts
+++ b/plugins/main/common/compliance-requirements/nist-requirements.ts
@@ -10,50 +10,50 @@
  * Find more information about this on the LICENSE file.
  */
 export const nistRequirementsFile = {
-  'AC.2':
+  'AC-2':
     'ACCOUNT MANAGEMENT - Identifies and selects the following types of information system accounts to support organizational missions/business functions.',
-  'AC.6':
+  'AC-6':
     'LEAST PRIVILEGE - The organization employs the principle of least privilege, allowing only authorized accesses for users (or processes acting on behalf of users) which are necessary to accomplish assigned tasks in accordance with organizational missions and business functions.',
-  'AC.7':
+  'AC-7':
     'UNSUCCESSFUL LOGON ATTEMPTS - Enforces a limit of consecutive invalid logon attempts by a user during a time period.',
-  'AC.12':
+  'AC-12':
     'SESSION TERMINATION - The information system automatically terminates a user session.',
-  'AU.5':
+  'AU-5':
     'RESPONSE TO AUDIT PROCESSING FAILURES - The information system alerts organization-defined personnel or roles in the event of an audit processing failure and takes organization-defined actions to be taken (e.g., shut down information system, overwrite oldest audit records, stop generating audit records).',
-  'AU.6':
+  'AU-6':
     'AUDIT REVIEW, ANALYSIS, AND REPORTING - Reviews and analyzes information system audit records.',
-  'AU.8':
+  'AU-8':
     'TIME STAMPS - Uses internal system clocks to generate time stamps for audit records and records time stamps for audit records.',
-  'AU.9':
+  'AU-9':
     'PROTECTION OF AUDIT INFORMATION - The information system protects audit information and audit tools from unauthorized access, modification, and deletion.',
-  'AU.12':
+  'AU-12':
     'AUDIT GENERATION - The information system provides audit record generation capability for the auditable events at organization-defined information system components, allows organization-defined personnel or roles to select which auditable events are to be audited by specific components of the information system and generates audit records.',
-  'CA.3':
+  'CA-3':
     'SYSTEM INTERCONNECTIONS - Authorizes connections from the information system to other information systems through the use of Interconnection Security Agreements, Documents, for each interconnection, the interface characteristics, security requirements, and the nature of the information communicated and Reviews and updates Interconnection Security Agreements ',
-  'CM.1':
+  'CM-1':
     'CONFIGURATION MANAGEMENT POLICY AND PROCEDURES - Develops, documents, and disseminates to a configuration management policy. Revies and updates the current configuration management policy and procedures.',
-  'CM.3':
+  'CM-3':
     'CONFIGURATION CHANGE CONTROL - The organization determines the types of changes to the information system that are configuration-controlled. ',
-  'CM.5':
+  'CM-5':
     'ACCESS RESTRICTIONS FOR CHANGE - The organization defines, documents, approves, and enforces physical and logical access restrictions associated with changes to the information system.',
-  'IA.4':
+  'IA-4':
     'IDENTIFIER MANAGEMENT - The organization manages information system identifiers by: Receiving authorization from organization-defined personnel or roles to assign an individual, group, role, or device identifier. Selecting an identifier that identifies an individual, group, role, or device. Assigning the identifier to the intended individual, group, role, or device. Preventing reuse of identifiers for a organization-defined time period. Disabling the identifier after organization-defined time period of inactivity.',
-  'IA.5':
+  'IA-5':
     'AUTHENTICATOR MANAGEMENT - The organization manages information system authenticators by verifying, as part of the initial authenticator distribution, the identity of the individual, group role, or device receiving the authenticator.',
-  'IA.10':
+  'IA-10':
     'ADAPTIVE IDENTIFICATION AND AUTHENTICATION - The organization requires that individuals accessing the information system employ organization-defined supplemental authentication techniques or mechanisms under specific organization-defined circumstances or situations. ',
-  'SA.11':
+  'SA-11':
     'DEVELOPER SECURITY TESTING AND EVALUATION - The organization requires the developer of the information system, system component, or information system service to create and implement a security assessment plan.',
-  'SC.2':
+  'SC-2':
     'APPLICATION PARTITIONING - The information system separates user functionality (including user interface services) from information system management functionality.',
-  'SC.7':
+  'SC-7':
     'BOUNDARY PROTECTION - The information system monitors and controls communications at the external boundary of the system and at key internal boundaries within the system.',
-  'SC.8':
+  'SC-8':
     'TRANSMISSION CONFIDENTIALITY AND INTEGRITY - The information system protects the confidentiality and integrity of transmitted information.',
-  'SI.2':
+  'SI-2':
     'FLAW REMEDIATION - The organization identifies, reports, and corrects information system flaws; tests software and firmware updates related to flaw remediation for effectiveness and potential side effects before installation; installs security-relevant software and firmware updates within organizationdefined time period of the release of the updates and  incorporates flaw remediation into the organizational configuration management process.',
-  'SI.3':
+  'SI-3':
     'MALICIOUS CODE PROTECTION - The organization employs malicious code protection mechanisms at information system entry and exit points to detect and eradicate malicious code, updates malicious code protection mechanisms whenever new releases are available in accordance with organizational configuration management policy and procedures, configures malicious code protection mechanisms and addresses the receipt of false positives during malicious code detection and eradication and the resulting potential impact on the availability of the information system.',
-  'SI.7':
-    'SOFTWARE, FIRMWARE, AND INFORMATION INTEGRITY - The organization employs integrity verification tools to detect unauthorized changes to organization-defined software, firmware, and information.'
+  'SI-7':
+    'SOFTWARE, FIRMWARE, AND INFORMATION INTEGRITY - The organization employs integrity verification tools to detect unauthorized changes to organization-defined software, firmware, and information.',
 };

--- a/plugins/main/public/components/overview/compliance-table/compliance-table.tsx
+++ b/plugins/main/public/components/overview/compliance-table/compliance-table.tsx
@@ -95,7 +95,7 @@ function buildComplianceObject({ section }) {
     if (section === 'nist') {
       descriptions = nistRequirementsFile;
       Object.keys(nistRequirementsFile).forEach(item => {
-        const currentRequirement = item.split('.')[0];
+        const currentRequirement = item.split('-')[0];
         if (complianceRequirements[currentRequirement]) {
           complianceRequirements[currentRequirement].push(item);
         } else {


### PR DESCRIPTION
### Description
This PR changes the separator from `.` to `-` for the nist 800 53 regulatory compliance module, to align with the data found in `wazuh-findings*`.
 
### Issues Resolved
#8302 

### Evidence
<img width="1918" height="812" alt="imagen" src="https://github.com/user-attachments/assets/64e3a855-fc59-4817-a5d9-c15348e6aef0" />

<img width="1917" height="900" alt="imagen" src="https://github.com/user-attachments/assets/edb8da78-e355-45c1-b7be-c1394a698473" />

### Test
- Navigate to `Regulatory compliance > NIST 800-53 > Controls` and check that all the data that should appear, appears. 

### Check List
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 
