### PR TITLE
Change the default columns in Configuration assessment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Updated Vulnerability Detection Discover tab filters, and inventory columns [#8262](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8262) [#8283](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8283) [#8292](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8292)
 - Changed FIM table columns and index source in the agent view [#8269](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8269)
 - Changed IT Hygiene memory visualization [#8313](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8313)
+- Changed default columns in Configuration assessment [#8320](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8320)
 
 ### Fixed
 

--- a/plugins/main/public/components/overview/sca/components/inventory/utils/index.ts
+++ b/plugins/main/public/components/overview/sca/components/inventory/utils/index.ts
@@ -1,10 +1,8 @@
 export const tableColumns = [
   { id: 'wazuh.agent.name' },
   { id: 'policy.name' },
-  { id: 'policy.description' },
-  { id: 'policy.file' },
+  { id: 'check.id' },
   { id: 'check.name' },
-  { id: 'check.result' },
 ];
 
 export const managedFilters = [
@@ -15,7 +13,7 @@ export const managedFilters = [
   },
   {
     type: 'multiSelect',
-    key: 'check.result',
+    key: 'check.name',
     placeholder: 'Check',
   },
 ];

--- a/plugins/main/public/components/overview/sca/events/configuration-assessment-columns.tsx
+++ b/plugins/main/public/components/overview/sca/events/configuration-assessment-columns.tsx
@@ -5,7 +5,7 @@ export const configurationAssessmentColumns: tDataGridColumn[] = [
   commonColumns.timestamp,
   commonColumns['wazuh.agent.name'],
   { id: 'policy.name' },
-  { id: 'policy.description' },
-  { id: 'policy.file' },
+  { id: 'check.id' },
+  { id: 'check.name' },
   { id: 'event.outcome' },
 ];


### PR DESCRIPTION
### Description

Change the default columns in the **Configuration Assessment** module for both **Findings** and **Inventory** tabs.
 
### Issues Resolved

- Issue: https://github.com/wazuh/wazuh-dashboard-plugins/issues/8319

### Evidence
1. Findings tab:

<img width="1896" height="1030" alt="image" src="https://github.com/user-attachments/assets/dd92328c-94ba-4a3c-8c0c-56ea859d1757" />

2. Inventory tab:

<img width="1896" height="1030" alt="image" src="https://github.com/user-attachments/assets/31de1fe6-2b52-4dd4-bfe9-b8e83e8c7396" />

### Test
1. Navigate to the **Configuration Assessment** module.
2. Open the **Findings** tab and verify the default columns are: `@timestamp`, `wazuh.agent.name`, `policy.name`, `check.id`, `check.name`, `event.outcome`.
3. Open the **Inventory** tab and verify the default columns are: `wazuh.agent.name`, `policy.name`, `check.id`, `check.name`.

### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [X] Update [CHANGELOG.md](./../CHANGELOG.md)
- [X] Commits are signed per the DCO using --signoff 
