### PR TITLE
Fix: remove frontend RBAC gates for agent actions and rely on API authorization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 ### Fixed
 
 - Fixed message when the server cluster is disabled and access to **Cluster** app [#8447](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8447)
-- Fixed agent removal, group editing, and upgrading authorization by delegating RBAC enforcement to the API instead of the UI [#8464](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8464)
+- Fixed agent removal, group editing, upgrading, and upgrade task details authorization by delegating RBAC enforcement to the API instead of the UI, and avoiding duplicated permission error toasts in upgrade task queries [#8464](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8464)
 
 ## Wazuh v4.14.5 - OpenSearch Dashboards 2.19.5 - Revision 01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 ### Fixed
 
 - Fixed message when the server cluster is disabled and access to **Cluster** app [#8447](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8447)
-- Fixed agent removal authorization by delegating delete RBAC enforcement to the API instead of the UI [#8464](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8464)
+- Fixed agent removal, group editing, and upgrading authorization by delegating RBAC enforcement to the API instead of the UI [#8464](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8464)
 
 ## Wazuh v4.14.5 - OpenSearch Dashboards 2.19.5 - Revision 01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 ### Fixed
 
 - Fixed message when the server cluster is disabled and access to **Cluster** app  [#8447](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8447)
+- Fixed agent removal authorization by delegating delete RBAC enforcement to the API instead of the UI [#8464](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8464)
 
 ## Wazuh v4.14.5 - OpenSearch Dashboards 2.19.5 - Revision 01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 
 ### Fixed
 
-- Fixed message when the server cluster is disabled and access to **Cluster** app  [#8447](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8447)
+- Fixed message when the server cluster is disabled and access to **Cluster** app [#8447](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8447)
 - Fixed agent removal authorization by delegating delete RBAC enforcement to the API instead of the UI [#8464](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8464)
 
 ## Wazuh v4.14.5 - OpenSearch Dashboards 2.19.5 - Revision 01

--- a/plugins/main/public/components/endpoints-summary/table/actions/actions.tsx
+++ b/plugins/main/public/components/endpoints-summary/table/actions/actions.tsx
@@ -18,11 +18,10 @@ export const agentsTableActions = (
   {
     // TODO: consider moving the positional arguments to this to avoid bug related to position and allow to extend easily.
     setIsRemoveModalVisible,
-    allowRemove,
-  }: { setIsRemoveModalVisible: SetModalIsVisible; allowRemove: boolean },
+  }: { setIsRemoveModalVisible: SetModalIsVisible },
 ) => [
   {
-    name: agent => {
+    name: (agent: Agent) => {
       const name = 'View agent details';
 
       if (agent.status !== API_NAME_AGENT_STATUS.NEVER_CONNECTED) {
@@ -40,14 +39,15 @@ export const agentsTableActions = (
     type: 'icon',
     isPrimary: true,
     color: 'primary',
-    enabled: agent => agent.status !== API_NAME_AGENT_STATUS.NEVER_CONNECTED,
-    onClick: agent =>
+    enabled: (agent: Agent) =>
+      agent.status !== API_NAME_AGENT_STATUS.NEVER_CONNECTED,
+    onClick: (agent: Agent) =>
       NavigationService.getInstance().navigate(
         `/agents?tab=welcome&agent=${agent.id}`,
       ),
   },
   {
-    name: agent => {
+    name: (agent: Agent) => {
       const name = 'Agent configuration';
 
       if (agent.status !== API_NAME_AGENT_STATUS.NEVER_CONNECTED) {
@@ -63,11 +63,12 @@ export const agentsTableActions = (
     description: 'Agent configuration',
     icon: 'wrench',
     type: 'icon',
-    onClick: agent =>
+    onClick: (agent: Agent) =>
       NavigationService.getInstance().navigate(
         `/agents?tab=configuration&agent=${agent.id}`,
       ),
-    enabled: agent => agent.status !== API_NAME_AGENT_STATUS.NEVER_CONNECTED,
+    enabled: (agent: Agent) =>
+      agent.status !== API_NAME_AGENT_STATUS.NEVER_CONNECTED,
     'data-test-subj': 'action-configuration',
   },
   {
@@ -119,7 +120,7 @@ export const agentsTableActions = (
     description: 'Upgrade',
     icon: 'package',
     type: 'icon',
-    onClick: agent => {
+    onClick: (agent: Agent) => {
       setAgent(agent);
       setIsUpgradeModalVisible(true);
     },
@@ -134,29 +135,15 @@ export const agentsTableActions = (
     },
   },
   {
-    name: (agent: Agent) => {
-      return (
-        <WzElementPermissions
-          permissions={[
-            // FIXME: this should use the group permissions too adn the agent ID should be specific
-            { action: 'agent:delete', resource: `agent:id:*` },
-          ]}
-        >
-          <span>Remove</span>
-        </WzElementPermissions>
-      );
-    },
+    name: 'Remove',
     description: 'Remove',
     icon: 'trash',
     type: 'icon',
-    onClick: agent => {
+    onClick: (agent: Agent) => {
       setAgent(agent);
       setIsRemoveModalVisible(true);
     },
     'data-test-subj': 'action-remove',
-    enabled: (agent: Agent) => {
-      // FIXME: this should use the user permissions with agent:id and agent:group resources instead the generic allowRemove flag
-      return allowRemove;
-    },
+    enabled: () => true,
   },
 ];

--- a/plugins/main/public/components/endpoints-summary/table/actions/actions.tsx
+++ b/plugins/main/public/components/endpoints-summary/table/actions/actions.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { EuiToolTip } from '@elastic/eui';
 import { API_NAME_AGENT_STATUS } from '../../../../../common/constants';
-import { WzElementPermissions } from '../../../common/permissions/element';
 import { Agent } from '../../types';
 import NavigationService from '../../../../react-services/navigation-service';
 import { isVersionLower } from '../utils';
@@ -9,8 +8,6 @@ import { isVersionLower } from '../utils';
 type SetModalIsVisible = (visible: boolean) => void;
 
 export const agentsTableActions = (
-  allowEditGroups: boolean,
-  allowUpgrade: boolean,
   setAgent: (agent: Agent) => void,
   setIsEditGroupsVisible: (visible: boolean) => void,
   setIsUpgradeModalVisible: (visible: boolean) => void,
@@ -72,15 +69,7 @@ export const agentsTableActions = (
     'data-test-subj': 'action-configuration',
   },
   {
-    name: (
-      <WzElementPermissions
-        permissions={[
-          { action: 'group:modify_assignments', resource: 'group:id:*' },
-        ]}
-      >
-        <span>Edit groups</span>
-      </WzElementPermissions>
-    ),
+    name: 'Edit groups',
     description: 'Edit groups',
     icon: 'pencil',
     type: 'icon',
@@ -89,20 +78,14 @@ export const agentsTableActions = (
       setIsEditGroupsVisible(true);
     },
     'data-test-subj': 'action-groups',
-    enabled: () => allowEditGroups,
+    enabled: () => true,
   },
   {
     name: (agent: Agent) => {
       const isOutdated = isVersionLower(agent.version, apiVersion);
 
       if (agent.status === API_NAME_AGENT_STATUS.ACTIVE && isOutdated) {
-        return (
-          <WzElementPermissions
-            permissions={[{ action: 'agent:upgrade', resource: 'agent:id:*' }]}
-          >
-            <span>Upgrade</span>
-          </WzElementPermissions>
-        );
+        return 'Upgrade';
       }
 
       return (
@@ -127,11 +110,7 @@ export const agentsTableActions = (
     'data-test-subj': 'action-upgrade',
     enabled: (agent: Agent) => {
       const isOutdated = isVersionLower(agent.version, apiVersion);
-      return (
-        allowUpgrade &&
-        agent.status === API_NAME_AGENT_STATUS.ACTIVE &&
-        isOutdated
-      );
+      return agent.status === API_NAME_AGENT_STATUS.ACTIVE && isOutdated;
     },
   },
   {

--- a/plugins/main/public/components/endpoints-summary/table/actions/edit-groups-modal.tsx
+++ b/plugins/main/public/components/endpoints-summary/table/actions/edit-groups-modal.tsx
@@ -15,6 +15,7 @@ import {
   EuiDescriptionList,
   EuiDescriptionListTitle,
   EuiDescriptionListDescription,
+  EuiCallOut,
 } from '@elastic/eui';
 import { compose } from 'redux';
 import { withErrorBoundary } from '../../../common/hocs';
@@ -77,6 +78,17 @@ export const EditAgentGroupsModal = compose(withErrorBoundary)(
       });
     };
 
+    const getEditGroupsErrorMessage = (error: any) => {
+      const apiMessage = error?.response?.data?.message;
+      const message = apiMessage || error?.message || 'Unknown error';
+
+      if (/permission denied/i.test(message)) {
+        return `No permissions to edit this agent groups. ${message}`;
+      }
+
+      return message;
+    };
+
     const handleOnSave = async () => {
       setIsSaving(true);
 
@@ -106,7 +118,8 @@ export const EditAgentGroupsModal = compose(withErrorBoundary)(
           }));
         showToast('success', 'Edit agent groups', 'Groups saved successfully');
         reloadAgents();
-      } catch (error) {
+      } catch (error: any) {
+        const errorMessage = getEditGroupsErrorMessage(error);
         const options = {
           context: `EditAgentGroupsModal.handleOnSave`,
           level: UI_LOGGER_LEVELS.ERROR,
@@ -114,7 +127,7 @@ export const EditAgentGroupsModal = compose(withErrorBoundary)(
           store: true,
           error: {
             error,
-            message: error.message || error,
+            message: errorMessage,
             title: `Could not save agent groups`,
           },
         };
@@ -163,6 +176,19 @@ export const EditAgentGroupsModal = compose(withErrorBoundary)(
                 clearOnBlur
               />
             </EuiFormRow>
+            {errorGroups ? (
+              <EuiCallOut
+                color='danger'
+                iconType='alert'
+                title='Could not load groups. Check your permissions.'
+              />
+            ) : !isGroupsLoading && !groups?.length ? (
+              <EuiCallOut
+                color='warning'
+                iconType='iInCircle'
+                title='No groups available.'
+              />
+            ) : null}
           </EuiFlexItem>
         </EuiFlexGroup>
       </EuiForm>

--- a/plugins/main/public/components/endpoints-summary/table/actions/remove-agent-modal.tsx
+++ b/plugins/main/public/components/endpoints-summary/table/actions/remove-agent-modal.tsx
@@ -33,6 +33,17 @@ interface RemoveAgentModalProps {
 
 export const RemoveAgentModal = compose(withErrorBoundary)(
   ({ agent, onClose, reloadAgents }: RemoveAgentModalProps) => {
+    const getDeleteErrorMessage = (error: any) => {
+      const apiMessage = error?.response?.data?.message;
+      const message = apiMessage || error?.message || 'Unknown error';
+
+      if (/permission denied/i.test(message)) {
+        return `No permissions to remove this agent. ${message}`;
+      }
+
+      return message;
+    };
+
     const action = useAsyncAction(async agent => {
       try {
         const response = await removeAgentService(agent.id);
@@ -46,7 +57,9 @@ export const RemoveAgentModal = compose(withErrorBoundary)(
           });
         }
         reloadAgents();
-      } catch (error) {
+      } catch (error: any) {
+        const errorMessage = getDeleteErrorMessage(error);
+
         const options = {
           context: `RemoveAgentModal.handleOnSave`,
           level: UI_LOGGER_LEVELS.ERROR,
@@ -54,7 +67,7 @@ export const RemoveAgentModal = compose(withErrorBoundary)(
           store: true,
           error: {
             error,
-            message: error.message || error,
+            message: errorMessage,
             title: `Could not remove agent`,
           },
         };

--- a/plugins/main/public/components/endpoints-summary/table/actions/upgrade-agent-modal.tsx
+++ b/plugins/main/public/components/endpoints-summary/table/actions/upgrade-agent-modal.tsx
@@ -58,6 +58,17 @@ export const UpgradeAgentModal = compose(withErrorBoundary)(
     const [isLoading, setIsLoading] = useState(false);
     const [packageType, setPackageType] = useState<'deb' | 'rpm'>();
 
+    const getUpgradeErrorMessage = (error: any) => {
+      const apiMessage = error?.response?.data?.message;
+      const message = apiMessage || error?.message || 'Unknown error';
+
+      if (/permission denied/i.test(message)) {
+        return `No permissions to upgrade this agent. ${message}`;
+      }
+
+      return message;
+    };
+
     const showToast = (
       color: string,
       title: string = '',
@@ -80,7 +91,8 @@ export const UpgradeAgentModal = compose(withErrorBoundary)(
         showToast('success', 'Upgrade agent', 'Upgrade task in progress');
         reloadAgents();
         setIsUpgradePanelClosed(false);
-      } catch (error) {
+      } catch (error: any) {
+        const errorMessage = getUpgradeErrorMessage(error);
         const options = {
           context: `UpgradeAgentModal.handleOnSave`,
           level: UI_LOGGER_LEVELS.ERROR,
@@ -88,7 +100,7 @@ export const UpgradeAgentModal = compose(withErrorBoundary)(
           store: true,
           error: {
             error,
-            message: error.message || error,
+            message: errorMessage,
             title: `Could not upgrade agent`,
           },
         };

--- a/plugins/main/public/components/endpoints-summary/table/agents-table.tsx
+++ b/plugins/main/public/components/endpoints-summary/table/agents-table.tsx
@@ -79,12 +79,6 @@ export const AgentsTable = withErrorBoundary((props: AgentsTableProps) => {
   const [isRemoveModalVisible, setIsRemoveModalVisible] = useState(false);
   const [selectedItems, setSelectedItems] = useState<Agent[]>([]);
   const [allAgentsSelected, setAllAgentsSelected] = useState(false);
-  const [denyEditGroups] = useUserPermissionsRequirements([
-    { action: 'group:modify_assignments', resource: 'group:id:*' },
-  ]);
-  const [denyUpgrade] = useUserPermissionsRequirements([
-    { action: 'agent:upgrade', resource: 'agent:id:*' },
-  ]);
   const [denyGetTasks] = useUserPermissionsRequirements([
     { action: 'task:status', resource: '*:*:*' },
   ]);
@@ -254,8 +248,6 @@ export const AgentsTable = withErrorBoundary((props: AgentsTableProps) => {
                   allAgentsSelected={allAgentsSelected}
                   allAgentsCount={agentList.totalItems}
                   filters={filters?.q}
-                  allowEditGroups={!denyEditGroups}
-                  allowUpgrade={!denyUpgrade}
                   allowGetTasks={!denyGetTasks}
                   reloadAgents={() => reloadAgents()}
                   setIsUpgradeTasksModalVisible={setIsUpgradeTasksModalVisible}
@@ -265,8 +257,6 @@ export const AgentsTable = withErrorBoundary((props: AgentsTableProps) => {
             )}
             endpoint={'/agents'}
             tableColumns={agentsTableColumns(
-              !denyEditGroups,
-              !denyUpgrade,
               setAgent,
               setIsEditGroupsVisible,
               setIsUpgradeModalVisible,

--- a/plugins/main/public/components/endpoints-summary/table/agents-table.tsx
+++ b/plugins/main/public/components/endpoints-summary/table/agents-table.tsx
@@ -85,10 +85,6 @@ export const AgentsTable = withErrorBoundary((props: AgentsTableProps) => {
   const [denyUpgrade] = useUserPermissionsRequirements([
     { action: 'agent:upgrade', resource: 'agent:id:*' },
   ]);
-  // FIXME: This defines if the user has the capability to not remove agent, negating it we got the capability to this action. This is used to enable the action despite this should use the specific agent ID and group. Same happens with the upgrade and probably with the edition of groups too.
-  const [denyRemove] = useUserPermissionsRequirements([
-    { action: 'agent:delete', resource: 'agent:id:*' },
-  ]);
   const [denyGetTasks] = useUserPermissionsRequirements([
     { action: 'task:status', resource: '*:*:*' },
   ]);
@@ -259,7 +255,6 @@ export const AgentsTable = withErrorBoundary((props: AgentsTableProps) => {
                   allAgentsCount={agentList.totalItems}
                   filters={filters?.q}
                   allowEditGroups={!denyEditGroups}
-                  allowRemove={!denyRemove}
                   allowUpgrade={!denyUpgrade}
                   allowGetTasks={!denyGetTasks}
                   reloadAgents={() => reloadAgents()}
@@ -277,7 +272,7 @@ export const AgentsTable = withErrorBoundary((props: AgentsTableProps) => {
               setIsUpgradeModalVisible,
               setFilters,
               apiVersion,
-              { setIsRemoveModalVisible, allowRemove: !denyRemove },
+              { setIsRemoveModalVisible },
             )}
             tableInitialSortingField='id'
             tablePageSizeOptions={[10, 25, 50, 100]}

--- a/plugins/main/public/components/endpoints-summary/table/agents-table.tsx
+++ b/plugins/main/public/components/endpoints-summary/table/agents-table.tsx
@@ -79,9 +79,6 @@ export const AgentsTable = withErrorBoundary((props: AgentsTableProps) => {
   const [isRemoveModalVisible, setIsRemoveModalVisible] = useState(false);
   const [selectedItems, setSelectedItems] = useState<Agent[]>([]);
   const [allAgentsSelected, setAllAgentsSelected] = useState(false);
-  const [denyGetTasks] = useUserPermissionsRequirements([
-    { action: 'task:status', resource: '*:*:*' },
-  ]);
 
   const [isUpgradeTasksModalVisible, setIsUpgradeTasksModalVisible] =
     useState(false);
@@ -221,7 +218,6 @@ export const AgentsTable = withErrorBoundary((props: AgentsTableProps) => {
                 setIsModalVisible={setIsUpgradeTasksModalVisible}
                 isPanelClosed={isUpgradePanelClosed}
                 setIsPanelClosed={setIsUpgradePanelClosed}
-                allowGetTasks={!denyGetTasks}
               />
             }
             actionButtons={
@@ -248,7 +244,6 @@ export const AgentsTable = withErrorBoundary((props: AgentsTableProps) => {
                   allAgentsSelected={allAgentsSelected}
                   allAgentsCount={agentList.totalItems}
                   filters={filters?.q}
-                  allowGetTasks={!denyGetTasks}
                   reloadAgents={() => reloadAgents()}
                   setIsUpgradeTasksModalVisible={setIsUpgradeTasksModalVisible}
                   setIsUpgradePanelClosed={setIsUpgradePanelClosed}

--- a/plugins/main/public/components/endpoints-summary/table/columns.tsx
+++ b/plugins/main/public/components/endpoints-summary/table/columns.tsx
@@ -21,8 +21,6 @@ type SetModalIsVisible = (visible: boolean) => void;
 // Columns with the property truncateText: true won't wrap the text
 // This is added to prevent the wrap because of the table-layout: auto
 export const agentsTableColumns = (
-  allowEditGroups: boolean,
-  allowUpgrade: boolean,
   setAgent: (agents: Agent) => void,
   setIsEditGroupsVisible: SetModalIsVisible,
   setIsUpgradeModalVisible: SetModalIsVisible,
@@ -163,8 +161,6 @@ export const agentsTableColumns = (
     name: 'Actions',
     show: true,
     actions: agentsTableActions(
-      allowEditGroups,
-      allowUpgrade,
       setAgent,
       setIsEditGroupsVisible,
       setIsUpgradeModalVisible,

--- a/plugins/main/public/components/endpoints-summary/table/columns.tsx
+++ b/plugins/main/public/components/endpoints-summary/table/columns.tsx
@@ -31,8 +31,7 @@ export const agentsTableColumns = (
   {
     // TODO: consider moving the positional arguments to this to avoid bug related to position and allow to extend easily.
     setIsRemoveModalVisible,
-    allowRemove,
-  }: { setIsRemoveModalVisible: SetModalIsVisible; allowRemove: boolean },
+  }: { setIsRemoveModalVisible: SetModalIsVisible },
 ) => [
   {
     field: 'id',
@@ -170,7 +169,7 @@ export const agentsTableColumns = (
       setIsEditGroupsVisible,
       setIsUpgradeModalVisible,
       apiVersion,
-      { setIsRemoveModalVisible, allowRemove },
+      { setIsRemoveModalVisible },
     ),
   },
 ];

--- a/plugins/main/public/components/endpoints-summary/table/global-actions/edit-groups/edit-groups-modal.tsx
+++ b/plugins/main/public/components/endpoints-summary/table/global-actions/edit-groups/edit-groups-modal.tsx
@@ -64,6 +64,17 @@ export const EditAgentsGroupsModal = compose(withErrorBoundary)(
     reloadAgents,
     addOrRemove,
   }: EditAgentsGroupsModalProps) => {
+    const getEditGroupsErrorMessage = (error: any) => {
+      const apiMessage = error?.response?.data?.message;
+      const message = apiMessage || error?.message || 'Unknown error';
+
+      if (/permission denied/i.test(message)) {
+        return `No permissions to modify groups for one or more selected agents. ${message}`;
+      }
+
+      return message;
+    };
+
     const [selectedGroups, setSelectedGroups] = useState<Option[]>([]);
     const [finalAgents, setFinalAgents] = useState<Agent[]>([]);
     const [getAgentsStatus, setGetAgentsStatus] = useState('disabled');
@@ -164,15 +175,16 @@ export const EditAgentsGroupsModal = compose(withErrorBoundary)(
               return [...results, newGroupResult];
             });
           })
-          .catch(error => {
+          .catch((error: any) => {
+            const errorMessage = getEditGroupsErrorMessage(error);
             setGroupResults(results => {
               const newResult: GroupResult = {
                 group,
                 result: RESULT_TYPE.ERROR,
-                errorMessage: error.message,
+                errorMessage,
                 errorAgents: [
                   {
-                    error: { message: error.message },
+                    error: { message: errorMessage },
                     id: agentIds,
                   },
                 ],
@@ -186,7 +198,7 @@ export const EditAgentsGroupsModal = compose(withErrorBoundary)(
               store: true,
               error: {
                 error,
-                message: error.message || error,
+                message: errorMessage,
                 title:
                   addOrRemove === 'add'
                     ? `Could not add agents to group`
@@ -254,6 +266,23 @@ export const EditAgentsGroupsModal = compose(withErrorBoundary)(
             clearOnBlur
           />
         </EuiFormRow>
+        {errorGetGroups ? (
+          <EuiFormRow>
+            <EuiCallOut
+              color='danger'
+              iconType='alert'
+              title='Could not load groups. Check your permissions.'
+            />
+          </EuiFormRow>
+        ) : !isGroupsLoading && !groups?.length ? (
+          <EuiFormRow>
+            <EuiCallOut
+              color='warning'
+              iconType='iInCircle'
+              title='No groups available for your permissions.'
+            />
+          </EuiFormRow>
+        ) : null}
       </EuiForm>
     );
 

--- a/plugins/main/public/components/endpoints-summary/table/global-actions/global-actions.test.tsx
+++ b/plugins/main/public/components/endpoints-summary/table/global-actions/global-actions.test.tsx
@@ -25,11 +25,9 @@ describe('AgentsTableGlobalActions component', () => {
         allAgentsSelected={false}
         allAgentsCount={3}
         filters={{}}
-        allowEditGroups={true}
         reloadAgents={() => {}}
         setIsUpgradeTasksModalVisible={() => {}}
         setIsUpgradePanelClosed={() => {}}
-        allowUpgrade={true}
         allowGetTasks={true}
       />,
     );
@@ -47,11 +45,9 @@ describe('AgentsTableGlobalActions component', () => {
         allAgentsSelected={false}
         allAgentsCount={3}
         filters={{}}
-        allowEditGroups={true}
         reloadAgents={() => {}}
         setIsUpgradeTasksModalVisible={() => {}}
         setIsUpgradePanelClosed={() => {}}
-        allowUpgrade={true}
         allowGetTasks={true}
       />,
     );

--- a/plugins/main/public/components/endpoints-summary/table/global-actions/global-actions.test.tsx
+++ b/plugins/main/public/components/endpoints-summary/table/global-actions/global-actions.test.tsx
@@ -5,7 +5,9 @@ import { AgentsTableGlobalActions } from './global-actions';
 import { Agent } from '../../types';
 
 jest.mock('../../../common/permissions/element', () => ({
-  WzElementPermissions: ({ children }) => <div>{children}</div>,
+  WzElementPermissions: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
 }));
 
 // the jest.mock of @osd/monaco is added due to a problem transcribing the files to run the tests.
@@ -16,7 +18,7 @@ jest.mock('@osd/monaco', () => ({
 }));
 
 describe('AgentsTableGlobalActions component', () => {
-  test('should return the component', async () => {
+  test('should return the component', () => {
     const { container, getByText } = render(
       <AgentsTableGlobalActions
         selectedAgents={[{ id: '001', name: 'agent1' } as Agent]}
@@ -29,7 +31,6 @@ describe('AgentsTableGlobalActions component', () => {
         setIsUpgradePanelClosed={() => {}}
         allowUpgrade={true}
         allowGetTasks={true}
-        allowRemove={true}
       />,
     );
 
@@ -52,7 +53,6 @@ describe('AgentsTableGlobalActions component', () => {
         setIsUpgradePanelClosed={() => {}}
         allowUpgrade={true}
         allowGetTasks={true}
-        allowRemove={true}
       />,
     );
 

--- a/plugins/main/public/components/endpoints-summary/table/global-actions/global-actions.tsx
+++ b/plugins/main/public/components/endpoints-summary/table/global-actions/global-actions.tsx
@@ -18,8 +18,6 @@ export interface AgentsTableGlobalActionsProps {
   allAgentsSelected: boolean;
   allAgentsCount: number;
   filters: unknown;
-  allowEditGroups: boolean;
-  allowUpgrade: boolean;
   allowGetTasks: boolean;
   reloadAgents: () => void;
   setIsUpgradeTasksModalVisible: (isModalVisible: boolean) => void;
@@ -31,8 +29,6 @@ export const AgentsTableGlobalActions = ({
   allAgentsSelected,
   allAgentsCount,
   filters,
-  allowEditGroups,
-  allowUpgrade,
   allowGetTasks,
   reloadAgents,
   setIsUpgradeTasksModalVisible,
@@ -96,83 +92,56 @@ export const AgentsTableGlobalActions = ({
         <EuiContextMenuPanel>
           <EuiContextMenuItem
             icon='plusInCircle'
-            disabled={!totalAgents || !allowEditGroups}
+            disabled={!totalAgents}
             onClick={() => {
               setAddOrRemoveGroups('add');
               closePopover();
               setIsEditGroupsVisible(true);
             }}
           >
-            {allowEditGroups && !totalAgents ? (
+            {!totalAgents ? (
               selectAgentsTooltip(actions.addGroups)
             ) : (
-              <WzElementPermissions
-                permissions={[
-                  {
-                    action: 'group:modify_assignments',
-                    resource: 'group:id:*',
-                  },
-                ]}
-              >
-                <span>
-                  {actions.addGroups}
-                  {totalAgents ? ` (${totalAgents})` : ''}
-                </span>
-              </WzElementPermissions>
+              <span>
+                {actions.addGroups}
+                {totalAgents ? ` (${totalAgents})` : ''}
+              </span>
             )}
           </EuiContextMenuItem>
           <EuiContextMenuItem
             icon='trash'
-            disabled={!totalAgents || !allowEditGroups}
+            disabled={!totalAgents}
             onClick={() => {
               setAddOrRemoveGroups('remove');
               closePopover();
               setIsEditGroupsVisible(true);
             }}
           >
-            {allowEditGroups && !totalAgents ? (
+            {!totalAgents ? (
               selectAgentsTooltip(actions.removeGroups)
             ) : (
-              <WzElementPermissions
-                permissions={[
-                  {
-                    action: 'group:modify_assignments',
-                    resource: 'group:id:*',
-                  },
-                ]}
-              >
-                <span>
-                  {actions.removeGroups}
-                  {totalAgents ? ` (${totalAgents})` : ''}
-                </span>
-              </WzElementPermissions>
+              <span>
+                {actions.removeGroups}
+                {totalAgents ? ` (${totalAgents})` : ''}
+              </span>
             )}
           </EuiContextMenuItem>
           <EuiHorizontalRule margin='xs' />
           <EuiContextMenuItem
             icon='package'
-            disabled={!totalAgents || !allowUpgrade}
+            disabled={!totalAgents}
             onClick={() => {
               closePopover();
               setIsUpgradeAgentsVisible(true);
             }}
           >
-            {allowUpgrade && !totalAgents ? (
+            {!totalAgents ? (
               selectAgentsTooltip(actions.upgrade)
             ) : (
-              <WzElementPermissions
-                permissions={[
-                  {
-                    action: 'agent:upgrade',
-                    resource: 'agent:id:*',
-                  },
-                ]}
-              >
-                <span>
-                  {actions.upgrade}
-                  {totalAgents ? ` (${totalAgents})` : ''}
-                </span>
-              </WzElementPermissions>
+              <span>
+                {actions.upgrade}
+                {totalAgents ? ` (${totalAgents})` : ''}
+              </span>
             )}
           </EuiContextMenuItem>
           <EuiContextMenuItem

--- a/plugins/main/public/components/endpoints-summary/table/global-actions/global-actions.tsx
+++ b/plugins/main/public/components/endpoints-summary/table/global-actions/global-actions.tsx
@@ -18,7 +18,6 @@ export interface AgentsTableGlobalActionsProps {
   allAgentsSelected: boolean;
   allAgentsCount: number;
   filters: unknown;
-  allowGetTasks: boolean;
   reloadAgents: () => void;
   setIsUpgradeTasksModalVisible: (isModalVisible: boolean) => void;
   setIsUpgradePanelClosed: (isUpgradePanelClosed: boolean) => void;
@@ -29,7 +28,6 @@ export const AgentsTableGlobalActions = ({
   allAgentsSelected,
   allAgentsCount,
   filters,
-  allowGetTasks,
   reloadAgents,
   setIsUpgradeTasksModalVisible,
   setIsUpgradePanelClosed,
@@ -146,22 +144,13 @@ export const AgentsTableGlobalActions = ({
           </EuiContextMenuItem>
           <EuiContextMenuItem
             icon='eye'
-            disabled={!allowGetTasks}
+            disabled={!totalAgents}
             onClick={() => {
               closePopover();
               setIsUpgradeTasksModalVisible(true);
             }}
           >
-            <WzElementPermissions
-              permissions={[
-                {
-                  action: 'task:status',
-                  resource: '*:*:*',
-                },
-              ]}
-            >
-              <span>Upgrade task details</span>
-            </WzElementPermissions>
+            <span>Upgrade task details</span>
           </EuiContextMenuItem>
           <EuiHorizontalRule margin='xs' />
           <EuiContextMenuItem

--- a/plugins/main/public/components/endpoints-summary/table/global-actions/global-actions.tsx
+++ b/plugins/main/public/components/endpoints-summary/table/global-actions/global-actions.tsx
@@ -17,9 +17,8 @@ export interface AgentsTableGlobalActionsProps {
   selectedAgents: Agent[];
   allAgentsSelected: boolean;
   allAgentsCount: number;
-  filters: any;
+  filters: unknown;
   allowEditGroups: boolean;
-  allowRemove: boolean;
   allowUpgrade: boolean;
   allowGetTasks: boolean;
   reloadAgents: () => void;
@@ -33,7 +32,6 @@ export const AgentsTableGlobalActions = ({
   allAgentsCount,
   filters,
   allowEditGroups,
-  allowRemove,
   allowUpgrade,
   allowGetTasks,
   reloadAgents,
@@ -199,34 +197,19 @@ export const AgentsTableGlobalActions = ({
           <EuiHorizontalRule margin='xs' />
           <EuiContextMenuItem
             icon='trash'
-            disabled={!totalAgents || !allowRemove}
+            disabled={!totalAgents}
             onClick={() => {
               closePopover();
               setIsRemoveAgentsModalVisible(true);
             }}
           >
-            {allowRemove && !totalAgents ? (
+            {!totalAgents ? (
               selectAgentsTooltip(actions.remove)
             ) : (
-              <WzElementPermissions
-                permissions={[
-                  [
-                    {
-                      action: 'agent:delete',
-                      resource: 'agent:id:*',
-                    },
-                    {
-                      action: 'agent:delete',
-                      resource: 'agent:group:*',
-                    },
-                  ],
-                ]}
-              >
-                <span>
-                  {actions.remove}
-                  {totalAgents ? ` (${totalAgents})` : ''}
-                </span>
-              </WzElementPermissions>
+              <span>
+                {actions.remove}
+                {totalAgents ? ` (${totalAgents})` : ''}
+              </span>
             )}
           </EuiContextMenuItem>
         </EuiContextMenuPanel>

--- a/plugins/main/public/components/endpoints-summary/table/global-actions/remove/remove-modal.tsx
+++ b/plugins/main/public/components/endpoints-summary/table/global-actions/remove/remove-modal.tsx
@@ -49,6 +49,17 @@ export const RemoveAgentsModal = compose(withErrorBoundary)(
     reloadAgents,
     setIsUpgradePanelClosed,
   }: RemoveAgentsModalProps) => {
+    const getDeleteErrorMessage = (error: any) => {
+      const apiMessage = error?.response?.data?.message;
+      const message = apiMessage || error?.message || 'Unknown error';
+
+      if (/permission denied/i.test(message)) {
+        return `No permissions to remove one or more selected agents. ${message}`;
+      }
+
+      return message;
+    };
+
     const [finalAgents, setFinalAgents] = useState<Agent[]>([]);
     const [getAgentsStatus, setGetAgentsStatus] = useState('disabled');
     const [getAgentsError, setGetAgentsError] = useState();
@@ -65,7 +76,7 @@ export const RemoveAgentsModal = compose(withErrorBoundary)(
         const { affected_items } = await getAgentsService({ filters });
         setGetAgentsStatus('complete');
         return affected_items;
-      } catch (error) {
+      } catch (error: any) {
         setGetAgentsStatus('danger');
         setGetAgentsError(error);
 
@@ -123,12 +134,14 @@ export const RemoveAgentsModal = compose(withErrorBoundary)(
         });
 
         setSaveChangesStatus('complete');
-      } catch (error) {
+      } catch (error: any) {
+        const errorMessage = getDeleteErrorMessage(error);
+
         setResult({
-          errorMessage: error.message,
+          errorMessage,
           errorAgents: [
             {
-              error: { message: error.message },
+              error: { message: errorMessage },
               id: agentIds,
             },
           ],
@@ -141,7 +154,7 @@ export const RemoveAgentsModal = compose(withErrorBoundary)(
           store: true,
           error: {
             error,
-            message: error.message || error,
+            message: errorMessage,
             title: `Could not remove agents`,
           },
         };

--- a/plugins/main/public/components/endpoints-summary/table/global-actions/upgrade/upgrade-modal.tsx
+++ b/plugins/main/public/components/endpoints-summary/table/global-actions/upgrade/upgrade-modal.tsx
@@ -47,6 +47,17 @@ export const UpgradeAgentsModal = compose(withErrorBoundary)(
     reloadAgents,
     setIsUpgradePanelClosed,
   }: UpgradeAgentsModalProps) => {
+    const getUpgradeErrorMessage = (error: any) => {
+      const apiMessage = error?.response?.data?.message;
+      const message = apiMessage || error?.message || 'Unknown error';
+
+      if (/permission denied/i.test(message)) {
+        return `No permissions to upgrade one or more selected agents. ${message}`;
+      }
+
+      return message;
+    };
+
     const [finalAgents, setFinalAgents] = useState<Agent[]>([]);
     const [getAgentsStatus, setGetAgentsStatus] = useState('disabled');
     const [getAgentsError, setGetAgentsError] = useState();
@@ -127,12 +138,13 @@ export const UpgradeAgentsModal = compose(withErrorBoundary)(
         }
 
         setSaveChangesStatus('complete');
-      } catch (error) {
+      } catch (error: any) {
+        const errorMessage = getUpgradeErrorMessage(error);
         setResult({
-          errorMessage: error.message,
+          errorMessage,
           errorAgents: [
             {
-              error: { message: error.message },
+              error: { message: errorMessage },
               id: agentIds,
             },
           ],
@@ -145,7 +157,7 @@ export const UpgradeAgentsModal = compose(withErrorBoundary)(
           store: true,
           error: {
             error,
-            message: error.message || error,
+            message: errorMessage,
             title: `Could not upgrade agents`,
           },
         };

--- a/plugins/main/public/components/endpoints-summary/table/upgrades-in-progress/upgrades-in-progress.test.tsx
+++ b/plugins/main/public/components/endpoints-summary/table/upgrades-in-progress/upgrades-in-progress.test.tsx
@@ -29,7 +29,6 @@ describe('AgentUpgradesInProgress component', () => {
         setIsModalVisible={() => {}}
         isPanelClosed={false}
         setIsPanelClosed={() => {}}
-        allowGetTasks={true}
       />,
     );
 
@@ -53,7 +52,6 @@ describe('AgentUpgradesInProgress component', () => {
         setIsModalVisible={() => {}}
         isPanelClosed={false}
         setIsPanelClosed={() => {}}
-        allowGetTasks={true}
       />,
     );
 

--- a/plugins/main/public/components/endpoints-summary/table/upgrades-in-progress/upgrades-in-progress.tsx
+++ b/plugins/main/public/components/endpoints-summary/table/upgrades-in-progress/upgrades-in-progress.tsx
@@ -23,7 +23,6 @@ interface AgentUpgradesInProgress {
   setIsModalVisible: (isModalVisible: boolean) => void;
   isPanelClosed: boolean;
   setIsPanelClosed: (isPanelClosed: boolean) => void;
-  allowGetTasks: boolean;
 }
 
 export const AgentUpgradesInProgress = ({
@@ -31,9 +30,9 @@ export const AgentUpgradesInProgress = ({
   setIsModalVisible,
   isPanelClosed,
   setIsPanelClosed,
-  allowGetTasks,
 }: AgentUpgradesInProgress) => {
   const [isUpgrading, setIsUpgrading] = useState(false);
+  const [errorShown, setErrorShown] = useState(false);
 
   const {
     totalInProgressTasks = 0,
@@ -44,7 +43,7 @@ export const AgentUpgradesInProgress = ({
     getErrorTasksError = undefined,
     totalTimeoutUpgradeTasks = 0,
     getTimeoutError = undefined,
-  } = allowGetTasks ? useGetUpgradeTasks(reload) : {};
+  } = useGetUpgradeTasks(reload);
 
   useEffect(() => {
     if (totalInProgressTasks > 0) {
@@ -52,37 +51,58 @@ export const AgentUpgradesInProgress = ({
     }
   }, [totalInProgressTasks]);
 
-  const showErrorToast = (status: string, error: any) => {
-    API_NAME_TASK_STATUS;
-    const options = {
-      context: `AgentUpgradesInProgress.useGetUpgradeTasks`,
-      level: UI_LOGGER_LEVELS.ERROR,
-      severity: UI_ERROR_SEVERITIES.BUSINESS,
-      store: true,
-      error: {
-        error,
-        message: error.message || error,
-        title: `Could not get upgrade tasks: ${status}`,
-      },
+  const anyError =
+    getInProgressError ||
+    getSuccessError ||
+    getErrorTasksError ||
+    getTimeoutError;
+  const isPermissionError = anyError?.response?.status === 403;
+
+  // Show error toast only once per error
+  useEffect(() => {
+    if (!anyError || errorShown) return;
+
+    const showErrorToast = (status: string, error: any) => {
+      const options = {
+        context: `AgentUpgradesInProgress.useGetUpgradeTasks`,
+        level: UI_LOGGER_LEVELS.ERROR,
+        severity: UI_ERROR_SEVERITIES.BUSINESS,
+        store: true,
+        error: {
+          error,
+          message: error.message || error,
+          title: isPermissionError
+            ? 'No permissions to view upgrade tasks'
+            : `Could not get upgrade tasks: ${status}`,
+        },
+      };
+      getErrorOrchestrator().handleError(options);
     };
-    getErrorOrchestrator().handleError(options);
-  };
 
-  if (getInProgressError) {
-    showErrorToast(API_NAME_TASK_STATUS.IN_PROGRESS, getInProgressError);
-  }
+    if (isPermissionError) {
+      showErrorToast('', anyError);
+    } else {
+      if (getInProgressError) {
+        showErrorToast(API_NAME_TASK_STATUS.IN_PROGRESS, getInProgressError);
+      } else if (getSuccessError) {
+        showErrorToast(API_NAME_TASK_STATUS.DONE, getSuccessError);
+      } else if (getErrorTasksError) {
+        showErrorToast(API_NAME_TASK_STATUS.FAILED, getErrorTasksError);
+      } else if (getTimeoutError) {
+        showErrorToast(API_NAME_TASK_STATUS.TIMEOUT, getTimeoutError);
+      }
+    }
 
-  if (getSuccessError) {
-    showErrorToast(API_NAME_TASK_STATUS.DONE, getSuccessError);
-  }
-
-  if (getErrorTasksError) {
-    showErrorToast(API_NAME_TASK_STATUS.FAILED, getErrorTasksError);
-  }
-
-  if (getTimeoutError) {
-    showErrorToast(API_NAME_TASK_STATUS.TIMEOUT, getTimeoutError);
-  }
+    setErrorShown(true);
+  }, [
+    anyError,
+    errorShown,
+    isPermissionError,
+    getInProgressError,
+    getSuccessError,
+    getErrorTasksError,
+    getTimeoutError,
+  ]);
 
   const showTasks = isUpgrading || totalSuccessTasks || totalErrorUpgradeTasks;
   if (isPanelClosed || !showTasks) return null;


### PR DESCRIPTION
## Description

Removed frontend RBAC permission gates for agent actions and delegated authorization to the API as the single source of truth. Previously, UI checks were hardcoded to wildcard resources (for example, `agent:id:*` or `task:status` on *:*:*), which caused actions to appear blocked for users with valid scoped permissions such as `agent:group:Team_A`. This change applies to remove, upgrade, edit groups, and upgrade task details flows. It also improves permission-denied feedback by showing clearer messages and avoids duplicated upgrade-task permission error toasts.
 
### Issues Resolved
https://github.com/wazuh/wazuh/issues/35458

### Evidence

<details><summary>Details</summary>
<p>


<img width="1282" height="329" alt="Screenshot 2026-05-11 at 1 25 19 PM" src="https://github.com/user-attachments/assets/ac0c59db-9e02-4026-839d-5e4c379c5a98" />
<img width="1367" height="378" alt="Screenshot 2026-05-11 at 3 43 14 PM" src="https://github.com/user-attachments/assets/3faa6f1f-141d-428b-bb95-16c40567e123" />


Delete agents
https://github.com/user-attachments/assets/4e54b829-b795-4268-b58e-09b3a4174d7e

Upgrade agent:
<img width="458" height="291" alt="Screenshot 2026-05-11 at 1 27 34 PM" src="https://github.com/user-attachments/assets/a94c4449-66cf-4363-a8ca-dd8d9f796975" />
<img width="272" height="183" alt="Screenshot 2026-05-11 at 1 35 34 PM" src="https://github.com/user-attachments/assets/b9fba0fb-ab99-4f84-8123-38832ae77d42" />
<img width="544" height="223" alt="Screenshot 2026-05-11 at 1 36 52 PM" src="https://github.com/user-attachments/assets/429207e7-8086-46d5-8fa9-3d895b1eba78" />

Editing agent groups
<img width="582" height="488" alt="Screenshot 2026-05-11 at 2 08 36 PM" src="https://github.com/user-attachments/assets/745b2999-1731-4868-937f-a8bd29ac33f6" />
<img width="432" height="309" alt="Screenshot 2026-05-11 at 2 45 58 PM" src="https://github.com/user-attachments/assets/5f1556b7-9e79-4a74-aa58-c4dcdf4d92c5" />
<img width="241" height="107" alt="Screenshot 2026-05-11 at 2 46 03 PM" src="https://github.com/user-attachments/assets/5a9837e5-11f0-4ea0-abec-36b94593d282" />


Task status
<img width="1367" height="378" alt="Screenshot 2026-05-11 at 3 43 14 PM" src="https://github.com/user-attachments/assets/7ad844ea-02ad-411f-9b9d-04aa26717a9e" />
<img width="1063" height="779" alt="Screenshot 2026-05-11 at 6 02 34 PM" src="https://github.com/user-attachments/assets/33e88065-fbc8-4eb0-9ba4-152bd65b8179" />


</p>
</details> 

## Test
### Environment Setup
- Start the app using a local manager environment.
- Before creating the agents, ensure there is a Wazuh agent package inside:
`docker/osd-dev/agents/`
Example:
`docker/osd-dev/agents/wazuh-agent_4.14.4-1_amd64.deb`
After the app is running, create 4 local agents with Docker:

```console
NET=$(docker network ls --format '{{.Name}}' | grep '^os-dev-' | head -n1)

AGENT_PACKAGE=$(basename docker/osd-dev/agents/*.deb)

for i in 1 2 3 4; do
  docker run --platform linux/amd64 \
    --name wazuh-agent-local-$i \
    --network "$NET" \
    -v "$(pwd)/docker/osd-dev/agents:/packages-agents:ro" \
    -d ubuntu:24.04 bash -c "
      apt update -y &&
      apt install -y lsb-release adduser &&
      WAZUH_MANAGER='wazuh.manager.local' \
      WAZUH_AGENT_GROUP='default' \
      dpkg -i /packages-agents/$AGENT_PACKAGE &&
      /etc/init.d/wazuh-agent start &&
      tail -f /var/ossec/logs/ossec.log
    "
done
```
- Wait until all agents appear in the UI.
- Follow the RBAC setup documentation: [Wazuh Use case: Give a user permissions to read and manage a group of agents](https://documentation.wazuh.com/current/user-manual/user-administration/rbac.html#use-case-give-a-user-permissions-to-read-and-manage-a-group-of-agents) and ensure to:

1. Create groups `Team_A` and `Team_B` and add at least 2 agents to each.
2. Create a policy with:
- Actions:` agent:read,` `agent:delete`, `agent:upgrade`
- Resource: `agent:group`, `Team_A`
- Effect: `Allow`
3. Create a role, assign that policy + `cluster_readonly`.
4. Create an internal user, map it to that role.
5. Ensure `run_as: true` in `wazuh.yml` and restart the dashboard.

### Test the following on the UI:

| Steps | Expected |
|--------|--------|
| Go to Endpoints Summary, click Remove on a Team_A agent, confirm | Agent removed |
| Click Remove on a Team_B agent, confirm | Error toast about no permissions to remove this agent |
| Select 1 Team_A agent + 1 Team_B agent → More → Remove agents (2), confirm | Result modal: 1 removed (success), 1 failed with permission error logged | 
| Click Upgrade on a Team_A agent, confirm | Agent upgraded |
| Without `agent:upgrade` action Upgrade on a Team_A agent, confirm | Error toast appear |
| Click Edit groups on a Team_A agent | groups does not appears on select |
| Add the groups actions to all agents resources, go to endopints summary and click Edit groups on a Team_A agent, add/remove a group, confirm |	Groups updated |
| Add action task:status with resource ::* in the policy, then in Endpoints Summary select agents and click More → Upgrade task details | Upgrade task details action is available and task details are shown |
| Remove `task:status` (or resource *:*:*), then select agents and click More → Upgrade task details | Request is rejected and a permission error is logged



### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff 

