### PR TITLE
use literal single quotes for Linux register-agent password

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,6 +124,7 @@ All notable changes to the Wazuh app project will be documented in this file.
 - Fixed FIM visualizations height [#8610](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8610)
 - Fixed the GitHub link in the About page pointing to the legacy `wazuh-kibana-app` repository [#8653](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8653)
 - Fixed SCA module columns width [#8699](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8699)
+- Fixed Linux Deploy new agent command altering passwords with special characters [#8736](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8736)
 
 ### Removed
 

--- a/plugins/main/public/components/endpoints-summary/register-agent/core/config/os-commands-definitions.ts
+++ b/plugins/main/public/components/endpoints-summary/register-agent/core/config/os-commands-definitions.ts
@@ -253,7 +253,7 @@ export const optionalParamsDefinitions: tOptionalParams<tOptionalParameters> = {
         let osName = selectedOS.name.toLocaleLowerCase();
         switch (osName) {
           case 'linux':
-            return `${property}=$'${scapeSpecialCharsForLinux(value)}'`;
+            return `${property}='${scapeSpecialCharsForLinux(value)}'`;
           case 'macos':
             return `${property}='${scapeSpecialCharsForMacOS(value)}'`;
           case 'windows':

--- a/plugins/main/public/components/endpoints-summary/register-agent/services/wazuh-password-service.ts
+++ b/plugins/main/public/components/endpoints-summary/register-agent/services/wazuh-password-service.ts
@@ -55,9 +55,9 @@ export const osdfucatePasswordInCommand = (password: string, commandText: string
     case 'linux':
     {
       const replacedString = command.replace(
-        `WAZUH_REGISTRATION_PASSWORD=\$'${scapeSpecialCharsForLinux(password)}'`,
+        `WAZUH_REGISTRATION_PASSWORD=\'${scapeSpecialCharsForLinux(password)}'`,
         () => {
-          return `WAZUH_REGISTRATION_PASSWORD=\$\'${'*'.repeat(scapeSpecialCharsForLinux(password).length)}\'`;
+          return `WAZUH_REGISTRATION_PASSWORD=\'${'*'.repeat(scapeSpecialCharsForLinux(password).length)}\'`;
         }
       );
       return replacedString;


### PR DESCRIPTION
### Description
Removed $ from Linux deploy agent password command so special chars aren't altered.

### Issues Resolved
Closes #8732 

### Evidence
<img width="1484" height="854" alt="image" src="https://github.com/user-attachments/assets/fc36e5fa-bbf5-46e9-8ef0-25d146466287" />

### Test
1. Deploy new agent → OS: **Linux**, using a password with special chars.
2. The command shows `WAZUH_REGISTRATION_PASSWORD='...'` (no `$`).
3. The password is still masked (`****`) in the UI.
4. Running the command enrolls the agent with the exact password.

### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 
