### PR TITLE
Fixed suggested values on multi select when switching tabs in a short period of time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fixed custom filter buttons not being rendered in pdf reports [#8525](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8525)
 - Fixed MITRE technique fields being truncated in the Document Details flyout by showing the full list of clickable items [#8579](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8579)
 - Fixed FIM visualizations height [#8610](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8610)
+- Fixed the suggested valued on multi select filters are not displayed when switching tabs in a short period of time [#8666](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8666)
 
 ### Removed
 

--- a/plugins/main/public/components/common/custom-search-bar/components/multi-select.tsx
+++ b/plugins/main/public/components/common/custom-search-bar/components/multi-select.tsx
@@ -136,33 +136,36 @@ export const MultiSelect: React.FC<MultiSelectProps> = ({
     }
   };
 
-  const buildSelectedOptions = () => {
-    const result = items.map(item => ({
-      ...item,
-      checked: selectedOptions.find(element => element.label === item.label)
-        ? (Switch.ON as FilterChecked)
-        : (Switch.OFF as FilterChecked),
-      key: setSelectedKey(item),
-    }));
-
-    return orderByChecked(orderByLabel(result));
-  };
-
   useEffect(() => {
-    setItems(buildSelectedOptions());
     setActiveFilters(selectedOptions.length);
   }, [selectedOptions]);
 
+  // Define the checked state depending on the selected options coming from props and the items coming from the suggested values
+  const enhancedItems = items.map(item => ({
+    ...item,
+    checked: selectedOptions.find(element => element.label === item.label)
+      ? (Switch.ON as FilterChecked)
+      : (Switch.OFF as FilterChecked),
+    key: setSelectedKey(item),
+  }));
+
   const toggleFilter = (item: Item) => {
-    items.map(item => (item.key = setSelectedKey(item)));
-    item.checked = item.checked === Switch.ON ? Switch.OFF : Switch.ON;
-    item.key = setSelectedKey(item);
-    updateFilters(item.value);
+    const newItems = enhancedItems.map(element => ({
+      ...element,
+      key: setSelectedKey(element),
+      checked:
+        element.label === item.label
+          ? item.checked === Switch.ON
+            ? Switch.OFF
+            : Switch.ON
+          : element.checked,
+    }));
+    updateFilters(item.value, newItems);
   };
 
-  const updateFilters = (id: string) => {
-    const selectedItems = items.filter(item => item.checked === Switch.ON);
-    setActiveFilters(selectedItems.length);
+  const updateFilters = (id: string, newItems: Item[]) => {
+    const selectedItems = newItems.filter(item => item.checked === Switch.ON);
+    // This updated the selectedOptions count state, but this has been delegated to be updated when the props selectedOptions change. This avoids a problem where the current component update to the current selected options in the toogleFilter function, but the useEffect depending on the selectedOptions props is executed with a not updated state, causing the state is updated to previous state (e.g. current - 1 when increasing or current + 1 when decreasing, which causes a mismatch in the count of selected options.
     if (selectedItems.length) {
       onChange(selectedItems, id);
     } else {
@@ -212,7 +215,7 @@ export const MultiSelect: React.FC<MultiSelectProps> = ({
           <EuiFieldSearch onChange={onSearch} />
         </EuiPopoverTitle>
         <div className='euiFilterSelect__items'>
-          {items.map(item => (
+          {enhancedItems.map(item => (
             <EuiFilterSelectItem
               checked={item.checked}
               key={item.key}

--- a/plugins/main/public/components/common/custom-search-bar/custom-search-bar.tsx
+++ b/plugins/main/public/components/common/custom-search-bar/custom-search-bar.tsx
@@ -149,7 +149,7 @@ export const CustomSearchBar = ({
   };
 
   const refreshCustomSelectedFilter = () => {
-    setSelectedOptions(defaultSelectedOptions());
+    let state = defaultSelectedOptions();
     // The dropdown filters could be added like fixed filters and user filters
     const currentFilters =
       [...filters, ...fixedFilters]
@@ -189,13 +189,18 @@ export const CustomSearchBar = ({
     if (filterCustom.length != 0) {
       filterCustom.forEach(item => {
         item.forEach(element => {
-          setSelectedOptions(prevState => ({
-            ...prevState,
-            [element.value]: [...prevState[element.value], element],
-          }));
+          state = {
+            ...state,
+            [element.value]: [...state[element.value], element],
+          }
         });
       });
     }
+
+    setSelectedOptions(prevState => ({
+      ...prevState,
+      ...state,
+    }));
   };
 
   const onChange = (values: any[], id: string) => {
@@ -237,6 +242,8 @@ export const CustomSearchBar = ({
     };
     return types[item.type] || types.default;
   };
+
+  console.log('CustomSearchBar', { selectedOptions, filters, fixedFilters });
 
   return (
     <I18nProvider>

--- a/plugins/main/public/components/common/custom-search-bar/custom-search-bar.tsx
+++ b/plugins/main/public/components/common/custom-search-bar/custom-search-bar.tsx
@@ -192,7 +192,7 @@ export const CustomSearchBar = ({
           state = {
             ...state,
             [element.value]: [...state[element.value], element],
-          }
+          };
         });
       });
     }
@@ -242,8 +242,6 @@ export const CustomSearchBar = ({
     };
     return types[item.type] || types.default;
   };
-
-  console.log('CustomSearchBar', { selectedOptions, filters, fixedFilters });
 
   return (
     <I18nProvider>


### PR DESCRIPTION
### Description
This pull request fixes a problem in the suggested values of multi select component when switching tabs in a short period of time.

The suggested values are retrieved from caché and there was 2 useEffects that updated the current options in the component: one with the retrieved values and the another one redefined to empty list due to the item value was not updated on the exection time after the first effect.
 
### Issues Resolved
#8665

### Evidence

<img width="1918" height="366" alt="image" src="https://github.com/user-attachments/assets/01213a8d-d796-4e93-9c1d-699b06d5c27b" />
<img width="1918" height="314" alt="image" src="https://github.com/user-attachments/assets/957f8b75-03ad-494e-abe9-93e78e4924b0" />
<img width="1474" height="521" alt="image" src="https://github.com/user-attachments/assets/da67e1da-b503-48cc-9df1-1f89767259b1" />
<img width="1586" height="390" alt="image" src="https://github.com/user-attachments/assets/b452b2f3-0e0a-4d5c-bc15-ba18ba9deb0f" />
<img width="1202" height="513" alt="image" src="https://github.com/user-attachments/assets/e5b3f300-d44d-4f39-89b6-e5ac7c18fe38" />
<img width="362" height="355" alt="image" src="https://github.com/user-attachments/assets/c42ba046-04de-4412-b393-11821e18251c" />
<img width="593" height="565" alt="image" src="https://github.com/user-attachments/assets/f4c0646f-1e89-411b-9c74-a2f7ce8a6ff4" />


### Test

Legend:
:black_circle:: none
:green_circle:: pass
:yellow_circle:: warning
:red_circle:: fail
:white_circle:: not applicable

## UI

| Test | Chrome | Firefox | Safari |
| --- |  --- | --- | --- |
| With data on VUlenrability Detection > Dashboard, go to Vulnerability Detection > Dashboard, go to Vulnerability Dection > Inventory and ensure there are a request for each multiselect filter. Then go to  Vulnerability Detection > Dashboard, clean request in dev tools, go to Vulnerability Detection > Inventory and ensure the related request is not done, open the multiselect, this should display the suggested values. | :black_circle: | :black_circle: | :black_circle: |
| Test the #case1 with other views with the same multiselect, e.g. IT Hygiene tabs | :black_circle: | :black_circle: | :black_circle: |

**Details**
<details>
<summary>:black_circle: With data on VUlenrability Detection > Dashboard, go to Vulnerability Detection > Dashboard, go to Vulnerability Dection > Inventory and ensure there are a request for each multiselect filter. Then go to  Vulnerability Detection > Dashboard, clean request in dev tools, go to Vulnerability Detection > Inventory and ensure the related request is not done, open the multiselect, this should display the suggested values.</summary>

Chrome - :black_circle:

Firefox - :black_circle:

Safari - :black_circle:

</details>

<details>
<summary>:black_circle: Test the #case1 with other views with the same multiselect, e.g. IT Hygiene tabs</summary>

Chrome - :black_circle:

Firefox - :black_circle:

Safari - :black_circle:

</details>

### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 
