### PR TITLE
Updates Ubuntu version from 24.04 to 26.04

### DIFF
--- a/.github/actions/comment-test-coverage/README.md
+++ b/.github/actions/comment-test-coverage/README.md
@@ -13,7 +13,7 @@ name: test-pull-request
 on: [pull_request]
 jobs:
   build:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4

--- a/.github/workflows/4_codelinter_prettier.yml
+++ b/.github/workflows/4_codelinter_prettier.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   prettier:
     name: Ensure the code format on the changed files
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     if: github.event.pull_request.draft == false
     steps:
       # https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs

--- a/.github/workflows/4_testunit_dev_sh.yml
+++ b/.github/workflows/4_testunit_dev_sh.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   scripts-tests:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@v4
       - name: Run dev scripts tests (Jest in container)

--- a/.github/workflows/5_codelinter_prettier.yml
+++ b/.github/workflows/5_codelinter_prettier.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   prettier:
     name: Ensure the code format on the changed files
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     if: github.event.pull_request.draft == false
     steps:
       # https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs

--- a/.github/workflows/5_testunit_dev_sh.yml
+++ b/.github/workflows/5_testunit_dev_sh.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   scripts-tests:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@v4
       - name: Run dev scripts tests (Jest in container)

--- a/.github/workflows/6_documentation_deploy-to-gh-pages.yml
+++ b/.github/workflows/6_documentation_deploy-to-gh-pages.yml
@@ -23,7 +23,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     permissions:
       contents: write # To push a branch
       pages: write # To push to a GitHub Pages site

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -19,7 +19,7 @@ on:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -31,7 +31,7 @@ permissions:
 
 jobs:
   dependency-review:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     if: github.event.pull_request.draft == false
     steps:
       - name: 'Checkout Repository'

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     permissions:
       contents: write # To push a branch
       pages: write # To push to a GitHub Pages site

--- a/.github/workflows/dev-environment.yml
+++ b/.github/workflows/dev-environment.yml
@@ -46,7 +46,7 @@ jobs:
     permissions:
       pull-requests: write
     name: Deploy and run command
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     strategy:
       matrix:
         plugins:

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -20,7 +20,7 @@ on:
 jobs:
   linter:
     name: Ensure the code format on the changed files
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     if: github.event.pull_request.draft == false
     steps:
       # https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs

--- a/.github/workflows/manual-build.yml
+++ b/.github/workflows/manual-build.yml
@@ -37,7 +37,7 @@ jobs:
   test-packages:
     needs: build
     name: Test packages
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
 
     steps:
       - name: Step 01 - Download the plugin's source code

--- a/docker/osd-dev/dev.yml
+++ b/docker/osd-dev/dev.yml
@@ -399,7 +399,7 @@ services:
       - '55000:55000'
 
   wazuh.agent.deb.local:
-    image: ubuntu:24.04
+    image: ubuntu:26.04
     profiles:
       - 'server-local' # server profile to use the local packages with agents deb and rpm
       - 'server-local-deb' # server profile to use the local packages with agent deb

--- a/docker/osd-dev/indexer/Dockerfile
+++ b/docker/osd-dev/indexer/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:24.04
+FROM ubuntu:26.04
 
 ADD --chown=root:root installer.sh /installer/installer.sh
 ADD wazuh-indexer*.deb /installer/wazuh-indexer.deb

--- a/docker/osd-dev/manager/Dockerfile
+++ b/docker/osd-dev/manager/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:24.04
+FROM ubuntu:26.04
 
 ADD --chown=root:root installer.sh /installer/installer.sh
 ADD wazuh-manager*.deb /installer/wazuh-manager.deb

--- a/docs/ref/compatibility.md
+++ b/docs/ref/compatibility.md
@@ -8,7 +8,7 @@ We support the operating system versions and architectures included in the table
 | Name | Version | Architecture |
 | ------------ | ------------ | --------------- |
 | Red Hat | 9, 10 | x86_64, aarch64 |
-| Ubuntu | 22.04, 24.04 | x86_64, aarch64 |
+| Ubuntu | 22.04, 24.04, 26.04 | x86_64, aarch64 |
 | Amazon Linux | 2023 | x86_64, aarch64 |
 
 ## Hardware requirements

--- a/docs/ref/getting-started/requirements.md
+++ b/docs/ref/getting-started/requirements.md
@@ -27,7 +27,7 @@ Supported Linux distributions:
 
 - **Debian-based** (DEB packages):
   - Debian 10, 11, 12
-  - Ubuntu 18.04, 20.04, 22.04, 24.04
+  - Ubuntu 18.04, 20.04, 22.04, 24.04, 26.04
 - **Red Hat-based** (RPM packages):
   - RHEL 7, 8, 9
   - CentOS 7, 8


### PR DESCRIPTION
### Description

This PR updates the Ubuntu version used into GHA workflows to latest LTS version, 26.04

### Issues Resolved

- https://github.com/wazuh/wazuh/issues/35755

### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff 
