### PR TITLE
Migrate non-build workflows to GitHub-hosted runner to reduce costs

### DIFF
--- a/.github/workflows/4_builderpackage_plugins.yml
+++ b/.github/workflows/4_builderpackage_plugins.yml
@@ -59,6 +59,7 @@ jobs:
       command: 'yarn build'
       artifact_name: 'wazuh-dashboard-plugins'
       execution_repository: ${{ inputs.execution_repository || 'wazuh-dashboard-plugins/4_builderpackage_plugins' }}
+      runner: codebuild-github-actions-codebuild-runner-dashboard-amd-${{ github.run_id }}-${{ github.run_attempt }}
     secrets: inherit
 
   test-packages:

--- a/.github/workflows/4_builderprecompiled_base-dev-environment.yml
+++ b/.github/workflows/4_builderprecompiled_base-dev-environment.yml
@@ -43,6 +43,11 @@ on:
         type: boolean
         default: false
         required: false
+      runner:
+        type: string
+        default: 'ubuntu-24.04'
+        required: false
+        description: Runner to use for the job.
 
 env:
   CI_DEV_INTERNAL_BUCKET: ${{ secrets.CI_DEV_INTERNAL_BUCKET }}
@@ -55,7 +60,7 @@ jobs:
       pull-requests: write
       id-token: write
     name: Deploy and run command
-    runs-on: ubuntu-24.04
+    runs-on: ${{ inputs.runner }}
     strategy:
       matrix:
         plugins:

--- a/.github/workflows/4_builderprecompiled_base-dev-environment.yml
+++ b/.github/workflows/4_builderprecompiled_base-dev-environment.yml
@@ -55,7 +55,7 @@ jobs:
       pull-requests: write
       id-token: write
     name: Deploy and run command
-    runs-on: codebuild-github-actions-codebuild-runner-dashboard-amd-${{ github.run_id }}-${{ github.run_attempt }}
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         plugins:

--- a/.github/workflows/4_codelinter_prettier.yml
+++ b/.github/workflows/4_codelinter_prettier.yml
@@ -13,7 +13,7 @@ concurrency:
 jobs:
   prettier:
     name: Ensure the code format on the changed files
-    runs-on: codebuild-github-actions-codebuild-runner-dashboard-amd-${{ github.run_id }}-${{ github.run_attempt }}
+    runs-on: ubuntu-24.04
     if: github.event.pull_request.draft == false
     steps:
       # https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs

--- a/.github/workflows/4_testunit_dev_sh.yml
+++ b/.github/workflows/4_testunit_dev_sh.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   scripts-tests:
     if: github.event.pull_request.draft == false
-    runs-on: codebuild-github-actions-codebuild-runner-dashboard-amd-${{ github.run_id }}-${{ github.run_attempt }}
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - name: Run dev scripts tests (Jest in container)

--- a/.github/workflows/5_builderpackage_plugins.yml
+++ b/.github/workflows/5_builderpackage_plugins.yml
@@ -54,6 +54,7 @@ jobs:
       command: 'yarn build'
       artifact_name: 'wazuh-dashboard-plugins'
       execution_repository: ${{ inputs.execution_repository || 'wazuh-dashboard-plugins/5_builderpackage_plugins' }}
+      runner: codebuild-github-actions-codebuild-runner-dashboard-amd-${{ github.run_id }}-${{ github.run_attempt }}
     secrets: inherit
 
   test-packages:

--- a/.github/workflows/5_builderprecompiled_base-dev-environment.yml
+++ b/.github/workflows/5_builderprecompiled_base-dev-environment.yml
@@ -43,6 +43,11 @@ on:
         type: boolean
         default: false
         required: false
+      runner:
+        type: string
+        default: 'ubuntu-24.04'
+        required: false
+        description: Runner to use for the job.
 
 env:
   CI_DEV_INTERNAL_BUCKET: ${{ secrets.CI_DEV_INTERNAL_BUCKET }}
@@ -55,7 +60,7 @@ jobs:
       pull-requests: write
       id-token: write
     name: Deploy and run command
-    runs-on: ubuntu-24.04
+    runs-on: ${{ inputs.runner }}
     strategy:
       matrix:
         plugins:

--- a/.github/workflows/5_builderprecompiled_base-dev-environment.yml
+++ b/.github/workflows/5_builderprecompiled_base-dev-environment.yml
@@ -55,7 +55,7 @@ jobs:
       pull-requests: write
       id-token: write
     name: Deploy and run command
-    runs-on: codebuild-github-actions-codebuild-runner-dashboard-amd-${{ github.run_id }}-${{ github.run_attempt }}
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         plugins:

--- a/.github/workflows/5_codelinter_prettier.yml
+++ b/.github/workflows/5_codelinter_prettier.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   prettier:
     name: Ensure the code format on the changed files
-    runs-on: codebuild-github-actions-codebuild-runner-dashboard-amd-${{ github.run_id }}-${{ github.run_attempt }}
+    runs-on: ubuntu-24.04
     if: github.event.pull_request.draft == false
     steps:
       # https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs

--- a/.github/workflows/5_testunit_dev_sh.yml
+++ b/.github/workflows/5_testunit_dev_sh.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   scripts-tests:
     if: github.event.pull_request.draft == false
-    runs-on: codebuild-github-actions-codebuild-runner-dashboard-amd-${{ github.run_id }}-${{ github.run_attempt }}
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - name: Run dev scripts tests (Jest in container)

--- a/.github/workflows/6_builderpackage_plugins.yml
+++ b/.github/workflows/6_builderpackage_plugins.yml
@@ -41,6 +41,7 @@ jobs:
       reference: ${{ inputs.reference }}
       command: 'yarn build'
       artifact_name: 'wazuh-dashboard-plugins'
+      runner: codebuild-github-actions-codebuild-runner-dashboard-amd-${{ github.run_id }}-${{ github.run_attempt }}
     secrets: inherit
 
   test-packages:

--- a/.github/workflows/6_builderprecompiled_base-dev-environment.yml
+++ b/.github/workflows/6_builderprecompiled_base-dev-environment.yml
@@ -52,7 +52,7 @@ jobs:
   # using a pre-built Docker image, hosted in Quay.io.
   deploy_and_run_command:
     name: Deploy and run command
-    runs-on: codebuild-github-actions-codebuild-runner-dashboard-amd-${{ github.run_id }}-${{ github.run_attempt }}
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         plugins:

--- a/.github/workflows/6_builderprecompiled_base-dev-environment.yml
+++ b/.github/workflows/6_builderprecompiled_base-dev-environment.yml
@@ -46,13 +46,18 @@ on:
         type: boolean
         default: false
         required: false
+      runner:
+        type: string
+        default: 'ubuntu-24.04'
+        required: false
+        description: Runner to use for the job.
 
 jobs:
   # Deploy the plugin in a development environment and run a command
   # using a pre-built Docker image, hosted in Quay.io.
   deploy_and_run_command:
     name: Deploy and run command
-    runs-on: ubuntu-24.04
+    runs-on: ${{ inputs.runner }}
     strategy:
       matrix:
         plugins:

--- a/.github/workflows/6_documentation_deploy-to-gh-pages.yml
+++ b/.github/workflows/6_documentation_deploy-to-gh-pages.yml
@@ -23,7 +23,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: codebuild-github-actions-codebuild-runner-dashboard-amd-${{ github.run_id }}-${{ github.run_attempt }}
+    runs-on: ubuntu-24.04
     permissions:
       contents: write # To push a branch
       pages: write # To push to a GitHub Pages site


### PR DESCRIPTION
### Description
Migrate non-build GitHub Actions workflows from the dedicated CodeBuild
runner to the default GitHub-hosted runner (`ubuntu-24.04`), reducing
unnecessary usage of the paid runner.

Workflows moved to `ubuntu-24.04`:
- `4/5/6_builderprecompiled_base-dev-environment.yml` (also covers
  `*_testunit_jest.yml` and `6_builderprecompiled_playground.yml` which
  call these as reusable workflows)
- `4/5_codelinter_prettier.yml`
- `4/5_testunit_dev_sh.yml`
- `6_documentation_deploy-to-gh-pages.yml`

Workflows that remain on the dedicated runner (actual package builds):
- `4/5/6_builderpackage_plugins.yml`
- `4/5/6_bumper_repository.yml`

### Issues Resolved
idr

### Evidence

https://github.com/wazuh/wazuh-dashboard-plugins/actions/runs/28875073087

### Test
Trigger any of the migrated workflows (e.g. open a draft PR against a
`4.x` or `5.x` branch and check that the Prettier and unit test jobs
execute on an `ubuntu-24.04` runner instead of the CodeBuild runner).

### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
