### PR TITLE
Change bumper_repository workflows merge type

### DIFF
--- a/.github/workflows/4_bumper_repository.yml
+++ b/.github/workflows/4_bumper_repository.yml
@@ -133,7 +133,7 @@ jobs:
       - name: Merge pull request
         run: |
           # Any checks for the PR are bypassed since the branch is expected to be functional (i.e. the bump process does not introduce any bugs)
-          gh pr merge "${{ steps.create_pr.outputs.pull_request_url }}" --merge --admin
+          gh pr merge "${{ steps.create_pr.outputs.pull_request_url }}" --squash --admin
 
       - name: Show logs
         run: |


### PR DESCRIPTION
## Description

`4_bumper_repository.yml` currently merges its generated bump PRs with `gh pr merge --merge --admin`, which creates a merge commit — inconsistent with this repo's squash-merge convention for single-purpose PRs. This PR switches it to `--squash --admin`.

Closes https://github.com/wazuh/wazuh-dashboard/issues/1459

## Proposed Changes

- `.github/workflows/4_bumper_repository.yml`: `gh pr merge ... --merge --admin` → `gh pr merge ... --squash --admin`.

### Results and Evidence

`git diff origin/4.14.8..HEAD` shows exactly 1 file changed, 1 line:

```diff
--- a/.github/workflows/4_bumper_repository.yml
+++ b/.github/workflows/4_bumper_repository.yml
@@ -133,7 +133,7 @@
       - name: Merge pull request
         run: |
           # Any checks for the PR are bypassed since the branch is expected to be functional (i.e. the bump process does not introduce any bugs)
-          gh pr merge "${{ steps.create_pr.outputs.pull_request_url }}" --merge --admin
+          gh pr merge "${{ steps.create_pr.outputs.pull_request_url }}" --squash --admin
```

### Artifacts Affected

- `.github/workflows/4_bumper_repository.yml` (CI workflow, no runtime/build artifact)

### Configuration Changes

None (CI merge-strategy flag only).

### Documentation Updates

None.

### Tests Introduced

None. Non-executable CLI flag change in a GitHub Actions step — no unit-testable logic exists. Verified manually via direct diff/read inspection against `origin/4.14.8`.

### How to Test

1. Confirm `.github/workflows/4_bumper_repository.yml` passes `--squash --admin` (not `--merge --admin`).
2. (Optional, real effect only observable in CI) On the next bumper run on this branch, confirm the generated bump PR is merged via squash rather than a merge commit.

### Review Checklist

- [ ] All tests pass
  - [ ] `yarn test:jest` — N/A, no JS/TS changed
- [ ] New functionality includes testing. — N/A, no executable logic changed
- [ ] New functionality has been documented. — N/A
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md) — Skipped: internal CI tooling, no user-facing impact
- [x] Commits are signed per the DCO using --signoff
