### PR TITLE
Remove revision from the agent installation command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,7 +87,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Reduce the request done to get the index pattern to use in some views [#8318](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8318)
 - Changed default columns in Configuration assessment [#8320](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8320)
 - Set the downloaded local agent package name same to the remote one [#8350](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8350)
-- Updated agent install and download commands to use the release stage for package naming [#8559](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8559)
+- Updated agent install and download commands to use the release stage for package naming [#8559](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8559) [#8586](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8586)
 - Changed FIM findings default columns [#8417](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8417)
 - Allowed only 1 server API configuration per indexer [#8436](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8436)
 - Updated the OS icon source field in the Endpoints summary table to display Linux agent icons [#8459](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8459)

--- a/plugins/main/public/components/endpoints-summary/register-agent/core/config/os-commands-definitions.ts
+++ b/plugins/main/public/components/endpoints-summary/register-agent/core/config/os-commands-definitions.ts
@@ -18,7 +18,6 @@ import { IOSDefinition, tOptionalParams } from '../register-commands/types';
 import { PLUGIN_MAJOR_VERSION } from '../../../../../../common/constants';
 import {
   getWazuhStage,
-  getWazuhRevision,
   isWazuhPreRelease,
 } from '../../../../../kibana-services';
 
@@ -86,11 +85,11 @@ export type tOptionalParameters =
 /**
  * Build qualifier appended to the package filename.
  * Pre-release builds use the stage label (e.g. "beta2").
- * Production builds use the numeric revision (e.g. "01").
+ * Production builds do not append any qualifier.
  * Evaluated lazily so the value from injectedMetadata is available.
  */
 const getPackageBuildQualifier = () =>
-  isWazuhPreRelease() ? getWazuhStage() : getWazuhRevision();
+  isWazuhPreRelease() ? `-${getWazuhStage()}` : '';
 
 /**
  * Base URL for the package repository.
@@ -115,7 +114,7 @@ const linuxDefinition: IOSDefinition<ILinuxOSTypes, tOptionalParameters> = {
       packageName: props =>
         `wazuh-agent_${
           props.wazuhVersion
-        }-${getPackageBuildQualifier()}_amd64.deb`,
+        }${getPackageBuildQualifier()}_amd64.deb`,
       urlPackage: props =>
         `${getPackagesBaseUrl()}/apt/pool/main/w/wazuh-agent/${
           props.packageName
@@ -128,7 +127,7 @@ const linuxDefinition: IOSDefinition<ILinuxOSTypes, tOptionalParameters> = {
       packageName: props =>
         `wazuh-agent-${
           props.wazuhVersion
-        }-${getPackageBuildQualifier()}.x86_64.rpm`,
+        }${getPackageBuildQualifier()}.x86_64.rpm`,
       urlPackage: props => `${getPackagesBaseUrl()}/yum/${props.packageName}`,
       installCommand: props => getRPMAMD64InstallCommand(props),
       startCommand: props => getLinuxStartCommand(props),
@@ -138,7 +137,7 @@ const linuxDefinition: IOSDefinition<ILinuxOSTypes, tOptionalParameters> = {
       packageName: props =>
         `wazuh-agent_${
           props.wazuhVersion
-        }-${getPackageBuildQualifier()}_arm64.deb`,
+        }${getPackageBuildQualifier()}_arm64.deb`,
       urlPackage: props =>
         `${getPackagesBaseUrl()}/apt/pool/main/w/wazuh-agent/${
           props.packageName
@@ -151,7 +150,7 @@ const linuxDefinition: IOSDefinition<ILinuxOSTypes, tOptionalParameters> = {
       packageName: props =>
         `wazuh-agent-${
           props.wazuhVersion
-        }-${getPackageBuildQualifier()}.aarch64.rpm`,
+        }${getPackageBuildQualifier()}.aarch64.rpm`,
       urlPackage: props => `${getPackagesBaseUrl()}/yum/${props.packageName}`,
       installCommand: props => getRPMARM64InstallCommand(props),
       startCommand: props => getLinuxStartCommand(props),
@@ -165,7 +164,7 @@ const windowsDefinition: IOSDefinition<IWindowsOSTypes, tOptionalParameters> = {
     {
       architecture: 'MSI 32/64 bits',
       packageName: props =>
-        `wazuh-agent-${props.wazuhVersion}-${getPackageBuildQualifier()}.msi`,
+        `wazuh-agent-${props.wazuhVersion}${getPackageBuildQualifier()}.msi`,
       urlPackage: props =>
         `${getPackagesBaseUrl()}/windows/${props.packageName}`,
       installCommand: props => getWindowsInstallCommand(props),
@@ -182,7 +181,7 @@ const macDefinition: IOSDefinition<IMacOSTypes, tOptionalParameters> = {
       packageName: props =>
         `wazuh-agent-${
           props.wazuhVersion
-        }-${getPackageBuildQualifier()}.intel64.pkg`,
+        }${getPackageBuildQualifier()}.intel64.pkg`,
       urlPackage: props => `${getPackagesBaseUrl()}/macos/${props.packageName}`,
       installCommand: props => getMacOsInstallCommand(props),
       startCommand: props => getMacosStartCommand(props),
@@ -192,7 +191,7 @@ const macDefinition: IOSDefinition<IMacOSTypes, tOptionalParameters> = {
       packageName: props =>
         `wazuh-agent-${
           props.wazuhVersion
-        }-${getPackageBuildQualifier()}.arm64.pkg`,
+        }${getPackageBuildQualifier()}.arm64.pkg`,
       urlPackage: props => `${getPackagesBaseUrl()}/macos/${props.packageName}`,
       installCommand: props => getMacOsInstallCommand(props),
       startCommand: props => getMacosStartCommand(props),

--- a/plugins/main/public/kibana-services.ts
+++ b/plugins/main/public/kibana-services.ts
@@ -128,11 +128,6 @@ export function getWazuhStage(): string {
   return _wazuhBuildInfo.stage;
 }
 
-/** Returns the Wazuh package release revision (e.g. "01", "02"). */
-export function getWazuhRevision(): string {
-  return _wazuhBuildInfo.revision;
-}
-
 /** Returns true when the dashboard build uses production package nomenclature. */
 export function isWazuhProductionBuild(): boolean {
   return _wazuhBuildInfo.isProduction;


### PR DESCRIPTION
### Description

Remove revision from the agent installation command
 
### Issues Resolved

- #8550 

### Evidence

isProduction: false

<img width="1532" height="1380" alt="Screenshot 2026-06-08 at 12 07 56 PM" src="https://github.com/user-attachments/assets/73715bf6-b124-477f-88c2-34de2dda3aeb" />

isProduction: true

<img width="1590" height="1373" alt="Screenshot 2026-06-08 at 12 12 00 PM" src="https://github.com/user-attachments/assets/349489c9-dda4-40d2-8e68-1985854d7dee" />


### Test

1. Navigate to "Deploy new agent"
2. Check that the installation command does not include the revision when `isProduction` is set to true in `package.json` of wazuh-dashboard
3. Check that the installation command include the stage when `isProduction` is set to false in `package.json` of wazuh-dashboard

### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff 
