### PR TITLE
Change FIM findings default columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Reduce the request done to get the index pattern to use in some views [#8318](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8318)
 - Changed default columns in Configuration assessment [#8320](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8320)
 - Set the downloaded local agent package name same to the remote one [#8350](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8350)
+- Changed FIM findings default columns [#8417](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8417)
 
 ### Fixed
 

--- a/plugins/main/public/components/overview/fim/events/file-integrity-monitoring-columns.tsx
+++ b/plugins/main/public/components/overview/fim/events/file-integrity-monitoring-columns.tsx
@@ -5,8 +5,8 @@ export const fileIntegrityMonitoringColumns: tDataGridColumn[] = [
   commonColumns.timestamp,
   commonColumns['wazuh.agent.id'],
   commonColumns['wazuh.agent.name'],
-  { id: 'file.path' },
-  { id: 'event.type' },
+  { id: 'rule.title' },
+  { id: 'rule.level' },
   { id: 'event.action' },
-  { id: 'file.inode' },
+  { id: 'file.path' },
 ];


### PR DESCRIPTION
### Description
Changed the default columns in the FIM Findings table.
 
### Issues Resolved
- **Closes**: https://github.com/wazuh/wazuh-dashboard-plugins/issues/8416

### Evidence

<img width="1893" height="934" alt="image" src="https://github.com/user-attachments/assets/8296f9e3-3962-4dd8-bf11-e5fc4465a175" />

### Test
1. Navigate to `Endpoint security` > `File Integrity Monitoring` > `Findings` tab

### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [X] Update [CHANGELOG.md](./../CHANGELOG.md)
- [X] Commits are signed per the DCO using --signoff 
