### PR TITLE
Fix/8778 dev env ts pin and enrollments password

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,7 @@
 - Fixed the GitHub link in the About page pointing to the legacy `wazuh-kibana-app` repository [#8653](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8653)
 - Fixed SCA module columns width [#8699](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8699)
 - Fixed Home KPI's visualization persistent filters [#8708](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8708)
+- Fixed the osd-dev environment by pinning the TypeScript tooling of the scripts image and configuring a matching agent enrollment password for the local server profiles [#8778](https://github.com/wazuh/wazuh-dashboard-plugins/issues/8778)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,7 +123,6 @@
 - Fixed the GitHub link in the About page pointing to the legacy `wazuh-kibana-app` repository [#8653](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8653)
 - Fixed SCA module columns width [#8699](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8699)
 - Fixed Home KPI's visualization persistent filters [#8708](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8708)
-- Fixed the osd-dev environment by pinning the TypeScript tooling of the scripts image and configuring a matching agent enrollment password for the local server profiles [#8778](https://github.com/wazuh/wazuh-dashboard-plugins/issues/8778)
 
 ### Removed
 

--- a/docker/osd-dev/dev.yml
+++ b/docker/osd-dev/dev.yml
@@ -403,6 +403,8 @@ services:
     networks:
       - os-dev
       - mon
+    environment:
+      - WAZUH_REGISTRATION_PASSWORD=${WAZUH_REGISTRATION_PASSWORD:-WazuhRegistrationDev123}
     volumes:
       - ./agents:/packages-agents
     command:
@@ -413,8 +415,12 @@ services:
         apt update -y
         apt install -y lsb-release adduser
 
-        # Install Wazuh agent
-        WAZUH_MANAGER='wazuh.manager.local' WAZUH_AGENT_GROUP='default' WAZUH_REGISTRATION_PASSWORD='WazuhRegistrationDev123' dpkg -i /packages-agents/wazuh-agent*.deb
+        # Install Wazuh agent (registration password only if defined)
+        if [ -n "$$WAZUH_REGISTRATION_PASSWORD" ]; then
+          WAZUH_MANAGER='wazuh.manager.local' WAZUH_AGENT_GROUP='default' WAZUH_REGISTRATION_PASSWORD="$$WAZUH_REGISTRATION_PASSWORD" dpkg -i /packages-agents/wazuh-agent*.deb
+        else
+          WAZUH_MANAGER='wazuh.manager.local' WAZUH_AGENT_GROUP='default' dpkg -i /packages-agents/wazuh-agent*.deb
+        fi
 
         # Start Wazuh agent
         /etc/init.d/wazuh-agent start
@@ -429,6 +435,8 @@ services:
     networks:
       - os-dev
       - mon
+    environment:
+      - WAZUH_REGISTRATION_PASSWORD=${WAZUH_REGISTRATION_PASSWORD:-WazuhRegistrationDev123}
     volumes:
       - ./agents:/packages-agents
     command:
@@ -442,8 +450,12 @@ services:
         yum makecache
         yum upgrade -y
 
-        # Install wazuh-agent
-        WAZUH_MANAGER='wazuh.manager.local' WAZUH_AGENT_GROUP='default' WAZUH_REGISTRATION_PASSWORD='WazuhRegistrationDev123' yum localinstall -y /packages-agents/wazuh-agent*.rpm
+        # Install wazuh-agent (registration password only if defined)
+        if [ -n "$$WAZUH_REGISTRATION_PASSWORD" ]; then
+          WAZUH_MANAGER='wazuh.manager.local' WAZUH_AGENT_GROUP='default' WAZUH_REGISTRATION_PASSWORD="$$WAZUH_REGISTRATION_PASSWORD" yum localinstall -y /packages-agents/wazuh-agent*.rpm
+        else
+          WAZUH_MANAGER='wazuh.manager.local' WAZUH_AGENT_GROUP='default' yum localinstall -y /packages-agents/wazuh-agent*.rpm
+        fi
 
         # Start wazuh-agent
         /var/ossec/bin/wazuh-control start

--- a/docker/osd-dev/dev.yml
+++ b/docker/osd-dev/dev.yml
@@ -384,6 +384,7 @@ services:
       - INDEXER_SSL_CA=/etc/server_certs/root-ca.pem
       - INDEXER_SSL_CERTIFICATE=/etc/server_certs/server.pem
       - INDEXER_SSL_CERTIFICATE_KEY=/etc/server_certs/server-key.pem
+      - WAZUH_REGISTRATION_PASSWORD=WazuhRegistrationDev123
     volumes:
       - wm_certs:/etc/server_certs
     ports:
@@ -413,7 +414,7 @@ services:
         apt install -y lsb-release adduser
 
         # Install Wazuh agent
-        WAZUH_MANAGER='wazuh.manager.local' WAZUH_AGENT_GROUP='default' dpkg -i /packages-agents/wazuh-agent*.deb
+        WAZUH_MANAGER='wazuh.manager.local' WAZUH_AGENT_GROUP='default' WAZUH_REGISTRATION_PASSWORD='WazuhRegistrationDev123' dpkg -i /packages-agents/wazuh-agent*.deb
 
         # Start Wazuh agent
         /etc/init.d/wazuh-agent start
@@ -442,7 +443,7 @@ services:
         yum upgrade -y
 
         # Install wazuh-agent
-        WAZUH_MANAGER='wazuh.manager.local' WAZUH_AGENT_GROUP='default' yum localinstall -y /packages-agents/wazuh-agent*.rpm
+        WAZUH_MANAGER='wazuh.manager.local' WAZUH_AGENT_GROUP='default' WAZUH_REGISTRATION_PASSWORD='WazuhRegistrationDev123' yum localinstall -y /packages-agents/wazuh-agent*.rpm
 
         # Start wazuh-agent
         /var/ossec/bin/wazuh-control start

--- a/docker/osd-dev/manager/entrypoint.sh
+++ b/docker/osd-dev/manager/entrypoint.sh
@@ -23,6 +23,15 @@ if [ -n "$INDEXER_SSL_CERTIFICATE_KEY" ]; then
   chmod 400 $INDEXER_SSL_CERTIFICATE_KEY
 fi
 
+# Configure the agent enrollment password expected by authd (use_password is
+# enabled by default in the manager package; without this file authd generates
+# a random password and agent enrollment fails with "Invalid password")
+if [ -n "$WAZUH_REGISTRATION_PASSWORD" ]; then
+  echo "$WAZUH_REGISTRATION_PASSWORD" > /var/wazuh-manager/etc/authd.pass
+  chmod 640 /var/wazuh-manager/etc/authd.pass
+  chown root:wazuh-manager /var/wazuh-manager/etc/authd.pass
+fi
+
 # Clean up stale PID and socket files from previous unclean shutdowns
 # (e.g. after docker stop + docker start without recreating the container)
 find /var/wazuh-manager/var/run -name "*.pid" -delete 2>/dev/null || true

--- a/docker/osd-dev/scripts/Dockerfile
+++ b/docker/osd-dev/scripts/Dockerfile
@@ -12,7 +12,9 @@ RUN apk add --no-cache \
 WORKDIR /app
 
 # Install global TypeScript tooling (no app deps here)
-RUN npm install -g typescript ts-node @types/node
+# Pinned: ts-node 10.x is incompatible with TypeScript >= 7 (native compiler
+# drops the ts.sys JS API), so floating to latest breaks this image.
+RUN npm install -g typescript@6.0.3 ts-node@10.9.2 @types/node@26.0.0
 
 # Copy the wazuh-core package.json for version detection
 COPY plugins/wazuh-core/package.json /workspace/plugins/wazuh-core/package.json


### PR DESCRIPTION
### Description

The local dev environment (`docker/osd-dev`) had two problems:

1. **TypeScript tooling floated to latest and broke the dev scripts.** `scripts/Dockerfile` installed `typescript ts-node @types/node` with no version pin. TypeScript 7 (native compiler, released 2026-07-08) drops the `ts.sys` JS API that ts-node 10.x depends on, so any fresh image build crashed with `TypeError: Cannot read properties of undefined (reading 'fileExists')`, making `dev.sh` unusable. The versions are now pinned to the known-compatible set (`typescript@6.0.3 ts-node@10.9.2 @types/node@26.0.0`).

2. **Local agents failed enrollment with `Invalid password`.** The Wazuh manager 5.0 package ships with `<auth><use_password>yes</use_password>` by default; with no `authd.pass` provisioned, authd generates a random password at startup, so agents (which sent none) were rejected. A shared registration password is now configured: the manager entrypoint seeds `/var/wazuh-manager/etc/authd.pass` from `WAZUH_REGISTRATION_PASSWORD`, and both local agent services pass the same variable at package install time (the agent package writes it to `/var/ossec/etc/authd.pass`, already referenced by the generated enrollment config).

### Issues Resolved

closes #8778

### Evidence
**Test environment:** macOS (Apple Silicon) + Docker Desktop, local packages tag `05-07`, brought up with `./dev.sh up --server-local 07-21 --indexer-local 07-21`.

#### 1. Pinned TypeScript tooling — fresh `osd-dev-script` image works

<details><summary>Versions inside the freshly rebuilt image + dev.sh runs cleanly</summary>

```console
$ docker run --rm --entrypoint sh osd-dev-script:latest -c 'tsc --version && ts-node --version'
Version 6.0.3
v10.9.2
```

```console
$ ./dev.sh

```

Without the pin, a fresh install resolves TypeScript 7.0.2 (latest) and ts-node 10.9.2 crashes immediately:

```console
$ docker run --rm node:22-alpine sh -c "npm i -g typescript ts-node @types/node --silent && echo 'console.log(1)' > /t.ts && ts-node /t.ts"
TypeError: Cannot read properties of undefined (reading 'fileExists')
    at readConfig (/usr/local/lib/node_modules/ts-node/dist/configuration.js:91:33)
```

</details>

#### 2. Agent enrollment — `server-local` profile (deb + rpm)

<details><summary>Manager: authd uses the seeded enrollment password</summary>

```console
$ docker exec os-dev-360-wazuh.manager.local-1 ls -l /var/wazuh-manager/etc/authd.pass
-rw-r----- 1 root wazuh-manager 24 Jul 22 12:51 /var/wazuh-manager/etc/authd.pass
```

```console
$ docker exec os-dev-360-wazuh.manager.local-1 grep authd /var/wazuh-manager/logs/wazuh-manager.log
2026/07/21 12:51:53 wazuh-manager-authd: INFO: Accepting connections on port 1515. Using existing authentication password from 'etc/authd.pass'. To rotate the password, delete the file and restart.
```

</details>

<details><summary>DEB agent: password from file → valid key → connected</summary>

```console
$ docker logs os-dev-360-wazuh.agent.deb.local-1 2>&1 | grep -E "Using password|Valid key|Connected to"
2026/07/21 12:52:30 wazuh-agentd: INFO: Using password specified on file: etc/authd.pass
2026/07/21 12:52:30 wazuh-agentd: INFO: Valid key received
2026/07/21 12:52:50 wazuh-agentd: INFO: (4102): Connected to the server ([wazuh.manager.local]:1514/tcp).
```

</details>

<details><summary>RPM agent: password from file → valid key → connected</summary>

```console
$ docker logs os-dev-360-wazuh.agent.rpm.local-1 2>&1 | grep -E "Using password|Valid key|Connected to"
2026/07/21 12:52:23 wazuh-agentd: INFO: Using password specified on file: etc/authd.pass
2026/07/21 12:52:23 wazuh-agentd: INFO: Valid key received
2026/07/21 12:52:43 wazuh-agentd: INFO: (4102): Connected to the server ([wazuh.manager.local]:1514/tcp).
```

</details>

<details><summary>Manager client.keys: both agents registered</summary>

```console
$ docker exec os-dev-360-wazuh.manager.local-1 cat /var/wazuh-manager/etc/client.keys
001 wazuh.agent.rpm.local any 1eb3725ea2b2c136460f4856d5fe2515d2538011af12c582b2bc9886d7d88453
002 wazuh.agent.deb.local any 7693fae89f3994aa5b4b6a419bc3ef2bb98ffdb1134f1181cb401d04cb2d5f67
```

</details>

#### 3. Agent enrollment — `server-local-deb` profile

<details><summary>Fresh manager + deb agent recreated from scratch with `-a deb`</summary>

```console
$ docker exec os-dev-360-wazuh.manager.local-1 grep authd /var/wazuh-manager/logs/wazuh-manager.log
wazuh-manager-authd: INFO: Accepting connections on port 1515. Using existing authentication password from 'etc/authd.pass'. ...
```

```console
$ docker logs os-dev-360-wazuh.agent.deb.local-1 2>&1 | grep -E "Using password|Valid key|Connected to"
2026/07/21 12:29:31 wazuh-agentd: INFO: Using password specified on file: etc/authd.pass
2026/07/21 12:29:31 wazuh-agentd: INFO: Valid key received
2026/07/21 12:29:51 wazuh-agentd: INFO: (4102): Connected to the server ([wazuh.manager.local]:1514/tcp).
```

```console
$ docker exec os-dev-360-wazuh.manager.local-1 cat /var/wazuh-manager/etc/client.keys
001 wazuh.agent.deb.local any b549fb962666c1cae28d6a79d2b71be669735c59285b523184a88386f8edf2b0
```

</details>

#### 4. Agent enrollment — `server-local-rpm` profile

<details><summary>Fresh manager + rpm agent recreated from scratch with `-a rpm`</summary>

```console
$ docker exec os-dev-360-wazuh.manager.local-1 grep authd /var/wazuh-manager/logs/wazuh-manager.log
2026/07/21 12:54:22 wazuh-manager-authd: INFO: Accepting connections on port 1515. Using existing authentication password from 'etc/authd.pass'. ...
```

```console
$ docker logs os-dev-360-wazuh.agent.rpm.local-1 2>&1 | grep -E "Using password|Valid key|Connected to"
2026/07/21 12:54:31 wazuh-agentd: INFO: Using password specified on file: etc/authd.pass
2026/07/21 12:54:31 wazuh-agentd: INFO: Valid key received
2026/07/21 12:54:51 wazuh-agentd: INFO: (4102): Connected to the server ([wazuh.manager.local]:1514/tcp).
```

```console
$ docker exec os-dev-360-wazuh.manager.local-1 cat /var/wazuh-manager/etc/client.keys
001 wazuh.agent.rpm.local any 5e0be8a9e3792f955ad2512916b3c17f66201f4ff5bfe5e9ad5a91405daac37b
```

</details>
### Test

1. `cd docker/osd-dev && ./dev.sh up --server-local <tag> --indexer-local <tag>` (rebuild the `wazuh-manager-pkg` image first if it already exists, so the new entrypoint is picked up).
2. Verify the scripts image: `docker run --rm --entrypoint sh osd-dev-script:latest -c 'tsc --version && ts-node --version'` → `6.0.3` / `10.9.2`, and `./dev.sh` prints its usage cleanly.
3. Verify enrollment: manager log shows `Using existing authentication password from 'etc/authd.pass'`; both agent logs show `Using password specified on file: etc/authd.pass` → `Valid key received` → `Connected to the server`; `/var/wazuh-manager/etc/client.keys` lists both agents.

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff