### PR TITLE
Implement new version check endpoint

### DIFF
--- a/plugins/main/public/components/settings/api/api-table.js
+++ b/plugins/main/public/components/settings/api/api-table.js
@@ -117,8 +117,6 @@ export const ApiTable = compose(withErrorBoundary)(
         'wazuh.updates.disabled',
       ));
 
-
-
       if (this.isUpdatesEnabled) {
         this.getApisAvailableUpdates();
       }
@@ -753,7 +751,8 @@ export const ApiTable = compose(withErrorBoundary)(
                         <EuiToolTip
                           title='Last dashboard check'
                           content={
-                            this.state.availableUpdates?.last_check_date_dashboard
+                            this.state.availableUpdates
+                              ?.last_check_date_dashboard
                               ? getWazuhCorePlugin().utils.formatUIDate(
                                   this.state.availableUpdates.last_check_date,
                                 )

--- a/plugins/main/public/components/settings/api/api-table.js
+++ b/plugins/main/public/components/settings/api/api-table.js
@@ -117,7 +117,8 @@ export const ApiTable = compose(withErrorBoundary)(
         'wazuh.updates.disabled',
       ));
 
-      console.log('API updates enabled:', this.isUpdatesEnabled);
+
+
       if (this.isUpdatesEnabled) {
         this.getApisAvailableUpdates();
       }

--- a/plugins/main/public/components/settings/api/api-table.js
+++ b/plugins/main/public/components/settings/api/api-table.js
@@ -116,6 +116,8 @@ export const ApiTable = compose(withErrorBoundary)(
       this.isUpdatesEnabled = !(await getWazuhCorePlugin().configuration.get(
         'wazuh.updates.disabled',
       ));
+
+      console.log('API updates enabled:', this.isUpdatesEnabled);
       if (this.isUpdatesEnabled) {
         this.getApisAvailableUpdates();
       }
@@ -370,13 +372,9 @@ export const ApiTable = compose(withErrorBoundary)(
       const isLoading =
         this.state.refreshingEntries || this.state.refreshingAvailableUpdates;
 
+      const versionData = this.state.availableUpdates || {};
       const items = [
         ...this.state.apiEntries?.map(apiEntry => {
-          const versionData =
-            this.state.availableUpdates?.apis_available_updates?.find(
-              apiAvailableUpdates => apiAvailableUpdates.api_id === apiEntry.id,
-            ) || {};
-
           return {
             ...versionData,
             ...apiEntry,
@@ -645,7 +643,7 @@ export const ApiTable = compose(withErrorBoundary)(
                       tooltip={{ content: 'View available updates' }}
                       flyoutTitle={'Available updates'}
                       flyoutBody={() => {
-                        return <AvailableUpdatesFlyout api={api} />;
+                        return <AvailableUpdatesFlyout updates={versionData} />;
                       }}
                       buttonProps={{
                         buttonType: 'icon',
@@ -754,7 +752,7 @@ export const ApiTable = compose(withErrorBoundary)(
                         <EuiToolTip
                           title='Last dashboard check'
                           content={
-                            this.state.availableUpdates?.last_check_date
+                            this.state.availableUpdates?.last_check_date_dashboard
                               ? getWazuhCorePlugin().utils.formatUIDate(
                                   this.state.availableUpdates.last_check_date,
                                 )

--- a/plugins/main/public/components/settings/api/available-updates-flyout/__snapshots__/index.test.tsx.snap
+++ b/plugins/main/public/components/settings/api/available-updates-flyout/__snapshots__/index.test.tsx.snap
@@ -14,24 +14,6 @@ exports[`AvailableUpdatesFlyout component should return the AvailableUpdatesFlyo
         <dt
           class="euiDescriptionList__title"
         >
-          API ID
-        </dt>
-        <dd
-          class="euiDescriptionList__description"
-        >
-          api id
-        </dd>
-      </dl>
-    </div>
-    <div
-      class="euiFlexItem euiFlexItem--flexGrowZero"
-    >
-      <dl
-        class="euiDescriptionList euiDescriptionList--row"
-      >
-        <dt
-          class="euiDescriptionList__title"
-        >
           Version
         </dt>
         <dd

--- a/plugins/main/public/components/settings/api/available-updates-flyout/index.test.tsx
+++ b/plugins/main/public/components/settings/api/available-updates-flyout/index.test.tsx
@@ -9,12 +9,12 @@ jest.mock('./update-detail', () => ({
 
 describe('AvailableUpdatesFlyout component', () => {
   test('should return the AvailableUpdatesFlyout component', async () => {
-    const { container, getByText, getByRole } = render(
+    const { container, getByText } = render(
       <AvailableUpdatesFlyout
-        api={{
-          api_id: 'api id',
+        updates={{
           current_version: '4.3.1',
           status: 'availableUpdates' as any,
+          last_check_date_dashboard: new Date('2023-09-30T14:00:00.000Z'),
           last_available_patch: {
             description:
               '## Manager\r\n\r\n### Fixed\r\n\r\n- Fixed a crash when overwrite rules are triggered...',
@@ -28,12 +28,13 @@ describe('AvailableUpdatesFlyout component', () => {
             title: 'Wazuh v4.3.8',
           },
         }}
+        isVisible={true}
+        onClose={() => {}}
       />,
     );
 
     expect(container).toMatchSnapshot();
 
-    expect(getByText('api id')).toBeInTheDocument();
     expect(getByText('4.3.1')).toBeInTheDocument();
   });
 });

--- a/plugins/main/public/components/settings/api/available-updates-flyout/index.tsx
+++ b/plugins/main/public/components/settings/api/available-updates-flyout/index.tsx
@@ -8,18 +8,18 @@ import {
   EuiFlexGroup,
   EuiFlexItem,
 } from '@elastic/eui';
-import { ApiAvailableUpdates } from '../../../../../../wazuh-check-updates/common/types';
+import { AvailableUpdates } from '../../../../../../wazuh-check-updates/common/types';
 import { UpdateDetail } from './update-detail';
 import { WzFlyout } from '../../../../components/common/flyouts';
 
 interface AvailableUpdatesFlyoutProps {
-  api: ApiAvailableUpdates;
+  updates: AvailableUpdates;
   isVisible: boolean;
   onClose: () => void;
 }
 
 export const AvailableUpdatesFlyout = ({
-  api,
+  updates,
 }: AvailableUpdatesFlyoutProps) => {
   return (
     <>
@@ -28,18 +28,8 @@ export const AvailableUpdatesFlyout = ({
           <EuiDescriptionList
             listItems={[
               {
-                title: 'API ID',
-                description: api.api_id,
-              },
-            ]}
-          />
-        </EuiFlexItem>
-        <EuiFlexItem grow={false}>
-          <EuiDescriptionList
-            listItems={[
-              {
                 title: 'Version',
-                description: api.current_version as string,
+                description: updates.current_version as string,
               },
             ]}
           />
@@ -47,15 +37,15 @@ export const AvailableUpdatesFlyout = ({
       </EuiFlexGroup>
       <EuiSpacer />
       <UpdateDetail
-        update={api.last_available_major || {}}
+        update={updates.last_available_major || {}}
         type='Last available major'
       />
       <UpdateDetail
-        update={api.last_available_minor || {}}
+        update={updates.last_available_minor || {}}
         type='Last available minor'
       />
       <UpdateDetail
-        update={api.last_available_patch || {}}
+        update={updates.last_available_patch || {}}
         type='Last available patch'
       />
     </>

--- a/plugins/wazuh-check-updates/common/types.ts
+++ b/plugins/wazuh-check-updates/common/types.ts
@@ -1,26 +1,16 @@
 export enum API_UPDATES_STATUS {
   UP_TO_DATE = 'upToDate',
   AVAILABLE_UPDATES = 'availableUpdates',
-  DISABLED = 'disabled',
   ERROR = 'error',
 }
 
-export interface ResponseApiAvailableUpdates {
+export interface ResponseIndexerAvailableUpdates {
+  uuid?: string;
   current_version?: string;
-  update_check?: boolean;
   last_available_major?: Update;
   last_available_minor?: Update;
   last_available_patch?: Update;
   last_check_date?: string;
-}
-
-export interface ApiAvailableUpdates extends ResponseApiAvailableUpdates {
-  api_id: string;
-  status: API_UPDATES_STATUS;
-  error?: {
-    title?: string;
-    detail?: string;
-  };
 }
 
 export interface Update {
@@ -36,20 +26,23 @@ export interface Update {
 }
 
 export interface UserPreferencesDimissedUpdate {
-  api_id: string;
   last_major?: string;
   last_minor?: string;
   last_patch?: string;
 }
 
 export interface UserPreferences {
-  last_dismissed_updates?: UserPreferencesDimissedUpdate[];
+  last_dismissed_updates?: UserPreferencesDimissedUpdate;
   hide_update_notifications?: boolean;
 }
 
-export interface AvailableUpdates {
-  apis_available_updates: ApiAvailableUpdates[];
-  last_check_date: Date;
+export interface AvailableUpdates extends ResponseIndexerAvailableUpdates {
+  last_check_date_dashboard: Date;
+  status: API_UPDATES_STATUS;
+  error?: {
+    title?: string;
+    detail?: string;
+  };
 }
 
 export type savedObjectType = AvailableUpdates | UserPreferences;

--- a/plugins/wazuh-check-updates/public/components/dismiss-notification-check.test.tsx
+++ b/plugins/wazuh-check-updates/public/components/dismiss-notification-check.test.tsx
@@ -8,7 +8,7 @@ jest.mock(
   '../../../../node_modules/@elastic/eui/lib/services/accessibility/html_id_generator',
   () => ({
     htmlIdGenerator: () => () => 'htmlId',
-  })
+  }),
 );
 
 const mockedUseUserPreferences = useUserPreferences as jest.Mock;

--- a/plugins/wazuh-check-updates/public/components/dismiss-notification-check.test.tsx
+++ b/plugins/wazuh-check-updates/public/components/dismiss-notification-check.test.tsx
@@ -19,12 +19,7 @@ describe('DismissNotificationCheck component', () => {
     mockedUseUserPreferences.mockImplementation(() => ({
       isLoading: false,
       userPreferences: {
-        last_dismissed_updates: [
-          {
-            api_id: 'api id',
-            last_patch: 'v4.3.1',
-          },
-        ],
+        last_dismissed_updates: { last_patch: 'v4.3.1' },
         hide_update_notifications: false,
       },
       updateUserPreferences: () => {},

--- a/plugins/wazuh-check-updates/public/components/updates-notification.test.tsx
+++ b/plugins/wazuh-check-updates/public/components/updates-notification.test.tsx
@@ -48,36 +48,22 @@ jest.mock('../utils/are-there-new-updates');
 describe('UpdatesNotification component', () => {
   test('should return the nofication component', async () => {
     mockedGetAvailableUpdates.mockImplementation(() => ({
-      isLoading: false,
-      apisAvailableUpdates: [
-        {
-          api_id: 'api id',
-          current_version: '4.3.1',
-          status: 'availableUpdates' as API_UPDATES_STATUS,
-          last_available_patch: {
-            description:
-              '## Manager\r\n\r\n### Fixed\r\n\r\n- Fixed a crash when overwrite rules are triggered...',
-            published_date: '2022-05-18T10:12:43Z',
-            semver: {
-              major: 4,
-              minor: 3,
-              patch: 8,
-            },
-            tag: 'v4.3.8',
-            title: 'Wazuh v4.3.8',
-          },
-        },
-      ],
+      current_version: 'v4.3.1',
+      status: 'availableUpdates' as API_UPDATES_STATUS,
+      last_check_date_dashboard: new Date('2023-09-30T14:00:00.000Z'),
+      last_available_patch: {
+        description:
+          '## Manager\r\n\r\n### Fixed\r\n\r\n- Fixed a crash when overwrite rules are triggered...',
+        published_date: '2022-05-18T10:12:43Z',
+        semver: { major: 4, minor: 3, patch: 8 },
+        tag: 'v4.3.8',
+        title: 'Wazuh v4.3.8',
+      },
     }));
     mockedUseUserPreferences.mockImplementation(() => ({
       isLoading: false,
       userPreferences: {
-        last_dismissed_updates: [
-          {
-            api_id: 'api id',
-            last_patch: 'v4.3.1',
-          },
-        ],
+        last_dismissed_updates: { last_patch: 'v4.3.1' },
         hide_update_notifications: false,
       },
     }));
@@ -104,36 +90,22 @@ describe('UpdatesNotification component', () => {
 
   test('should return null when user close notification', async () => {
     mockedGetAvailableUpdates.mockImplementation(() => ({
-      apisAvailableUpdates: [
-        {
-          api_id: 'api id',
-          current_version: '4.3.1',
-          status: 'availableUpdates' as API_UPDATES_STATUS,
-          last_available_patch: {
-            description:
-              '## Manager\r\n\r\n### Fixed\r\n\r\n- Fixed a crash when overwrite rules are triggered...',
-            published_date: '2022-05-18T10:12:43Z',
-            semver: {
-              major: 4,
-              minor: 3,
-              patch: 8,
-            },
-            tag: 'v4.3.8',
-            title: 'Wazuh v4.3.8',
-          },
-        },
-      ],
-      last_check_date: '20231027 14:39',
+      current_version: 'v4.3.1',
+      status: 'availableUpdates' as API_UPDATES_STATUS,
+      last_check_date_dashboard: new Date('2023-09-30T14:00:00.000Z'),
+      last_available_patch: {
+        description:
+          '## Manager\r\n\r\n### Fixed\r\n\r\n- Fixed a crash when overwrite rules are triggered...',
+        published_date: '2022-05-18T10:12:43Z',
+        semver: { major: 4, minor: 3, patch: 8 },
+        tag: 'v4.3.8',
+        title: 'Wazuh v4.3.8',
+      },
     }));
     mockedUseUserPreferences.mockImplementation(() => ({
       isLoading: false,
       userPreferences: {
-        last_dismissed_updates: [
-          {
-            api_id: 'api id',
-            last_patch: 'v4.3.1',
-          },
-        ],
+        last_dismissed_updates: { last_patch: 'v4.3.1' },
         hide_update_notifications: false,
       },
       updateUserPreferences: () => {},
@@ -169,8 +141,9 @@ describe('UpdatesNotification component', () => {
 
   test('should return null when there are no available updates', async () => {
     mockedGetAvailableUpdates.mockImplementation(() => ({
-      apisAvailableUpdates: [],
-      last_check_date: '20231027 14:39',
+      current_version: 'v4.3.8',
+      status: 'upToDate' as API_UPDATES_STATUS,
+      last_check_date_dashboard: new Date('2023-09-30T14:00:00.000Z'),
     }));
     mockedUseUserPreferences.mockImplementation(() => ({
       isLoading: false,
@@ -190,12 +163,7 @@ describe('UpdatesNotification component', () => {
     mockedUseUserPreferences.mockImplementation(() => ({
       isLoading: false,
       userPreferences: {
-        last_dismissed_updates: [
-          {
-            api_id: 'api id',
-            last_patch: 'v4.3.1',
-          },
-        ],
+        last_dismissed_updates: { last_patch: 'v4.3.1' },
         hide_update_notifications: true,
       },
     }));
@@ -210,36 +178,22 @@ describe('UpdatesNotification component', () => {
 
   test('should return null when user already dismissed the notifications for available updates', async () => {
     mockedGetAvailableUpdates.mockImplementation(() => ({
-      apisAvailableUpdates: [
-        {
-          api_id: 'api id',
-          current_version: '4.3.1',
-          status: 'availableUpdates' as API_UPDATES_STATUS,
-          last_available_patch: {
-            description:
-              '## Manager\r\n\r\n### Fixed\r\n\r\n- Fixed a crash when overwrite rules are triggered...',
-            published_date: '2022-05-18T10:12:43Z',
-            semver: {
-              major: 4,
-              minor: 3,
-              patch: 8,
-            },
-            tag: 'v4.3.8',
-            title: 'Wazuh v4.3.8',
-          },
-        },
-      ],
-      last_check_date: '20231027 14:39',
+      current_version: 'v4.3.1',
+      status: 'availableUpdates' as API_UPDATES_STATUS,
+      last_check_date_dashboard: new Date('2023-09-30T14:00:00.000Z'),
+      last_available_patch: {
+        description:
+          '## Manager\r\n\r\n### Fixed\r\n\r\n- Fixed a crash when overwrite rules are triggered...',
+        published_date: '2022-05-18T10:12:43Z',
+        semver: { major: 4, minor: 3, patch: 8 },
+        tag: 'v4.3.8',
+        title: 'Wazuh v4.3.8',
+      },
     }));
     mockedUseUserPreferences.mockImplementation(() => ({
       isLoading: false,
       userPreferences: {
-        last_dismissed_updates: [
-          {
-            api_id: 'api id',
-            last_patch: 'v4.3.8',
-          },
-        ],
+        last_dismissed_updates: { last_patch: 'v4.3.8' },
         hide_update_notifications: false,
       },
     }));

--- a/plugins/wazuh-check-updates/public/components/updates-notification.tsx
+++ b/plugins/wazuh-check-updates/public/components/updates-notification.tsx
@@ -58,7 +58,7 @@ export const UpdatesNotification = () => {
   }
 
   const mustNotifyUser = areThereNewUpdates(
-    availableUpdates?.apis_available_updates,
+    availableUpdates,
     userPreferences.last_dismissed_updates,
   );
 
@@ -68,22 +68,11 @@ export const UpdatesNotification = () => {
 
   const handleOnClose = () => {
     updateUserPreferences({
-      last_dismissed_updates: availableUpdates?.apis_available_updates?.map(
-        apiAvailableUpdates => {
-          const {
-            api_id,
-            last_available_major,
-            last_available_minor,
-            last_available_patch,
-          } = apiAvailableUpdates;
-          return {
-            api_id,
-            last_major: last_available_major?.tag,
-            last_minor: last_available_minor?.tag,
-            last_patch: last_available_patch?.tag,
-          };
-        },
-      ),
+      last_dismissed_updates: {
+        last_major: availableUpdates?.last_available_major?.tag,
+        last_minor: availableUpdates?.last_available_minor?.tag,
+        last_patch: availableUpdates?.last_available_patch?.tag,
+      },
       ...(dismissFutureUpdates ? { hide_update_notifications: true } : {}),
     });
     setIsDismissed(true);

--- a/plugins/wazuh-check-updates/public/hooks/user-preferences.test.ts
+++ b/plugins/wazuh-check-updates/public/hooks/user-preferences.test.ts
@@ -7,21 +7,15 @@ jest.mock('../plugin-services', () => ({
   getCore: jest.fn().mockReturnValue({
     http: {
       get: jest.fn().mockResolvedValue({
-        last_dismissed_updates: [
-          {
-            api_id: 'api id',
-            last_patch: '4.3.1',
-          },
-        ],
+        last_dismissed_updates: {
+          last_patch: '4.3.1',
+        },
         hide_update_notifications: false,
       }),
       patch: jest.fn().mockResolvedValue({
-        last_dismissed_updates: [
-          {
-            api_id: 'api id',
-            last_patch: '4.3.1',
-          },
-        ],
+        last_dismissed_updates: {
+          last_patch: '4.3.1',
+        },
         hide_update_notifications: false,
       }),
     },
@@ -31,12 +25,9 @@ jest.mock('../plugin-services', () => ({
 describe('useUserPreferences hook', () => {
   it('should fetch initial data without any error', async () => {
     const mockUserPreferences: UserPreferences = {
-      last_dismissed_updates: [
-        {
-          api_id: 'api id',
-          last_patch: '4.3.1',
-        },
-      ],
+      last_dismissed_updates: {
+        last_patch: '4.3.1',
+      },
       hide_update_notifications: false,
     };
     const { result, waitForNextUpdate } = renderHook(() => useUserPreferences());
@@ -49,12 +40,9 @@ describe('useUserPreferences hook', () => {
 
   it('should update user preferences', async () => {
     const mockUserPreferences: UserPreferences = {
-      last_dismissed_updates: [
-        {
-          api_id: 'api id',
-          last_patch: '4.3.1',
-        },
-      ],
+      last_dismissed_updates: {
+        last_patch: '4.3.1',
+      },
       hide_update_notifications: false,
     };
     const { result, waitForNextUpdate } = renderHook(() => useUserPreferences());
@@ -88,12 +76,9 @@ describe('useUserPreferences hook', () => {
 
   it('should handle error while updating user preferences', async () => {
     const mockUserPreferences: UserPreferences = {
-      last_dismissed_updates: [
-        {
-          api_id: 'api id',
-          last_patch: '4.3.1',
-        },
-      ],
+      last_dismissed_updates: {
+        last_patch: '4.3.1',
+      },
       hide_update_notifications: false,
     };
     const mockErrorMessage = 'Some error occurred';

--- a/plugins/wazuh-check-updates/public/services/available-updates.test.ts
+++ b/plugins/wazuh-check-updates/public/services/available-updates.test.ts
@@ -5,26 +5,21 @@ jest.mock('../plugin-services', () => ({
   getCore: jest.fn().mockReturnValue({
     http: {
       get: jest.fn().mockResolvedValue({
-        last_check_date: '2023-09-30T14:00:00.000Z',
-        apis_available_updates: [
-          {
-            api_id: 'api id',
-            current_version: '4.3.1',
-            status: 'availableUpdates',
-            last_available_patch: {
-              description:
-                '## Manager\r\n\r\n### Fixed\r\n\r\n- Fixed a crash when overwrite rules are triggered...',
-              published_date: '2022-05-18T10:12:43Z',
-              semver: {
-                major: 4,
-                minor: 3,
-                patch: 8,
-              },
-              tag: 'v4.3.8',
-              title: 'Wazuh v4.3.8',
-            },
+        last_check_date_dashboard: '2023-09-30T14:00:00.000Z',
+        current_version: 'v4.3.1',
+        status: 'availableUpdates',
+        last_available_patch: {
+          description:
+            '## Manager\r\n\r\n### Fixed\r\n\r\n- Fixed a crash when overwrite rules are triggered...',
+          published_date: '2022-05-18T10:12:43Z',
+          semver: {
+            major: 4,
+            minor: 3,
+            patch: 8,
           },
-        ],
+          tag: 'v4.3.8',
+          title: 'Wazuh v4.3.8',
+        },
       }),
     },
   }),
@@ -33,33 +28,28 @@ jest.mock('../plugin-services', () => ({
 describe('getAvailableUpdates functions', () => {
   test('should fetch data without any error', async () => {
     const mockAvailableUpdates: AvailableUpdates = {
-      last_check_date: new Date('2023-09-30T14:00:00.000Z'),
-      apis_available_updates: [
-        {
-          api_id: 'api id',
-          current_version: '4.3.1',
-          status: 'availableUpdates' as API_UPDATES_STATUS,
-          last_available_patch: {
-            description:
-              '## Manager\r\n\r\n### Fixed\r\n\r\n- Fixed a crash when overwrite rules are triggered...',
-            published_date: '2022-05-18T10:12:43Z',
-            semver: {
-              major: 4,
-              minor: 3,
-              patch: 8,
-            },
-            tag: 'v4.3.8',
-            title: 'Wazuh v4.3.8',
-          },
+      last_check_date_dashboard: new Date('2023-09-30T14:00:00.000Z'),
+      current_version: 'v4.3.1',
+      status: 'availableUpdates' as API_UPDATES_STATUS,
+      last_available_patch: {
+        description:
+          '## Manager\r\n\r\n### Fixed\r\n\r\n- Fixed a crash when overwrite rules are triggered...',
+        published_date: '2022-05-18T10:12:43Z',
+        semver: {
+          major: 4,
+          minor: 3,
+          patch: 8,
         },
-      ],
+        tag: 'v4.3.8',
+        title: 'Wazuh v4.3.8',
+      },
     };
 
     const availableUpdates = await getAvailableUpdates();
 
     expect(availableUpdates).toEqual({
       ...mockAvailableUpdates,
-      last_check_date: '2023-09-30T14:00:00.000Z',
+      last_check_date_dashboard: '2023-09-30T14:00:00.000Z',
     });
   });
 });

--- a/plugins/wazuh-check-updates/public/services/available-updates.ts
+++ b/plugins/wazuh-check-updates/public/services/available-updates.ts
@@ -4,7 +4,6 @@ import { getCore } from '../plugin-services';
 
 export const getAvailableUpdates = async (
   queryApi = false,
-  forceQuery = false,
 ): Promise<AvailableUpdates> => {
   const checkUpdates = sessionStorage.getItem('checkUpdates');
   const alreadyCheckUpdates = checkUpdates === 'executed';
@@ -12,7 +11,6 @@ export const getAvailableUpdates = async (
   const availableUpdates = await getCore().http.get(routes.checkUpdates, {
     query: {
       query_api: queryApi || !alreadyCheckUpdates,
-      force_query: forceQuery,
     },
   });
 

--- a/plugins/wazuh-check-updates/public/utils/are-there-new-updates.test.ts
+++ b/plugins/wazuh-check-updates/public/utils/are-there-new-updates.test.ts
@@ -31,7 +31,10 @@ describe('areThereNewUpdates function', () => {
     const lastDismissedUpdate: UserPreferencesDimissedUpdate = {
       last_patch: 'v4.3.8',
     };
-    const result = areThereNewUpdates(mockAvailableUpdates, lastDismissedUpdate);
+    const result = areThereNewUpdates(
+      mockAvailableUpdates,
+      lastDismissedUpdate,
+    );
     expect(result).toBe(false);
   });
 
@@ -39,7 +42,10 @@ describe('areThereNewUpdates function', () => {
     const lastDismissedUpdate: UserPreferencesDimissedUpdate = {
       last_patch: 'v4.3.7',
     };
-    const result = areThereNewUpdates(mockAvailableUpdates, lastDismissedUpdate);
+    const result = areThereNewUpdates(
+      mockAvailableUpdates,
+      lastDismissedUpdate,
+    );
     expect(result).toBe(true);
   });
 

--- a/plugins/wazuh-check-updates/public/utils/are-there-new-updates.test.ts
+++ b/plugins/wazuh-check-updates/public/utils/are-there-new-updates.test.ts
@@ -1,93 +1,55 @@
 import {
   API_UPDATES_STATUS,
-  ApiAvailableUpdates,
+  AvailableUpdates,
   UserPreferencesDimissedUpdate,
 } from '../../common/types';
 import { areThereNewUpdates } from './are-there-new-updates';
 
+const mockPatch = {
+  description:
+    '## Manager\r\n\r\n### Fixed\r\n\r\n- Fixed a crash when overwrite rules are triggered...',
+  published_date: '2022-05-18T10:12:43Z',
+  semver: { major: 4, minor: 3, patch: 8 },
+  tag: 'v4.3.8',
+  title: 'Wazuh v4.3.8',
+};
+
+const mockAvailableUpdates: AvailableUpdates = {
+  current_version: 'v4.3.1',
+  status: API_UPDATES_STATUS.AVAILABLE_UPDATES,
+  last_check_date_dashboard: new Date('2023-09-30T14:00:00.000Z'),
+  last_available_patch: mockPatch,
+};
+
 describe('areThereNewUpdates function', () => {
-  it('should return true', async () => {
-    const mockApisAvailableUpdates: ApiAvailableUpdates[] = [
-      {
-        api_id: 'api id',
-        current_version: '4.3.1',
-        status: 'availableUpdates' as API_UPDATES_STATUS,
-        last_available_patch: {
-          description:
-            '## Manager\r\n\r\n### Fixed\r\n\r\n- Fixed a crash when overwrite rules are triggered...',
-          published_date: '2022-05-18T10:12:43Z',
-          semver: {
-            major: 4,
-            minor: 3,
-            patch: 8,
-          },
-          tag: 'v4.3.8',
-          title: 'Wazuh v4.3.8',
-        },
-      },
-    ];
-    const mockLastDismissedUpdates: UserPreferencesDimissedUpdate[] = [];
-
-    const result = areThereNewUpdates(mockApisAvailableUpdates, mockLastDismissedUpdates);
-
+  it('should return true when there are updates and no dismissed record', () => {
+    const result = areThereNewUpdates(mockAvailableUpdates, undefined);
     expect(result).toBe(true);
   });
 
-  it('should return false', async () => {
-    const mockApisAvailableUpdates: ApiAvailableUpdates[] = [
-      {
-        api_id: 'api id',
-        current_version: '4.3.1',
-        status: 'availableUpdates' as API_UPDATES_STATUS,
-        last_available_patch: {
-          description:
-            '## Manager\r\n\r\n### Fixed\r\n\r\n- Fixed a crash when overwrite rules are triggered...',
-          published_date: '2022-05-18T10:12:43Z',
-          semver: {
-            major: 4,
-            minor: 3,
-            patch: 8,
-          },
-          tag: 'v4.3.8',
-          title: 'Wazuh v4.3.8',
-        },
-      },
-    ];
-    const mockLastDismissedUpdates: UserPreferencesDimissedUpdate[] = [
-      { api_id: 'api id', last_patch: 'v4.3.8' },
-    ];
-
-    const result = areThereNewUpdates(mockApisAvailableUpdates, mockLastDismissedUpdates);
-
+  it('should return false when the current patch is already dismissed', () => {
+    const lastDismissedUpdate: UserPreferencesDimissedUpdate = {
+      last_patch: 'v4.3.8',
+    };
+    const result = areThereNewUpdates(mockAvailableUpdates, lastDismissedUpdate);
     expect(result).toBe(false);
   });
 
-  it('should return true', async () => {
-    const mockApisAvailableUpdates: ApiAvailableUpdates[] = [
-      {
-        api_id: 'api id',
-        current_version: '4.3.1',
-        status: 'availableUpdates' as API_UPDATES_STATUS,
-        last_available_patch: {
-          description:
-            '## Manager\r\n\r\n### Fixed\r\n\r\n- Fixed a crash when overwrite rules are triggered...',
-          published_date: '2022-05-18T10:12:43Z',
-          semver: {
-            major: 4,
-            minor: 3,
-            patch: 8,
-          },
-          tag: 'v4.3.8',
-          title: 'Wazuh v4.3.8',
-        },
-      },
-    ];
-    const mockLastDismissedUpdates: UserPreferencesDimissedUpdate[] = [
-      { api_id: 'api id', last_patch: 'v4.3.9' },
-    ];
-
-    const result = areThereNewUpdates(mockApisAvailableUpdates, mockLastDismissedUpdates);
-
+  it('should return true when a newer patch is available than what was dismissed', () => {
+    const lastDismissedUpdate: UserPreferencesDimissedUpdate = {
+      last_patch: 'v4.3.7',
+    };
+    const result = areThereNewUpdates(mockAvailableUpdates, lastDismissedUpdate);
     expect(result).toBe(true);
+  });
+
+  it('should return false when no updates are available', () => {
+    const noUpdates: AvailableUpdates = {
+      current_version: 'v4.3.8',
+      status: API_UPDATES_STATUS.UP_TO_DATE,
+      last_check_date_dashboard: new Date('2023-09-30T14:00:00.000Z'),
+    };
+    const result = areThereNewUpdates(noUpdates, undefined);
+    expect(result).toBe(false);
   });
 });

--- a/plugins/wazuh-check-updates/public/utils/are-there-new-updates.ts
+++ b/plugins/wazuh-check-updates/public/utils/are-there-new-updates.ts
@@ -1,37 +1,28 @@
-import { ApiAvailableUpdates, UserPreferencesDimissedUpdate } from '../../common/types';
+import { AvailableUpdates, UserPreferencesDimissedUpdate } from '../../common/types';
 
 export const areThereNewUpdates = (
-  apisAvailableUpdates?: ApiAvailableUpdates[],
-  lastDismissedUpdates?: UserPreferencesDimissedUpdate[]
-) => {
-  const notifyUser = !!apisAvailableUpdates?.find((apiAvailableUpdates) => {
-    const {
-      api_id,
-      last_available_major,
-      last_available_minor,
-      last_available_patch,
-    } = apiAvailableUpdates;
+  availableUpdates?: AvailableUpdates,
+  lastDismissedUpdate?: UserPreferencesDimissedUpdate,
+): boolean => {
+  const { last_available_major, last_available_minor, last_available_patch } =
+    availableUpdates ?? {};
 
-    const apiDismissed = lastDismissedUpdates?.find(
-      (lastDismissedUpdate) => lastDismissedUpdate.api_id === api_id
-    );
+  if (
+    !lastDismissedUpdate &&
+    (last_available_major?.tag || last_available_minor?.tag || last_available_patch?.tag)
+  ) {
+    return true;
+  }
 
-    if (
-      !apiDismissed &&
-      (last_available_major?.tag || last_available_minor?.tag || last_available_patch?.tag)
-    ) {
-      return true;
-    }
+  const isNewMajor =
+    last_available_major?.tag &&
+    last_available_major.tag !== lastDismissedUpdate?.last_major;
+  const isNewMinor =
+    last_available_minor?.tag &&
+    last_available_minor.tag !== lastDismissedUpdate?.last_minor;
+  const isNewPatch =
+    last_available_patch?.tag &&
+    last_available_patch.tag !== lastDismissedUpdate?.last_patch;
 
-    const isNewMajor =
-      last_available_major?.tag && last_available_major.tag !== apiDismissed?.last_major;
-    const isNewMinor =
-      last_available_minor?.tag && last_available_minor.tag !== apiDismissed?.last_minor;
-    const isNewPatch =
-      last_available_patch?.tag && last_available_patch.tag !== apiDismissed?.last_patch;
-
-    return isNewMajor || isNewMinor || isNewPatch;
-  });
-
-  return notifyUser;
+  return !!(isNewMajor || isNewMinor || isNewPatch);
 };

--- a/plugins/wazuh-check-updates/public/utils/are-there-new-updates.ts
+++ b/plugins/wazuh-check-updates/public/utils/are-there-new-updates.ts
@@ -1,4 +1,7 @@
-import { AvailableUpdates, UserPreferencesDimissedUpdate } from '../../common/types';
+import {
+  AvailableUpdates,
+  UserPreferencesDimissedUpdate,
+} from '../../common/types';
 
 export const areThereNewUpdates = (
   availableUpdates?: AvailableUpdates,
@@ -9,7 +12,9 @@ export const areThereNewUpdates = (
 
   if (
     !lastDismissedUpdate &&
-    (last_available_major?.tag || last_available_minor?.tag || last_available_patch?.tag)
+    (last_available_major?.tag ||
+      last_available_minor?.tag ||
+      last_available_patch?.tag)
   ) {
     return true;
   }

--- a/plugins/wazuh-check-updates/server/routes/updates/get-updates.test.ts
+++ b/plugins/wazuh-check-updates/server/routes/updates/get-updates.test.ts
@@ -17,6 +17,13 @@ jest.mock('../../services/updates');
 const loggingService = loggingSystemMock.create();
 const logger = loggingService.get();
 const context = {
+  core: {
+    opensearch: {
+      client: {
+        asCurrentUser: {},
+      },
+    },
+  },
   wazuh: {
     security: {
       getCurrentUser: () => {
@@ -76,26 +83,21 @@ describe(`[endpoint] GET ${routes.checkUpdates}`, () => {
 
   test('get available updates', async () => {
     const mockResponse: AvailableUpdates = {
-      last_check_date: new Date('2023-09-30T14:00:00.000Z'),
-      apis_available_updates: [
-        {
-          api_id: 'api id',
-          current_version: '4.3.1',
-          status: API_UPDATES_STATUS.UP_TO_DATE,
-          last_available_patch: {
-            description:
-              '## Manager\r\n\r\n### Fixed\r\n\r\n- Fixed a crash when overwrite rules are triggered...',
-            published_date: '2022-05-18T10:12:43Z',
-            semver: {
-              major: 4,
-              minor: 3,
-              patch: 8,
-            },
-            tag: 'v4.3.8',
-            title: 'Wazuh v4.3.8',
-          },
+      last_check_date_dashboard: new Date('2023-09-30T14:00:00.000Z'),
+      current_version: 'v4.3.1',
+      status: API_UPDATES_STATUS.UP_TO_DATE,
+      last_available_patch: {
+        description:
+          '## Manager\r\n\r\n### Fixed\r\n\r\n- Fixed a crash when overwrite rules are triggered...',
+        published_date: '2022-05-18T10:12:43Z',
+        semver: {
+          major: 4,
+          minor: 3,
+          patch: 8,
         },
-      ],
+        tag: 'v4.3.8',
+        title: 'Wazuh v4.3.8',
+      },
     };
 
     mockedGetUpdates.mockImplementation(() => mockResponse);
@@ -106,7 +108,7 @@ describe(`[endpoint] GET ${routes.checkUpdates}`, () => {
 
     expect(response.body).toEqual({
       ...mockResponse,
-      last_check_date: '2023-09-30T14:00:00.000Z',
+      last_check_date_dashboard: '2023-09-30T14:00:00.000Z',
     });
   });
 });

--- a/plugins/wazuh-check-updates/server/routes/updates/get-updates.ts
+++ b/plugins/wazuh-check-updates/server/routes/updates/get-updates.ts
@@ -10,7 +10,6 @@ export const getUpdatesRoute = (router: IRouter) => {
       validate: {
         query: schema.object({
           query_api: schema.maybe(schema.string()),
-          force_query: schema.maybe(schema.string()),
         }),
       },
     },
@@ -18,7 +17,7 @@ export const getUpdatesRoute = (router: IRouter) => {
       try {
         const updates = await getUpdates(
           request.query?.query_api === 'true',
-          request.query?.force_query === 'true',
+          context.core.opensearch.client,
         );
         return response.ok({
           body: updates,

--- a/plugins/wazuh-check-updates/server/routes/user-preferences/get-user-preferences.test.ts
+++ b/plugins/wazuh-check-updates/server/routes/user-preferences/get-user-preferences.test.ts
@@ -77,12 +77,9 @@ describe(`[endpoint] GET ${routes.userPreferences}`, () => {
 
   test('get user preferences', async () => {
     const mockResponse: UserPreferences = {
-      last_dismissed_updates: [
-        {
-          api_id: 'api id',
-          last_patch: '4.3.1',
-        },
-      ],
+      last_dismissed_updates: {
+        last_patch: '4.3.1',
+      },
       hide_update_notifications: false,
     };
 

--- a/plugins/wazuh-check-updates/server/routes/user-preferences/update-user-preferences.test.ts
+++ b/plugins/wazuh-check-updates/server/routes/user-preferences/update-user-preferences.test.ts
@@ -77,12 +77,9 @@ describe(`[endpoint] PATCH ${routes.userPreferences}`, () => {
 
   test('update user preferences', async () => {
     const mockResponse: UserPreferences = {
-      last_dismissed_updates: [
-        {
-          api_id: 'api id',
-          last_patch: '4.3.1',
-        },
-      ],
+      last_dismissed_updates: {
+        last_patch: '4.3.1',
+      },
       hide_update_notifications: false,
     };
 

--- a/plugins/wazuh-check-updates/server/routes/user-preferences/update-user-preferences.ts
+++ b/plugins/wazuh-check-updates/server/routes/user-preferences/update-user-preferences.ts
@@ -10,14 +10,11 @@ export const updateUserPreferencesRoutes = (router: IRouter) => {
       validate: {
         body: schema.object({
           last_dismissed_updates: schema.maybe(
-            schema.arrayOf(
-              schema.object({
-                api_id: schema.string(),
-                last_major: schema.maybe(schema.string()),
-                last_minor: schema.maybe(schema.string()),
-                last_patch: schema.maybe(schema.string()),
-              })
-            )
+            schema.object({
+              last_major: schema.maybe(schema.string()),
+              last_minor: schema.maybe(schema.string()),
+              last_patch: schema.maybe(schema.string()),
+            })
           ),
           hide_update_notifications: schema.maybe(schema.boolean()),
         }),

--- a/plugins/wazuh-check-updates/server/routes/user-preferences/update-user-preferences.ts
+++ b/plugins/wazuh-check-updates/server/routes/user-preferences/update-user-preferences.ts
@@ -14,7 +14,7 @@ export const updateUserPreferencesRoutes = (router: IRouter) => {
               last_major: schema.maybe(schema.string()),
               last_minor: schema.maybe(schema.string()),
               last_patch: schema.maybe(schema.string()),
-            })
+            }),
           ),
           hide_update_notifications: schema.maybe(schema.boolean()),
         }),
@@ -27,7 +27,9 @@ export const updateUserPreferencesRoutes = (router: IRouter) => {
     },
     async (context, request, response) => {
       try {
-        const user = await context['wazuh_check_updates'].security.getCurrentUser(request, context);
+        const user = await context[
+          'wazuh_check_updates'
+        ].security.getCurrentUser(request, context);
 
         if (!user?.username) {
           return response.customError({
@@ -36,7 +38,10 @@ export const updateUserPreferencesRoutes = (router: IRouter) => {
           });
         }
 
-        const userPreferences = await updateUserPreferences(user.username, request.body);
+        const userPreferences = await updateUserPreferences(
+          user.username,
+          request.body,
+        );
 
         return response.ok({
           body: userPreferences,
@@ -54,6 +59,6 @@ export const updateUserPreferencesRoutes = (router: IRouter) => {
           body: finalError,
         });
       }
-    }
+    },
   );
 };

--- a/plugins/wazuh-check-updates/server/services/saved-object/types/available-updates.ts
+++ b/plugins/wazuh-check-updates/server/services/saved-object/types/available-updates.ts
@@ -1,4 +1,7 @@
-import { SavedObjectsFieldMapping, SavedObjectsType } from 'opensearch-dashboards/server';
+import {
+  SavedObjectsFieldMapping,
+  SavedObjectsType,
+} from 'opensearch-dashboards/server';
 import { SAVED_OBJECT_UPDATES } from '../../../../common/constants';
 
 const updateObjectType: SavedObjectsFieldMapping = {

--- a/plugins/wazuh-check-updates/server/services/saved-object/types/available-updates.ts
+++ b/plugins/wazuh-check-updates/server/services/saved-object/types/available-updates.ts
@@ -38,40 +38,32 @@ export const availableUpdatesObject: SavedObjectsType = {
   namespaceType: 'agnostic',
   mappings: {
     properties: {
+      uuid: {
+        type: 'keyword',
+      },
+      current_version: {
+        type: 'text',
+      },
+      status: {
+        type: 'text',
+      },
       last_check_date: {
         type: 'date',
       },
-      apis_available_updates: {
+      last_check_date_dashboard: {
+        type: 'date',
+      },
+      last_available_major: updateObjectType,
+      last_available_minor: updateObjectType,
+      last_available_patch: updateObjectType,
+      error: {
         type: 'nested',
         properties: {
-          api_id: {
+          title: {
             type: 'text',
           },
-          current_version: {
+          detail: {
             type: 'text',
-          },
-          update_check: {
-            type: 'boolean',
-          },
-          status: {
-            type: 'text',
-          },
-          last_check_date: {
-            type: 'date',
-          },
-          last_available_major: updateObjectType,
-          last_available_minor: updateObjectType,
-          last_available_patch: updateObjectType,
-          error: {
-            type: 'nested',
-            properties: {
-              title: {
-                type: 'text',
-              },
-              detail: {
-                type: 'text',
-              },
-            },
           },
         },
       },

--- a/plugins/wazuh-check-updates/server/services/saved-object/types/user-preferences.ts
+++ b/plugins/wazuh-check-updates/server/services/saved-object/types/user-preferences.ts
@@ -8,11 +8,8 @@ export const userPreferencesObject: SavedObjectsType = {
   mappings: {
     properties: {
       last_dismissed_updates: {
-        type: 'nested',
+        type: 'object',
         properties: {
-          api_id: {
-            type: 'text',
-          },
           last_major: {
             type: 'text',
           },

--- a/plugins/wazuh-check-updates/server/services/updates/get-updates.test.ts
+++ b/plugins/wazuh-check-updates/server/services/updates/get-updates.test.ts
@@ -1,14 +1,9 @@
 import { SAVED_OBJECT_UPDATES } from '../../../common/constants';
 import { API_UPDATES_STATUS } from '../../../common/types';
-import {
-  getWazuhCheckUpdatesServices,
-  getWazuhCore,
-} from '../../plugin-services';
+import { getWazuhCheckUpdatesServices } from '../../plugin-services';
 import { getSavedObject } from '../saved-object/get-saved-object';
 import { setSavedObject } from '../saved-object/set-saved-object';
 import { getUpdates } from './get-updates';
-
-const API_ID = 'api id';
 
 const mockGetSavedObject = getSavedObject as jest.Mock;
 jest.mock('../saved-object/get-saved-object');
@@ -17,27 +12,14 @@ const mockSetSavedObject = setSavedObject as jest.Mock;
 mockSetSavedObject.mockImplementation(() => ({}));
 jest.mock('../saved-object/set-saved-object');
 
-const mockGetWazuhCore = getWazuhCore as jest.Mock;
-const mockRequest = jest.fn();
-const mockManageHosts = {
-  get: jest.fn(() => [{ id: API_ID }]),
+const mockTransportRequest = jest.fn();
+const mockOpensearchClient = {
+  asCurrentUser: {
+    transport: {
+      request: mockTransportRequest,
+    },
+  },
 };
-const mockGetHostsEntries = jest.fn(() => []);
-mockGetWazuhCore.mockImplementation(() => {
-  return {
-    api: {
-      client: {
-        asInternalUser: {
-          request: mockRequest,
-        },
-      },
-    },
-    manageHosts: mockManageHosts,
-    serverAPIHostEntries: {
-      getHostsEntries: mockGetHostsEntries,
-    },
-  };
-});
 
 const mockedGetWazuhCheckUpdatesServices =
   getWazuhCheckUpdatesServices as jest.Mock;
@@ -49,7 +31,9 @@ mockedGetWazuhCheckUpdatesServices.mockImplementation(() => ({
     error: jest.fn(),
   },
 }));
-jest.mock('../../plugin-services');
+jest.mock('../../plugin-services', () => ({
+  getWazuhCheckUpdatesServices: jest.fn(),
+}));
 
 describe('getUpdates function', () => {
   afterEach(() => {
@@ -57,11 +41,7 @@ describe('getUpdates function', () => {
   });
 
   it('should return available updates from saved object', async () => {
-    const semver = {
-      major: 4,
-      minor: 3,
-      patch: 1,
-    };
+    const semver = { major: 4, minor: 3, patch: 1 };
     const version = `${semver.major}.${semver.minor}.${semver.patch}`;
     const last_available_patch = {
       description:
@@ -71,17 +51,11 @@ describe('getUpdates function', () => {
       tag: `v${version}`,
       title: `Wazuh v${version}`,
     };
-    const last_check_date = '2023-09-30T14:00:00.000Z';
     const savedObject = {
-      last_check_date,
-      apis_available_updates: [
-        {
-          api_id: API_ID,
-          current_version: `v${version}`,
-          status: API_UPDATES_STATUS.UP_TO_DATE,
-          last_available_patch,
-        },
-      ],
+      last_check_date_dashboard: new Date('2023-09-30T14:00:00.000Z'),
+      current_version: `v${version}`,
+      status: API_UPDATES_STATUS.UP_TO_DATE,
+      last_available_patch,
     };
     mockGetSavedObject.mockImplementation(() => savedObject);
 
@@ -89,16 +63,11 @@ describe('getUpdates function', () => {
 
     expect(getSavedObject).toHaveBeenCalledTimes(1);
     expect(getSavedObject).toHaveBeenCalledWith(SAVED_OBJECT_UPDATES);
-
     expect(updates).toEqual(savedObject);
   });
 
-  it('should return available updates from api when both requests succeed', async () => {
-    const semver = {
-      major: 4,
-      minor: 3,
-      patch: 1,
-    };
+  it('should return available updates from indexer when request succeeds', async () => {
+    const semver = { major: 4, minor: 3, patch: 1 };
     const version = `${semver.major}.${semver.minor}.${semver.patch}`;
     const last_available_patch = {
       description:
@@ -108,249 +77,90 @@ describe('getUpdates function', () => {
       tag: `v${version}`,
       title: `Wazuh v${version}`,
     };
-    mockRequest
-      .mockImplementationOnce(() => ({
-        data: {
-          data: {
-            api_version: version,
-          },
-        },
-      }))
-      .mockImplementationOnce(() => ({
-        data: {
-          data: {
-            uuid: '7f828fd6-ef68-4656-b363-247b5861b84c',
-            current_version: `v${version}`,
-            update_check: undefined,
-            last_available_major: undefined,
-            last_available_minor: undefined,
-            last_available_patch,
-            last_check_date: undefined,
-          },
-        },
-      }));
 
-    const updates = await getUpdates(true);
-
-    expect(updates).toEqual({
-      last_check_date: expect.any(Date),
-      apis_available_updates: [
-        {
-          api_id: API_ID,
+    mockTransportRequest.mockImplementationOnce(() => ({
+      body: {
+        message: {
+          uuid: '7f828fd6-ef68-4656-b363-247b5861b84c',
           current_version: `v${version}`,
-          status: API_UPDATES_STATUS.AVAILABLE_UPDATES,
-          update_check: undefined,
-          last_available_major: undefined,
-          last_available_minor: undefined,
           last_available_patch,
-          last_check_date: undefined,
+          last_check_date: '2023-09-30T14:00:00.000Z',
         },
-      ],
+        status: 200,
+      },
+    }));
+
+    const updates = await getUpdates(true, mockOpensearchClient as any);
+
+    expect(updates).toEqual({
+      uuid: '7f828fd6-ef68-4656-b363-247b5861b84c',
+      current_version: `v${version}`,
+      last_available_major: undefined,
+      last_available_minor: undefined,
+      last_available_patch,
+      last_check_date: '2023-09-30T14:00:00.000Z',
+      last_check_date_dashboard: expect.any(Date),
+      status: API_UPDATES_STATUS.AVAILABLE_UPDATES,
     });
   });
 
-  it('should return updates when api version undefined on first request', async () => {
-    const semver = {
-      major: 4,
-      minor: 3,
-      patch: 1,
-    };
-    const version = `${semver.major}.${semver.minor}.${semver.patch}`;
-    const last_available_patch = {
-      description:
-        '## Manager\r\n\r\n### Fixed\r\n\r\n- Fixed a crash when overwrite rules are triggered...',
-      published_date: '2022-05-18T10:12:43Z',
-      semver,
-      tag: `v${version}`,
-      title: `Wazuh v${version}`,
-    };
-    mockRequest
-      .mockImplementationOnce(() => ({
-        data: {
-          data: {
-            api_version: undefined,
-          },
+  it('should return up to date when no updates in indexer response', async () => {
+    mockTransportRequest.mockImplementationOnce(() => ({
+      body: {
+        message: {
+          uuid: '7f828fd6-ef68-4656-b363-247b5861b84c',
+          current_version: 'v4.3.1',
+          last_check_date: '2023-09-30T14:00:00.000Z',
         },
-      }))
-      .mockImplementationOnce(() => ({
-        data: {
-          data: {
-            uuid: '7f828fd6-ef68-4656-b363-247b5861b84c',
-            current_version: `v${version}`,
-            update_check: undefined,
-            last_available_major: undefined,
-            last_available_minor: undefined,
-            last_available_patch,
-            last_check_date: undefined,
-          },
-        },
-      }));
+        status: 200,
+      },
+    }));
 
-    const updates = await getUpdates(true);
+    const updates = await getUpdates(true, mockOpensearchClient as any);
 
     expect(updates).toEqual({
-      last_check_date: expect.any(Date),
-      apis_available_updates: [
-        {
-          api_id: API_ID,
-          current_version: `v${version}`,
-          status: API_UPDATES_STATUS.AVAILABLE_UPDATES,
-          update_check: undefined,
-          last_available_major: undefined,
-          last_available_minor: undefined,
-          last_available_patch,
-          last_check_date: undefined,
-        },
-      ],
+      uuid: '7f828fd6-ef68-4656-b363-247b5861b84c',
+      current_version: 'v4.3.1',
+      last_available_major: undefined,
+      last_available_minor: undefined,
+      last_available_patch: undefined,
+      last_check_date: '2023-09-30T14:00:00.000Z',
+      last_check_date_dashboard: expect.any(Date),
+      status: API_UPDATES_STATUS.UP_TO_DATE,
     });
   });
-  it('should return updates when api version undefined on first request and second request fails', async () => {
-    const semver = {
-      major: 4,
-      minor: 3,
-      patch: 1,
-    };
-    const version = `${semver.major}.${semver.minor}.${semver.patch}`;
-    mockRequest
-      .mockImplementationOnce(() => ({
-        data: {
-          data: {
-            api_version: undefined,
-          },
-        },
-      }))
-      .mockImplementationOnce(() => {
-        throw new Error('Error');
-      });
 
-    const updates = await getUpdates(true);
+  it('should return error when indexer returns non-200 status', async () => {
+    mockTransportRequest.mockImplementationOnce(() => ({
+      body: {
+        message: 'Unable to reach the CTI API to check for updates.',
+        status: 500,
+      },
+    }));
+
+    const updates = await getUpdates(true, mockOpensearchClient as any);
 
     expect(updates).toEqual({
-      last_check_date: expect.any(Date),
-      apis_available_updates: [
-        {
-          api_id: API_ID,
-          current_version: undefined,
-          status: API_UPDATES_STATUS.ERROR,
-          error: {
-            detail: 'Error',
-            title: 'Error',
-          },
-        },
-      ],
+      last_check_date_dashboard: expect.any(Date),
+      status: API_UPDATES_STATUS.ERROR,
+      error: { detail: 'Unable to reach the CTI API to check for updates.' },
     });
   });
-  it('should return updates when first request fails', async () => {
-    const semver = {
-      major: 4,
-      minor: 3,
-      patch: 1,
-    };
-    const version = `${semver.major}.${semver.minor}.${semver.patch}`;
-    const last_available_patch = {
-      description:
-        '## Manager\r\n\r\n### Fixed\r\n\r\n- Fixed a crash when overwrite rules are triggered...',
-      published_date: '2022-05-18T10:12:43Z',
-      semver,
-      tag: `v${version}`,
-      title: `Wazuh v${version}`,
-    };
-    mockRequest
-      .mockImplementationOnce(() => {
-        throw new Error('Error');
-      })
-      .mockImplementationOnce(() => ({
-        data: {
-          data: {
-            uuid: '7f828fd6-ef68-4656-b363-247b5861b84c',
-            current_version: `v${version}`,
-            update_check: undefined,
-            last_available_major: undefined,
-            last_available_minor: undefined,
-            last_available_patch,
-            last_check_date: undefined,
-          },
-        },
-      }));
 
-    const updates = await getUpdates(true);
-
-    expect(updates).toEqual({
-      last_check_date: expect.any(Date),
-      apis_available_updates: [
-        {
-          api_id: API_ID,
-          current_version: `v${version}`,
-          status: API_UPDATES_STATUS.AVAILABLE_UPDATES,
-          update_check: undefined,
-          last_available_major: undefined,
-          last_available_minor: undefined,
-          last_available_patch,
-          last_check_date: undefined,
-        },
-      ],
+  it('should return error when indexer request throws', async () => {
+    mockTransportRequest.mockImplementationOnce(() => {
+      throw new Error('Connection refused');
     });
-  });
-  it('should return updates when second request fails', async () => {
-    const semver = {
-      major: 4,
-      minor: 3,
-      patch: 1,
-    };
-    const version = `${semver.major}.${semver.minor}.${semver.patch}`;
-    mockRequest
-      .mockImplementationOnce(() => ({
-        data: {
-          data: {
-            api_version: version,
-          },
-        },
-      }))
-      .mockImplementationOnce(() => {
-        throw new Error('Error');
-      });
 
-    const updates = await getUpdates(true);
+    const updates = await getUpdates(true, mockOpensearchClient as any);
 
     expect(updates).toEqual({
-      last_check_date: expect.any(Date),
-      apis_available_updates: [
-        {
-          api_id: API_ID,
-          current_version: `v${version}`,
-          status: API_UPDATES_STATUS.ERROR,
-          error: {
-            detail: 'Error',
-            title: 'Error',
-          },
-        },
-      ],
-    });
-  });
-  it('should return error when both requests fail', async () => {
-    mockRequest
-      .mockImplementationOnce(() => {
-        throw new Error('Error');
-      })
-      .mockImplementationOnce(() => {
-        throw new Error('Error');
-      });
-
-    const updates = await getUpdates(true);
-
-    expect(updates).toEqual({
-      last_check_date: expect.any(Date),
-      apis_available_updates: [
-        {
-          api_id: API_ID,
-          current_version: undefined,
-          status: API_UPDATES_STATUS.ERROR,
-          error: {
-            detail: 'Error',
-            title: 'Error',
-          },
-        },
-      ],
+      last_check_date_dashboard: expect.any(Date),
+      status: API_UPDATES_STATUS.ERROR,
+      error: {
+        title: 'Connection refused',
+        detail: 'Connection refused',
+      },
     });
   });
 });

--- a/plugins/wazuh-check-updates/server/services/updates/get-updates.ts
+++ b/plugins/wazuh-check-updates/server/services/updates/get-updates.ts
@@ -17,14 +17,18 @@ const getStatus = ({
   last_available_minor,
   last_available_patch,
 }: ResponseIndexerAvailableUpdates): API_UPDATES_STATUS =>
-  last_available_major?.tag || last_available_minor?.tag || last_available_patch?.tag
+  last_available_major?.tag ||
+  last_available_minor?.tag ||
+  last_available_patch?.tag
     ? API_UPDATES_STATUS.AVAILABLE_UPDATES
     : API_UPDATES_STATUS.UP_TO_DATE;
 
 const presentUpdate = (update?: Update): Update | undefined =>
   update?.tag ? update : undefined;
 
-const saveAndReturn = async (result: AvailableUpdates): Promise<AvailableUpdates> => {
+const saveAndReturn = async (
+  result: AvailableUpdates,
+): Promise<AvailableUpdates> => {
   await setSavedObject(SAVED_OBJECT_UPDATES, result);
   return result;
 };
@@ -78,7 +82,11 @@ export const getUpdates = async (
     });
   } catch (error: any) {
     logger.error(
-      `[ERROR]: Cannot get available updates from indexer. Message: ${error.message}. Status: ${error.meta?.statusCode}. Body: ${JSON.stringify(error.meta?.body)}`,
+      `[ERROR]: Cannot get available updates from indexer. Message: ${
+        error.message
+      }. Status: ${error.meta?.statusCode}. Body: ${JSON.stringify(
+        error.meta?.body,
+      )}`,
     );
     return saveAndReturn({
       last_check_date_dashboard: new Date(),

--- a/plugins/wazuh-check-updates/server/services/updates/get-updates.ts
+++ b/plugins/wazuh-check-updates/server/services/updates/get-updates.ts
@@ -1,153 +1,89 @@
+import { IScopedClusterClient } from 'opensearch-dashboards/server';
 import {
   API_UPDATES_STATUS,
   AvailableUpdates,
-  ResponseApiAvailableUpdates,
+  ResponseIndexerAvailableUpdates,
+  Update,
 } from '../../../common/types';
 import { SAVED_OBJECT_UPDATES } from '../../../common/constants';
 import { getSavedObject, setSavedObject } from '../saved-object';
-import {
-  getWazuhCheckUpdatesServices,
-  getWazuhCore,
-} from '../../plugin-services';
-import { IAPIHost } from '../../../../wazuh-core/server/services';
+import { getWazuhCheckUpdatesServices } from '../../plugin-services';
+
+const CONTENT_MANAGER_VERSION_CHECK_PATH =
+  '/_plugins/_content_manager/version/check';
+
+const getStatus = ({
+  last_available_major,
+  last_available_minor,
+  last_available_patch,
+}: ResponseIndexerAvailableUpdates): API_UPDATES_STATUS =>
+  last_available_major?.tag || last_available_minor?.tag || last_available_patch?.tag
+    ? API_UPDATES_STATUS.AVAILABLE_UPDATES
+    : API_UPDATES_STATUS.UP_TO_DATE;
+
+const presentUpdate = (update?: Update): Update | undefined =>
+  update?.tag ? update : undefined;
+
+const saveAndReturn = async (result: AvailableUpdates): Promise<AvailableUpdates> => {
+  await setSavedObject(SAVED_OBJECT_UPDATES, result);
+  return result;
+};
 
 export const getUpdates = async (
   queryApi = false,
-  forceQuery = false,
+  opensearchClient?: IScopedClusterClient,
 ): Promise<AvailableUpdates> => {
   const { logger } = getWazuhCheckUpdatesServices();
 
-  try {
-    if (!queryApi) {
-      const availableUpdates = (await getSavedObject(
-        SAVED_OBJECT_UPDATES,
-      )) as AvailableUpdates;
+  if (!queryApi) {
+    return (await getSavedObject(SAVED_OBJECT_UPDATES)) as AvailableUpdates;
+  }
 
-      return availableUpdates;
+  if (!opensearchClient) {
+    return Promise.reject(
+      new Error('OpenSearch client is required to query updates'),
+    );
+  }
+
+  try {
+    const response = await opensearchClient.asCurrentUser.transport.request({
+      method: 'GET',
+      path: CONTENT_MANAGER_VERSION_CHECK_PATH,
+    });
+
+    const { message, status } = response.body as {
+      message: ResponseIndexerAvailableUpdates | string;
+      status: number;
+    };
+
+    if (status !== 200 || typeof message === 'string') {
+      return saveAndReturn({
+        last_check_date_dashboard: new Date(),
+        status: API_UPDATES_STATUS.ERROR,
+        error: {
+          detail: typeof message === 'string' ? message : 'Unknown error',
+        },
+      });
     }
 
-    const getStatus = ({
-      update_check,
-      last_available_major,
-      last_available_minor,
-      last_available_patch,
-    }: ResponseApiAvailableUpdates) => {
-      if (update_check === false) {
-        return API_UPDATES_STATUS.DISABLED;
-      }
-
-      if (
-        last_available_major?.tag ||
-        last_available_minor?.tag ||
-        last_available_patch?.tag
-      ) {
-        return API_UPDATES_STATUS.AVAILABLE_UPDATES;
-      }
-
-      return API_UPDATES_STATUS.UP_TO_DATE;
-    };
-
-    const { manageHosts, api: wazuhApiClient } = getWazuhCore();
-
-    const hosts = (await manageHosts.get()) as IAPIHost[];
-
-    const apisAvailableUpdates = await Promise.all(
-      hosts?.map(async api => {
-        const data = {};
-        const method = 'GET';
-        const path = `/cluster/version/check?force_query=${forceQuery}`;
-        const options = {
-          apiHostID: api.id,
-          forceRefresh: true,
-        };
-        let currentVersion: string | undefined = undefined;
-        let availableUpdates: ResponseApiAvailableUpdates = {};
-
-        try {
-          const {
-            data: {
-              data: { api_version },
-            },
-          } = await wazuhApiClient.client.asInternalUser.request(
-            'GET',
-            '/',
-            {},
-            options,
-          );
-          if (api_version !== undefined) {
-            currentVersion = `v${api_version}`;
-          }
-        } catch {
-          logger.debug('[ERROR]: Cannot get the API version');
-        }
-
-        try {
-          const response = await wazuhApiClient.client.asInternalUser.request(
-            method,
-            path,
-            data,
-            options,
-          );
-
-          availableUpdates = response.data.data as ResponseApiAvailableUpdates;
-
-          const {
-            update_check,
-            last_available_major,
-            last_available_minor,
-            last_available_patch,
-            last_check_date,
-          } = availableUpdates;
-
-          // If for some reason, the previous request fails
-          if (currentVersion === undefined) {
-            currentVersion = availableUpdates.current_version;
-          }
-
-          return {
-            current_version: currentVersion,
-            update_check,
-            last_available_major,
-            last_available_minor,
-            last_available_patch,
-            last_check_date: last_check_date || undefined,
-            api_id: api.id,
-            status: getStatus(availableUpdates),
-          };
-        } catch (error: any) {
-          logger.debug('[ERROR]: Cannot get the API status');
-          const errorResponse = {
-            title: error.response?.data?.title ?? error.message,
-            detail: error.response?.data?.detail ?? error.message,
-          };
-
-          return {
-            api_id: api.id,
-            status: API_UPDATES_STATUS.ERROR,
-            current_version: currentVersion,
-            error: errorResponse,
-          };
-        }
-      }),
+    return saveAndReturn({
+      uuid: message.uuid,
+      current_version: message.current_version,
+      last_available_major: presentUpdate(message.last_available_major),
+      last_available_minor: presentUpdate(message.last_available_minor),
+      last_available_patch: presentUpdate(message.last_available_patch),
+      last_check_date: message.last_check_date,
+      last_check_date_dashboard: new Date(),
+      status: getStatus(message),
+    });
+  } catch (error: any) {
+    logger.error(
+      `[ERROR]: Cannot get available updates from indexer. Message: ${error.message}. Status: ${error.meta?.statusCode}. Body: ${JSON.stringify(error.meta?.body)}`,
     );
-
-    const savedObject = {
-      apis_available_updates: apisAvailableUpdates,
-      last_check_date: new Date(),
-    };
-
-    await setSavedObject(SAVED_OBJECT_UPDATES, savedObject);
-
-    return savedObject;
-  } catch (error) {
-    const message =
-      error instanceof Error
-        ? error.message
-        : typeof error === 'string'
-        ? error
-        : 'Error trying to get available updates';
-
-    logger.error(message);
-    return Promise.reject(error);
+    return saveAndReturn({
+      last_check_date_dashboard: new Date(),
+      status: API_UPDATES_STATUS.ERROR,
+      error: { title: error.message, detail: error.message },
+    });
   }
 };

--- a/plugins/wazuh-core/public/services/configuration/ui-settings-provider.ts
+++ b/plugins/wazuh-core/public/services/configuration/ui-settings-provider.ts
@@ -37,7 +37,7 @@ export class UISettingsConfigProvider implements IConfigurationProvider {
     for (const key in settings) {
       if (settings[key].category) {
         wazuhCoreSettings[key] =
-          settings[key]?.userValue || settings[key]?.value;
+          settings[key]?.userValue ?? settings[key]?.value;
       }
     }
 


### PR DESCRIPTION
### Description
- Implement new indexer version check endpoint
- Updated saved objects (user preferences and available updates)
 
### Issues Resolved
- https://github.com/wazuh/wazuh-dashboard-plugins/issues/8347

### Evidence

<img width="2932" height="1496" alt="image" src="https://github.com/user-attachments/assets/4f895a4b-5aad-4bf4-8b6f-ebe49b5ce758" />

<img width="2936" height="1494" alt="image" src="https://github.com/user-attachments/assets/3a49c863-41d1-4979-9eb4-5d7a60751e7e" />

<img width="2938" height="1510" alt="image" src="https://github.com/user-attachments/assets/29d1f33d-cd82-4a66-9e32-da2f5da423f2" />



### Test
- In **Dashboard  management => Advanced Settings**, ensure `wazuh.updates.disabled` is set to `false`.

- Check updates
  1. Go to `Dashboard management => Server APIs`
  2. Click **Check updates**, the status column should update to "Up to date" or "Available updates".

- Updates flyout: to force an "available updates" state, manually patch the saved object after clicking **Check updates**:
```bash
curl -u admin:admin -k -X POST \
  "https://localhost:9200/.kibana/_update/wazuh-check-updates-available-updates:wazuh-check-updates-available-updates" \
  -H 'Content-Type: application/json' \
  -d '{"doc":{"wazuh-check-updates-available-updates":{"status":"availableUpdates","last_available_patch":{"tag":"v99.0.0","title":"Wazuh v99.0.0","description":"Test patch","published_date":"2025-01-01T00:00:00Z","semver":{"major":99,"minor":0,"patch":0}}}}}'
```
Then reload the page, the status column should show "Available updates" and the flyout should display the patch details.

- Notification bar: with the patched saved object above, navigate to any Wazuh page, a notification bar should appear at the bottom. 

### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff 
