### PR TITLE
Restart cluster exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,7 +113,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Removed the monitoring and statistics jobs in the backend side [#7597](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7597)
 - Removed the settings related to monitoring and statistics job from the configuration [#7597](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7597) [#7698](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7698)
 - Removed prompt related to statistic job is disabled in Statistics app [#7597](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7597)
-- Removed the configuration for modules that relied on the following deprecated daemons: wazuh-agentlessd, wazuh-csyslogd, wazuh-dbd, wazuh-integratord, wazuh-maild, and wazuh-reportd. [#7612](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7612)
+- Removed the configuration for modules that relied on the following deprecated daemons: wazuh-agentlessd, wazuh-csyslogd, wazuh-dbd, wazuh-integratord, wazuh-maild, and wazuh-reportd. [#7612](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7612) [#8519](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8519)
 - Removed deprecated modules OpenSCAP, CIS-CAT, Osquery [#7645](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7645)
 - Removed `/health-check` and `/blank-screen` frontend routes [#7622](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7622)
 - Removed `Miscellaneous` from `App Settings`[#7622](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7622)

--- a/plugins/main/public/components/wz-menu/wz-menu.js
+++ b/plugins/main/public/components/wz-menu/wz-menu.js
@@ -188,6 +188,7 @@ export const WzMenu = withWindowSize(
 
     buildWazuhNotReadyYet() {
       const container = document.getElementsByClassName('wazuhNotReadyYet');
+      if (!container[0]) return null;
       return ReactDOM.createPortal(
         <EuiCallOut title={this.props.state.wazuhNotReadyYet} color='warning'>
           <EuiFlexGroup

--- a/plugins/main/public/controllers/management/components/management/configuration/utils/wz-fetch.js
+++ b/plugins/main/public/controllers/management/components/management/configuration/utils/wz-fetch.js
@@ -255,15 +255,27 @@ export const checkDaemons = async () => {
       ((((daemonsStatus || {}).data || {}).data || {}).affected_items ||
         [])[0] || {};
 
-    const wazuhdbExists = typeof daemons['wazuh-manager-db'] !== 'undefined';
-    const execdExists = typeof daemons['wazuh-manager-execd'] !== 'undefined';
+    const wazuhdbExists =
+      typeof daemons['wazuh-manager-db'] !== 'undefined' ||
+      typeof daemons['wazuh-db'] !== 'undefined';
+    const execdExists =
+      typeof daemons['wazuh-manager-execd'] !== 'undefined' ||
+      typeof daemons['wazuh-execd'] !== 'undefined';
 
-    const execd = execdExists ? daemons['wazuh-manager-execd'] === 'running' : true;
-    const modulesd = daemons['wazuh-manager-modulesd'] === 'running';
-    const wazuhdb = wazuhdbExists ? daemons['wazuh-manager-db'] === 'running' : true;
+    const execd = execdExists
+      ? (daemons['wazuh-manager-execd'] ?? daemons['wazuh-execd']) === 'running'
+      : true;
+    const modulesd =
+      (daemons['wazuh-manager-modulesd'] ?? daemons['wazuh-modulesd']) ===
+      'running';
+    const wazuhdb = wazuhdbExists
+      ? (daemons['wazuh-manager-db'] ?? daemons['wazuh-db']) === 'running'
+      : true;
 
     // In cluster by default, always check clusterd daemon
-    const clusterd = daemons['wazuh-manager-clusterd'] === 'running';
+    const clusterd =
+      (daemons['wazuh-manager-clusterd'] ?? daemons['wazuh-clusterd']) ===
+      'running';
 
     const isValid = execd && modulesd && wazuhdb && clusterd;
 

--- a/plugins/main/public/controllers/management/components/management/configuration/utils/wz-fetch.js
+++ b/plugins/main/public/controllers/management/components/management/configuration/utils/wz-fetch.js
@@ -256,28 +256,20 @@ export const checkDaemons = async () => {
         [])[0] || {};
 
     const wazuhdbExists =
-      typeof daemons['wazuh-manager-db'] !== 'undefined' ||
-      typeof daemons['wazuh-db'] !== 'undefined';
-    const execdExists =
-      typeof daemons['wazuh-manager-execd'] !== 'undefined' ||
-      typeof daemons['wazuh-execd'] !== 'undefined';
+      typeof daemons['wazuh-manager-db'] !== 'undefined';
 
-    const execd = execdExists
-      ? (daemons['wazuh-manager-execd'] ?? daemons['wazuh-execd']) === 'running'
-      : true;
     const modulesd =
-      (daemons['wazuh-manager-modulesd'] ?? daemons['wazuh-modulesd']) ===
-      'running';
+      daemons['wazuh-manager-modulesd'] === 'running';
     const wazuhdb = wazuhdbExists
-      ? (daemons['wazuh-manager-db'] ?? daemons['wazuh-db']) === 'running'
+      ? daemons['wazuh-manager-db'] === 'running'
       : true;
 
     // In cluster by default, always check clusterd daemon
     const clusterd =
-      (daemons['wazuh-manager-clusterd'] ?? daemons['wazuh-clusterd']) ===
+      daemons['wazuh-manager-clusterd'] === 'running';
       'running';
 
-    const isValid = execd && modulesd && wazuhdb && clusterd;
+    const isValid = modulesd && wazuhdb && clusterd;
 
     if (isValid) {
       return { isValid };

--- a/plugins/main/public/controllers/management/components/management/configuration/utils/wz-fetch.js
+++ b/plugins/main/public/controllers/management/components/management/configuration/utils/wz-fetch.js
@@ -255,19 +255,16 @@ export const checkDaemons = async () => {
       ((((daemonsStatus || {}).data || {}).data || {}).affected_items ||
         [])[0] || {};
 
-    const wazuhdbExists =
-      typeof daemons['wazuh-manager-db'] !== 'undefined';
+    const wazuhdbExists = typeof daemons['wazuh-manager-db'] !== 'undefined';
 
-    const modulesd =
-      daemons['wazuh-manager-modulesd'] === 'running';
+    const modulesd = daemons['wazuh-manager-modulesd'] === 'running';
     const wazuhdb = wazuhdbExists
       ? daemons['wazuh-manager-db'] === 'running'
       : true;
 
     // In cluster by default, always check clusterd daemon
-    const clusterd =
-      daemons['wazuh-manager-clusterd'] === 'running';
-      'running';
+    const clusterd = daemons['wazuh-manager-clusterd'] === 'running';
+    ('running');
 
     const isValid = modulesd && wazuhdb && clusterd;
 

--- a/plugins/main/public/controllers/management/components/management/configuration/utils/wz-fetch.js
+++ b/plugins/main/public/controllers/management/components/management/configuration/utils/wz-fetch.js
@@ -255,14 +255,15 @@ export const checkDaemons = async () => {
       ((((daemonsStatus || {}).data || {}).data || {}).affected_items ||
         [])[0] || {};
 
-    const wazuhdbExists = typeof daemons['wazuh-db'] !== 'undefined';
+    const wazuhdbExists = typeof daemons['wazuh-manager-db'] !== 'undefined';
+    const execdExists = typeof daemons['wazuh-manager-execd'] !== 'undefined';
 
-    const execd = daemons['wazuh-execd'] === 'running';
-    const modulesd = daemons['wazuh-modulesd'] === 'running';
-    const wazuhdb = wazuhdbExists ? daemons['wazuh-db'] === 'running' : true;
+    const execd = execdExists ? daemons['wazuh-manager-execd'] === 'running' : true;
+    const modulesd = daemons['wazuh-manager-modulesd'] === 'running';
+    const wazuhdb = wazuhdbExists ? daemons['wazuh-manager-db'] === 'running' : true;
 
     // In cluster by default, always check clusterd daemon
-    const clusterd = daemons['wazuh-clusterd'] === 'running';
+    const clusterd = daemons['wazuh-manager-clusterd'] === 'running';
 
     const isValid = execd && modulesd && wazuhdb && clusterd;
 

--- a/plugins/main/server/controllers/wazuh-api.ts
+++ b/plugins/main/server/controllers/wazuh-api.ts
@@ -1021,16 +1021,15 @@ export class WazuhApiCtrl {
         ((((daemonsStatus || {}).data || {}).data || {}).affected_items ||
           [])[0] || {};
 
-      const wazuhdbExists = typeof daemons['wazuh-db'] !== 'undefined';
+      const wazuhdbExists = typeof daemons['wazuh-manager-db'] !== 'undefined';
 
-      const execd = daemons['wazuh-execd'] === 'running';
-      const modulesd = daemons['wazuh-modulesd'] === 'running';
-      const wazuhdb = wazuhdbExists ? daemons['wazuh-db'] === 'running' : true;
+      const modulesd = daemons['wazuh-manager-modulesd'] === 'running';
+      const wazuhdb = wazuhdbExists ? daemons['wazuh-manager-db'] === 'running' : true;
 
       // In cluster by default, always check clusterd daemon
-      const clusterd = daemons['wazuh-clusterd'] === 'running';
+      const clusterd = daemons['wazuh-manager-clusterd'] === 'running';
 
-      const isValid = execd && modulesd && wazuhdb && clusterd;
+      const isValid = modulesd && wazuhdb && clusterd;
 
       isValid && context.wazuh.logger.debug('Wazuh is ready');
 

--- a/plugins/main/server/controllers/wazuh-api.ts
+++ b/plugins/main/server/controllers/wazuh-api.ts
@@ -1024,7 +1024,9 @@ export class WazuhApiCtrl {
       const wazuhdbExists = typeof daemons['wazuh-manager-db'] !== 'undefined';
 
       const modulesd = daemons['wazuh-manager-modulesd'] === 'running';
-      const wazuhdb = wazuhdbExists ? daemons['wazuh-manager-db'] === 'running' : true;
+      const wazuhdb = wazuhdbExists
+        ? daemons['wazuh-manager-db'] === 'running'
+        : true;
 
       // In cluster by default, always check clusterd daemon
       const clusterd = daemons['wazuh-manager-clusterd'] === 'running';


### PR DESCRIPTION
### Description
- Fixed exception while rendering wazuh not ready element.
- Fixed outdated wazuh processes names that caused restarting status check to fail.
 
### Issues Resolved
- https://github.com/wazuh/wazuh-dashboard-plugins/issues/8518

### Evidence

https://github.com/user-attachments/assets/fb6e0c11-7b23-4c50-bf16-3a58eeb3886c

### Test

- Go to Server management / Settings
- Click on Edit configuration
- Click on Restart node
- Click on the Home icon
- Verify there is no exception.

### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff 
