### PR TITLE
hide deploy commands when authd:read_config is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 
 - Fixed message when the server cluster is disabled and access to **Cluster** app [#8447](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8447)
 - Fixed agent removal, group editing, upgrading, and upgrade task details authorization by delegating RBAC enforcement to the API instead of the UI, and avoiding duplicated permission error toasts in upgrade task queries [#8464](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8464)
+- Fixed deployment and start commands being shown in the agent registration flow when the user lacks 'manager:update_config'/'cluster:update_config' permissions required to read the registration password [#8522](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8522)
 
 ## Wazuh v4.14.5 - OpenSearch Dashboards 2.19.5 - Revision 01
 

--- a/plugins/main/public/components/endpoints-summary/register-agent/containers/register-agent/register-agent.tsx
+++ b/plugins/main/public/components/endpoints-summary/register-agent/containers/register-agent/register-agent.tsx
@@ -30,6 +30,7 @@ import {
   withRouteResolvers,
   withUserAuthorizationPrompt,
 } from '../../../../common/hocs';
+import { useUserPermissionsRequirements } from '../../../../common/hooks/useUserPermissions';
 import GroupInput from '../../components/group-input/group-input';
 import { OsCard } from '../../components/os-selector/os-card/os-card';
 import { validateAgentName } from '../../utils/validations';
@@ -69,6 +70,13 @@ export const RegisterAgent = compose(
   const [wazuhPassword, setWazuhPassword] = useState('');
   const [groups, setGroups] = useState([]);
   const [needsPassword, setNeedsPassword] = useState<boolean>(false);
+  const [missingPasswordReadPermissions] = useUserPermissionsRequirements([
+    [
+      { action: 'manager:update_config', resource: '*:*:*' },
+      { action: 'cluster:update_config', resource: 'node:id:*' },
+    ],
+  ]);
+  const canReadAuthdPassword = !missingPasswordReadPermissions;
 
   const initialFields: FormConfiguration = {
     operatingSystemSelection: {
@@ -213,6 +221,7 @@ export const RegisterAgent = compose(
                       form={form}
                       needsPassword={needsPassword}
                       wazuhPassword={wazuhPassword}
+                      canReadAuthdPassword={canReadAuthdPassword}
                       osCard={osCard}
                       connection={{
                         isUDP: haveUdpProtocol ? true : false,

--- a/plugins/main/public/components/endpoints-summary/register-agent/containers/steps/steps.tsx
+++ b/plugins/main/public/components/endpoints-summary/register-agent/containers/steps/steps.tsx
@@ -1,5 +1,11 @@
 import React, { useEffect, useState } from 'react';
-import { EuiCallOut, EuiLink, EuiSteps, EuiButton } from '@elastic/eui';
+import {
+  EuiCallOut,
+  EuiLink,
+  EuiSteps,
+  EuiButton,
+  EuiCode,
+} from '@elastic/eui';
 import './steps.scss';
 import { OPERATING_SYSTEMS_OPTIONS } from '../../utils/register-agent-data';
 import {
@@ -192,7 +198,12 @@ export const Steps = ({
                 title='Missing permission to read the registration password'
                 iconType='iInCircle'
                 className='warningForAgentName'
-              />
+              >
+                <p>
+                  Require <EuiCode>manager:config_update</EuiCode> or{' '}
+                  <EuiCode>cluster:config_update</EuiCode> permission.
+                </p>
+              </EuiCallOut>
             ),
             status: getPasswordStepStatus(form.fields),
           },

--- a/plugins/main/public/components/endpoints-summary/register-agent/containers/steps/steps.tsx
+++ b/plugins/main/public/components/endpoints-summary/register-agent/containers/steps/steps.tsx
@@ -215,8 +215,8 @@ export const Steps = ({
           iconType='iInCircle'
         >
           <p>
-            You do not have the required permissions to view the deployment
-            commands.
+            Missing permissions to read the manager configuration required to
+            view the deployment commands.
           </p>
         </EuiCallOut>
       ) : (
@@ -267,7 +267,8 @@ export const Steps = ({
           iconType='iInCircle'
         >
           <p>
-            You do not have the required permissions to view the start command.
+            Missing permissions to read the manager configuration required to
+            view the start command.
           </p>
         </EuiCallOut>
       ) : (

--- a/plugins/main/public/components/endpoints-summary/register-agent/containers/steps/steps.tsx
+++ b/plugins/main/public/components/endpoints-summary/register-agent/containers/steps/steps.tsx
@@ -46,6 +46,7 @@ interface IStepsProps {
     isUDP: boolean;
   };
   wazuhPassword: string;
+  canReadAuthdPassword: boolean;
 }
 
 export const Steps = ({
@@ -54,7 +55,9 @@ export const Steps = ({
   osCard,
   connection,
   wazuhPassword,
+  canReadAuthdPassword,
 }: IStepsProps) => {
+  const passwordPermissionMissing = !canReadAuthdPassword;
   const initialParsedFormValues = {
     operatingSystem: {
       name: '',
@@ -64,7 +67,7 @@ export const Steps = ({
       agentGroups: '',
       agentName: '',
       serverAddress: '',
-      wazuhPassword,
+      wazuhPassword: 'simulated-registration-password',
       protocol: connection.isUDP ? 'UDP' : '',
     },
   } as IParseRegisterFormValues;
@@ -179,6 +182,22 @@ export const Steps = ({
           },
         ]
       : []),
+    ...(passwordPermissionMissing
+      ? [
+          {
+            title: 'Password',
+            children: (
+              <EuiCallOut
+                color='warning'
+                title='Missing permission to read the registration password'
+                iconType='iInCircle'
+                className='warningForAgentName'
+              />
+            ),
+            status: getPasswordStepStatus(form.fields),
+          },
+        ]
+      : []),
     {
       title: 'Optional settings:',
       children: <OptionalsInputs formFields={form.fields} />,
@@ -189,7 +208,18 @@ export const Steps = ({
     },
     {
       title: 'Run the following commands to download and install the agent:',
-      children: (
+      children: passwordPermissionMissing ? (
+        <EuiCallOut
+          color='warning'
+          title='Deployment commands hidden'
+          iconType='iInCircle'
+        >
+          <p>
+            You do not have the required permissions to view the deployment
+            commands.
+          </p>
+        </EuiCallOut>
+      ) : (
         <>
           {missingStepsName?.length ? (
             <EuiCallOut
@@ -230,7 +260,17 @@ export const Steps = ({
     },
     {
       title: 'Start the agent:',
-      children: (
+      children: passwordPermissionMissing ? (
+        <EuiCallOut
+          color='warning'
+          title='Start command hidden'
+          iconType='iInCircle'
+        >
+          <p>
+            You do not have the required permissions to view the start command.
+          </p>
+        </EuiCallOut>
+      ) : (
         <>
           {missingStepsName?.length ? (
             <EuiCallOut

--- a/plugins/main/public/components/endpoints-summary/register-agent/containers/steps/steps.tsx
+++ b/plugins/main/public/components/endpoints-summary/register-agent/containers/steps/steps.tsx
@@ -57,7 +57,7 @@ export const Steps = ({
   wazuhPassword,
   canReadAuthdPassword,
 }: IStepsProps) => {
-  const passwordPermissionMissing = !canReadAuthdPassword;
+  const passwordPermissionMissing = needsPassword && !canReadAuthdPassword;
   const initialParsedFormValues = {
     operatingSystem: {
       name: '',
@@ -67,7 +67,7 @@ export const Steps = ({
       agentGroups: '',
       agentName: '',
       serverAddress: '',
-      wazuhPassword: 'simulated-registration-password',
+      wazuhPassword: '',
       protocol: connection.isUDP ? 'UDP' : '',
     },
   } as IParseRegisterFormValues;

--- a/plugins/main/public/components/endpoints-summary/register-agent/containers/steps/steps.tsx
+++ b/plugins/main/public/components/endpoints-summary/register-agent/containers/steps/steps.tsx
@@ -67,7 +67,7 @@ export const Steps = ({
       agentGroups: '',
       agentName: '',
       serverAddress: '',
-      wazuhPassword: '',
+      wazuhPassword,
       protocol: connection.isUDP ? 'UDP' : '',
     },
   } as IParseRegisterFormValues;


### PR DESCRIPTION
### Description
  - When the user lacks permission, show a warning callout and hide the install/start commands instead of rendering them with an empty password.
  - Prevents broken install commands from being shown to users without permission
 
### Issues Resolved
closes  https://github.com/wazuh/wazuh-dashboard-plugins/issues/8521
closes #8521 

### Evidence
<img width="1265" height="956" alt="image" src="https://github.com/user-attachments/assets/ce3297cf-6f83-4465-a1bb-f0ef8e582054" />

### Test
1. Go to **Endpoints Summary → Deploy new agent**,  pick an OS and fill in server address + agent name.
 2. Confirm a warning callout is shown and the install/start commands are hidden

### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 
