### PR TITLE
Add generate report feature to vulnerabilities dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Added NIS2 regulatory compliance module [#8298](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8298)
 - Added NIST 800-171 regulatory compliance module [#8294](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8294)
 - Added `wazuh-threatintel-enrichments*` and `wazuh-threatintel-vulnerabilities*` index patterns [#8357](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8357)
+- Allow report generation in Vulnerabilities dashboard [#8403](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8403)
 
 ### Changed
 

--- a/plugins/main/public/components/common/modules/modules-defaults.tsx
+++ b/plugins/main/public/components/common/modules/modules-defaults.tsx
@@ -337,6 +337,7 @@ export const ModulesDefaults = {
               moduleIndexPatternTitle={WAZUH_VULNERABILITIES_PATTERN}
             />
           ),
+          ButtonModuleGenerateReport,
         ],
       },
       {


### PR DESCRIPTION
### Description
Add `Generate report` button in vulnerabilities dashboard. 
 
### Issues Resolved
- https://github.com/wazuh/wazuh-dashboard-plugins/issues/8401

### Evidence


https://github.com/user-attachments/assets/74689108-f0ca-4d73-82f5-0482d3ed0881



### Test
Make sure your dev environment has up and running the `wazuh-dashboard-reporting` plugin, and then:
- Go to `Threat intelligence > Vulnerability Detection` and verify `Generate Report` appears and works. 

### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff 
