### PR TITLE
rename clusterEnabled to isClusterEnabled in ClusterOverview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to the Wazuh app project will be documented in this file.
 
 - Support for Wazuh 4.14.6
 
+### Fixed
+
+- Fixed message when the server cluster is disabled and access to **Cluster** app  [#8447](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8447)
+
 ## Wazuh v4.14.5 - OpenSearch Dashboards 2.19.5 - Revision 01
 
 ### Added

--- a/docker/imposter/security/login.js
+++ b/docker/imposter/security/login.js
@@ -1,6 +1,6 @@
 exports = {};
 
-load('https://raw.githubusercontent.com/kjur/jsrsasign/master/npm/lib/jsrsasign.js', exports);
+load('https://raw.githubusercontent.com/kjur/jsrsasign/11.0.0/npm/lib/jsrsasign.js', exports);
 header = {
   "alg": "HS256",
   "typ": "JWT",

--- a/plugins/main/public/controllers/management/components/management/cluster/cluster-overview.tsx
+++ b/plugins/main/public/controllers/management/components/management/cluster/cluster-overview.tsx
@@ -14,7 +14,7 @@ import { LoadingSearchbarProgress } from '../../../../../components/common/loadi
 import { FormattedMessage } from '@osd/i18n/react';
 
 interface ClusterOverviewState {
-  clusterEnabled: boolean;
+  isClusterEnabled: boolean;
   isClusterRunning: boolean;
   statusRunning: string;
 }
@@ -29,7 +29,7 @@ const checkClusterIsEnabledAndRunning = async () => {
     return {
       ok: !(isClusterEnabled && isClusterRunning),
       data: {
-        clusterEnabled,
+        isClusterEnabled,
         isClusterRunning,
         statusRunning,
       },
@@ -52,10 +52,10 @@ export const ClusterOverview = compose(
   ]),
   withGuardAsync(
     checkClusterIsEnabledAndRunning,
-    ({ clusterEnabled, isClusterRunning, error }) => (
+    ({ isClusterEnabled, isClusterRunning, error }) => (
       <ClusterDisabled
         error={error}
-        enabled={clusterEnabled}
+        enabled={isClusterEnabled}
         running={isClusterRunning}
       />
     ),
@@ -72,13 +72,13 @@ export const ClusterOverview = compose(
   ),
 )(
   ({
-    clusterEnabled,
+    isClusterEnabled,
     isClusterRunning,
     statusRunning,
   }: ClusterOverviewState) => {
     return (
       <>
-        {clusterEnabled && isClusterRunning ? (
+        {isClusterEnabled && isClusterRunning ? (
           <ClusterDashboard statusRunning={statusRunning} />
         ) : null}
       </>


### PR DESCRIPTION
### Description
- Aligns the boolean prop/state name with the existing isClusterRunning convention so all booleans in ClusterOverviewState use the `is` prefix.
- Pass boolean property isClusterEnabled instead of pass the value clusterEnabled
 
### Issues Resolved
- *Closes:*  https://github.com/wazuh/wazuh-dashboard-plugins/issues/8384

### Evidence
<img width="721" height="243" alt="image" src="https://github.com/user-attachments/assets/3a755c4f-ae19-408f-9659-5b5188aec922" />

### Test
- Disable the cluster and go to **Server management** > **Cluster**, this should display a message about the cluster is disabled.

### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 
