### PR TITLE
Fix agent configuration section descriptions

### DIFF
--- a/plugins/main/public/controllers/management/components/management/configuration/configuration-settings.js
+++ b/plugins/main/public/controllers/management/components/management/configuration/configuration-settings.js
@@ -79,7 +79,7 @@ export default [
       {
         name: 'Policy monitoring',
         description:
-          'Configuration to ensure compliance with security policies, standards and hardening guides',
+          'Configuration to ensure compliance with security policies, standards, and hardening guides',
         goto: 'policy-monitoring',
         when: 'agent',
       },
@@ -100,7 +100,7 @@ export default [
         // Wazuh: Removed this section for the manager.
         name: 'Inventory data',
         description:
-          'Gather relevant information about system operating system, hardware, networking and packages',
+          'Gather relevant information about system operating system, hardware, networking, and packages',
         goto: 'inventory',
         when: 'agent',
       },


### PR DESCRIPTION
## Description

The descriptions of the **Policy monitoring** and **Inventory data** sections in the agent/group Configuration view were missing the serial comma before "and", unlike other section descriptions (e.g. Integrity monitoring), making the copy inconsistent.

Closes #8791

## Proposed Changes

- Added the missing comma before "and" in the **Policy monitoring** description: "Configuration to ensure compliance with security policies, standards, and hardening guides".
- Added the missing comma before "and" in the **Inventory data** description: "Gather relevant information about system operating system, hardware, networking, and packages".

### Results and Evidence
<img width="923" height="559" alt="image" src="https://github.com/user-attachments/assets/c3ade797-394d-4bf6-88e3-eb2a60920b36" />

### Artifacts Affected

- `plugins/main` (Wazuh dashboard main plugin bundle)

### Configuration Changes

None.

### Documentation Updates

None.

### Tests Introduced

None — display-only string change with no logic involved; no existing test or snapshot references these descriptions.

## Review Checklist

- [x] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [x] PR is linked to the relevant issue(s)
- [ ] Correct labels applied (e.g., `no-changelog`)