### PR TITLE
 Change agent registration path in command

### DIFF
--- a/plugins/main/public/components/endpoints-summary/register-agent/core/config/os-commands-definitions.ts
+++ b/plugins/main/public/components/endpoints-summary/register-agent/core/config/os-commands-definitions.ts
@@ -84,28 +84,28 @@ const linuxDefinition: IOSDefinition<ILinuxOSTypes, tOptionalParameters> = {
     {
       architecture: 'DEB amd64',
       urlPackage: props =>
-        `https://packages.wazuh.com/${PLUGIN_MAJOR_VERSION}.x/apt/pool/main/w/wazuh-agent/wazuh-agent_${props.wazuhVersion}-1_amd64.deb`,
+        `https://packages-staging.xdrsiem.wazuh.info/pre-release/${PLUGIN_MAJOR_VERSION}.x/apt/pool/main/w/wazuh-agent/wazuh-agent_${props.wazuhVersion}-beta1_amd64.deb`,
       installCommand: props => getDEBAMD64InstallCommand(props),
       startCommand: props => getLinuxStartCommand(props),
     },
     {
       architecture: 'RPM amd64',
       urlPackage: props =>
-        `https://packages.wazuh.com/${PLUGIN_MAJOR_VERSION}.x/yum/wazuh-agent-${props.wazuhVersion}-1.x86_64.rpm`,
+        `https://packages-staging.xdrsiem.wazuh.info/pre-release/${PLUGIN_MAJOR_VERSION}.x/yum/wazuh-agent-${props.wazuhVersion}-beta1.x86_64.rpm`,
       installCommand: props => getRPMAMD64InstallCommand(props),
       startCommand: props => getLinuxStartCommand(props),
     },
     {
       architecture: 'DEB aarch64',
       urlPackage: props =>
-        `https://packages.wazuh.com/${PLUGIN_MAJOR_VERSION}.x/apt/pool/main/w/wazuh-agent/wazuh-agent_${props.wazuhVersion}-1_arm64.deb`,
+        `https://packages-staging.xdrsiem.wazuh.info/pre-release/${PLUGIN_MAJOR_VERSION}.x/apt/pool/main/w/wazuh-agent/wazuh-agent_${props.wazuhVersion}-beta1_arm64.deb`,
       installCommand: props => getDEBARM64InstallCommand(props),
       startCommand: props => getLinuxStartCommand(props),
     },
     {
       architecture: 'RPM aarch64',
       urlPackage: props =>
-        `https://packages.wazuh.com/${PLUGIN_MAJOR_VERSION}.x/yum/wazuh-agent-${props.wazuhVersion}-1.aarch64.rpm`,
+        `https://packages-staging.xdrsiem.wazuh.info/pre-release/${PLUGIN_MAJOR_VERSION}.x/yum/wazuh-agent-${props.wazuhVersion}-beta1.aarch64.rpm`,
       installCommand: props => getRPMARM64InstallCommand(props),
       startCommand: props => getLinuxStartCommand(props),
     },
@@ -118,7 +118,7 @@ const windowsDefinition: IOSDefinition<IWindowsOSTypes, tOptionalParameters> = {
     {
       architecture: 'MSI 32/64 bits',
       urlPackage: props =>
-        `https://packages.wazuh.com/${PLUGIN_MAJOR_VERSION}.x/windows/wazuh-agent-${props.wazuhVersion}-1.msi`,
+        `https://packages-staging.xdrsiem.wazuh.info/pre-release/${PLUGIN_MAJOR_VERSION}.x/windows/wazuh-agent-${props.wazuhVersion}-beta1.msi`,
       installCommand: props => getWindowsInstallCommand(props),
       startCommand: props => getWindowsStartCommand(props),
     },
@@ -131,14 +131,14 @@ const macDefinition: IOSDefinition<IMacOSTypes, tOptionalParameters> = {
     {
       architecture: 'Intel',
       urlPackage: props =>
-        `https://packages.wazuh.com/${PLUGIN_MAJOR_VERSION}.x/macos/wazuh-agent-${props.wazuhVersion}-1.intel64.pkg`,
+        `https://packages-staging.xdrsiem.wazuh.info/pre-release/${PLUGIN_MAJOR_VERSION}.x/macos/wazuh-agent-${props.wazuhVersion}-beta1.intel64.pkg`,
       installCommand: props => getMacOsInstallCommand(props),
       startCommand: props => getMacosStartCommand(props),
     },
     {
       architecture: 'Apple silicon',
       urlPackage: props =>
-        `https://packages.wazuh.com/${PLUGIN_MAJOR_VERSION}.x/macos/wazuh-agent-${props.wazuhVersion}-1.arm64.pkg`,
+        `https://packages-staging.xdrsiem.wazuh.info/pre-release/${PLUGIN_MAJOR_VERSION}.x/macos/wazuh-agent-${props.wazuhVersion}-beta1.arm64.pkg`,
       installCommand: props => getMacOsInstallCommand(props),
       startCommand: props => getMacosStartCommand(props),
     },


### PR DESCRIPTION
### Description

Update the agent download URLs in the enrollment wizard to use the pre-release staging server (`packages-staging.xdrsiem.wazuh.info/pre-release/`) and the `-beta1` package suffix, replacing the standard `packages.wazuh.com` production URLs.
 
### Issues Resolved
- **Issue**: https://github.com/wazuh/wazuh-dashboard-plugins/issues/8329

### Test
1. Go to **Agents management > Summary > Deploy new agent**.
2. Select each OS/architecture combination and verify the generated install command uses the staging URL and `-beta1` suffix.

### Check List
- [X] Commits are signed per the DCO using --signoff 
