### PR TITLE
Change to the response of the isWazuhPreRelease function

### DIFF
--- a/plugins/main/public/kibana-services.ts
+++ b/plugins/main/public/kibana-services.ts
@@ -135,5 +135,7 @@ export function isWazuhProductionBuild(): boolean {
 
 /** Returns true when the build is a pre-release (uses staging package repository). */
 export function isWazuhPreRelease(): boolean {
-  return !_wazuhBuildInfo.isProduction;
+  // TODO: Review this logic once we have a better understanding of how the staging vs production package repositories will be used across different release stages (e.g. alpha, beta, release candidate). For now, we'll consider any non-production build as a pre-release.
+  // return !_wazuhBuildInfo.isProduction;
+  return true;
 }


### PR DESCRIPTION
### Description
The response from the isWazuhPreRelease function has been modified, and a comment has been added to clarify where the information would be sourced from if it is a production package. 
 
### Issues Resolved
- #8550 

### Evidence
isProduction: true

<img width="2289" height="470" alt="image" src="https://github.com/user-attachments/assets/c8e7a0de-5151-4640-bc44-eb42a451ecd8" />

isProduction: false

<img width="2321" height="362" alt="image" src="https://github.com/user-attachments/assets/a5953000-f0b9-43a3-abe4-77d6ff1eae05" />


### Test

Test both versions of isProduction; both should have the pre-release link


### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff 
