### PR TITLE
Enrichments unknown field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Added `server-api:run_as` health check to warn when `allow_run_as` is disabled for configured API hosts [#8050](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8050)
 - Fixed styling issues for v9 theme [#8064](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8064)
 - Added Indexer management **Settings** [#8206](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8206)
-- Added `wazuh-findings-v5*` index patterns [#8233](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8233) [#8520](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8520)
+- Added `wazuh-findings-v5*` index patterns [#8233](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8233) [#8520](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8520) [#8577](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8577)
 - Added `policy.name`, `policy.description`, `policy.file` and `event.outcome` columns to the Configuration Assessment Findings table [#8264](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8264)
 - Added `wazuh-state-fim*` index pattern [#8248](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8248)
 - Added Indexer configuration UI section in Server Management Settings [#8289](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8289)

--- a/plugins/main/scripts/generate-known-fields/generate-known-fields.js
+++ b/plugins/main/scripts/generate-known-fields/generate-known-fields.js
@@ -375,13 +375,17 @@ function mapIndexFieldType(esType, field) {
   const typeMapping = {
     keyword: 'string',
     text: 'string',
+    flat_object: 'string',
     date: 'date',
     long: 'number',
     integer: 'number',
+    short: 'number',
     double: 'number',
     float: 'number',
     byte: 'number',
+    half_float: 'number',
     scaled_float: 'number',
+    unsigned_long: 'number',
     boolean: 'boolean',
     ip: 'ip',
     geo_point: 'geo_point',
@@ -428,7 +432,7 @@ function isAggregatable(fieldProps, esType) {
     return false;
 
   // Most structured types are aggregatable
-  return !['text', '_source', 'nested'].includes(esType);
+  return !['text', 'flat_object', '_source', 'nested'].includes(esType);
 }
 
 /**
@@ -436,7 +440,7 @@ function isAggregatable(fieldProps, esType) {
  */
 function shouldReadFromDocValues(fieldProps, esType) {
   // These field types don't use doc values
-  if (['_id', '_index', '_source', '_type', 'text', 'nested'].includes(esType))
+  if (['_id', '_index', '_source', '_type', 'text', 'flat_object', 'nested'].includes(esType))
     return false;
 
   // Check if explicitly disabled
@@ -468,7 +472,7 @@ function createExtractionIssuesContext() {
 /**
  * Recursively extracts field definitions from template mappings
  */
-function extractFieldsFromProperties(properties, prefix = '', issues) {
+function extractFieldsFromProperties(properties, prefix = '', issues, nestedPath = null) {
   const fields = [];
 
   // Add basic index meta fields if we're at root level
@@ -532,6 +536,11 @@ function extractFieldsFromProperties(properties, prefix = '', issues) {
         readFromDocValues: shouldReadFromDocValues(fieldDef, esType),
       };
 
+      // Add subType for fields that live inside a nested object
+      if (nestedPath && esType !== 'nested' && esType !== 'object') {
+        field.subType = { nested: { path: nestedPath } };
+      }
+
       if (!(esType === 'object' || esType === 'nested') || !fieldDef.properties)
         fields.push(field);
 
@@ -550,17 +559,23 @@ function extractFieldsFromProperties(properties, prefix = '', issues) {
             aggregatable: isAggregatable(subFieldDef, subEsType),
             readFromDocValues: shouldReadFromDocValues(subFieldDef, subEsType),
           };
+          if (nestedPath) {
+            subField.subType = { nested: { path: nestedPath } };
+          }
           fields.push(subField);
         }
       }
 
       // Handle nested or object type with properties
       if ((esType === 'nested' || esType === 'object') && fieldDef.properties) {
+        // When entering a nested type, set it as the new nestedPath
+        const childNestedPath = esType === 'nested' ? fullFieldName : nestedPath;
         fields.push(
           ...extractFieldsFromProperties(
             fieldDef.properties,
             fullFieldName,
             issues,
+            childNestedPath,
           ),
         );
       }
@@ -571,6 +586,7 @@ function extractFieldsFromProperties(properties, prefix = '', issues) {
           fieldDef.properties,
           fullFieldName,
           issues,
+          nestedPath,
         ),
       );
     }

--- a/plugins/main/scripts/generate-known-fields/generate-known-fields.js
+++ b/plugins/main/scripts/generate-known-fields/generate-known-fields.js
@@ -440,7 +440,17 @@ function isAggregatable(fieldProps, esType) {
  */
 function shouldReadFromDocValues(fieldProps, esType) {
   // These field types don't use doc values
-  if (['_id', '_index', '_source', '_type', 'text', 'flat_object', 'nested'].includes(esType))
+  if (
+    [
+      '_id',
+      '_index',
+      '_source',
+      '_type',
+      'text',
+      'flat_object',
+      'nested',
+    ].includes(esType)
+  )
     return false;
 
   // Check if explicitly disabled
@@ -472,7 +482,12 @@ function createExtractionIssuesContext() {
 /**
  * Recursively extracts field definitions from template mappings
  */
-function extractFieldsFromProperties(properties, prefix = '', issues, nestedPath = null) {
+function extractFieldsFromProperties(
+  properties,
+  prefix = '',
+  issues,
+  nestedPath = null,
+) {
   const fields = [];
 
   // Add basic index meta fields if we're at root level
@@ -569,7 +584,8 @@ function extractFieldsFromProperties(properties, prefix = '', issues, nestedPath
       // Handle nested or object type with properties
       if ((esType === 'nested' || esType === 'object') && fieldDef.properties) {
         // When entering a nested type, set it as the new nestedPath
-        const childNestedPath = esType === 'nested' ? fullFieldName : nestedPath;
+        const childNestedPath =
+          esType === 'nested' ? fullFieldName : nestedPath;
         fields.push(
           ...extractFieldsFromProperties(
             fieldDef.properties,


### PR DESCRIPTION
### Description

Fix field type mapping issues in the `generate-known-fields` script that caused `wazuh.threat.enrichments` fields to appear as "unknown" in Discover.

The following bugs were identified and fixed in `generate-known-fields.js` script:

- **Missing numeric ES types in `typeMapping`**: `short`, `half_float`, and `unsigned_long` were not mapped, causing them to fall back to `string`. This directly caused `wazuh.threat.indicator.confidence` (type `short`) to be registered as `string` instead of `number`.
- **`flat_object` not handled in `isAggregatable` and `shouldReadFromDocValues`**: Fields with `esType: flat_object` were incorrectly marked as `aggregatable: true` and `readFromDocValues: true`. `flat_object` fields are not aggregatable and do not use doc values.
- **Missing `subType` for fields inside `nested` objects**: Fields that are children of a `nested` type field require a `subType: { nested: { path: "<nested-field-path>" } }` property. The extraction function was not propagating the nested path context, so all nested child fields were missing this property.

### Issues Resolved

- https://github.com/wazuh/wazuh-dashboard-plugins/issues/8574

### Evidence

<img width="1912" height="960" alt="Screenshot 2026-06-02 at 10 38 48" src="https://github.com/user-attachments/assets/f0937ce9-f427-40f4-8174-5e7d14c755e5" />


### Test

1. Run the known fields generation script:
   ```bash
   yarn generate:indexer-resources
   ```
2. Verify the generated known fields files are correct, spot check fields like `wazuh.threat.indicator.confidence` and confirm they have `type: "number"`, and that `flat_object` fields have `aggregatable: false` and `readFromDocValues: false`.
3. In the Wazuh Dashboard, navigate to **Dashboadrd Management → Index Patterns** and inspect the index pattern that includes `wazuh.threat.enrichments` fields. Confirm:
   - `wazuh.threat.indicator.confidence` is listed as type `number`.
   - `flat_object` fields (e.g. `wazuh.threat.enrichments.indicator.file.elf.exports`) are marked as non-aggregatable.
4. In **Discover**, filter by a findings index pattern and open a document that contains `wazuh.threat.enrichments` data. Confirm that the enrichment fields are displayed correctly as nested object , and don't appear as "unknown field".

### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
