### PR TITLE
Fix MITRE ATT&CK Framework tab not applying date range and fetch filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,7 @@
 - Fixed the GitHub link in the About page pointing to the legacy `wazuh-kibana-app` repository [#8653](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8653)
 - Fixed SCA module columns width [#8699](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8699)
 - Fixed Home KPI's visualization persistent filters [#8708](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8708)
+- Fixed MITRE ATT&CK Framework tab not applying the date range and fetch filters [#8775](https://github.com/wazuh/wazuh-dashboard-plugins/issues/8775)
 
 ### Removed
 

--- a/plugins/main/public/components/overview/mitre/framework/mitre.tsx
+++ b/plugins/main/public/components/overview/mitre/framework/mitre.tsx
@@ -67,7 +67,7 @@ const MitreComponent = compose(
   }),
 )(props => {
   const { onSelectedTabChanged, dataSource } = props;
-  const { dateRangeFrom, dateRangeTo } = dataSource;
+  const { dateRangeFrom, dateRangeTo } = dataSource.searchBarProps;
   const [mitreState, setMitreState] = useState<tMitreState>({
     tacticsObject: {},
     selectedTactics: {},
@@ -102,7 +102,7 @@ const MitreComponent = compose(
     initialize();
   }, [
     dataSource.searchBarProps.query,
-    JSON.stringify(dataSource.filters),
+    JSON.stringify(dataSource.fetchFilters),
     dateRangeFrom,
     dateRangeTo,
     dataSource.fingerprint,


### PR DESCRIPTION
## Description

Closes #8775

The MITRE ATT&CK **Framework** tab was not reacting to changes in the date range picker or to filters applied from the search bar: it read stale/incorrect properties off `dataSource`, so the tactics/techniques view never refreshed when the time range or fetch filters changed.

## Proposed Changes

- Destructure `dateRangeFrom`/`dateRangeTo` from `dataSource.searchBarProps` instead of `dataSource` directly.
- Track `JSON.stringify(dataSource.fetchFilters)` instead of `JSON.stringify(dataSource.filters)` in the data-fetching effect's dependency array.

### Results and Evidence

https://github.com/user-attachments/assets/d31e3d4a-ddb1-4e89-9a69-baa24e57115b

### Artifacts Affected

None.

### Configuration Changes

None.

### Documentation Updates

None.

### Tests Introduced

None. `plugins/main/public/components/overview/mitre/framework/mitre.tsx` has no colocated test file; existing MITRE ATT&CK Jest suite (`intelligence.test.tsx`) passes unaffected.

### How to test

- Navigate to `MITRE ATTACK > Framework` and verify that all types of filters apply.

## Review Checklist

- [x] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [x] Configuration changes documented
- [x] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [x] PR is linked to the relevant issue(s)
- [x] Correct labels applied (e.g., `no-changelog`)

Done with claude pr-creation skill.
