### PR TITLE
Update beta1 url to beta2

### DIFF
--- a/plugins/main/public/components/endpoints-summary/register-agent/core/config/os-commands-definitions.ts
+++ b/plugins/main/public/components/endpoints-summary/register-agent/core/config/os-commands-definitions.ts
@@ -83,7 +83,7 @@ const linuxDefinition: IOSDefinition<ILinuxOSTypes, tOptionalParameters> = {
   options: [
     {
       architecture: 'DEB amd64',
-      packageName: props => `wazuh-agent_${props.wazuhVersion}-beta1_amd64.deb`,
+      packageName: props => `wazuh-agent_${props.wazuhVersion}-beta2_amd64.deb`,
       urlPackage: props =>
         `https://packages-staging.xdrsiem.wazuh.info/pre-release/${PLUGIN_MAJOR_VERSION}.x/apt/pool/main/w/wazuh-agent/${props.packageName}`,
       installCommand: props => getDEBAMD64InstallCommand(props),
@@ -92,7 +92,7 @@ const linuxDefinition: IOSDefinition<ILinuxOSTypes, tOptionalParameters> = {
     {
       architecture: 'RPM amd64',
       packageName: props =>
-        `wazuh-agent-${props.wazuhVersion}-beta1.x86_64.rpm`,
+        `wazuh-agent-${props.wazuhVersion}-beta2.x86_64.rpm`,
       urlPackage: props =>
         `https://packages-staging.xdrsiem.wazuh.info/pre-release/${PLUGIN_MAJOR_VERSION}.x/yum/${props.packageName}`,
       installCommand: props => getRPMAMD64InstallCommand(props),
@@ -100,7 +100,7 @@ const linuxDefinition: IOSDefinition<ILinuxOSTypes, tOptionalParameters> = {
     },
     {
       architecture: 'DEB aarch64',
-      packageName: props => `wazuh-agent_${props.wazuhVersion}-beta1_arm64.deb`,
+      packageName: props => `wazuh-agent_${props.wazuhVersion}-beta2_arm64.deb`,
       urlPackage: props =>
         `https://packages-staging.xdrsiem.wazuh.info/pre-release/${PLUGIN_MAJOR_VERSION}.x/apt/pool/main/w/wazuh-agent/${props.packageName}`,
       installCommand: props => getDEBARM64InstallCommand(props),
@@ -109,7 +109,7 @@ const linuxDefinition: IOSDefinition<ILinuxOSTypes, tOptionalParameters> = {
     {
       architecture: 'RPM aarch64',
       packageName: props =>
-        `wazuh-agent-${props.wazuhVersion}-beta1.aarch64.rpm`,
+        `wazuh-agent-${props.wazuhVersion}-beta2.aarch64.rpm`,
       urlPackage: props =>
         `https://packages-staging.xdrsiem.wazuh.info/pre-release/${PLUGIN_MAJOR_VERSION}.x/yum/${props.packageName}`,
       installCommand: props => getRPMARM64InstallCommand(props),
@@ -123,7 +123,7 @@ const windowsDefinition: IOSDefinition<IWindowsOSTypes, tOptionalParameters> = {
   options: [
     {
       architecture: 'MSI 32/64 bits',
-      packageName: props => `wazuh-agent-${props.wazuhVersion}-beta1.msi`,
+      packageName: props => `wazuh-agent-${props.wazuhVersion}-beta2.msi`,
       urlPackage: props =>
         `https://packages-staging.xdrsiem.wazuh.info/pre-release/${PLUGIN_MAJOR_VERSION}.x/windows/${props.packageName}`,
       installCommand: props => getWindowsInstallCommand(props),
@@ -138,7 +138,7 @@ const macDefinition: IOSDefinition<IMacOSTypes, tOptionalParameters> = {
     {
       architecture: 'Intel',
       packageName: props =>
-        `wazuh-agent-${props.wazuhVersion}-beta1.intel64.pkg`,
+        `wazuh-agent-${props.wazuhVersion}-beta2.intel64.pkg`,
       urlPackage: props =>
         `https://packages-staging.xdrsiem.wazuh.info/pre-release/${PLUGIN_MAJOR_VERSION}.x/macos/${props.packageName}`,
       installCommand: props => getMacOsInstallCommand(props),
@@ -146,7 +146,7 @@ const macDefinition: IOSDefinition<IMacOSTypes, tOptionalParameters> = {
     },
     {
       architecture: 'Apple silicon',
-      packageName: props => `wazuh-agent-${props.wazuhVersion}-beta1.arm64.pkg`,
+      packageName: props => `wazuh-agent-${props.wazuhVersion}-beta2.arm64.pkg`,
       urlPackage: props =>
         `https://packages-staging.xdrsiem.wazuh.info/pre-release/${PLUGIN_MAJOR_VERSION}.x/macos/${props.packageName}`,
       installCommand: props => getMacOsInstallCommand(props),

--- a/plugins/main/public/components/endpoints-summary/register-agent/services/register-agent-os-commands-services.test.ts
+++ b/plugins/main/public/components/endpoints-summary/register-agent/services/register-agent-os-commands-services.test.ts
@@ -58,19 +58,19 @@ describe('getDEBAMD64InstallCommand', () => {
         protocol: 'http',
       },
       urlPackage: 'https://example.com/package.deb',
-      packageName: 'wazuh-agent_4.0.0-beta1_amd64.deb',
+      packageName: 'wazuh-agent_4.0.0-beta2_amd64.deb',
       wazuhVersion: '4.0.0',
     };
     const result = getDEBAMD64InstallCommand(props);
     expect(result).toBe(
-      'wget https://example.com/package.deb && sudo localhost password group1 agent1 http dpkg -i ./wazuh-agent_4.0.0-beta1_amd64.deb',
+      'wget https://example.com/package.deb && sudo localhost password group1 agent1 http dpkg -i ./wazuh-agent_4.0.0-beta2_amd64.deb',
     );
   });
 });
 
 describe('getDEBAMD64InstallCommand', () => {
   it('should return the correct command', () => {
-    test.packageName = `wazuh-agent_${test.wazuhVersion}-beta1_amd64.deb`;
+    test.packageName = `wazuh-agent_${test.wazuhVersion}-beta2_amd64.deb`;
     let expected = `wget ${test.urlPackage} && sudo ${test.optionals.serverAddress} ${test.optionals.wazuhPassword} ${test.optionals.agentGroups} ${test.optionals.agentName} dpkg -i ./${test.packageName}`;
     const withAllOptionals = getDEBAMD64InstallCommand(test);
     expect(withAllOptionals).toEqual(expected);
@@ -87,7 +87,7 @@ describe('getDEBAMD64InstallCommand', () => {
 
 describe('getDEBARM64InstallCommand', () => {
   it('should return the correct command', () => {
-    test.packageName = `wazuh-agent_${test.wazuhVersion}-beta1_arm64.deb`;
+    test.packageName = `wazuh-agent_${test.wazuhVersion}-beta2_arm64.deb`;
     let expected = `wget ${test.urlPackage} && sudo ${test.optionals.serverAddress} ${test.optionals.wazuhPassword} ${test.optionals.agentGroups} ${test.optionals.agentName} dpkg -i ./${test.packageName}`;
     const withAllOptionals = getDEBARM64InstallCommand(test);
     expect(withAllOptionals).toEqual(expected);
@@ -104,7 +104,7 @@ describe('getDEBARM64InstallCommand', () => {
 
 describe('getRPMAMD64InstallCommand', () => {
   it('should return the correct command', () => {
-    test.packageName = `wazuh-agent-${test.wazuhVersion}-beta1.x86_64.rpm`;
+    test.packageName = `wazuh-agent-${test.wazuhVersion}-beta2.x86_64.rpm`;
     let expected = `curl -o ${test.packageName} ${test.urlPackage} && sudo ${test.optionals.serverAddress} ${test.optionals.wazuhPassword} ${test.optionals.agentGroups} ${test.optionals.agentName} rpm -ihv ${test.packageName}`;
     const withAllOptionals = getRPMAMD64InstallCommand(test);
     expect(withAllOptionals).toEqual(expected);
@@ -121,7 +121,7 @@ describe('getRPMAMD64InstallCommand', () => {
 
 describe('getRPMARM64InstallCommand', () => {
   it('should return the correct command', () => {
-    test.packageName = `wazuh-agent-${test.wazuhVersion}-beta1.aarch64.rpm`;
+    test.packageName = `wazuh-agent-${test.wazuhVersion}-beta2.aarch64.rpm`;
     let expected = `curl -o ${test.packageName} ${test.urlPackage} && sudo ${test.optionals.serverAddress} ${test.optionals.wazuhPassword} ${test.optionals.agentGroups} ${test.optionals.agentName} rpm -ihv ${test.packageName}`;
     const withAllOptionals = getRPMARM64InstallCommand(test);
     expect(withAllOptionals).toEqual(expected);
@@ -150,7 +150,7 @@ describe('getLinuxStartCommand', () => {
 
 describe('getWindowsInstallCommand', () => {
   it('should return the correct install command', () => {
-    test.packageName = `wazuh-agent-${test.wazuhVersion}-beta1.msi`;
+    test.packageName = `wazuh-agent-${test.wazuhVersion}-beta2.msi`;
     let expected = `Invoke-WebRequest -Uri ${test.urlPackage} -OutFile \$env:tmp\\${test.packageName}; msiexec.exe /i \$env:tmp\\${test.packageName} /q ${test.optionals.serverAddress} ${test.optionals.wazuhPassword} ${test.optionals.agentGroups} ${test.optionals.agentName} `;
 
     const withAllOptionals = getWindowsInstallCommand(test);
@@ -211,7 +211,7 @@ describe('transformOptionalsParamatersMacOSCommand', () => {
 
 describe('getMacOsInstallCommand', () => {
   it('should return the correct macOS installation script', () => {
-    test.packageName = `wazuh-agent-${test.wazuhVersion}-beta1.intel64.pkg`;
+    test.packageName = `wazuh-agent-${test.wazuhVersion}-beta2.intel64.pkg`;
     let expected = `curl -so ${test.packageName} ${test.urlPackage} && echo "${test.optionals.serverAddress} && ${test.optionals.agentGroups} && ${test.optionals.agentName} && ${test.optionals.wazuhPassword}\" > /tmp/wazuh_envs && sudo installer -pkg ./${test.packageName} -target /`;
 
     const withAllOptionals = getMacOsInstallCommand(test);


### PR DESCRIPTION
### Description
This PR updates beta1 url to beta2 in agent enrollment commands.
 
### Evidence
<img width="2639" height="558" alt="image" src="https://github.com/user-attachments/assets/a3dada99-a29f-4f89-ac69-13adafaf12b6" />


### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff 
