### PR TITLE
Resize FIM inventory columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fixed home KPIs not being vertically centered [#8267](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8267)
 - Fixed MITRE ATT&CK Findings data grid not spanning the full available width [#8311](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8311)
 - Fixed pinned agent being lost when opening module links (FIM, SCA, Vulnerability Detection, MITRE ATT&CK, agent menu) in a new tab from the agent overview [#8358](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8358)
+- Fixed File Integrity Monitoring files inventory table layout by using smaller default widths for `file.owner`, `file.uid`, and `file.size`, allowing `file.path` to use more horizontal space [#8475](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8475)
 - Fixed long labels in IT Hygiene horizontal bar visualizations causing display issues [#8330](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8330)
 
 ### Removed

--- a/plugins/main/public/components/overview/fim/inventory/inventories/files/table-columns.ts
+++ b/plugins/main/public/components/overview/fim/inventory/inventories/files/table-columns.ts
@@ -10,11 +10,14 @@ export default [
   },
   {
     id: 'file.owner',
+    initialWidth: 120,
   },
   {
     id: 'file.uid',
+    initialWidth: 80,
   },
   {
     id: 'file.size',
+    initialWidth: 100,
   },
 ];


### PR DESCRIPTION
### Description
Resize fim columns 
 
### Issues Resolved
https://github.com/wazuh/wazuh-dashboard-plugins/issues/8471

### Evidence
<img width="1912" height="936" alt="image" src="https://github.com/user-attachments/assets/9e32495f-ff87-4b1b-a81d-27e4366f8a92" />

### Test
Go to FIM --> Inventoty: Validate the size of the columns `file.owner,` f`ile.uid`, `file.size`

### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff 
