### PR TITLE
Change docker columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,7 +60,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Updated Threat Hunting dashboard with new index pattern definition [#8063](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8063) [#8421](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8421)
 - Upgraded the `axios` dependency to `1.15.2` [#8125](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8125) [#8179](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8179) [#8482](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8482)
 - Upgraded loglovel to 1.9.2 [#8125](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8125)
-- Updated Docker module under Cloud Security, with new index pattern definition [#8128](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8128) [#8364](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8364)
+- Updated Docker module under Cloud Security, with new index pattern definition [#8128](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8128) [#8364](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8364) [#8513](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8513)
 - Changed Ossec references to wazuh-manager [#8136](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8136)
 - Changed default Dev Tools request from deprecated `GET /manager/info` to `GET /cluster/<NODE_NAME>/info` [#8137](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8137)
 - Upgraded ESLint from version 8 to version 10 and migrated configuration from legacy `.eslintrc.json` to the new flat config format (`eslint.config.mjs`) [#8145](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8145)

--- a/plugins/main/public/components/overview/docker/events/docker-columns.tsx
+++ b/plugins/main/public/components/overview/docker/events/docker-columns.tsx
@@ -12,8 +12,7 @@ export const dockerColumns: tDataGridColumn[] = [
     initialWidth: 161,
   },
   {
-    id: 'event.category',
-    initialWidth: 130,
+    id: 'wazuh.rule.title',
   },
   {
     id: 'container.name',

--- a/plugins/main/public/components/overview/docker/events/docker-columns.tsx
+++ b/plugins/main/public/components/overview/docker/events/docker-columns.tsx
@@ -8,14 +8,14 @@ export const dockerColumns: tDataGridColumn[] = [
     id: 'container.image.name',
   },
   {
-    id: 'event.action',
-    initialWidth: 161,
-  },
-  {
     id: 'wazuh.rule.title',
   },
   {
     id: 'container.name',
     initialWidth: 160,
+  },
+  {
+    id: 'event.action',
+    initialWidth: 161,
   },
 ];


### PR DESCRIPTION
### Description
This PR edits the Docker findings data grid columns by removing event.category and adding wazuh.rule.title.
 
### Issues Resolved
[#8511 ](https://github.com/wazuh/wazuh-dashboard-plugins/issues/8511)

### Evidence
<img width="1849" height="628" alt="Captura desde 2026-05-15 14-16-39" src="https://github.com/user-attachments/assets/b53ea300-1e65-451b-a259-9183b10fcfb6" />

### Test
- Navigate to Cloud Security > Docker > Findings.
- Check the data grid columns: verify event.category is no longer visible and wazuh.rule.title is now displayed.

### Check List
- [X] Update [CHANGELOG.md](./../CHANGELOG.md)
- [X] Commits are signed per the DCO using --signoff 
