### PR TITLE
Adds `getSettingDefinition` to configuration service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fixed date and more format errors [#7754](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7754)
 - Upgraded the `brace-expansion` dependency to `1.1.12` and `2.0.2` [#7812](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7812)
 - Upgraded the `tar-fs` dependency to `2.1.4` [#7812](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7812)
-- Migrated the `wazuh.yml` settings to `opensearch_dashboards.yml` and advanced settings [#7871](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7871)
+- Migrated the `wazuh.yml` settings to `opensearch_dashboards.yml` and advanced settings [#7871](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7871) [#8467](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8467)
 - Changed the sample data index names [#7871](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7871)
 - Rework generate report button [#7900](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7900)
 - Changed dashboards renderer by saved objects [#7842](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7842) [#7847](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7847) [#7916](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7916) [#7938](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7938) [#8310](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8310)

--- a/plugins/main/public/components/settings/api/add-api.tsx
+++ b/plugins/main/public/components/settings/api/add-api.tsx
@@ -12,9 +12,9 @@ import { getWazuhCorePlugin } from '../../../kibana-services';
 
 export const AddApi = withErrorBoundary(() => {
   const data = React.useMemo(() => {
-
     const settings = Object.entries(
-      getWazuhCorePlugin().configuration.getSettingDefinition('hosts').options.objectOf
+      getWazuhCorePlugin().configuration.getSettingDefinition('hosts').options
+        .objectOf,
     ).map(([key, { description }]) => [
       key,
       description.charAt(0).toLowerCase() + description.slice(1), // lower case the first letter
@@ -25,9 +25,9 @@ export const AddApi = withErrorBoundary(() => {
       example: `wazuh_core.hosts:
     - <id>:
      ${settings
-          .filter(([key]) => key !== 'id')
-          .map(([key]) => `${key}: <${key}>`)
-          .join('\n     ')}`,
+       .filter(([key]) => key !== 'id')
+       .map(([key]) => `${key}: <${key}>`)
+       .join('\n     ')}`,
     };
   }, []);
 
@@ -36,9 +36,8 @@ export const AddApi = withErrorBoundary(() => {
       <EuiFlexGroup>
         <EuiFlexItem>
           <EuiText>
-            Modify{' '}
-            <EuiCode>opensearch_dashboards.yml</EuiCode>{' '}
-            to set the connection information.
+            Modify <EuiCode>opensearch_dashboards.yml</EuiCode> to set the
+            connection information.
           </EuiText>
         </EuiFlexItem>
       </EuiFlexGroup>

--- a/plugins/main/public/components/settings/api/add-api.tsx
+++ b/plugins/main/public/components/settings/api/add-api.tsx
@@ -12,8 +12,9 @@ import { getWazuhCorePlugin } from '../../../kibana-services';
 
 export const AddApi = withErrorBoundary(() => {
   const data = React.useMemo(() => {
+
     const settings = Object.entries(
-      getWazuhCorePlugin().configuration._settings.get('hosts').options.arrayOf,
+      getWazuhCorePlugin().configuration.getSettingDefinition('hosts').options.objectOf
     ).map(([key, { description }]) => [
       key,
       description.charAt(0).toLowerCase() + description.slice(1), // lower case the first letter
@@ -21,12 +22,12 @@ export const AddApi = withErrorBoundary(() => {
 
     return {
       settings,
-      example: `hosts:
+      example: `wazuh_core.hosts:
     - <id>:
      ${settings
-       .filter(([key]) => key !== 'id')
-       .map(([key]) => `${key}: <${key}>`)
-       .join('\n     ')}`,
+          .filter(([key]) => key !== 'id')
+          .map(([key]) => `${key}: <${key}>`)
+          .join('\n     ')}`,
     };
   }, []);
 
@@ -36,7 +37,7 @@ export const AddApi = withErrorBoundary(() => {
         <EuiFlexItem>
           <EuiText>
             Modify{' '}
-            <EuiCode>{getWazuhCorePlugin().configuration.store.file}</EuiCode>{' '}
+            <EuiCode>opensearch_dashboards.yml</EuiCode>{' '}
             to set the connection information.
           </EuiText>
         </EuiFlexItem>

--- a/plugins/wazuh-core/common/services/configuration/configuration.ts
+++ b/plugins/wazuh-core/common/services/configuration/configuration.ts
@@ -1,4 +1,6 @@
 import { IConfiguration, IConfigurationStore, ILogger } from './types';
+import { PLUGIN_SETTINGS } from '../../constants';
+import { TPluginSetting } from '../../constants';
 
 export class Configuration implements IConfiguration {
   store: IConfigurationStore | null = null;
@@ -36,5 +38,9 @@ export class Configuration implements IConfiguration {
 
   async getAll() {
     return (await this.store?.getAll()) || {};
+  }
+
+  getSettingDefinition(key: string): TPluginSetting | undefined {
+    return PLUGIN_SETTINGS[key];
   }
 }

--- a/plugins/wazuh-core/common/services/configuration/types.ts
+++ b/plugins/wazuh-core/common/services/configuration/types.ts
@@ -1,3 +1,4 @@
+import { TPluginSetting } from '../../constants';
 import { IConfigurationProvider } from './configuration-provider';
 
 export interface ILogger {
@@ -13,6 +14,7 @@ export interface IConfiguration {
   stop: () => Promise<any>;
   get: (settingsKey: string) => Promise<any>;
   getAll: () => Promise<Record<string, any>>;
+  getSettingDefinition: (key: string) => TPluginSetting | undefined;
 }
 
 export type IConfigurationStore = {


### PR DESCRIPTION
### Description

The guide flyout has been updated to allow adding a new API configuration when CCS is enabled
 
### Issues Resolved
- #8466 

### Evidence

<img width="1237" height="957" alt="image" src="https://github.com/user-attachments/assets/f18c11cc-e573-4a2c-abad-c013241702cf" />

### Test

1. Navigate to Indexer Management > Dev Tools.
2. Execute the following request to register remote clusters:
```
PUT _cluster/settings
{
  "persistent": {
    "cluster.remote": {
      "ca-wazuh-indexer-1": {
        "seeds": ["imposter:9300"]
      },
      "cb-wazuh-indexer-1": {
        "seeds": ["manager-local:9300"]
      }
    }
  }
}
```
3. Reload the page (hard refresh).
4. Navigate to `Server APIs`.
5. Click on the "Add API connection" button.
6. The flyout opens.

### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff 
