### PR TITLE
Add missing evaluation filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Added Normalization tab and dashboard in `Server Management` > `Statistics`[#8485](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8485) [#8600](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8600) [#8524](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8524)
 - Added Case Management tab to Findings document details flyout [#8580](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8580)[#8589](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8589) [#8598](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8598) [#8630](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8630)
 - Added Cases tab to the Threat Hunting module [#8583](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8583)
-- Added visualizations to Vulnerability Detection > Inventory [#8611](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8611)
+- Added visualizations to Vulnerability Detection > Inventory [#8611](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8611) [#8663](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8663)
 - Added Cases tab to the Threat Hunting module [#8583](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8583) [#8608](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8608) [#8630](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8630)
 - Added Active Responses dashboard [8601](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8601)
 

--- a/plugins/main/public/components/common/custom-search-bar/custom-search-bar.tsx
+++ b/plugins/main/public/components/common/custom-search-bar/custom-search-bar.tsx
@@ -64,6 +64,10 @@ export const CustomSearchBar = ({
 }: CustomSearchBarProps) => {
   const { filters } = searchBarProps;
 
+  /* Use the search bar's onFiltersUpdated handler, which re attaches the managed filters kept out of
+  the filter list so they are not dropped. */
+  const updateFilters = searchBarProps.onFiltersUpdated ?? setFilters;
+
   const defaultSelectedOptions = () => {
     const array: string[][] = [];
     filterInputs.forEach(item => {
@@ -93,10 +97,6 @@ export const CustomSearchBar = ({
       filterDrillDownValue.value != ''
       ? true
       : false;
-  };
-
-  const onFiltersUpdated = (filters?: Filter[]) => {
-    setFilters([filters]);
   };
 
   const changeSwitch = () => {
@@ -145,7 +145,7 @@ export const CustomSearchBar = ({
     if (values.length != 0) {
       customFilter = [buildCustomFilter(values)];
     }
-    setFilters([...currentFilters, ...customFilter]);
+    updateFilters([...currentFilters, ...customFilter]);
   };
 
   const refreshCustomSelectedFilter = () => {
@@ -205,7 +205,7 @@ export const CustomSearchBar = ({
 
   const onRemove = filter => {
     const currentFilters = filters.filter(item => item.meta.key != filter);
-    setFilters(currentFilters);
+    updateFilters(currentFilters);
     refreshCustomSelectedFilter();
   };
 
@@ -245,7 +245,7 @@ export const CustomSearchBar = ({
           {...searchBarProps}
           fixedFilters={fixedFilters}
           showQueryInput={avancedFiltersState}
-          onFiltersUpdated={onFiltersUpdated}
+          onFiltersUpdated={updateFilters}
           onManualRefresh={() =>
             searchBarProps.onQuerySubmit(
               {

--- a/plugins/main/public/components/overview/vulnerabilities/common/vulnerability-managed-filters.tsx
+++ b/plugins/main/public/components/overview/vulnerabilities/common/vulnerability-managed-filters.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import VulsEvaluationFilter, {
+  getUnderEvaluationFilterValue,
+  createUnderEvaluationFilter,
+  UNDER_EVALUATION_FIELD,
+} from './components/vuls-evaluation-filter';
+import { WAZUH_VULNERABILITIES_PATTERN } from '../../../../../../common/constants';
+
+export const vulnerabilityManagedFilters = {
+  underEvaluation: {
+    managedField: UNDER_EVALUATION_FIELD,
+    selector: f =>
+      f.meta?.key === UNDER_EVALUATION_FIELD && f.meta?.type === 'phrase',
+    component: (props: {
+      managedFilter?: any;
+      setManagedFilter: (filters: any[]) => void;
+    }) => {
+      const onChange = (underEvaluation: boolean | null) => {
+        const newFilters = [];
+        if (underEvaluation !== null) {
+          newFilters.push(
+            createUnderEvaluationFilter(
+              underEvaluation,
+              WAZUH_VULNERABILITIES_PATTERN,
+            ),
+          );
+        }
+        props?.setManagedFilter(newFilters);
+      };
+
+      return (
+        <VulsEvaluationFilter
+          value={getUnderEvaluationFilterValue(props?.managedFilter)}
+          setValue={onChange}
+        />
+      );
+    },
+    order: 1,
+  },
+};

--- a/plugins/main/public/components/overview/vulnerabilities/common/vulnerability-managed-filters.tsx
+++ b/plugins/main/public/components/overview/vulnerabilities/common/vulnerability-managed-filters.tsx
@@ -4,7 +4,7 @@ import VulsEvaluationFilter, {
   createUnderEvaluationFilter,
   UNDER_EVALUATION_FIELD,
 } from './components/vuls-evaluation-filter';
-import { WAZUH_VULNERABILITIES_PATTERN } from '../../../../../../common/constants';
+import { WAZUH_VULNERABILITIES_PATTERN } from '../../../../../common/constants';
 
 export const vulnerabilityManagedFilters = {
   underEvaluation: {

--- a/plugins/main/public/components/overview/vulnerabilities/dashboards/inventory/inventory.tsx
+++ b/plugins/main/public/components/overview/vulnerabilities/dashboards/inventory/inventory.tsx
@@ -61,6 +61,12 @@ import {
   VULNERABILITIES_INVENTORY_DASHBOARD_ID,
   VULNERABILITIES_INVENTORY_AGENT_DASHBOARD_ID,
 } from '../../../../../../common/constants';
+import VulsEvaluationFilter, {
+  getUnderEvaluationFilterValue,
+  createUnderEvaluationFilter,
+  UNDER_EVALUATION_FIELD,
+} from '../../common/components/vuls-evaluation-filter';
+import { WAZUH_VULNERABILITIES_PATTERN } from '../../../../../../common/constants';
 import RestoreStateColumnsButton from '../../../../common/wazuh-discover/components/restore-state-columns';
 import managedFilters from './managed-filters';
 import DashboardRenderer from '../../../../common/dashboards/dashboard-renderer/dashboard-renderer';
@@ -91,6 +97,28 @@ const InventoryVulsComponent = () => {
     undefined,
   );
   const [isExporting, setIsExporting] = useState<boolean>(false);
+
+  const underEvaluationFilter = filters.find(
+    f => f.meta?.key === UNDER_EVALUATION_FIELD && f.meta?.type === 'phrase',
+  );
+
+  const onChangeEvaluationFilter = (underEvaluation: boolean | null) => {
+    const withoutEvalFilter = filters.filter(
+      f =>
+        !(f.meta?.key === UNDER_EVALUATION_FIELD && f.meta?.type === 'phrase'),
+    );
+    setFilters(
+      underEvaluation !== null
+        ? [
+            ...withoutEvalFilter,
+            createUnderEvaluationFilter(
+              underEvaluation,
+              WAZUH_VULNERABILITIES_PATTERN,
+            ),
+          ]
+        : withoutEvalFilter,
+    );
+  };
 
   const sideNavDocked = getWazuhCorePlugin().hooks.useDockedSideNav();
 
@@ -221,6 +249,10 @@ const InventoryVulsComponent = () => {
                     setFilters={setFilters}
                     fixedFilters={fixedFilters}
                     filterInputs={managedFilters}
+                  />
+                  <VulsEvaluationFilter
+                    value={getUnderEvaluationFilterValue(underEvaluationFilter)}
+                    setValue={onChangeEvaluationFilter}
                   />
                   <SampleDataWarning
                     categoriesSampleData={[WAZUH_SAMPLE_VULNERABILITIES]}

--- a/plugins/main/public/components/overview/vulnerabilities/dashboards/inventory/inventory.tsx
+++ b/plugins/main/public/components/overview/vulnerabilities/dashboards/inventory/inventory.tsx
@@ -61,7 +61,7 @@ import {
   VULNERABILITIES_INVENTORY_DASHBOARD_ID,
   VULNERABILITIES_INVENTORY_AGENT_DASHBOARD_ID,
 } from '../../../../../../common/constants';
-import { vulnerabilityManagedFilters } from '../overview/dashboard';
+import { vulnerabilityManagedFilters } from '../../common/vulnerability-managed-filters';
 import RestoreStateColumnsButton from '../../../../common/wazuh-discover/components/restore-state-columns';
 import managedFilters from './managed-filters';
 import DashboardRenderer from '../../../../common/dashboards/dashboard-renderer/dashboard-renderer';

--- a/plugins/main/public/components/overview/vulnerabilities/dashboards/inventory/inventory.tsx
+++ b/plugins/main/public/components/overview/vulnerabilities/dashboards/inventory/inventory.tsx
@@ -61,12 +61,7 @@ import {
   VULNERABILITIES_INVENTORY_DASHBOARD_ID,
   VULNERABILITIES_INVENTORY_AGENT_DASHBOARD_ID,
 } from '../../../../../../common/constants';
-import VulsEvaluationFilter, {
-  getUnderEvaluationFilterValue,
-  createUnderEvaluationFilter,
-  UNDER_EVALUATION_FIELD,
-} from '../../common/components/vuls-evaluation-filter';
-import { WAZUH_VULNERABILITIES_PATTERN } from '../../../../../../common/constants';
+import { vulnerabilityManagedFilters } from '../overview/dashboard';
 import RestoreStateColumnsButton from '../../../../common/wazuh-discover/components/restore-state-columns';
 import managedFilters from './managed-filters';
 import DashboardRenderer from '../../../../common/dashboards/dashboard-renderer/dashboard-renderer';
@@ -89,6 +84,7 @@ const InventoryVulsComponent = () => {
     indexPattern: dataSource?.indexPattern as IndexPattern,
     filters,
     setFilters,
+    managedFiltersSpec: vulnerabilityManagedFilters,
   });
   const { query } = searchBarProps;
   const [results, setResults] = useState<SearchResponse>({} as SearchResponse);
@@ -97,28 +93,6 @@ const InventoryVulsComponent = () => {
     undefined,
   );
   const [isExporting, setIsExporting] = useState<boolean>(false);
-
-  const underEvaluationFilter = filters.find(
-    f => f.meta?.key === UNDER_EVALUATION_FIELD && f.meta?.type === 'phrase',
-  );
-
-  const onChangeEvaluationFilter = (underEvaluation: boolean | null) => {
-    const withoutEvalFilter = filters.filter(
-      f =>
-        !(f.meta?.key === UNDER_EVALUATION_FIELD && f.meta?.type === 'phrase'),
-    );
-    setFilters(
-      underEvaluation !== null
-        ? [
-            ...withoutEvalFilter,
-            createUnderEvaluationFilter(
-              underEvaluation,
-              WAZUH_VULNERABILITIES_PATTERN,
-            ),
-          ]
-        : withoutEvalFilter,
-    );
-  };
 
   const sideNavDocked = getWazuhCorePlugin().hooks.useDockedSideNav();
 
@@ -249,10 +223,6 @@ const InventoryVulsComponent = () => {
                     setFilters={setFilters}
                     fixedFilters={fixedFilters}
                     filterInputs={managedFilters}
-                  />
-                  <VulsEvaluationFilter
-                    value={getUnderEvaluationFilterValue(underEvaluationFilter)}
-                    setValue={onChangeEvaluationFilter}
                   />
                   <SampleDataWarning
                     categoriesSampleData={[WAZUH_SAMPLE_VULNERABILITIES]}

--- a/plugins/main/public/components/overview/vulnerabilities/dashboards/overview/dashboard.tsx
+++ b/plugins/main/public/components/overview/vulnerabilities/dashboards/overview/dashboard.tsx
@@ -1,4 +1,3 @@
-import React, { useCallback, useState } from 'react';
 import { withErrorBoundary } from '../../../../common/hocs';
 
 import {
@@ -11,13 +10,7 @@ import {
   WAZUH_SAMPLE_VULNERABILITIES,
   VULNERABILITIES_DASHBOARD_ID,
   VULNERABILITIES_AGENT_DASHBOARD_ID,
-  WAZUH_VULNERABILITIES_PATTERN,
 } from '../../../../../../common/constants';
-import VulsEvaluationFilter, {
-  getUnderEvaluationFilterValue,
-  createUnderEvaluationFilter,
-  UNDER_EVALUATION_FIELD,
-} from '../../common/components/vuls-evaluation-filter';
 import { vulnerabilityManagedFilters } from '../../common/vulnerability-managed-filters';
 
 export const DashboardVuls = withErrorBoundary(

--- a/plugins/main/public/components/overview/vulnerabilities/dashboards/overview/dashboard.tsx
+++ b/plugins/main/public/components/overview/vulnerabilities/dashboards/overview/dashboard.tsx
@@ -18,37 +18,7 @@ import VulsEvaluationFilter, {
   createUnderEvaluationFilter,
   UNDER_EVALUATION_FIELD,
 } from '../../common/components/vuls-evaluation-filter';
-
-export const vulnerabilityManagedFilters = {
-  underEvaluation: {
-    managedField: UNDER_EVALUATION_FIELD,
-    selector: f =>
-      f.meta?.key === UNDER_EVALUATION_FIELD && f.meta?.type === 'phrase',
-    component: (props: {
-      managedFilter?: any;
-      setManagedFilter: (filters: any[]) => void;
-    }) => {
-      const onChange = (underEvaluation: boolean | null) => {
-        const newFilters = [];
-        if (underEvaluation !== null) {
-          const indexId = WAZUH_VULNERABILITIES_PATTERN;
-          newFilters.push(
-            createUnderEvaluationFilter(underEvaluation, indexId),
-          );
-        }
-        props?.setManagedFilter(newFilters);
-      };
-
-      return (
-        <VulsEvaluationFilter
-          value={getUnderEvaluationFilterValue(props?.managedFilter)}
-          setValue={onChange}
-        />
-      );
-    },
-    order: 1,
-  },
-};
+import { vulnerabilityManagedFilters } from '../../common/vulnerability-managed-filters';
 
 export const DashboardVuls = withErrorBoundary(
   withVulnerabilitiesStateDataSource(


### PR DESCRIPTION
### Description
This PR adds the missing custom evaluation filter to the Inventory view inside Vulnerability Detection.
 
### Issues Resolved
[#8662](https://github.com/wazuh/wazuh-dashboard-plugins/issues/8662)

### Evidence
<img width="1851" height="962" alt="Captura desde 2026-06-23 13-02-18" src="https://github.com/user-attachments/assets/6034d18e-d03d-4a45-b816-0754995aa048" />

<img width="1851" height="960" alt="Captura desde 2026-06-23 13-02-26" src="https://github.com/user-attachments/assets/6f00c64e-44d8-407e-a3be-aee692ffb06a" />



### Test
- Navigate to `Vulnerability Detection` > `Inventory` and check the `Evaluated` and `Under Evaluation` filters work correctly.

### Check List
- [X] Update [CHANGELOG.md](./../CHANGELOG.md)
- [X] Commits are signed per the DCO using --signoff 
