### PR TITLE
Rename Endpoints breadcrumb to Summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Allowed only 1 server API configuration per indexer [#8436](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8436)
 - Updated the OS icon source field in the Endpoints summary table to display Linux agent icons [#8459](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8459)
 - Reworked Statistics dashboard [#8254](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8254)
+- Updated the breadcrumb label in `Agents management / Summary` [#8498](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8498)
 
 ### Fixed
 

--- a/plugins/main/public/utils/applications.ts
+++ b/plugins/main/public/utils/applications.ts
@@ -430,7 +430,7 @@ export const endpointSummary = {
     defaultMessage: 'Summary',
   }),
   breadcrumbLabel: i18n.translate('wz-app-endpoints-summary-breadcrumbLabel', {
-    defaultMessage: 'Endpoints',
+    defaultMessage: 'Summary',
   }),
   description: i18n.translate('wz-app-endpoints-summary-description', {
     defaultMessage: 'Summary of agents and their status.',


### PR DESCRIPTION
### Description
Changed the `Agents management / Summary` breadcrumb from `Endpoints` to `Summary`
 
### Issues Resolved
- **Closes:** https://github.com/wazuh/wazuh-dashboard-plugins/issues/8494

### Evidence
<img width="1140" height="826" alt="image" src="https://github.com/user-attachments/assets/3c8ce556-b887-4970-b01b-926afc545443" />

### Test
1. Go to `Agents management / Summary` and verify that the breadcrumb now says `Summary`

### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [X] Update [CHANGELOG.md](./../CHANGELOG.md)
- [X] Commits are signed per the DCO using --signoff 
