### PR TITLE
Fix pinned agent filter leaking into Home overview widgets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,7 +101,7 @@
 - Condensed the setting labels and added info tooltips in the registration service configuration view [#8616](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8616)
 - Adapt management of daemons status to the new API response schema [#8706](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8706)
 - Enhanced description of `reports.csv.maxRows` setting [#1434](https://github.com/wazuh/wazuh-dashboard/issues/1434)
-- Rework the Home page overview with more platform metrics [#8760](https://github.com/wazuh/wazuh-dashboard-plugins/issues/8760)
+- Rework the Home page overview with more platform metrics [#8760](https://github.com/wazuh/wazuh-dashboard-plugins/issues/8760) [#8792](https://github.com/wazuh/wazuh-dashboard-plugins/issues/8792)
 
 ### Fixed
 

--- a/plugins/main/public/components/common/welcome/home-overview/hooks/use-overview-data.ts
+++ b/plugins/main/public/components/common/welcome/home-overview/hooks/use-overview-data.ts
@@ -27,6 +27,7 @@ import {
   tParsedIndexPattern,
 } from '../../../data-source';
 import { WzRequest } from '../../../../../react-services';
+import { PinnedAgentManager } from '../../../../wz-agent-selector/wz-agent-selector-service';
 import {
   buildCvesMatchedAgg,
   buildFindingsOverviewAggs,
@@ -86,6 +87,14 @@ const NO_HITS: { pageSize: number } = { pageSize: 0 };
 
 function isDataSourceNotFound(error: unknown): boolean {
   return (error as { type?: string })?.type === DATA_SOURCE_NOT_FOUND;
+}
+
+function excludePinnedAgentFilter(filters: tFilter[] = []): tFilter[] {
+  return filters.filter(
+    filter =>
+      filter.meta?.controlledBy !==
+      PinnedAgentManager.FILTER_CONTROLLED_PINNED_AGENT_KEY,
+  );
 }
 
 /**
@@ -191,8 +200,12 @@ function useAggregationGroup<T>(options: {
 
   // Scope every search to the data source's fixed filters only, so global /
   // pinned filters set elsewhere in the app don't leak into the Home overview
+  const scopedFixedFilters = excludePinnedAgentFilter(fixedFilters);
   const scopedFetchData: FetchData = params =>
-    fetchData({ ...params, filters: fixedFilters } as Parameters<FetchData>[0]);
+    fetchData({
+      ...params,
+      filters: scopedFixedFilters,
+    } as Parameters<FetchData>[0]);
 
   const result = useDataGroup<T>({
     isLoading,
@@ -205,8 +218,8 @@ function useAggregationGroup<T>(options: {
   });
 
   return useMemo(
-    () => ({ ...result, dataSource, fixedFilters }),
-    [result, dataSource, fixedFilters],
+    () => ({ ...result, dataSource, fixedFilters: scopedFixedFilters }),
+    [result, dataSource, scopedFixedFilters],
   );
 }
 
@@ -467,6 +480,10 @@ function useIndexDocCount(
       repository,
     });
 
+  // Scope every search to the data source's fixed filters only, so global /
+  // pinned filters set elsewhere in the app don't leak into the Home overview
+  const scopedFixedFilters = excludePinnedAgentFilter(fixedFilters);
+
   return useDataGroup<number | undefined>({
     isLoading,
     initError: error,
@@ -477,7 +494,7 @@ function useIndexDocCount(
         await fetchData({
           dateRange,
           pagination: NO_HITS,
-          filters: fixedFilters,
+          filters: scopedFixedFilters,
         } as Parameters<typeof fetchData>[0]),
       ),
     deps: [isLoading, error, dataSource, enabled],

--- a/plugins/main/public/components/endpoints-summary/hooks/upgrade-tasks.test.ts
+++ b/plugins/main/public/components/endpoints-summary/hooks/upgrade-tasks.test.ts
@@ -84,13 +84,9 @@ describe('useGetUpgradeTasks hook', () => {
     const mockGetTasks = jest.requireMock('../services').getTasks;
     mockGetTasks.mockResolvedValue({ total_affected_items: 0 });
 
-    const { waitForNextUpdate } = renderHook(() =>
-      useGetUpgradeTasks(false, true),
-    );
+    renderHook(() => useGetUpgradeTasks(false, true));
 
-    await waitForNextUpdate();
-
-    expect(mockGetTasks).toHaveBeenCalled();
+    await waitFor(() => expect(mockGetTasks).toHaveBeenCalled());
   });
 
   it('should handle error while fetching data', async () => {


### PR DESCRIPTION
## Description

Closes #8792

When an agent was pinned on any dashboard (e.g. IT Hygiene) and the user then navigated back to the Home overview, several widgets kept applying that pinned agent instead of showing data across all agents. Home overview is meant to be a cross-agent summary, so no widget should ever be scoped to a pinned agent.

## Proposed Changes

Root cause: the pinned agent filter isn't a filter layered on top of a search — it's injected directly into `getFixedFilters()` by the base `PatternDataSource` class. The Home overview hooks already scoped every fetch to `filters: fixedFilters` (instead of the full search-bar filter set) specifically to keep stray global/pinned filters out, but that guard didn't help here because the pinned agent filter *is* one of the "fixed" filters for most data sources (`SystemInventory*`, `SCAStatesDataSource`, `FIMFilesStatesDataSource`, `VulnerabilitiesDataSource`, `ThreatIntelEnrichmentsStatesDataSource`, `ActiveResponsesDataSource`). `OverviewDataSource` (backing the Overview/Threat Hunting sections) happens to override `getFixedFilters()` to exclude it, which is why those widgets were unaffected.

Added `excludePinnedAgentFilter()` in `use-overview-data.ts` and applied it in the two shared hooks that every Home overview widget's data flows through (`useAggregationGroup` and `useIndexDocCount`), stripping any filter whose `meta.controlledBy` is the pinned-agent sentinel before it's used to scope a fetch. Since there are no other `useDataSource`/`fetchData` call sites under `home-overview/`, this closes the leak for every current widget (Top Operating Systems, Top Network Services, Configuration Assessment, File Integrity Monitoring, Vulnerability Detection, IT Hygiene counts, Threat Intelligence/IOC feed tiles, Active Response) in one place, and for any future one added through the same hooks.

The cluster filter and per-widget discriminator filters (e.g. `destination.port` used to distinguish the Network Services vs Traffic views) are left untouched — only the pinned-agent entry is dropped.

### Tests Introduced

No new test file added — `use-overview-data.ts` has no colocated test today (pre-existing gap). Verified instead by running the full `home-overview` Jest suite (25 suites / 135 tests, all passing) and manual reasoning through each affected data source's `getFixedFilters()` chain.

## Review Checklist

- [x] Code changes reviewed
- [ ] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented
- [x] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [x] PR is linked to the relevant issue(s)
- [x] Correct labels applied (e.g., `no-changelog`)
- [ ] ...

### How to Test

1. Go to any dashboard that supports pinning an agent (e.g. IT Hygiene) and pin one.
2. Navigate to the Home overview.
3. Confirm every widget (Top Operating Systems, Top Network Services, Configuration Assessment, File Integrity Monitoring, Vulnerability Detection, IT Hygiene counts, Threat Intelligence/IOC feed, Active Response, Overview/Threat Hunting) shows data across **all** agents, not just the previously pinned one.
4. Unpin the agent and confirm the Home overview is unchanged (this fix only removes the pinned-agent filter; cluster scoping and other fixed filters still apply).
