### PR TITLE
Update GitHub repository link in About pag

### DIFF
--- a/.github/ISSUE_TEMPLATE/new_release.md
+++ b/.github/ISSUE_TEMPLATE/new_release.md
@@ -1,30 +1,31 @@
 ---
 name: New release
-about: "[wazuh-team] Track the effort of the team to release a new version of Wazuh"
+about: '[wazuh-team] Track the effort of the team to release a new version of Wazuh'
 title: Support for Wazuh 4.x.x
 labels: enhancement
 assignees: ''
-
 ---
 
 ## Description
 
 Example:
-> Wazuh 4.3.8 will be released shortly. Our Wazuh Dashboard and Kibana apps need to support this new version. From our side, no changes will be included, so we only need to bump the version.
 
+> Wazuh 4.3.8 will be released shortly. Our Wazuh Dashboard and Kibana apps need to support this new version. From our side, no changes will be included, so we only need to bump the version.
 
 ## Tasks
 
 ### Pre-release
+
 - [ ] Add support for Wazuh 4.x.x (bump).
 - [ ] Generate the required tags.
 - [ ] Generate the packages.
 - [ ] Test the packages, to verify they install, and the app works as expected.
-- [ ] [Optional] Run Regression Testing (#issue) 
+- [ ] [Optional] Run Regression Testing (#issue)
 - [ ] Generate draft releases.
 - [ ] Notify the @wazuh/cicd and @wazuh/content teams that the release is good to go, from our side.
 
 ### Post-release
+
 - [ ] Make draft releases final and public.
 - [ ] Sync branches.
 - [ ] Update [Compatibility Matrix](https://github.com/wazuh/wazuh-dashboard-plugins/wiki/Compatibility).

--- a/.github/ISSUE_TEMPLATE/new_release.md
+++ b/.github/ISSUE_TEMPLATE/new_release.md
@@ -27,7 +27,7 @@ Example:
 ### Post-release
 - [ ] Make draft releases final and public.
 - [ ] Sync branches.
-- [ ] Update [Compatibility Matrix](https://github.com/wazuh/wazuh-kibana-app/wiki/Compatibility).
+- [ ] Update [Compatibility Matrix](https://github.com/wazuh/wazuh-dashboard-plugins/wiki/Compatibility).
 
 ### Supported versions
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fixed custom filter buttons not being rendered in pdf reports [#8525](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8525)
 - Fixed MITRE technique fields being truncated in the Document Details flyout by showing the full list of clickable items [#8579](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8579)
 - Fixed FIM visualizations height [#8610](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8610)
+- Fixed the GitHub link in the About page pointing to the legacy `wazuh-kibana-app` repository [#8653](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8653)
 
 ### Removed
 

--- a/plugins/main/public/components/settings/about/__snapshots__/generalInfo.test.tsx.snap
+++ b/plugins/main/public/components/settings/about/__snapshots__/generalInfo.test.tsx.snap
@@ -98,7 +98,7 @@ exports[`SettingsAboutGeneralInfo component should render a component 1`] = `
               <a
                 aria-label="Github"
                 class="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall"
-                href="https://github.com/wazuh/wazuh-kibana-app"
+                href="https://github.com/wazuh/wazuh-dashboard-plugins"
                 rel="noopener noreferrer"
                 target="_blank"
               >

--- a/plugins/main/public/components/settings/about/generalInfo.tsx
+++ b/plugins/main/public/components/settings/about/generalInfo.tsx
@@ -69,7 +69,6 @@ export const SettingsAboutGeneralInfo = ({
             <EuiFlexGroup
               alignItems='center'
               justifyContent='center'
-              gutterSize='xl'
               responsive={false}
             >
               <EuiFlexItem grow={false}>
@@ -98,6 +97,7 @@ export const SettingsAboutGeneralInfo = ({
                 <EuiButtonIcon
                   aria-label='Github'
                   iconType='logoGithub'
+                  color='text'
                   iconSize='xxl'
                   href='https://github.com/wazuh/wazuh-dashboard-plugins'
                   target='_blank'

--- a/plugins/main/public/components/settings/about/generalInfo.tsx
+++ b/plugins/main/public/components/settings/about/generalInfo.tsx
@@ -99,7 +99,7 @@ export const SettingsAboutGeneralInfo = ({
                   aria-label='Github'
                   iconType='logoGithub'
                   iconSize='xxl'
-                  href='https://github.com/wazuh/wazuh-kibana-app'
+                  href='https://github.com/wazuh/wazuh-dashboard-plugins'
                   target='_blank'
                 >
                   Github

--- a/plugins/main/test/cypress/images/ubuntu-cypress/Dockerfile
+++ b/plugins/main/test/cypress/images/ubuntu-cypress/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update -y \
     && apt-get install -y curl wget gnupg2 vim nano git libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb \
     && apt-get update -y \
     && mkdir -p $AUTOMATION_HOME \
-    && git clone --single-branch --depth 1 -b $UBUNTU_CYPRESS_BRANCH https://github.com/wazuh/wazuh-kibana-app.git $CYPRESS_DIR
+    && git clone --single-branch --depth 1 -b $UBUNTU_CYPRESS_BRANCH https://github.com/wazuh/wazuh-dashboard-plugins.git $CYPRESS_DIR
 
 RUN wget -O /usr/src/google-chrome-stable_current_amd64.deb "https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb" \
     && dpkg -i /usr/src/google-chrome-stable_current_amd64.deb ; \


### PR DESCRIPTION
### Description
The "Github" link in the **Settings → About → General Information** section  pointed to the legacy repository `wazuh/wazuh-kibana-app`. This PR updates it  to the current repository `wazuh/wazuh-dashboard-plugins`.
 
### Issues Resolved
Closes #8652 

### Evidence

https://github.com/user-attachments/assets/001c5758-5296-4fa3-8cf5-4b75a0a65162

### Test
Dashboard management > About page.

### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff 
