### PR TITLE
Improve provider form UX and error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@
 - Added `wazuh.disabledSettings` configuration to hide specific settings in the Indexer Settings UI [#8643](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8643) [8693](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8693)
 - Expanded the case management form with title, description, severity, priority and TLP fields, comments that can be added or edited individually, and a confirmation dialog before discarding unsaved changes [#8718](https://github.com/wazuh/wazuh-dashboard-plugins/issues/8718)
 - Added queue usage in bytes and agent cache visualizations to `Server Management` > `Statistics`, and relabeled the Comms "Queue usage" Y-axis to Bytes [#8768](https://github.com/wazuh/wazuh-dashboard-plugins/issues/8768)
-- Added Wazuh AI Assistant plugin: provider-agnostic AI chat over Wazuh data with a read-only tool catalog, server-side guardrails, optional pseudonymization, and API-key encryption at rest [#8788](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8788) [#8797](https://github.com/wazuh/wazuh-dashboard-plugins/issues/8797)
+- Added Wazuh AI Assistant plugin: provider-agnostic AI chat over Wazuh data with a read-only tool catalog, server-side guardrails, optional pseudonymization, and API-key encryption at rest [#8788](https://github.com/wazuh/wazuh-dashboard-plugins/pull/8788) [#8797](https://github.com/wazuh/wazuh-dashboard-plugins/issues/8797) [#8829](https://github.com/wazuh/wazuh-dashboard-plugins/issues/8829)
 
 ### Changed
 

--- a/plugins/wazuh-ai-assistant/public/components/settings/provider-form-flyout.test.tsx
+++ b/plugins/wazuh-ai-assistant/public/components/settings/provider-form-flyout.test.tsx
@@ -246,3 +246,33 @@ describe('ProviderFormFlyout — API key encryption gate', () => {
     expect(screen.getByRole('button', { name: /^save$/i })).toBeEnabled();
   });
 });
+
+describe('ProviderFormFlyout — endpoint URL guidance', () => {
+  it('shows an OpenAI placeholder/example and docs link by default (openai_compatible)', () => {
+    render(<ProviderFormFlyout {...baseProps} />);
+
+    expect(screen.getByLabelText(/endpoint url/i)).toHaveAttribute(
+      'placeholder',
+      'https://api.openai.com/v1',
+    );
+    expect(
+      screen.getByRole('link', { name: /openai api reference/i }),
+    ).toHaveAttribute('href', 'https://platform.openai.com/docs/api-reference');
+  });
+
+  it('switches to the Anthropic placeholder/example and docs link when the provider type changes', () => {
+    render(<ProviderFormFlyout {...baseProps} />);
+
+    fireEvent.change(screen.getByLabelText(/provider type/i), {
+      target: { value: 'anthropic' },
+    });
+
+    expect(screen.getByLabelText(/endpoint url/i)).toHaveAttribute(
+      'placeholder',
+      'https://api.anthropic.com',
+    );
+    expect(
+      screen.getByRole('link', { name: /anthropic api reference/i }),
+    ).toHaveAttribute('href', 'https://docs.anthropic.com/en/api/overview');
+  });
+});

--- a/plugins/wazuh-ai-assistant/public/components/settings/provider-form-flyout.test.tsx
+++ b/plugins/wazuh-ai-assistant/public/components/settings/provider-form-flyout.test.tsx
@@ -248,7 +248,7 @@ describe('ProviderFormFlyout — API key encryption gate', () => {
 });
 
 describe('ProviderFormFlyout — endpoint URL guidance', () => {
-  it('shows an OpenAI placeholder/example and docs link by default (openai_compatible)', () => {
+  it('shows an OpenAI placeholder/example and one docs link per covered service by default (openai_compatible)', () => {
     render(<ProviderFormFlyout {...baseProps} />);
 
     expect(screen.getByLabelText(/endpoint url/i)).toHaveAttribute(
@@ -258,6 +258,15 @@ describe('ProviderFormFlyout — endpoint URL guidance', () => {
     expect(
       screen.getByRole('link', { name: /openai api reference/i }),
     ).toHaveAttribute('href', 'https://platform.openai.com/docs/api-reference');
+    expect(
+      screen.getByRole('link', { name: /groq api reference/i }),
+    ).toHaveAttribute('href', 'https://console.groq.com/docs/api-reference');
+    expect(
+      screen.getByRole('link', { name: /ollama api reference/i }),
+    ).toHaveAttribute(
+      'href',
+      'https://github.com/ollama/ollama/blob/main/docs/api.md',
+    );
   });
 
   it('switches to the Anthropic placeholder/example and docs link when the provider type changes', () => {
@@ -274,5 +283,8 @@ describe('ProviderFormFlyout — endpoint URL guidance', () => {
     expect(
       screen.getByRole('link', { name: /anthropic api reference/i }),
     ).toHaveAttribute('href', 'https://docs.anthropic.com/en/api/overview');
+    expect(
+      screen.queryByRole('link', { name: /groq api reference/i }),
+    ).not.toBeInTheDocument();
   });
 });

--- a/plugins/wazuh-ai-assistant/public/components/settings/provider-form-flyout.test.tsx
+++ b/plugins/wazuh-ai-assistant/public/components/settings/provider-form-flyout.test.tsx
@@ -39,6 +39,17 @@ describe('ProviderFormFlyout — create mode', () => {
     expect(screen.getByLabelText(/^name$/i)).toHaveValue('');
   });
 
+  it('clarifies the API key is optional for auth-free endpoints and encrypted at rest', () => {
+    render(<ProviderFormFlyout {...baseProps} />);
+
+    expect(
+      screen.getByText(
+        /optional for endpoints that don't require authentication/i,
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/stored encrypted at rest/i)).toBeInTheDocument();
+  });
+
   it('blocks submit and shows an error when the endpoint URL is invalid', async () => {
     render(<ProviderFormFlyout {...baseProps} />);
 

--- a/plugins/wazuh-ai-assistant/public/components/settings/provider-form-flyout.test.tsx
+++ b/plugins/wazuh-ai-assistant/public/components/settings/provider-form-flyout.test.tsx
@@ -275,6 +275,9 @@ describe('ProviderFormFlyout — endpoint URL guidance', () => {
       'href',
       'https://github.com/ollama/ollama/blob/main/docs/api.md',
     );
+    expect(
+      screen.getByText(/using another openai-compatible provider or gateway/i),
+    ).toBeInTheDocument();
   });
 
   it('switches to the Anthropic placeholder/example and docs link when the provider type changes', async () => {
@@ -298,6 +301,60 @@ describe('ProviderFormFlyout — endpoint URL guidance', () => {
     ).toHaveAttribute('href', 'https://docs.anthropic.com/en/api/overview');
     expect(
       screen.queryByRole('link', { name: /groq api reference/i }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(
+        /using another openai-compatible provider or gateway/i,
+      ),
+    ).not.toBeInTheDocument();
+  });
+});
+
+describe('ProviderFormFlyout — Model field guidance', () => {
+  it('shows OpenAI-compatible model examples and one docs link per covered service by default', async () => {
+    render(<ProviderFormFlyout {...baseProps} />);
+
+    expect(screen.getByText(/gpt-4o-mini/i)).toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole('button', { name: /^see available models$/i }),
+    );
+
+    expect(
+      await screen.findByRole('link', { name: /openai model list/i }),
+    ).toHaveAttribute('href', 'https://platform.openai.com/docs/models');
+    expect(
+      screen.getByRole('link', { name: /groq model list/i }),
+    ).toHaveAttribute('href', 'https://console.groq.com/docs/models');
+    expect(
+      screen.getByRole('link', { name: /ollama model library/i }),
+    ).toHaveAttribute('href', 'https://ollama.com/library');
+    expect(
+      screen.getByText(/using another openai-compatible provider or gateway/i),
+    ).toBeInTheDocument();
+  });
+
+  it('switches to Anthropic model examples and docs link when the provider type changes', async () => {
+    render(<ProviderFormFlyout {...baseProps} />);
+
+    fireEvent.change(screen.getByLabelText(/provider type/i), {
+      target: { value: 'anthropic' },
+    });
+
+    expect(screen.getByText(/claude-sonnet-4-5/i)).toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole('button', { name: /^see available models$/i }),
+    );
+
+    expect(
+      await screen.findByRole('link', { name: /anthropic model list/i }),
+    ).toHaveAttribute(
+      'href',
+      'https://docs.anthropic.com/en/docs/about-claude/models/overview',
+    );
+    expect(
+      screen.queryByRole('link', { name: /groq model list/i }),
     ).not.toBeInTheDocument();
   });
 });

--- a/plugins/wazuh-ai-assistant/public/components/settings/provider-form-flyout.test.tsx
+++ b/plugins/wazuh-ai-assistant/public/components/settings/provider-form-flyout.test.tsx
@@ -248,7 +248,7 @@ describe('ProviderFormFlyout — API key encryption gate', () => {
 });
 
 describe('ProviderFormFlyout — endpoint URL guidance', () => {
-  it('shows an OpenAI placeholder/example and one docs link per covered service by default (openai_compatible)', () => {
+  it('shows an OpenAI placeholder/example, with one docs link per covered service behind the documentation popover, by default (openai_compatible)', async () => {
     render(<ProviderFormFlyout {...baseProps} />);
 
     expect(screen.getByLabelText(/endpoint url/i)).toHaveAttribute(
@@ -256,7 +256,15 @@ describe('ProviderFormFlyout — endpoint URL guidance', () => {
       'https://api.openai.com/v1',
     );
     expect(
-      screen.getByRole('link', { name: /openai api reference/i }),
+      screen.queryByRole('link', { name: /openai api reference/i }),
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole('button', { name: /^api documentation$/i }),
+    );
+
+    expect(
+      await screen.findByRole('link', { name: /openai api reference/i }),
     ).toHaveAttribute('href', 'https://platform.openai.com/docs/api-reference');
     expect(
       screen.getByRole('link', { name: /groq api reference/i }),
@@ -269,7 +277,7 @@ describe('ProviderFormFlyout — endpoint URL guidance', () => {
     );
   });
 
-  it('switches to the Anthropic placeholder/example and docs link when the provider type changes', () => {
+  it('switches to the Anthropic placeholder/example and docs link when the provider type changes', async () => {
     render(<ProviderFormFlyout {...baseProps} />);
 
     fireEvent.change(screen.getByLabelText(/provider type/i), {
@@ -280,8 +288,13 @@ describe('ProviderFormFlyout — endpoint URL guidance', () => {
       'placeholder',
       'https://api.anthropic.com',
     );
+
+    fireEvent.click(
+      screen.getByRole('button', { name: /^api documentation$/i }),
+    );
+
     expect(
-      screen.getByRole('link', { name: /anthropic api reference/i }),
+      await screen.findByRole('link', { name: /anthropic api reference/i }),
     ).toHaveAttribute('href', 'https://docs.anthropic.com/en/api/overview');
     expect(
       screen.queryByRole('link', { name: /groq api reference/i }),

--- a/plugins/wazuh-ai-assistant/public/components/settings/provider-form-flyout.tsx
+++ b/plugins/wazuh-ai-assistant/public/components/settings/provider-form-flyout.tsx
@@ -461,8 +461,12 @@ export const ProviderFormFlyout: React.FC<ProviderFormFlyoutProps> = ({
                 <>
                   <FormattedMessage
                     id='wazuhAiAssistant.settings.form.baseUrlExample'
-                    defaultMessage='Example: {example}'
+                    defaultMessage='{header}: {example}'
                     values={{
+                      header:
+                        urlGuidance.examples.length > 1
+                          ? 'Examples'
+                          : 'Example',
                       example: <EuiCode>{urlGuidance.examples[0]}</EuiCode>,
                     }}
                   />
@@ -473,6 +477,7 @@ export const ProviderFormFlyout: React.FC<ProviderFormFlyoutProps> = ({
                     </React.Fragment>
                   ))}
                   {'. '}
+                  <EuiSpacer size='xs' />
                   <DocsPopover
                     triggerLabel={i18n.translate(
                       'wazuhAiAssistant.settings.form.baseUrlDocsButton',
@@ -514,8 +519,12 @@ export const ProviderFormFlyout: React.FC<ProviderFormFlyoutProps> = ({
                   })}{' '}
                   <FormattedMessage
                     id='wazuhAiAssistant.settings.form.modelExample'
-                    defaultMessage='Example: {example}'
+                    defaultMessage='{header}: {example}'
                     values={{
+                      header:
+                        modelGuidance.examples.length > 1
+                          ? 'Examples'
+                          : 'Example',
                       example: <EuiCode>{modelGuidance.examples[0]}</EuiCode>,
                     }}
                   />
@@ -526,6 +535,7 @@ export const ProviderFormFlyout: React.FC<ProviderFormFlyoutProps> = ({
                     </React.Fragment>
                   ))}
                   {'. '}
+                  <EuiSpacer size='xs' />
                   <DocsPopover
                     triggerLabel={i18n.translate(
                       'wazuhAiAssistant.settings.form.modelDocsButton',

--- a/plugins/wazuh-ai-assistant/public/components/settings/provider-form-flyout.tsx
+++ b/plugins/wazuh-ai-assistant/public/components/settings/provider-form-flyout.tsx
@@ -331,7 +331,7 @@ export const ProviderFormFlyout: React.FC<ProviderFormFlyoutProps> = ({
     <>
       <EuiFlyout
         onClose={requestClose}
-        size='m'
+        size='s'
         aria-labelledby='wz-ai-provider-flyout-title'
       >
         <EuiFlyoutHeader hasBorder>
@@ -556,12 +556,24 @@ export const ProviderFormFlyout: React.FC<ProviderFormFlyoutProps> = ({
               helpText={
                 editingProvider
                   ? i18n.translate(
-                      'wazuhAiAssistant.settings.form.apiKeyHelp',
+                      'wazuhAiAssistant.settings.form.apiKeyHelpEditing',
                       {
-                        defaultMessage: 'Leave empty to keep the current key.',
+                        defaultMessage:
+                          'Leave empty to keep the current key. Optional for endpoints that ' +
+                          "don't require authentication (e.g. a local Ollama server without " +
+                          'auth) — stored encrypted at rest when an encryption key is ' +
+                          'configured.',
                       },
                     )
-                  : undefined
+                  : i18n.translate(
+                      'wazuhAiAssistant.settings.form.apiKeyHelpCreate',
+                      {
+                        defaultMessage:
+                          "Optional for endpoints that don't require authentication (e.g. a " +
+                          'local Ollama server without auth) — stored encrypted at rest when ' +
+                          'an encryption key is configured.',
+                      },
+                    )
               }
             >
               <EuiFieldPassword

--- a/plugins/wazuh-ai-assistant/public/components/settings/provider-form-flyout.tsx
+++ b/plugins/wazuh-ai-assistant/public/components/settings/provider-form-flyout.tsx
@@ -40,6 +40,11 @@ const PROVIDER_TYPE_FORM_LABELS: Record<string, string> = {
   }),
 };
 
+interface ProviderUrlDoc {
+  label: string;
+  url: string;
+}
+
 /**
  * Per-type endpoint URL guidance shown under the field: the adapters append their own path to
  * `baseUrl` (`/chat/completions` for openai_compatible, `/v1/messages` for anthropic — see
@@ -52,8 +57,7 @@ const PROVIDER_URL_GUIDANCE: Record<
   {
     placeholder: string;
     examples: string[];
-    docsLabel: string;
-    docsUrl: string;
+    docs: ProviderUrlDoc[];
   }
 > = {
   openai_compatible: {
@@ -63,20 +67,46 @@ const PROVIDER_URL_GUIDANCE: Record<
       'https://api.groq.com/openai/v1',
       'http://localhost:11434/v1',
     ],
-    docsLabel: i18n.translate(
-      'wazuhAiAssistant.settings.form.baseUrlDocsOpenai',
-      { defaultMessage: 'OpenAI API reference' },
-    ),
-    docsUrl: 'https://platform.openai.com/docs/api-reference',
+    // One link per actual service this type covers (see PROVIDER_TYPE_FORM_LABELS above) — a
+    // single "OpenAI API reference" link would be misleading for a Groq/Ollama/etc endpoint.
+    docs: [
+      {
+        label: i18n.translate(
+          'wazuhAiAssistant.settings.form.baseUrlDocsOpenai',
+          { defaultMessage: 'OpenAI API reference' },
+        ),
+        url: 'https://platform.openai.com/docs/api-reference',
+      },
+      {
+        label: i18n.translate(
+          'wazuhAiAssistant.settings.form.baseUrlDocsGroq',
+          {
+            defaultMessage: 'Groq API reference',
+          },
+        ),
+        url: 'https://console.groq.com/docs/api-reference',
+      },
+      {
+        label: i18n.translate(
+          'wazuhAiAssistant.settings.form.baseUrlDocsOllama',
+          { defaultMessage: 'Ollama API reference' },
+        ),
+        url: 'https://github.com/ollama/ollama/blob/main/docs/api.md',
+      },
+    ],
   },
   anthropic: {
     placeholder: 'https://api.anthropic.com',
     examples: ['https://api.anthropic.com'],
-    docsLabel: i18n.translate(
-      'wazuhAiAssistant.settings.form.baseUrlDocsAnthropic',
-      { defaultMessage: 'Anthropic API reference' },
-    ),
-    docsUrl: 'https://docs.anthropic.com/en/api/overview',
+    docs: [
+      {
+        label: i18n.translate(
+          'wazuhAiAssistant.settings.form.baseUrlDocsAnthropic',
+          { defaultMessage: 'Anthropic API reference' },
+        ),
+        url: 'https://docs.anthropic.com/en/api/overview',
+      },
+    ],
   },
 };
 
@@ -324,9 +354,14 @@ export const ProviderFormFlyout: React.FC<ProviderFormFlyoutProps> = ({
                     </React.Fragment>
                   ))}
                   {'. '}
-                  <EuiLink href={urlGuidance.docsUrl} target='_blank'>
-                    {urlGuidance.docsLabel}
-                  </EuiLink>
+                  {urlGuidance.docs.map((doc, index) => (
+                    <React.Fragment key={doc.url}>
+                      {index > 0 && ', '}
+                      <EuiLink href={doc.url} target='_blank'>
+                        {doc.label}
+                      </EuiLink>
+                    </React.Fragment>
+                  ))}
                 </>
               }
             >

--- a/plugins/wazuh-ai-assistant/public/components/settings/provider-form-flyout.tsx
+++ b/plugins/wazuh-ai-assistant/public/components/settings/provider-form-flyout.tsx
@@ -15,6 +15,7 @@ import {
   EuiFlyoutHeader,
   EuiForm,
   EuiFormRow,
+  EuiLink,
   EuiSelect,
   EuiSpacer,
   EuiTitle,
@@ -37,6 +38,46 @@ const PROVIDER_TYPE_FORM_LABELS: Record<string, string> = {
   anthropic: i18n.translate('wazuhAiAssistant.settings.type.anthropic', {
     defaultMessage: 'Anthropic',
   }),
+};
+
+/**
+ * Per-type endpoint URL guidance shown under the field: the adapters append their own path to
+ * `baseUrl` (`/chat/completions` for openai_compatible, `/v1/messages` for anthropic — see
+ * server/providers/openai-compatible.ts and anthropic.ts), so the placeholder/examples must be
+ * the API ROOT, not a full request URL, or a user copying the example verbatim would get a
+ * doubled path once the adapter appends its own suffix.
+ */
+const PROVIDER_URL_GUIDANCE: Record<
+  ProviderInput['type'],
+  {
+    placeholder: string;
+    examples: string[];
+    docsLabel: string;
+    docsUrl: string;
+  }
+> = {
+  openai_compatible: {
+    placeholder: 'https://api.openai.com/v1',
+    examples: [
+      'https://api.openai.com/v1',
+      'https://api.groq.com/openai/v1',
+      'http://localhost:11434/v1',
+    ],
+    docsLabel: i18n.translate(
+      'wazuhAiAssistant.settings.form.baseUrlDocsOpenai',
+      { defaultMessage: 'OpenAI API reference' },
+    ),
+    docsUrl: 'https://platform.openai.com/docs/api-reference',
+  },
+  anthropic: {
+    placeholder: 'https://api.anthropic.com',
+    examples: ['https://api.anthropic.com'],
+    docsLabel: i18n.translate(
+      'wazuhAiAssistant.settings.form.baseUrlDocsAnthropic',
+      { defaultMessage: 'Anthropic API reference' },
+    ),
+    docsUrl: 'https://docs.anthropic.com/en/api/overview',
+  },
 };
 
 const emptyForm: ProviderInput = {
@@ -87,6 +128,7 @@ export const ProviderFormFlyout: React.FC<ProviderFormFlyoutProps> = ({
   );
   const [baseUrlError, setBaseUrlError] = useState<string | null>(null);
   const [showCloseConfirm, setShowCloseConfirm] = useState(false);
+  const urlGuidance = PROVIDER_URL_GUIDANCE[form.type];
 
   const handleSave = async () => {
     const trimmedForm: ProviderInput = {
@@ -140,7 +182,7 @@ export const ProviderFormFlyout: React.FC<ProviderFormFlyoutProps> = ({
     <>
       <EuiFlyout
         onClose={requestClose}
-        size='s'
+        size='m'
         aria-labelledby='wz-ai-provider-flyout-title'
       >
         <EuiFlyoutHeader hasBorder>
@@ -266,10 +308,31 @@ export const ProviderFormFlyout: React.FC<ProviderFormFlyoutProps> = ({
               })}
               isInvalid={Boolean(baseUrlError)}
               error={baseUrlError}
+              helpText={
+                <>
+                  <FormattedMessage
+                    id='wazuhAiAssistant.settings.form.baseUrlExample'
+                    defaultMessage='Example: {example}'
+                    values={{
+                      example: <EuiCode>{urlGuidance.examples[0]}</EuiCode>,
+                    }}
+                  />
+                  {urlGuidance.examples.slice(1).map(example => (
+                    <React.Fragment key={example}>
+                      {', '}
+                      <EuiCode>{example}</EuiCode>
+                    </React.Fragment>
+                  ))}
+                  {'. '}
+                  <EuiLink href={urlGuidance.docsUrl} target='_blank'>
+                    {urlGuidance.docsLabel}
+                  </EuiLink>
+                </>
+              }
             >
               <EuiFieldText
                 value={form.baseUrl}
-                placeholder='https://api.openai.com/v1'
+                placeholder={urlGuidance.placeholder}
                 isInvalid={Boolean(baseUrlError)}
                 onChange={event => {
                   setForm({ ...form, baseUrl: event.target.value });

--- a/plugins/wazuh-ai-assistant/public/components/settings/provider-form-flyout.tsx
+++ b/plugins/wazuh-ai-assistant/public/components/settings/provider-form-flyout.tsx
@@ -16,6 +16,8 @@ import {
   EuiForm,
   EuiFormRow,
   EuiLink,
+  EuiPopover,
+  EuiPopoverTitle,
   EuiSelect,
   EuiSpacer,
   EuiTitle,
@@ -121,6 +123,44 @@ const emptyForm: ProviderInput = {
 function isValidEndpointUrl(value: string): boolean {
   return /^https?:\/\//i.test(value.trim());
 }
+
+/** Collapses the (potentially multi-service, for openai_compatible) docs links behind a single
+ * trigger rather than inlining them all in the help text — inlining every link for every provider
+ * type change would make the field's help text noisy and reflow the form on each type switch. */
+const DocsPopover: React.FC<{ docs: ProviderUrlDoc[] }> = ({ docs }) => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <EuiPopover
+      button={
+        <EuiLink onClick={() => setIsOpen(open => !open)}>
+          {i18n.translate('wazuhAiAssistant.settings.form.baseUrlDocsButton', {
+            defaultMessage: 'API documentation',
+          })}
+        </EuiLink>
+      }
+      isOpen={isOpen}
+      closePopover={() => setIsOpen(false)}
+      panelPaddingSize='s'
+      anchorPosition='downLeft'
+    >
+      <EuiPopoverTitle>
+        {i18n.translate('wazuhAiAssistant.settings.form.baseUrlDocsTitle', {
+          defaultMessage: 'API documentation',
+        })}
+      </EuiPopoverTitle>
+      <EuiFlexGroup direction='column' gutterSize='s' responsive={false}>
+        {docs.map(doc => (
+          <EuiFlexItem key={doc.url}>
+            <EuiLink href={doc.url} target='_blank'>
+              {doc.label}
+            </EuiLink>
+          </EuiFlexItem>
+        ))}
+      </EuiFlexGroup>
+    </EuiPopover>
+  );
+};
 
 interface ProviderFormFlyoutProps {
   editingProvider: ProviderSummary | null;
@@ -354,14 +394,7 @@ export const ProviderFormFlyout: React.FC<ProviderFormFlyoutProps> = ({
                     </React.Fragment>
                   ))}
                   {'. '}
-                  {urlGuidance.docs.map((doc, index) => (
-                    <React.Fragment key={doc.url}>
-                      {index > 0 && ', '}
-                      <EuiLink href={doc.url} target='_blank'>
-                        {doc.label}
-                      </EuiLink>
-                    </React.Fragment>
-                  ))}
+                  <DocsPopover docs={urlGuidance.docs} />
                 </>
               }
             >

--- a/plugins/wazuh-ai-assistant/public/components/settings/provider-form-flyout.tsx
+++ b/plugins/wazuh-ai-assistant/public/components/settings/provider-form-flyout.tsx
@@ -20,6 +20,7 @@ import {
   EuiPopoverTitle,
   EuiSelect,
   EuiSpacer,
+  EuiText,
   EuiTitle,
   EuiToolTip,
 } from '@elastic/eui';
@@ -47,6 +48,19 @@ interface ProviderUrlDoc {
   url: string;
 }
 
+/** Note shown under the docs links for openai_compatible: that type's label (see
+ * PROVIDER_TYPE_FORM_LABELS above) advertises more services (Gemini, LM Studio, vLLM...) than this
+ * file has room to keep a maintained doc link for — pointing the admin at their own provider's
+ * docs is more reliable than us trying to enumerate every compatible gateway. */
+const OTHER_OPENAI_COMPATIBLE_PROVIDERS_NOTE = i18n.translate(
+  'wazuhAiAssistant.settings.form.otherProvidersNote',
+  {
+    defaultMessage:
+      'Using another OpenAI-compatible provider or gateway (e.g. Gemini, LM Studio, vLLM)? ' +
+      'Check its own documentation for the correct values.',
+  },
+);
+
 /**
  * Per-type endpoint URL guidance shown under the field: the adapters append their own path to
  * `baseUrl` (`/chat/completions` for openai_compatible, `/v1/messages` for anthropic — see
@@ -60,6 +74,7 @@ const PROVIDER_URL_GUIDANCE: Record<
     placeholder: string;
     examples: string[];
     docs: ProviderUrlDoc[];
+    note?: string;
   }
 > = {
   openai_compatible: {
@@ -96,6 +111,7 @@ const PROVIDER_URL_GUIDANCE: Record<
         url: 'https://github.com/ollama/ollama/blob/main/docs/api.md',
       },
     ],
+    note: OTHER_OPENAI_COMPATIBLE_PROVIDERS_NOTE,
   },
   anthropic: {
     placeholder: 'https://api.anthropic.com',
@@ -107,6 +123,56 @@ const PROVIDER_URL_GUIDANCE: Record<
           { defaultMessage: 'Anthropic API reference' },
         ),
         url: 'https://docs.anthropic.com/en/api/overview',
+      },
+    ],
+  },
+};
+
+/**
+ * Per-type MODEL guidance: the model field is free text (no enum — providers add models faster
+ * than this form could track), so it gets the same examples-plus-docs treatment as the endpoint
+ * URL field, pointing at each provider's own model list instead of us mirroring it (which would
+ * always be stale).
+ */
+const PROVIDER_MODEL_GUIDANCE: Record<
+  ProviderInput['type'],
+  { examples: string[]; docs: ProviderUrlDoc[]; note?: string }
+> = {
+  openai_compatible: {
+    examples: ['gpt-4o', 'gpt-4o-mini', 'llama-3.3-70b-versatile'],
+    docs: [
+      {
+        label: i18n.translate(
+          'wazuhAiAssistant.settings.form.modelDocsOpenai',
+          { defaultMessage: 'OpenAI model list' },
+        ),
+        url: 'https://platform.openai.com/docs/models',
+      },
+      {
+        label: i18n.translate('wazuhAiAssistant.settings.form.modelDocsGroq', {
+          defaultMessage: 'Groq model list',
+        }),
+        url: 'https://console.groq.com/docs/models',
+      },
+      {
+        label: i18n.translate(
+          'wazuhAiAssistant.settings.form.modelDocsOllama',
+          { defaultMessage: 'Ollama model library' },
+        ),
+        url: 'https://ollama.com/library',
+      },
+    ],
+    note: OTHER_OPENAI_COMPATIBLE_PROVIDERS_NOTE,
+  },
+  anthropic: {
+    examples: ['claude-sonnet-4-5', 'claude-opus-4-1'],
+    docs: [
+      {
+        label: i18n.translate(
+          'wazuhAiAssistant.settings.form.modelDocsAnthropic',
+          { defaultMessage: 'Anthropic model list' },
+        ),
+        url: 'https://docs.anthropic.com/en/docs/about-claude/models/overview',
       },
     ],
   },
@@ -126,17 +192,21 @@ function isValidEndpointUrl(value: string): boolean {
 
 /** Collapses the (potentially multi-service, for openai_compatible) docs links behind a single
  * trigger rather than inlining them all in the help text — inlining every link for every provider
- * type change would make the field's help text noisy and reflow the form on each type switch. */
-const DocsPopover: React.FC<{ docs: ProviderUrlDoc[] }> = ({ docs }) => {
+ * type change would make the field's help text noisy and reflow the form on each type switch.
+ * Reused for both the endpoint URL and the Model field, with their own trigger label/title/note. */
+const DocsPopover: React.FC<{
+  triggerLabel: string;
+  title: string;
+  docs: ProviderUrlDoc[];
+  note?: string;
+}> = ({ triggerLabel, title, docs, note }) => {
   const [isOpen, setIsOpen] = useState(false);
 
   return (
     <EuiPopover
       button={
         <EuiLink onClick={() => setIsOpen(open => !open)}>
-          {i18n.translate('wazuhAiAssistant.settings.form.baseUrlDocsButton', {
-            defaultMessage: 'API documentation',
-          })}
+          {triggerLabel}
         </EuiLink>
       }
       isOpen={isOpen}
@@ -144,11 +214,7 @@ const DocsPopover: React.FC<{ docs: ProviderUrlDoc[] }> = ({ docs }) => {
       panelPaddingSize='s'
       anchorPosition='downLeft'
     >
-      <EuiPopoverTitle>
-        {i18n.translate('wazuhAiAssistant.settings.form.baseUrlDocsTitle', {
-          defaultMessage: 'API documentation',
-        })}
-      </EuiPopoverTitle>
+      <EuiPopoverTitle>{title}</EuiPopoverTitle>
       <EuiFlexGroup direction='column' gutterSize='s' responsive={false}>
         {docs.map(doc => (
           <EuiFlexItem key={doc.url}>
@@ -158,6 +224,14 @@ const DocsPopover: React.FC<{ docs: ProviderUrlDoc[] }> = ({ docs }) => {
           </EuiFlexItem>
         ))}
       </EuiFlexGroup>
+      {note && (
+        <>
+          <EuiSpacer size='s' />
+          <EuiText size='xs' color='subdued'>
+            {note}
+          </EuiText>
+        </>
+      )}
     </EuiPopover>
   );
 };
@@ -199,6 +273,7 @@ export const ProviderFormFlyout: React.FC<ProviderFormFlyoutProps> = ({
   const [baseUrlError, setBaseUrlError] = useState<string | null>(null);
   const [showCloseConfirm, setShowCloseConfirm] = useState(false);
   const urlGuidance = PROVIDER_URL_GUIDANCE[form.type];
+  const modelGuidance = PROVIDER_MODEL_GUIDANCE[form.type];
 
   const handleSave = async () => {
     const trimmedForm: ProviderInput = {
@@ -394,7 +469,18 @@ export const ProviderFormFlyout: React.FC<ProviderFormFlyoutProps> = ({
                     </React.Fragment>
                   ))}
                   {'. '}
-                  <DocsPopover docs={urlGuidance.docs} />
+                  <DocsPopover
+                    triggerLabel={i18n.translate(
+                      'wazuhAiAssistant.settings.form.baseUrlDocsButton',
+                      { defaultMessage: 'API documentation' },
+                    )}
+                    title={i18n.translate(
+                      'wazuhAiAssistant.settings.form.baseUrlDocsTitle',
+                      { defaultMessage: 'API documentation' },
+                    )}
+                    docs={urlGuidance.docs}
+                    note={urlGuidance.note}
+                  />
                 </>
               }
             >
@@ -415,16 +501,41 @@ export const ProviderFormFlyout: React.FC<ProviderFormFlyoutProps> = ({
               label={i18n.translate('wazuhAiAssistant.settings.form.model', {
                 defaultMessage: 'Model',
               })}
-              helpText={i18n.translate(
-                'wazuhAiAssistant.settings.form.modelHelp',
-                {
-                  defaultMessage:
-                    'Tool calling needs a model with solid function-calling support. Known ' +
-                    'good: GPT-4o or GPT-4o-mini (OpenAI), Claude Sonnet (Anthropic), ' +
-                    'llama-3.3-70b-versatile (Groq). Small or base models often fail with ' +
-                    'tool errors.',
-                },
-              )}
+              helpText={
+                <>
+                  {i18n.translate('wazuhAiAssistant.settings.form.modelHelp', {
+                    defaultMessage:
+                      'Tool calling needs a model with solid function-calling support. Small ' +
+                      'or base models often fail with tool errors.',
+                  })}{' '}
+                  <FormattedMessage
+                    id='wazuhAiAssistant.settings.form.modelExample'
+                    defaultMessage='Example: {example}'
+                    values={{
+                      example: <EuiCode>{modelGuidance.examples[0]}</EuiCode>,
+                    }}
+                  />
+                  {modelGuidance.examples.slice(1).map(example => (
+                    <React.Fragment key={example}>
+                      {', '}
+                      <EuiCode>{example}</EuiCode>
+                    </React.Fragment>
+                  ))}
+                  {'. '}
+                  <DocsPopover
+                    triggerLabel={i18n.translate(
+                      'wazuhAiAssistant.settings.form.modelDocsButton',
+                      { defaultMessage: 'See available models' },
+                    )}
+                    title={i18n.translate(
+                      'wazuhAiAssistant.settings.form.modelDocsTitle',
+                      { defaultMessage: 'Model documentation' },
+                    )}
+                    docs={modelGuidance.docs}
+                    note={modelGuidance.note}
+                  />
+                </>
+              }
             >
               <EuiFieldText
                 value={form.model}

--- a/plugins/wazuh-ai-assistant/public/components/settings/provider-form-flyout.tsx
+++ b/plugins/wazuh-ai-assistant/public/components/settings/provider-form-flyout.tsx
@@ -213,11 +213,15 @@ const DocsPopover: React.FC<{
       closePopover={() => setIsOpen(false)}
       panelPaddingSize='s'
       anchorPosition='downLeft'
+      // Without an explicit cap the panel sizes to its widest unwrapped line — the note sentence
+      // in particular — stretching the popover (and its trigger link) far past what the list of
+      // short doc links actually needs. Capping the width forces the note to wrap instead.
+      panelStyle={{ maxWidth: 280 }}
     >
       <EuiPopoverTitle>{title}</EuiPopoverTitle>
       <EuiFlexGroup direction='column' gutterSize='s' responsive={false}>
         {docs.map(doc => (
-          <EuiFlexItem key={doc.url}>
+          <EuiFlexItem key={doc.url} grow={false}>
             <EuiLink href={doc.url} target='_blank'>
               {doc.label}
             </EuiLink>

--- a/plugins/wazuh-ai-assistant/public/components/settings/settings-page.tsx
+++ b/plugins/wazuh-ai-assistant/public/components/settings/settings-page.tsx
@@ -818,7 +818,7 @@ export const SettingsPage: React.FC<SettingsPageProps> = ({
   ];
 
   return (
-    <EuiPage restrictWidth={960}>
+    <EuiPage>
       <EuiPageBody>
         <EuiPageContent
           hasShadow={false}

--- a/plugins/wazuh-ai-assistant/server/providers/retry.test.ts
+++ b/plugins/wazuh-ai-assistant/server/providers/retry.test.ts
@@ -1,5 +1,9 @@
 import assert from 'node:assert/strict';
-import { fetchProviderWithRetry, sanitizeProviderErrorBody } from './retry';
+import {
+  extractProviderErrorMessage,
+  fetchProviderWithRetry,
+  sanitizeProviderErrorBody,
+} from './retry';
 import { StreamEvent } from '../../common/types';
 
 /** Minimal fake fetch Response covering everything retry.ts touches: `.ok`, `.status`, `.body`,
@@ -247,4 +251,79 @@ test('sanitizeProviderErrorBody: an empty/absent secret does not change behavior
   );
   assert.equal(withoutSecret, 'plain message with no credentials');
   assert.equal(withUndefined, 'plain message with no credentials');
+});
+
+// extractProviderErrorMessage
+// "capture some cases, else display all": known JSON/HTML error shapes are unwrapped to just
+// their message text; anything else falls through to the raw body unchanged.
+
+test('extractProviderErrorMessage: unwraps an OpenAI/Groq-style {error: {message}} JSON body', () => {
+  const out = extractProviderErrorMessage(
+    '{"error":{"message":"Incorrect API key provided.","type":"invalid_request_error"}}',
+  );
+  assert.equal(out, 'Incorrect API key provided.');
+});
+
+test('extractProviderErrorMessage: does NOT unwrap a bare {error: "..."} JSON body — a sibling field could still carry something that needs redaction', () => {
+  const body =
+    '{"error":"bad request","echoed_body":{"api_key":"sk-should-stay-visible-here"}}';
+  const out = extractProviderErrorMessage(body);
+  assert.equal(out, body);
+});
+
+test('extractProviderErrorMessage: does NOT unwrap a generic top-level {message: "..."} JSON body (same ambiguous-shape reasoning)', () => {
+  const body =
+    '{"message":"quota exceeded","echoed_body":{"api_key":"sk-should-stay-visible-here"}}';
+  const out = extractProviderErrorMessage(body);
+  assert.equal(out, body);
+});
+
+test("extractProviderErrorMessage: extracts an HTML error page's <title>", () => {
+  const out = extractProviderErrorMessage(
+    '<html><head><title>502 Bad Gateway</title></head><body><center>nginx</center></body></html>',
+  );
+  assert.equal(out, '502 Bad Gateway');
+});
+
+test('extractProviderErrorMessage: falls back to tag-stripped text for HTML without a <title>', () => {
+  const out = extractProviderErrorMessage(
+    '<html><body><h1>Access Denied</h1></body></html>',
+  );
+  assert.equal(out, 'Access Denied');
+});
+
+test('extractProviderErrorMessage: decodes HTML entities in the extracted title', () => {
+  const out = extractProviderErrorMessage(
+    '<html><head><title>Bad Request &amp; Forbidden</title></head></html>',
+  );
+  assert.equal(out, 'Bad Request & Forbidden');
+});
+
+test('extractProviderErrorMessage: passes through plain text unchanged (display all)', () => {
+  const out = extractProviderErrorMessage('upstream timeout');
+  assert.equal(out, 'upstream timeout');
+});
+
+test('extractProviderErrorMessage: passes through an unrecognized JSON shape unchanged (display all)', () => {
+  const out = extractProviderErrorMessage(
+    '{"code":503,"detail":"unavailable"}',
+  );
+  assert.equal(out, '{"code":503,"detail":"unavailable"}');
+});
+
+test('extractProviderErrorMessage: passes through malformed/truncated JSON unchanged rather than throwing', () => {
+  const out = extractProviderErrorMessage('{"error":{"message":"cut off...');
+  assert.equal(out, '{"error":{"message":"cut off...');
+});
+
+test('extractProviderErrorMessage: an extracted JSON message is still redacted downstream by sanitizeProviderErrorBody (secret passthrough)', () => {
+  const extracted = extractProviderErrorMessage(
+    '{"error":{"message":"key sk-abc123def456ghi789 is invalid"}}',
+  );
+  const sanitized = sanitizeProviderErrorBody(
+    extracted,
+    'sk-abc123def456ghi789',
+  );
+  assert.doesNotMatch(sanitized, /sk-abc123def456ghi789/);
+  assert.match(sanitized, /\[redacted\]/);
 });

--- a/plugins/wazuh-ai-assistant/server/providers/retry.ts
+++ b/plugins/wazuh-ai-assistant/server/providers/retry.ts
@@ -146,6 +146,86 @@ export function sanitizeProviderErrorBody(
     : out;
 }
 
+/** Tries the ONE JSON error-body shape real providers actually use: OpenAI, Groq, Anthropic and
+ * the OpenAI-compatible gateways (vLLM, Ollama, LM Studio...) all nest the human message at
+ * `error.message`. Deliberately narrow — a bare top-level `{error: "..."}` or `{message: "..."}`
+ * is NOT unwrapped, even though some ad-hoc gateways use that shape, because such a body may carry
+ * OTHER top-level fields (e.g. a misbehaving gateway echoing the request body/credentials
+ * alongside a generic error string) that unwrapping to just one field would silently drop from the
+ * message sanitizeProviderErrorBody redacts — better to fall through to the raw, fully-redacted
+ * body than to risk narrowing past something that still needed redaction. Returns undefined —
+ * never throws — on non-JSON input or a shape mismatch, so the caller falls through to the next
+ * candidate. */
+function extractJsonErrorMessage(bodyText: string): string | undefined {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(bodyText);
+  } catch {
+    return undefined;
+  }
+  if (!parsed || typeof parsed !== 'object') {
+    return undefined;
+  }
+  const nestedError = (parsed as Record<string, unknown>).error;
+  if (nestedError && typeof nestedError === 'object') {
+    const message = (nestedError as Record<string, unknown>).message;
+    if (typeof message === 'string' && message.trim()) {
+      return message.trim();
+    }
+  }
+  return undefined;
+}
+
+/** A gateway/proxy sitting in front of the provider (a load balancer, an nginx front door, a
+ * corporate egress proxy) commonly rejects the request before it ever reaches the provider's own
+ * API, returning ITS OWN HTML error page rather than the provider's JSON error contract — e.g. a
+ * 502 from an nginx front door, or an SSO/captive-portal redirect page. `<title>` is normally the
+ * terse human-readable summary of such a page ("502 Bad Gateway", "Access Denied"); the
+ * tag-stripped body text is the fallback for a page that omits one. Returns undefined (never
+ * throws) for anything that doesn't look like HTML, so the caller falls through to the raw body. */
+function extractHtmlErrorMessage(bodyText: string): string | undefined {
+  const trimmed = bodyText.trim();
+  if (
+    !/^<(!doctype html|html)\b/i.test(trimmed) &&
+    !/<html[\s>]/i.test(trimmed)
+  ) {
+    return undefined;
+  }
+  const decodeEntities = (text: string): string =>
+    text
+      .replace(/&lt;/gi, '<')
+      .replace(/&gt;/gi, '>')
+      .replace(/&quot;/gi, '"')
+      .replace(/&#39;/g, "'")
+      .replace(/&amp;/gi, '&');
+  const titleMatch = trimmed.match(/<title[^>]*>([\s\S]*?)<\/title>/i);
+  const title = titleMatch
+    ? decodeEntities(titleMatch[1]).replace(/\s+/g, ' ').trim()
+    : '';
+  if (title) {
+    return title;
+  }
+  const text = decodeEntities(trimmed.replace(/<[^>]*>/g, ' '))
+    .replace(/\s+/g, ' ')
+    .trim();
+  return text || undefined;
+}
+
+/** Turns a raw provider/gateway HTTP error body into a short, human-meaningful message before
+ * `sanitizeProviderErrorBody` truncates/redacts it: a JSON body in one of the shapes providers
+ * actually use, or an HTML error page's `<title>`, is unwrapped to just its message text; anything
+ * else (an unrecognized JSON shape, plain text, a truncated/malformed body) is passed through
+ * unchanged so the existing raw-body behavior is preserved — "capture some cases, else display
+ * all". Exported so wazuh-brain.ts's non-streaming adapter, which hits the same raw-body-in-error
+ * shape, reuses it rather than duplicating the parsing. */
+export function extractProviderErrorMessage(bodyText: string): string {
+  return (
+    extractJsonErrorMessage(bodyText) ??
+    extractHtmlErrorMessage(bodyText) ??
+    bodyText
+  );
+}
+
 /** Wait hint from a rejected response: Retry-After header, else a "try again in Xs/Xms" body. */
 function parseWaitHintMs(
   retryAfterHeader: string | null,
@@ -340,7 +420,10 @@ export async function* fetchProviderWithRetry(
         type: 'error',
         message: `Provider responded with HTTP ${
           response.status
-        }: ${sanitizeProviderErrorBody(bodyText, secret)}`,
+        }: ${sanitizeProviderErrorBody(
+          extractProviderErrorMessage(bodyText),
+          secret,
+        )}`,
       };
       return undefined;
     }

--- a/plugins/wazuh-ai-assistant/server/providers/wazuh-brain.ts
+++ b/plugins/wazuh-ai-assistant/server/providers/wazuh-brain.ts
@@ -9,6 +9,7 @@ import {
 // Raw HTTP error bodies can echo a credential from a misbehaving gateway; reuse retry.ts's
 // truncate+redact helper rather than forwarding the body verbatim (see its doc comment).
 import {
+  extractProviderErrorMessage,
   fetchWithHeaderTimeout,
   safeReadText,
   sanitizeProviderErrorBody,
@@ -109,7 +110,10 @@ export class WazuhBrainAdapter implements ProviderAdapter {
         // credential shapes.
         message: `Provider responded with HTTP ${
           response.status
-        }: ${sanitizeProviderErrorBody(bodyText, config.apiKey)}`,
+        }: ${sanitizeProviderErrorBody(
+          extractProviderErrorMessage(bodyText),
+          config.apiKey,
+        )}`,
       };
       return;
     }


### PR DESCRIPTION
## Description

The AI Assistant provider settings form (the "Add/Edit provider" flyout) had a
few rough edges reported in the linked issue: the endpoint URL field always
showed an OpenAI-shaped placeholder regardless of the selected provider, there
was no example/documentation to help the admin fill in the URL or model name
correctly, raw provider/gateway error bodies (which can be JSON or HTML
depending on what rejected the request) were shown to the user unparsed, and
the flyout was narrow enough to make the form cramped.

Closes #8829

## Proposed Changes

- The **Endpoint URL** field's placeholder and inline examples now switch
  based on the selected **Provider type** (OpenAI-compatible vs Anthropic),
  instead of always showing the OpenAI format.
- The **Model** field (free text, no enum) gets the same treatment: per-type
  example model names (e.g. `gpt-4o-mini`, `llama-3.3-70b-versatile` for
  OpenAI-compatible; `claude-sonnet-4-5` for Anthropic).
- Both fields expose their documentation links behind a single **popover**
  trigger ("API documentation" / "See available models") instead of inlining
  every link in the help text — for `openai_compatible` this lists one link
  per actual service the type covers (OpenAI, Groq, Ollama), rather than a
  single misleading "OpenAI" link. A note in that popover points admins using
  another OpenAI-compatible provider or gateway (Gemini, LM Studio, vLLM,
  etc.) at that provider's own documentation. The popover panel width is
  capped so the note wraps instead of stretching the whole panel/trigger.
- Provider/gateway HTTP error bodies are now parsed for two well-known shapes
  before falling back to the raw (truncated, redacted) body: the
  `{"error": {"message": "..."}}` JSON contract used by OpenAI, Anthropic, Groq
  and OpenAI-compatible gateways (vLLM, Ollama, LM Studio...), and an HTML error
  page's `<title>` (or tag-stripped text), which is common when a reverse proxy
  or load balancer rejects the request before it reaches the provider. Any
  other shape still falls through to the previous raw-body behavior — "capture
  some cases, else display all". This applies to both the streaming chat path
  (`server/providers/retry.ts`) and the hosted-brain webhook adapter
  (`server/providers/wazuh-brain.ts`).
- Removed the settings page's `restrictWidth={960}` cap on `EuiPage`, so the
  page (provider list, privacy policy, etc.) uses the full available width
  instead of being capped at 960px.
- Clarified the **API key** field's help text: it's optional for endpoints
  that don't require authentication (e.g. a local Ollama server without
  auth) and is stored encrypted at rest when an encryption key is
  configured; edit mode keeps the existing "leave empty to keep the
  current key" note.

### Results and Evidence

<!-- Screenshot/video to be attached by the developer before marking this PR ready for review. -->

<img width="1918" height="879" alt="image" src="https://github.com/user-attachments/assets/3ce976fa-92d6-4a97-b8b5-b7572ef09b9d" />
<img width="469" height="712" alt="image" src="https://github.com/user-attachments/assets/a78c18be-8db9-4de5-b210-cd2d390ebd76" />
<img width="473" height="744" alt="image" src="https://github.com/user-attachments/assets/b5ee7dbf-2ae9-4356-ac74-3ac4b715a4d3" />
<img width="473" height="742" alt="image" src="https://github.com/user-attachments/assets/cccb36d2-a394-44d9-9dd0-3b4b65ff00d5" />


### Artifacts Affected

- `plugins/wazuh-ai-assistant` (public UI + server provider adapters). No
  executables, packaging, or default configuration files affected.

### Configuration Changes

None.

### Documentation Updates

None required — no public API or configuration surface changed.

### Tests Introduced

- `provider-form-flyout.test.tsx`:
  - Endpoint URL placeholder/example switch, and the documentation popover
    (OpenAI/Groq/Ollama links, the other-providers note) for both
    `openai_compatible` and `anthropic`.
  - Model field example switch, and its own documentation popover
    (OpenAI/Groq/Ollama model-list links, the other-providers note) for both
    provider types.
  - API key field's clarified help text in create mode (optional /
    encrypted-at-rest wording).
- `retry.test.ts`: new `extractProviderErrorMessage` coverage — unwraps the
  `{error:{message}}` JSON shape, extracts an HTML `<title>` (and decodes
  entities), falls back to tag-stripped text when no `<title>` is present,
  passes through plain text/unrecognized JSON/malformed JSON unchanged, and
  confirms an unwrapped JSON message still goes through
  `sanitizeProviderErrorBody`'s secret redaction. Also adds a regression test
  proving a bare `{error: "..."}` / `{message: "..."}` body is deliberately
  **not** unwrapped, since a sibling field in that shape could carry something
  that still needs redaction (this guards the existing
  `wazuh-brain.test.ts` API-key-echo redaction test, which exercises exactly
  that ambiguous shape).

## Review Checklist

- [x] Code changes reviewed
- [ ] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented (none needed)
- [x] Developer documentation reflects the changes (none needed)
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [x] PR is linked to the relevant issue(s)
- [ ] Correct labels applied (e.g., `no-changelog`)
- [ ] ...
