### PR TITLE
MITRE Att&ck data grid width falls short

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fixed a message in the group selector of the deploy new agent guide related to missing permissions when there was no groups available or they could not be obtained [#8216](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8216)
 - Fixed the under evaluation filter was removed on filter addition in Vulnerability Detection [#8252](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8252)
 - Fixed home KPIs not being vertically centered [#8267](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8267) [#8285](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8285)
+- Fixed MITRE ATT&CK Findings data grid not spanning the full available width [#8311](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8311)
 
 ### Removed
 

--- a/plugins/main/public/components/overview/mitre/events/mitre-attack-columns.tsx
+++ b/plugins/main/public/components/overview/mitre/events/mitre-attack-columns.tsx
@@ -6,14 +6,11 @@ export const mitreAttackColumns: tDataGridColumn[] = [
   commonColumns['wazuh.agent.name'],
   {
     id: 'rule.mitre.tactic',
-    initialWidth: 280,
   },
   {
     id: 'rule.title',
-    initialWidth: 280,
   },
   {
     id: 'rule.level',
-    initialWidth: 280,
   },
 ];


### PR DESCRIPTION
### Description
Remove default initial width 
 
### Issues Resolved
https://github.com/wazuh/wazuh-dashboard-plugins/issues/8309

### Evidence
<img width="1920" height="913" alt="image" src="https://github.com/user-attachments/assets/328c43eb-aa2c-4825-bccf-32c63cec406d" />


### Test
Go to Threat intelligence -->  MITRE Att&ck --> Findings, and validate the data grids displays correct width of th e columns

### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff 
