### PR TITLE
Migrate artifact handling to S3 in build workflows

### DIFF
--- a/.github/workflows/5_builderpackage_plugins.yml
+++ b/.github/workflows/5_builderpackage_plugins.yml
@@ -39,7 +39,7 @@ on:
 
 env:
   CI_DEV_INTERNAL_BUCKET: ${{ secrets.CI_DEV_INTERNAL_BUCKET }}
-  EXECUTION_REPOSITORY: 'wazuh-dashboard-plugins/4_builderpackage_plugins'
+  EXECUTION_REPOSITORY: 'wazuh-dashboard-plugins/5_builderpackage_plugins'
 
 jobs:
   # Build an app package from the given source code reference.
@@ -53,7 +53,7 @@ jobs:
       reference: ${{ inputs.reference }}
       command: 'yarn build'
       artifact_name: 'wazuh-dashboard-plugins'
-      execution_repository: ${{ inputs.execution_repository || 'wazuh-dashboard-plugins/4_builderpackage_plugins' }}
+      execution_repository: ${{ inputs.execution_repository || 'wazuh-dashboard-plugins/5_builderpackage_plugins' }}
     secrets: inherit
 
   test-packages:

--- a/.github/workflows/5_builderpackage_plugins.yml
+++ b/.github/workflows/5_builderpackage_plugins.yml
@@ -41,6 +41,9 @@ env:
   CI_DEV_INTERNAL_BUCKET: ${{ secrets.CI_DEV_INTERNAL_BUCKET }}
   EXECUTION_REPOSITORY: 'wazuh-dashboard-plugins/4_builderpackage_plugins'
 
+permissions:
+  id-token: write
+
 jobs:
   # Build an app package from the given source code reference.
   build:

--- a/.github/workflows/5_builderpackage_plugins.yml
+++ b/.github/workflows/5_builderpackage_plugins.yml
@@ -24,6 +24,11 @@ on:
         type: string
         default: 5.0.0
         description: Source code reference (branch, tag or commit SHA)
+      execution_repository:
+        required: true
+        type: string
+        default: ''
+        description: 'Repository and workflow run to upload the artifact to (format: repo/workflow). This is used to locate the artifacts in S3.'
   workflow_dispatch:
     inputs:
       reference:
@@ -31,6 +36,10 @@ on:
         type: string
         default: 5.0.0
         description: Source code reference (branch, tag or commit SHA)
+
+env:
+  CI_DEV_INTERNAL_BUCKET: ${{ secrets.CI_DEV_INTERNAL_BUCKET }}
+  EXECUTION_REPOSITORY: 'wazuh-dashboard-plugins/4_builderpackage_plugins'
 
 jobs:
   # Build an app package from the given source code reference.
@@ -43,6 +52,7 @@ jobs:
       reference: ${{ inputs.reference }}
       command: 'yarn build'
       artifact_name: 'wazuh-dashboard-plugins'
+      execution_repository: ${{ inputs.execution_repository || 'wazuh-dashboard-plugins/4_builderpackage_plugins' }}
     secrets: inherit
 
   test-packages:
@@ -51,47 +61,43 @@ jobs:
     runs-on: codebuild-github-actions-codebuild-runner-dashboard-amd-${{ github.run_id }}-${{ github.run_attempt }}
 
     steps:
-      - name: Step 01 - Download the plugin's source code
+      - name: Download the plugin's source code
         uses: actions/checkout@v4
         with:
           repository: wazuh/wazuh-dashboard-plugins
           ref: ${{ inputs.reference }}
           path: wazuh
 
-      - name: Step 02 - Set variables
+      - name: Set variables
         run: |
           echo "githubReference=$(echo ${{ inputs.reference }} | sed 's/\//-/g')" >> $GITHUB_ENV
-          echo "currentDir=$(pwd -P)" >> $GITHUB_ENV
           echo "version=$(jq -r '.version' $(pwd)/wazuh/plugins/main/package.json)" >> $GITHUB_ENV
           echo "revision=$(jq -r '.revision' $(pwd)/wazuh/plugins/main/package.json)" >> $GITHUB_ENV
           echo "versionPlatform=$(jq -r '.pluginPlatform.version' $(pwd)/wazuh/plugins/main/package.json)" >> $GITHUB_ENV
 
-      - name: Step 03 - Download the main plugin's artifact
-        uses: actions/download-artifact@v4
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6
         with:
-          name: wazuh-dashboard-plugins_main_${{ env.version }}-${{ env.revision }}_${{ env.githubReference }}.zip
-          path: ${{ env.currentDir }}/wazuh/scripts/test-packages/plugins/wazuh-dashboard-plugins_main_${{ env.version }}-${{ env.revision }}_${{ env.githubReference }}.zip
+          role-to-assume: ${{ secrets.AWS_IAM_ROLE }}
+          aws-region: ${{ secrets.AWS_REGION }}
 
-      - name: Step 04 - Download the core plugin's artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: wazuh-dashboard-plugins_wazuh-core_${{ env.version }}-${{ env.revision }}_${{ env.githubReference }}.zip
-          path: ${{ env.currentDir }}/wazuh/scripts/test-packages/plugins/wazuh-dashboard-plugins_wazuh-core_${{ env.version }}-${{ env.revision }}_${{ env.githubReference }}.zip
+      - name: Download plugin artifacts from S3
+        run: |
+          plugins_dir="${{ github.workspace }}/wazuh/scripts/test-packages/plugins"
+          mkdir -p "${plugins_dir}"
+          aws s3 cp --recursive \
+            "${{ env.CI_DEV_INTERNAL_BUCKET }}/${{ inputs.execution_repository || env.EXECUTION_REPOSITORY }}/${{github.run_id}}" \
+            "${plugins_dir}"
+          ls -l "${plugins_dir}"
 
-      - name: Step 05 - Download the check-updates plugin's artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: wazuh-dashboard-plugins_wazuh-check-updates_${{ env.version }}-${{ env.revision }}_${{ env.githubReference }}.zip
-          path: ${{ env.currentDir }}/wazuh/scripts/test-packages/plugins/wazuh-dashboard-plugins_wazuh-check-updates_${{ env.version }}-${{ env.revision }}_${{ env.githubReference }}.zip
-
-      - name: Step 06 - Log in to Docker Hub
+      - name: Log in to Docker Hub
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Step 07 - Build the Docker image
+      - name: Build the Docker image
         run: |
-          echo "current=${{ env.currentDir }}"
+          echo "current=${{ github.workspace }}"
           cd ./wazuh/scripts/test-packages
           docker build --build-arg OSD_VERSION=${{ env.versionPlatform }} -f osd-test-packages.Dockerfile ./

--- a/.github/workflows/5_builderpackage_plugins.yml
+++ b/.github/workflows/5_builderpackage_plugins.yml
@@ -41,9 +41,6 @@ env:
   CI_DEV_INTERNAL_BUCKET: ${{ secrets.CI_DEV_INTERNAL_BUCKET }}
   EXECUTION_REPOSITORY: 'wazuh-dashboard-plugins/4_builderpackage_plugins'
 
-permissions:
-  id-token: write
-
 jobs:
   # Build an app package from the given source code reference.
   build:
@@ -51,6 +48,7 @@ jobs:
     uses: ./.github/workflows/5_builderprecompiled_base-dev-environment.yml
     permissions:
       pull-requests: write
+      id-token: write
     with:
       reference: ${{ inputs.reference }}
       command: 'yarn build'

--- a/.github/workflows/5_builderpackage_plugins.yml
+++ b/.github/workflows/5_builderpackage_plugins.yml
@@ -60,6 +60,8 @@ jobs:
     needs: build
     name: Test packages
     runs-on: codebuild-github-actions-codebuild-runner-dashboard-amd-${{ github.run_id }}-${{ github.run_attempt }}
+    permissions:
+      id-token: write
 
     steps:
       - name: Download the plugin's source code

--- a/.github/workflows/5_builderprecompiled_base-dev-environment.yml
+++ b/.github/workflows/5_builderprecompiled_base-dev-environment.yml
@@ -53,6 +53,7 @@ jobs:
   deploy_and_run_command:
     permissions:
       pull-requests: write
+      id-token: write
     name: Deploy and run command
     runs-on: codebuild-github-actions-codebuild-runner-dashboard-amd-${{ github.run_id }}-${{ github.run_attempt }}
     strategy:

--- a/.github/workflows/5_builderprecompiled_base-dev-environment.yml
+++ b/.github/workflows/5_builderprecompiled_base-dev-environment.yml
@@ -34,10 +34,18 @@ on:
         default: 'build'
         description: Folder to include in the archive.
         required: false
+      execution_repository:
+        type: string
+        default: ''
+        description: 'Repository and workflow run to upload the artifact to (format: repo/workflow).'
+        required: false
       notify_jest_coverage_summary:
         type: boolean
         default: false
         required: false
+
+env:
+  CI_DEV_INTERNAL_BUCKET: ${{ secrets.CI_DEV_INTERNAL_BUCKET }}
 
 jobs:
   # Deploy the plugin in a development environment and run a command
@@ -69,7 +77,7 @@ jobs:
           ]
 
     steps:
-      - name: Step 01 - Download the plugin's source code
+      - name: Download the plugin's source code
         uses: actions/checkout@v4
         with:
           repository: wazuh/wazuh-dashboard-plugins
@@ -78,10 +86,10 @@ jobs:
 
       # Fix source code ownership so the internal user of the Docker
       # container is also owner.
-      - name: Step 02 - Change code ownership
+      - name: Change code ownership
         run: sudo chown 1000:1000 -R wazuh;
 
-      - name: Step 03 - Set up the environment and run the command
+      - name: Set up the environment and run the command
         run: |
           # Detect which platform to use from source code
           platform=kbn;
@@ -127,16 +135,23 @@ jobs:
           echo "version=$(jq -r '.version' $(pwd)/wazuh/plugins/main/package.json)" >> $GITHUB_ENV
           echo "revision=$(jq -r '.revision' $(pwd)/wazuh/plugins/main/package.json)" >> $GITHUB_ENV
 
-      - name: Step 04 - Upload artifact to GitHub
+      - name: Configure AWS credentials
         if: ${{ inputs.artifact_name && inputs.artifact_path }}
-        uses: actions/upload-artifact@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
-          name: ${{ inputs.artifact_name }}_${{ matrix.plugins.container_path }}_${{ env.version }}-${{ env.revision }}_${{ env.githubReference }}.zip
-          path: ${{ matrix.plugins.path }}/${{ inputs.artifact_path }}
-          if-no-files-found: 'error'
-          overwrite: true
+          role-to-assume: ${{ secrets.AWS_QA_AUTOMATION_ROLE }}
+          aws-region: ${{ secrets.AWS_REGION }}
 
-      - name: Step 05 - Upload coverage results to GitHub
+      - name: Upload artifact to S3
+        if: ${{ inputs.artifact_name && inputs.artifact_path }}
+        run: |
+          artifact_zip="${{ inputs.artifact_name }}_${{ matrix.plugins.container_path }}_${{ env.version }}-${{ env.revision }}_${{ env.githubReference }}.zip"
+          s3_path="${{ env.CI_DEV_INTERNAL_BUCKET }}/${{ inputs.execution_repository }}/${{ github.run_id}}/${artifact_zip}"
+          packagePath=$(find "${GITHUB_WORKSPACE}/${{ matrix.plugins.path }}/${{ inputs.artifact_path }}" -type f)
+          aws s3 cp "${packagePath}" "${s3_path}"
+          echo "::notice::Artifact uploaded to ${s3_path}"
+
+      - name: Upload coverage results to GitHub
         if: ${{ inputs.notify_jest_coverage_summary && github.event_name == 'pull_request' }}
         uses: ./wazuh/.github/actions/comment-test-coverage
         with:

--- a/.github/workflows/5_builderprecompiled_base-dev-environment.yml
+++ b/.github/workflows/5_builderprecompiled_base-dev-environment.yml
@@ -139,7 +139,7 @@ jobs:
         if: ${{ inputs.artifact_name && inputs.artifact_path }}
         uses: aws-actions/configure-aws-credentials@v6
         with:
-          role-to-assume: ${{ secrets.AWS_QA_AUTOMATION_ROLE }}
+          role-to-assume: ${{ secrets.AWS_IAM_ROLE }}
           aws-region: ${{ secrets.AWS_REGION }}
 
       - name: Upload artifact to S3

--- a/scripts/test-packages/install-plugins.sh
+++ b/scripts/test-packages/install-plugins.sh
@@ -1,8 +1,8 @@
 set -e
 
-plugins=$(ls /tmp)
+plugins=$(ls /tmp/wazuh-dashboard-plugins_*.zip 2>/dev/null || true)
 for plugin in $plugins; do
   echo $plugin
-  /usr/share/opensearch-dashboards/bin/opensearch-dashboards-plugin install file:///tmp/$plugin/$(ls /tmp/$plugin)
+  /usr/share/opensearch-dashboards/bin/opensearch-dashboards-plugin install file://$plugin
 done
 echo "All plugins installed successfully"


### PR DESCRIPTION
### Description
Migrate artifact handling to S3 in build workflows

### Evidence

[(5.x) Build app package (on demand)](https://github.com/wazuh/wazuh-dashboard-plugins/actions/runs/28447770857)

### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff 
