### PR TITLE
Change name to active response app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Added visualizations to Vulnerability Detection > Inventory [#8611](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8611) [#8663](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8663)
 - Added Cases tab to the Threat Hunting module [#8583](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8583) [#8608](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8608) [#8630](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8630)
 - Added Responses tab to the Active Response module [#8681](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8681)
-- Added Active Responses dashboard [#8601](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8601) [#8679](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8679)
+- Added Active Responses dashboard [#8601](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8601) [#8679](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8679) [#8724](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8724)
 - Added `wazuh.disabledSettings` configuration to hide specific settings in the Indexer Settings UI [#8643](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8643) [8693](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8693)
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,8 +37,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Added Cases tab to the Threat Hunting module [#8583](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8583)
 - Added visualizations to Vulnerability Detection > Inventory [#8611](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8611) [#8663](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8663)
 - Added Cases tab to the Threat Hunting module [#8583](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8583) [#8608](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8608) [#8630](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8630)
-- Added Responses tab to the Active Response module [#8681](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8681)
-- Added Active Responses dashboard [#8601](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8601) [#8679](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8679) [#8724](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8724)
+- Added Incident Response app [#8601](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8601) [#8679](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8679) [#8681](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8681) [#8724](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8724)
 - Added `wazuh.disabledSettings` configuration to hide specific settings in the Indexer Settings UI [#8643](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8643) [8693](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8693)
 
 ### Changed

--- a/plugins/main/public/components/common/modules/modules-defaults.tsx
+++ b/plugins/main/public/components/common/modules/modules-defaults.tsx
@@ -631,7 +631,7 @@ export const ModulesDefaults = {
     ],
     availableFor: ['manager', 'agent'],
   },
-  'active-response-dashboard': {
+  'incident-response-dashboard': {
     init: TAB_VIEW_ID_DASHBOARD,
     tabs: [
       {

--- a/plugins/main/public/utils/applications.ts
+++ b/plugins/main/public/utils/applications.ts
@@ -244,10 +244,10 @@ export const activeResponses = {
   category: 'wz-category-security-operations',
   id: 'active-response-dashboard',
   title: i18n.translate('wz-app-active-response-title', {
-    defaultMessage: 'Active Response',
+    defaultMessage: 'Incident Response',
   }),
   breadcrumbLabel: i18n.translate('wz-app-active-response-breadcrumbLabel', {
-    defaultMessage: 'Active Response',
+    defaultMessage: 'Incident Response',
   }),
   description: i18n.translate('wz-app-active-response-description', {
     defaultMessage:

--- a/plugins/main/public/utils/applications.ts
+++ b/plugins/main/public/utils/applications.ts
@@ -242,7 +242,7 @@ export const ITHygiene = {
 
 export const activeResponses = {
   category: 'wz-category-security-operations',
-  id: 'active-response-dashboard',
+  id: 'incident-response-dashboard',
   title: i18n.translate('wz-app-active-response-title', {
     defaultMessage: 'Incident Response',
   }),
@@ -258,7 +258,7 @@ export const activeResponses = {
   showInOverviewApp: true,
   showInAgentMenu: true,
   redirectTo: () =>
-    `/overview/?tab=active-response-dashboard&tabView=dashboard${
+    `/overview/?tab=incident-response-dashboard&tabView=dashboard${
       store.getState()?.appStateReducers?.currentAgentData?.id
         ? `&agentId=${store.getState()?.appStateReducers?.currentAgentData?.id}`
         : ''


### PR DESCRIPTION
### Description
Changes the active response app name, the breadcrumb and the url (dashboard under security operations).

### Issues Resolved
#8723 

### Evidence
<img width="1367" height="536" alt="imagen" src="https://github.com/user-attachments/assets/aab1d7ef-a431-48e1-9f3d-d854eeb7b40e" />


### Test
- Navigate to `Security operations > Incident Response` and validate both the name of the app and the breadcrumb align with the change.

### Check List
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 
