### PR TITLE
Enhance CTI registration components with subscription plan display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Added Refresh button to the suggested filters search bar [#8398](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8398)
 - Added ability to generate PDF report in Vulnerabilities dashboard [#8403](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8403)
 - Added button that allows to request CTI content update [#8201](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8201)
-- Added CTI Console registration flow (UI and registration status API) [#8486](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8486)[#7663](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7663)
+- Added CTI Console registration flow (UI and registration status API) [#8486](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8486)[#7663](https://github.com/wazuh/wazuh-dashboard-plugins/pull/7663)[#8629](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8629)
 - Added `wazuh-metrics-normalization*` index pattern [#8480](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8480)
 - Added Engine Health dashboard [#8485](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8485)
 - Added Case Management tab to Findings document details flyout [#8580](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8580)[#8589](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8589) [#8598](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8598)

--- a/plugins/wazuh-check-updates/public/shared-components/cti-registration/components/status-cti-registration.tsx
+++ b/plugins/wazuh-check-updates/public/shared-components/cti-registration/components/status-cti-registration.tsx
@@ -31,6 +31,12 @@ export const StatusCtiRegistration: React.FC<StatusCtiRegistrationProps> = ({
     statusCTI.status === statusCodes.NOT_FOUND &&
     isBackgroundRegistrationActive();
 
+  const subscriptionPlanName =
+    ctiFlowState.getSubscription()?.message?.plan?.name;
+
+  const showPlanName =
+    statusCTI.status === statusCodes.SUCCESS && Boolean(subscriptionPlanName);
+
   const openRegistrationModal = () => {
     onOpenModal();
   };
@@ -45,11 +51,19 @@ export const StatusCtiRegistration: React.FC<StatusCtiRegistrationProps> = ({
         aria-label={statusData[statusCTI.status].onClickAriaLabel}
         color={statusData[statusCTI.status].color}
       >
-        <span style={inlineRow}>
-          <FormattedMessage
-            id='wazuhCheckUpdates.ctiRegistration.statusNavTop'
-            defaultMessage='Wazuh Cloud'
-          />
+        <span style={inlineRow} data-test-subj='ctiRegistrationNavStatus'>
+          {showPlanName ? (
+            <FormattedMessage
+              id='wazuhCheckUpdates.ctiRegistration.statusNavTopWithPlan'
+              defaultMessage='Wazuh Cloud - {planName}'
+              values={{ planName: subscriptionPlanName }}
+            />
+          ) : (
+            <FormattedMessage
+              id='wazuhCheckUpdates.ctiRegistration.statusNavTop'
+              defaultMessage='Wazuh Cloud'
+            />
+          )}
           {backgroundSpinner}
         </span>
       </EuiHealth>

--- a/plugins/wazuh-check-updates/public/shared-components/cti-registration/cti-registration.test.tsx
+++ b/plugins/wazuh-check-updates/public/shared-components/cti-registration/cti-registration.test.tsx
@@ -22,9 +22,21 @@ jest.mock('@osd/i18n/react', () => ({
   I18nProvider: ({ children }: { children: React.ReactNode }) => (
     <>{children}</>
   ),
-  FormattedMessage: ({ defaultMessage }: { defaultMessage?: string }) => (
-    <span>{defaultMessage}</span>
-  ),
+  FormattedMessage: ({
+    defaultMessage,
+    values,
+  }: {
+    defaultMessage?: string;
+    values?: Record<string, string>;
+  }) => {
+    let text = defaultMessage ?? '';
+    if (values) {
+      Object.entries(values).forEach(([key, value]) => {
+        text = text.replace(`{${key}}`, value);
+      });
+    }
+    return <span>{text}</span>;
+  },
   __esModule: true,
 }));
 
@@ -80,7 +92,7 @@ describe('CtiRegistration', () => {
     expect(
       screen.queryByRole('button', { name: 'Wazuh XDR registration' }),
     ).not.toBeInTheDocument();
-    expect(screen.getByText('Wazuh Cloud')).toBeInTheDocument();
+    expect(screen.getByText('Wazuh Cloud - Premium Plan')).toBeInTheDocument();
     expect(mockHttpPost).not.toHaveBeenCalled();
     expect(ctiFlowState.isRegistered()).toBe(true);
   });


### PR DESCRIPTION
### Description
This pr improves user feedback regarding the current subscription status in the CTI registration UI.
 
### Issues Resolved
IDR

### Evidence
<img width="1926" height="559" alt="image" src="https://github.com/user-attachments/assets/c655864f-0ef1-4bfc-aea9-12db059cd757" />


### Test
Complete registration and check if Register button changes to show "Wazuh Cloud - {{plan}}"

### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff 
