### PR TITLE
Add refresh button to suggested filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Added NIS2 regulatory compliance module [#8298](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8298)
 - Added NIST 800-171 regulatory compliance module [#8294](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8294)
 - Added `wazuh-threatintel-enrichments*` and `wazuh-threatintel-vulnerabilities*` index patterns [#8357](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8357)
+- Added Refresh button to the suggested filters search bar [#8398](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8398)
 
 ### Changed
 

--- a/plugins/main/public/components/common/custom-search-bar/custom-search-bar.tsx
+++ b/plugins/main/public/components/common/custom-search-bar/custom-search-bar.tsx
@@ -246,6 +246,18 @@ export const CustomSearchBar = ({
           fixedFilters={fixedFilters}
           showQueryInput={avancedFiltersState}
           onFiltersUpdated={onFiltersUpdated}
+          onManualRefresh={() =>
+            searchBarProps.onQuerySubmit(
+              {
+                dateRange: {
+                  from: searchBarProps.dateRangeFrom,
+                  to: searchBarProps.dateRangeTo,
+                },
+                query: searchBarProps.query,
+              },
+              false,
+            )
+          }
           preQueryBar={
             !avancedFiltersState ? (
               <EuiFlexGroup

--- a/plugins/main/public/components/common/search-bar/search-bar.tsx
+++ b/plugins/main/public/components/common/search-bar/search-bar.tsx
@@ -1,7 +1,13 @@
 import React from 'react';
 import { getPlugins } from '../../../kibana-services';
 import './search-bar.scss';
-import { EuiPanel, EuiFlexGroup, EuiFlexItem, EuiBadge } from '@elastic/eui';
+import {
+  EuiPanel,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiBadge,
+  EuiButton,
+} from '@elastic/eui';
 import {
   SearchBarProps,
   Filter,
@@ -19,6 +25,7 @@ export interface WzSearchBarProps extends SearchBarProps {
   hideFixedFilters?: boolean;
   showSaveQueryButton?: boolean;
   showSaveQuery?: boolean;
+  onManualRefresh?: () => void;
 }
 
 export const WzSearchBar = ({
@@ -29,6 +36,7 @@ export const WzSearchBar = ({
   preQueryBar,
   hideFixedFilters,
   postFilters,
+  onManualRefresh,
   ...restProps
 }: WzSearchBarProps) => {
   const SearchBar = getPlugins().data.ui.SearchBar;
@@ -53,10 +61,29 @@ export const WzSearchBar = ({
           className='wz-search-bar-query'
           gutterSize='s'
           alignItems='center'
-          responsive={false}
           wrap={true}
         >
-          {preQueryBar ? <EuiFlexItem>{preQueryBar}</EuiFlexItem> : null}
+          {preQueryBar ? (
+            <EuiFlexItem>
+              <EuiFlexGroup alignItems='center' gutterSize='s'>
+                <EuiFlexItem>{preQueryBar}</EuiFlexItem>
+                {/* When preQueryBar is present and the date picker is disabled, the native SearchBar
+                  (which includes the platform Refresh button) is suppressed by the WORKAROUND below.
+                  Render an explicit Refresh button to compensate when the caller provides onManualRefresh. */}
+                {onManualRefresh && !restProps.showDatePicker ? (
+                  <EuiFlexItem grow={false}>
+                    <EuiButton
+                      size='s'
+                      iconType='refresh'
+                      onClick={onManualRefresh}
+                    >
+                      Refresh
+                    </EuiButton>
+                  </EuiFlexItem>
+                ) : null}
+              </EuiFlexGroup>
+            </EuiFlexItem>
+          ) : null}
           {/* WORKAROUND: The search bar is not displayed when the preQueryBar is enabled and the date picker is disabled to avoid rendering an empty flexItem */}
           {!preQueryBar || restProps?.showDatePicker ? (
             <EuiFlexItem grow={!preQueryBar}>


### PR DESCRIPTION
### Description

Added a Refresh button to the suggested filters search bar via an `onManualRefresh` optional prop on `WzSearchBar`. The button only renders when the native platform SearchBar (with its own Refresh) is suppressed. No callers need modification.

### Issues Resolved
- **Closes**: https://github.com/wazuh/wazuh-dashboard-plugins/issues/8391

### Evidence

<img width="1893" height="714" alt="image" src="https://github.com/user-attachments/assets/673a6208-eb4c-4b8e-b176-467da95c5880" />

### Test
1. Navigate to a module that uses the suggested filters search bar **without** a date picker (e.g. **IT Hygiene > Software** tab).
2. Verify the **Refresh** button appears next to the filter dropdowns.
3. Select some filters from the dropdowns, click **Refresh**, and confirm the dashboards/tables reload with the selected filters.
4. Toggle the **Advanced filters** switch ON > verify the Refresh button disappears (the native platform bar provides its own).
5. Toggle it back OFF > verify the Refresh button reappears.
6. Navigate to a module **with** a date picker (e.g. **Office 365** or **GitHub**) > verify no duplicate Refresh button appears (only the native one next to the date picker).
7. Resize the browser to a narrow width > verify the Refresh button stays inline with the filter dropdowns and wraps correctly.

### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [X] Update [CHANGELOG.md](./../CHANGELOG.md)
- [X] Commits are signed per the DCO using --signoff 
