### PR TITLE
Fix unclassified.json template not found on build time

### DIFF
--- a/plugins/main/scripts/generate-known-fields/generate-known-fields.js
+++ b/plugins/main/scripts/generate-known-fields/generate-known-fields.js
@@ -117,7 +117,7 @@ const TEMPLATE_SOURCES = {
   'events-unclassified': {
     urls: [
       wazuhUrl(
-        'plugins/setup/src/main/resources/templates/streams/unclassified.json',
+        'plugins/setup/src/main/resources/templates/streams/events.json',
       ),
     ],
     outputFile: 'events-unclassified.json',


### PR DESCRIPTION
### Description
This pull request changes the template used by unclassified events to `events.json`.
 
### Issues Resolved
https://github.com/wazuh/wazuh-dashboard/issues/1427

### Evidence

```console
node@osd:~/kbn/plugins/main$ yarn
yarn install v1.22.22
warning Skipping preferred cache folder "/home/node/.cache/yarn" because it is not writable.
warning Selected the next writable cache folder in the list, will be "/tmp/.yarn-cache-1000".
[1/4] Resolving packages...
warning Resolution field "cookie@0.7.0" is incompatible with requested version "cookie@^0.4.0"
warning Resolution field "axios@1.15.2" is incompatible with requested version "axios@^1.16.0"
[2/4] Fetching packages...
[3/4] Linking dependencies...
warning " > react-cookie@4.1.1" has unmet peer dependency "react@>= 16.3.0".
warning "react-cookie > @types/hoist-non-react-statics@3.3.7" has unmet peer dependency "@types/react@*".
warning " > eslint-plugin-filenames-simple@0.9.0" has incorrect peer dependency "eslint@>=7.0.0 <9.0.0".
warning " > eslint-plugin-import@2.32.0" has incorrect peer dependency "eslint@^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8 || ^9".
warning " > eslint-plugin-prettier@5.5.6" has incorrect peer dependency "prettier@>=3.0.0".
warning " > eslint-plugin-react@7.37.5" has incorrect peer dependency "eslint@^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7".
warning " > knip@5.88.1" has unmet peer dependency "@types/node@>=18".
warning " > redux-mock-store@1.5.5" has unmet peer dependency "redux@*".
warning Workspaces can only be enabled in private projects.
warning Workspaces can only be enabled in private projects.
warning Workspaces can only be enabled in private projects.
warning Workspaces can only be enabled in private projects.
warning Workspaces can only be enabled in private projects.
warning Workspaces can only be enabled in private projects.
warning Workspaces can only be enabled in private projects.
warning Workspaces can only be enabled in private projects.
warning Workspaces can only be enabled in private projects.
warning Workspaces can only be enabled in private projects.
warning Workspaces can only be enabled in private projects.
warning Workspaces can only be enabled in private projects.
warning Workspaces can only be enabled in private projects.
[4/4] Building fresh packages...
$ yarn run generate:indexer-resources
yarn run v1.22.22
warning Skipping preferred cache folder "/home/node/.cache/yarn" because it is not writable.
warning Selected the next writable cache folder in the list, will be "/tmp/.yarn-cache-1000".
$ if [ -f scripts/build-tools/update-indexer-resources ]; then bash scripts/build-tools/update-indexer-resources; else echo 'File does not exist. This could be related to the script file not being included at build time. Skipping...'; fi
Enter the git reference (branch/tag) of the current source code. This reference will be used to get the referece in the indexer git repository to update the resource files (e.g., main, develop): 5.0.0
Resolving branch references...
Getting candidate git references...
Candidate git references: 5.0.0 5.0.0 v5.0.0
Resolved candidate: 5.0.0
Updating known fields of index pattern templates with indexer reference [5.0.0]...
📦 Using Wazuh version: 5.0.0
🚀 Starting known fields generation...

⚙️  Processing states-vulnerabilities template...
  ✅ Successfully fetched from: https://raw.githubusercontent.com/wazuh/wazuh-indexer-plugins/5.0.0/plugins/setup/src/main/resources/templates/states/vulnerabilities.json
  ✅ Generated 92 known fields for states-vulnerabilities -> /home/node/kbn/plugins/main/common/known-fields/states-vulnerabilities.json

⚙️  Processing events-access-management template...
  ✅ Successfully fetched from: https://raw.githubusercontent.com/wazuh/wazuh-indexer-plugins/5.0.0/plugins/setup/src/main/resources/templates/streams/events.json
  ✅ Generated 2297 known fields for events-access-management -> /home/node/kbn/plugins/main/common/known-fields/events-access-management.json

⚙️  Processing events-applications template...
  ✅ Successfully fetched from: https://raw.githubusercontent.com/wazuh/wazuh-indexer-plugins/5.0.0/plugins/setup/src/main/resources/templates/streams/events.json
  ✅ Generated 2297 known fields for events-applications -> /home/node/kbn/plugins/main/common/known-fields/events-applications.json

⚙️  Processing events-cloud-services template...
  ✅ Successfully fetched from: https://raw.githubusercontent.com/wazuh/wazuh-indexer-plugins/5.0.0/plugins/setup/src/main/resources/templates/streams/events.json
  ✅ Generated 2297 known fields for events-cloud-services -> /home/node/kbn/plugins/main/common/known-fields/events-cloud-services.json

⚙️  Processing events-network-activity template...
  ✅ Successfully fetched from: https://raw.githubusercontent.com/wazuh/wazuh-indexer-plugins/5.0.0/plugins/setup/src/main/resources/templates/streams/events.json
  ✅ Generated 2297 known fields for events-network-activity -> /home/node/kbn/plugins/main/common/known-fields/events-network-activity.json

⚙️  Processing events-other template...
  ✅ Successfully fetched from: https://raw.githubusercontent.com/wazuh/wazuh-indexer-plugins/5.0.0/plugins/setup/src/main/resources/templates/streams/events.json
  ✅ Generated 2297 known fields for events-other -> /home/node/kbn/plugins/main/common/known-fields/events-other.json

⚙️  Processing events-security template...
  ✅ Successfully fetched from: https://raw.githubusercontent.com/wazuh/wazuh-indexer-plugins/5.0.0/plugins/setup/src/main/resources/templates/streams/events.json
  ✅ Generated 2297 known fields for events-security -> /home/node/kbn/plugins/main/common/known-fields/events-security.json

⚙️  Processing events-system-activity template...
  ✅ Successfully fetched from: https://raw.githubusercontent.com/wazuh/wazuh-indexer-plugins/5.0.0/plugins/setup/src/main/resources/templates/streams/events.json
  ✅ Generated 2297 known fields for events-system-activity -> /home/node/kbn/plugins/main/common/known-fields/events-system-activity.json

⚙️  Processing events-unclassified template...
  ✅ Successfully fetched from: https://raw.githubusercontent.com/wazuh/wazuh-indexer-plugins/5.0.0/plugins/setup/src/main/resources/templates/streams/events.json
  ✅ Generated 2297 known fields for events-unclassified -> /home/node/kbn/plugins/main/common/known-fields/events-unclassified.json

⚙️  Processing events-raw template...
  ✅ Successfully fetched from: https://raw.githubusercontent.com/wazuh/wazuh-indexer-plugins/5.0.0/plugins/setup/src/main/resources/templates/streams/raw.json
  ✅ Generated 80 known fields for events-raw -> /home/node/kbn/plugins/main/common/known-fields/events-raw.json

⚙️  Processing findings-access-management template...
  ✅ Successfully fetched from: https://raw.githubusercontent.com/wazuh/wazuh-indexer-plugins/5.0.0/plugins/setup/src/main/resources/templates/streams/findings.json
  ✅ Generated 2343 known fields for findings-access-management -> /home/node/kbn/plugins/main/common/known-fields/findings-access-management.json

⚙️  Processing findings-applications template...
  ✅ Successfully fetched from: https://raw.githubusercontent.com/wazuh/wazuh-indexer-plugins/5.0.0/plugins/setup/src/main/resources/templates/streams/findings.json
  ✅ Generated 2343 known fields for findings-applications -> /home/node/kbn/plugins/main/common/known-fields/findings-applications.json

⚙️  Processing findings-cloud-services template...
  ✅ Successfully fetched from: https://raw.githubusercontent.com/wazuh/wazuh-indexer-plugins/5.0.0/plugins/setup/src/main/resources/templates/streams/findings.json
  ✅ Generated 2343 known fields for findings-cloud-services -> /home/node/kbn/plugins/main/common/known-fields/findings-cloud-services.json

⚙️  Processing findings-network-activity template...
  ✅ Successfully fetched from: https://raw.githubusercontent.com/wazuh/wazuh-indexer-plugins/5.0.0/plugins/setup/src/main/resources/templates/streams/findings.json
  ✅ Generated 2343 known fields for findings-network-activity -> /home/node/kbn/plugins/main/common/known-fields/findings-network-activity.json

⚙️  Processing findings-other template...
  ✅ Successfully fetched from: https://raw.githubusercontent.com/wazuh/wazuh-indexer-plugins/5.0.0/plugins/setup/src/main/resources/templates/streams/findings.json
  ✅ Generated 2343 known fields for findings-other -> /home/node/kbn/plugins/main/common/known-fields/findings-other.json

⚙️  Processing findings-security template...
  ✅ Successfully fetched from: https://raw.githubusercontent.com/wazuh/wazuh-indexer-plugins/5.0.0/plugins/setup/src/main/resources/templates/streams/findings.json
  ✅ Generated 2343 known fields for findings-security -> /home/node/kbn/plugins/main/common/known-fields/findings-security.json

⚙️  Processing findings-system-activity template...
  ✅ Successfully fetched from: https://raw.githubusercontent.com/wazuh/wazuh-indexer-plugins/5.0.0/plugins/setup/src/main/resources/templates/streams/findings.json
  ✅ Generated 2343 known fields for findings-system-activity -> /home/node/kbn/plugins/main/common/known-fields/findings-system-activity.json

⚙️  Processing findings-unclassified template...
  ✅ Successfully fetched from: https://raw.githubusercontent.com/wazuh/wazuh-indexer-plugins/5.0.0/plugins/setup/src/main/resources/templates/streams/findings.json
  ✅ Generated 2343 known fields for findings-unclassified -> /home/node/kbn/plugins/main/common/known-fields/findings-unclassified.json

⚙️  Processing metrics-agents template...
  ✅ Successfully fetched from: https://raw.githubusercontent.com/wazuh/wazuh-indexer-plugins/5.0.0/plugins/setup/src/main/resources/templates/streams/metrics-agents.json
  ✅ Generated 28 known fields for metrics-agents -> /home/node/kbn/plugins/main/common/known-fields/metrics-agents.json

⚙️  Processing metrics-comms template...
  ✅ Successfully fetched from: https://raw.githubusercontent.com/wazuh/wazuh-indexer-plugins/5.0.0/plugins/setup/src/main/resources/templates/streams/metrics-comms.json
  ✅ Generated 26 known fields for metrics-comms -> /home/node/kbn/plugins/main/common/known-fields/metrics-comms.json

⚙️  Processing metrics-normalization template...
  ✅ Successfully fetched from: https://raw.githubusercontent.com/wazuh/wazuh-indexer-plugins/5.0.0/plugins/setup/src/main/resources/templates/streams/metrics-normalization.json
  ✅ Generated 16 known fields for metrics-normalization -> /home/node/kbn/plugins/main/common/known-fields/metrics-normalization.json

⚙️  Processing states-fim-files template...
  ✅ Successfully fetched from: https://raw.githubusercontent.com/wazuh/wazuh-indexer-plugins/5.0.0/plugins/setup/src/main/resources/templates/states/fim-files.json
  ✅ Generated 37 known fields for states-fim-files -> /home/node/kbn/plugins/main/common/known-fields/states-fim-files.json

⚙️  Processing states-fim-registries-keys template...
  ✅ Successfully fetched from: https://raw.githubusercontent.com/wazuh/wazuh-indexer-plugins/5.0.0/plugins/setup/src/main/resources/templates/states/fim-registry-keys.json
  ✅ Generated 33 known fields for states-fim-registries-keys -> /home/node/kbn/plugins/main/common/known-fields/states-fim-registries-keys.json

⚙️  Processing states-fim-registries-values template...
  ✅ Successfully fetched from: https://raw.githubusercontent.com/wazuh/wazuh-indexer-plugins/5.0.0/plugins/setup/src/main/resources/templates/states/fim-registry-values.json
  ✅ Generated 33 known fields for states-fim-registries-values -> /home/node/kbn/plugins/main/common/known-fields/states-fim-registries-values.json

⚙️  Processing states-inventory-system template...
  ✅ Successfully fetched from: https://raw.githubusercontent.com/wazuh/wazuh-indexer-plugins/5.0.0/plugins/setup/src/main/resources/templates/states/inventory-system.json
  ✅ Generated 39 known fields for states-inventory-system -> /home/node/kbn/plugins/main/common/known-fields/states-inventory-system.json

⚙️  Processing states-inventory-hardware template...
  ✅ Successfully fetched from: https://raw.githubusercontent.com/wazuh/wazuh-indexer-plugins/5.0.0/plugins/setup/src/main/resources/templates/states/inventory-hardware.json
  ✅ Generated 31 known fields for states-inventory-hardware -> /home/node/kbn/plugins/main/common/known-fields/states-inventory-hardware.json

⚙️  Processing states-inventory-networks template...
  ✅ Successfully fetched from: https://raw.githubusercontent.com/wazuh/wazuh-indexer-plugins/5.0.0/plugins/setup/src/main/resources/templates/states/inventory-networks.json
  ✅ Generated 30 known fields for states-inventory-networks -> /home/node/kbn/plugins/main/common/known-fields/states-inventory-networks.json

⚙️  Processing states-inventory-packages template...
  ✅ Successfully fetched from: https://raw.githubusercontent.com/wazuh/wazuh-indexer-plugins/5.0.0/plugins/setup/src/main/resources/templates/states/inventory-packages.json
  ✅ Generated 36 known fields for states-inventory-packages -> /home/node/kbn/plugins/main/common/known-fields/states-inventory-packages.json

⚙️  Processing states-inventory-ports template...
  ✅ Successfully fetched from: https://raw.githubusercontent.com/wazuh/wazuh-indexer-plugins/5.0.0/plugins/setup/src/main/resources/templates/states/inventory-ports.json
  ✅ Generated 34 known fields for states-inventory-ports -> /home/node/kbn/plugins/main/common/known-fields/states-inventory-ports.json

⚙️  Processing states-inventory-processes template...
  ✅ Successfully fetched from: https://raw.githubusercontent.com/wazuh/wazuh-indexer-plugins/5.0.0/plugins/setup/src/main/resources/templates/states/inventory-processes.json
  ✅ Generated 33 known fields for states-inventory-processes -> /home/node/kbn/plugins/main/common/known-fields/states-inventory-processes.json

⚙️  Processing states-inventory-protocols template...
  ✅ Successfully fetched from: https://raw.githubusercontent.com/wazuh/wazuh-indexer-plugins/5.0.0/plugins/setup/src/main/resources/templates/states/inventory-protocols.json
  ✅ Generated 28 known fields for states-inventory-protocols -> /home/node/kbn/plugins/main/common/known-fields/states-inventory-protocols.json

⚙️  Processing states-inventory-users template...
  ✅ Successfully fetched from: https://raw.githubusercontent.com/wazuh/wazuh-indexer-plugins/5.0.0/plugins/setup/src/main/resources/templates/states/inventory-users.json
  ✅ Generated 55 known fields for states-inventory-users -> /home/node/kbn/plugins/main/common/known-fields/states-inventory-users.json

⚙️  Processing states-inventory-groups template...
  ✅ Successfully fetched from: https://raw.githubusercontent.com/wazuh/wazuh-indexer-plugins/5.0.0/plugins/setup/src/main/resources/templates/states/inventory-groups.json
  ✅ Generated 30 known fields for states-inventory-groups -> /home/node/kbn/plugins/main/common/known-fields/states-inventory-groups.json

⚙️  Processing states-inventory-services template...
  ✅ Successfully fetched from: https://raw.githubusercontent.com/wazuh/wazuh-indexer-plugins/5.0.0/plugins/setup/src/main/resources/templates/states/inventory-services.json
  ✅ Generated 55 known fields for states-inventory-services -> /home/node/kbn/plugins/main/common/known-fields/states-inventory-services.json

⚙️  Processing states-inventory-interfaces template...
  ✅ Successfully fetched from: https://raw.githubusercontent.com/wazuh/wazuh-indexer-plugins/5.0.0/plugins/setup/src/main/resources/templates/states/inventory-interfaces.json
  ✅ Generated 37 known fields for states-inventory-interfaces -> /home/node/kbn/plugins/main/common/known-fields/states-inventory-interfaces.json

⚙️  Processing states-inventory-hotfixes template...
  ✅ Successfully fetched from: https://raw.githubusercontent.com/wazuh/wazuh-indexer-plugins/5.0.0/plugins/setup/src/main/resources/templates/states/inventory-hotfixes.json
  ✅ Generated 24 known fields for states-inventory-hotfixes -> /home/node/kbn/plugins/main/common/known-fields/states-inventory-hotfixes.json

⚙️  Processing states-inventory-browser-extensions template...
  ✅ Successfully fetched from: https://raw.githubusercontent.com/wazuh/wazuh-indexer-plugins/5.0.0/plugins/setup/src/main/resources/templates/states/inventory-browser-extensions.json
  ✅ Generated 45 known fields for states-inventory-browser-extensions -> /home/node/kbn/plugins/main/common/known-fields/states-inventory-browser-extensions.json

⚙️  Processing states-sca template...
  ✅ Successfully fetched from: https://raw.githubusercontent.com/wazuh/wazuh-indexer-plugins/5.0.0/plugins/setup/src/main/resources/templates/states/sca.json
  ✅ Generated 54 known fields for states-sca -> /home/node/kbn/plugins/main/common/known-fields/states-sca.json

⚙️  Processing active-responses template...
  ✅ Successfully fetched from: https://raw.githubusercontent.com/wazuh/wazuh-indexer-plugins/5.0.0/plugins/setup/src/main/resources/templates/streams/active-responses.json
  ✅ Generated 526 known fields for active-responses -> /home/node/kbn/plugins/main/common/known-fields/active-responses.json

⚙️  Processing threatintel-enrichments template...
  ✅ Successfully fetched from: https://raw.githubusercontent.com/wazuh/wazuh-indexer-plugins/5.0.0/plugins/setup/src/main/resources/templates/content/ioc.json
   ⚠️  Field name contains wildcard: type_hashes.*, skipping field extraction.
   ⚠️  Field name contains wildcard: type_hashes.*.hash.sha256, skipping field extraction.
  ✅ Generated 20 known fields for threatintel-enrichments -> /home/node/kbn/plugins/main/common/known-fields/threatintel-enrichments.json

⚙️  Processing combined states-fim fields...
  ✅ Generated 53 combined fields for states-fim -> /home/node/kbn/plugins/main/common/known-fields/states-fim.json

⚙️  Processing combined states-inventory fields...
  ✅ Generated 182 combined fields for states-inventory -> /home/node/kbn/plugins/main/common/known-fields/states-inventory.json

⚙️  Processing combined events fields...
  ✅ Generated 2297 combined fields for events -> /home/node/kbn/plugins/main/common/known-fields/events.json

⚙️  Processing combined findings fields...
  ✅ Generated 2343 combined fields for findings -> /home/node/kbn/plugins/main/common/known-fields/findings.json

📊 Summary:
  ✅  states-vulnerabilities: 92 fields generated
  ✅  events-access-management: 2297 fields generated
  ✅  events-applications: 2297 fields generated
  ✅  events-cloud-services: 2297 fields generated
  ✅  events-network-activity: 2297 fields generated
  ✅  events-other: 2297 fields generated
  ✅  events-security: 2297 fields generated
  ✅  events-system-activity: 2297 fields generated
  ✅  events-unclassified: 2297 fields generated
  ✅  events-raw: 80 fields generated
  ✅  findings-access-management: 2343 fields generated
  ✅  findings-applications: 2343 fields generated
  ✅  findings-cloud-services: 2343 fields generated
  ✅  findings-network-activity: 2343 fields generated
  ✅  findings-other: 2343 fields generated
  ✅  findings-security: 2343 fields generated
  ✅  findings-system-activity: 2343 fields generated
  ✅  findings-unclassified: 2343 fields generated
  ✅  metrics-agents: 28 fields generated
  ✅  metrics-comms: 26 fields generated
  ✅  metrics-normalization: 16 fields generated
  ✅  states-fim-files: 37 fields generated
  ✅  states-fim-registries-keys: 33 fields generated
  ✅  states-fim-registries-values: 33 fields generated
  ✅  states-inventory-system: 39 fields generated
  ✅  states-inventory-hardware: 31 fields generated
  ✅  states-inventory-networks: 30 fields generated
  ✅  states-inventory-packages: 36 fields generated
  ✅  states-inventory-ports: 34 fields generated
  ✅  states-inventory-processes: 33 fields generated
  ✅  states-inventory-protocols: 28 fields generated
  ✅  states-inventory-users: 55 fields generated
  ✅  states-inventory-groups: 30 fields generated
  ✅  states-inventory-services: 55 fields generated
  ✅  states-inventory-interfaces: 37 fields generated
  ✅  states-inventory-hotfixes: 24 fields generated
  ✅  states-inventory-browser-extensions: 45 fields generated
  ✅  states-sca: 54 fields generated
  ✅  active-responses: 526 fields generated
  ⚠️  threatintel-enrichments: 20 fields generated (⚠️ 2 warnings)
    ⚠️  Warnings (2):
      - Field name contains wildcard: type_hashes.*, skipping field extraction.
      - Field name contains wildcard: type_hashes.*.hash.sha256, skipping field extraction.
  ✅  states-fim: 53 fields generated
  ✅  states-inventory: 182 fields generated
  ✅  events: 2297 fields generated
  ✅  findings: 2343 fields generated

✨ Known fields generation completed!
Updating sample data of index pattern templates with indexer reference [5.0.0]...
Using specified branch: 5.0.0
Found 20 datasets to update.
Starting templates update...

Processing dataset: metrics-agents
Downloading: https://raw.githubusercontent.com/wazuh/wazuh-indexer-plugins/5.0.0/plugins/setup/src/main/resources/templates/streams/metrics-agents.json

Processing dataset: metrics-comms
Downloading: https://raw.githubusercontent.com/wazuh/wazuh-indexer-plugins/5.0.0/plugins/setup/src/main/resources/templates/streams/metrics-comms.json

Processing dataset: states-fim-files
Downloading: https://raw.githubusercontent.com/wazuh/wazuh-indexer-plugins/5.0.0/plugins/setup/src/main/resources/templates/states/fim-files.json

Processing dataset: states-fim-registry-keys
Downloading: https://raw.githubusercontent.com/wazuh/wazuh-indexer-plugins/5.0.0/plugins/setup/src/main/resources/templates/states/fim-registry-keys.json

Processing dataset: states-fim-registry-values
Downloading: https://raw.githubusercontent.com/wazuh/wazuh-indexer-plugins/5.0.0/plugins/setup/src/main/resources/templates/states/fim-registry-values.json

Processing dataset: states-inventory-browser-extensions
Downloading: https://raw.githubusercontent.com/wazuh/wazuh-indexer-plugins/5.0.0/plugins/setup/src/main/resources/templates/states/inventory-browser-extensions.json

Processing dataset: states-inventory-groups
Downloading: https://raw.githubusercontent.com/wazuh/wazuh-indexer-plugins/5.0.0/plugins/setup/src/main/resources/templates/states/inventory-groups.json

Processing dataset: states-inventory-hardware
Downloading: https://raw.githubusercontent.com/wazuh/wazuh-indexer-plugins/5.0.0/plugins/setup/src/main/resources/templates/states/inventory-hardware.json

Processing dataset: states-inventory-hotfixes
Downloading: https://raw.githubusercontent.com/wazuh/wazuh-indexer-plugins/5.0.0/plugins/setup/src/main/resources/templates/states/inventory-hotfixes.json

Processing dataset: states-inventory-interfaces
Downloading: https://raw.githubusercontent.com/wazuh/wazuh-indexer-plugins/5.0.0/plugins/setup/src/main/resources/templates/states/inventory-interfaces.json

Processing dataset: states-inventory-networks
Downloading: https://raw.githubusercontent.com/wazuh/wazuh-indexer-plugins/5.0.0/plugins/setup/src/main/resources/templates/states/inventory-networks.json

Processing dataset: states-inventory-packages
Downloading: https://raw.githubusercontent.com/wazuh/wazuh-indexer-plugins/5.0.0/plugins/setup/src/main/resources/templates/states/inventory-packages.json

Processing dataset: states-inventory-ports
Downloading: https://raw.githubusercontent.com/wazuh/wazuh-indexer-plugins/5.0.0/plugins/setup/src/main/resources/templates/states/inventory-ports.json

Processing dataset: states-inventory-processes
Downloading: https://raw.githubusercontent.com/wazuh/wazuh-indexer-plugins/5.0.0/plugins/setup/src/main/resources/templates/states/inventory-processes.json

Processing dataset: states-inventory-protocols
Downloading: https://raw.githubusercontent.com/wazuh/wazuh-indexer-plugins/5.0.0/plugins/setup/src/main/resources/templates/states/inventory-protocols.json

Processing dataset: states-inventory-services
Downloading: https://raw.githubusercontent.com/wazuh/wazuh-indexer-plugins/5.0.0/plugins/setup/src/main/resources/templates/states/inventory-services.json

Processing dataset: states-inventory-system
Downloading: https://raw.githubusercontent.com/wazuh/wazuh-indexer-plugins/5.0.0/plugins/setup/src/main/resources/templates/states/inventory-system.json

Processing dataset: states-inventory-users
Downloading: https://raw.githubusercontent.com/wazuh/wazuh-indexer-plugins/5.0.0/plugins/setup/src/main/resources/templates/states/inventory-users.json

Processing dataset: states-sca
Downloading: https://raw.githubusercontent.com/wazuh/wazuh-indexer-plugins/5.0.0/plugins/setup/src/main/resources/templates/states/sca.json

Processing dataset: states-vulnerabilities
Downloading: https://raw.githubusercontent.com/wazuh/wazuh-indexer-plugins/5.0.0/plugins/setup/src/main/resources/templates/states/vulnerabilities.json
✅ Template updated for states-fim-registry-keys
✅ Template updated for states-fim-files
✅ Template updated for states-fim-registry-values
✅ Template updated for states-inventory-hotfixes
✅ Template updated for metrics-agents
✅ Template updated for metrics-comms
✅ Template updated for states-vulnerabilities
✅ Template updated for states-inventory-hardware
✅ Template updated for states-inventory-packages
✅ Template updated for states-inventory-networks
✅ Template updated for states-inventory-interfaces
✅ Template updated for states-inventory-protocols
✅ Template updated for states-inventory-groups
✅ Template updated for states-inventory-browser-extensions
✅ Template updated for states-inventory-system
✅ Template updated for states-inventory-ports
✅ Template updated for states-sca
✅ Template updated for states-inventory-services
✅ Template updated for states-inventory-users
✅ Template updated for states-inventory-processes

===== UPDATE SUMMARY =====
✅ Successfully updated datasets: 20
❌ Datasets with errors: 0
Done in 10.62s.
Done in 16.96s.
```

Build package test job: https://github.com/wazuh/wazuh-dashboard/actions/runs/28927220815

### Test

No manual test required.

### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff 
