### PR TITLE
Custom filter buttons are not correctly rendered in the PDF reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fixed File Integrity Monitoring files inventory table layout by using smaller default widths for `file.owner`, `file.uid`, and `file.size`, allowing `file.path` to use more horizontal space [#8475](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8475)
 - Fixed long labels in IT Hygiene horizontal bar visualizations causing display issues [#8330](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8330)
 - Fixed rendering of the Tactics and Techniques cells in the MITRE ATT&CK flyout [#8516](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8516)
+- Fixed custom filter buttons not being rendered in pdf reports [#8525](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8525)
 
 ### Removed
 

--- a/plugins/main/public/components/overview/vulnerabilities/common/components/vuls-evaluation-filter.tsx
+++ b/plugins/main/public/components/overview/vulnerabilities/common/components/vuls-evaluation-filter.tsx
@@ -43,10 +43,12 @@ const VulsEvaluationFilter = ({
     {
       id: 'evaluated',
       label: 'Evaluated',
+      className: 'keep-for-report',
     },
     {
       id: 'underEvaluation',
       label: 'Under evaluation',
+      className: 'keep-for-report',
     },
   ];
 


### PR DESCRIPTION
### Description
Fixes an issue where custom button group filters (such as the Under Evaluation filter in the Vulnerabilities Detection dashboard) were not rendered in generated PDF reports.

### Issues Resolved
- **Closes** https://github.com/wazuh/wazuh-dashboard-reporting/issues/133

### Evidence

1. Generating report with a button filter applied:

<img width="1727" height="935" alt="image" src="https://github.com/user-attachments/assets/7827e823-e906-4cbd-bfc0-269d4648b506" />

2. Generated report:

<img width="1728" height="932" alt="image" src="https://github.com/user-attachments/assets/960b2d9d-e6b6-4947-bda0-f060234b279b" />

### Test

1. Navigate to Vulnerabilities Detection > Dashboard
2. Select a filter from the custom filter button group (Evaluated or Under Evaluation)
3. Click on Generate report
4. Verify that the report now displays the under evaluation filter correctly

### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [X] Update [CHANGELOG.md](./../CHANGELOG.md)
- [X] Commits are signed per the DCO using --signoff 
